### PR TITLE
Handle Jetty's removal of method ServletContextHandler.addFilter(String,String,int)

### DIFF
--- a/components/camel-jetty/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -370,7 +370,7 @@ public class JettyHttpComponent extends HttpComponent {
             if (endpoint.isMatchOnUriPrefix()) {
                 pathSpec = pathSpec.endsWith("/") ? pathSpec + "*" : pathSpec + "/*";
             }
-            context.addFilter(filterHolder, pathSpec, 0);
+            context.addFilter(filterHolder, pathSpec, null);
         }
         
     }
@@ -404,7 +404,7 @@ public class JettyHttpComponent extends HttpComponent {
         if (endpoint.isMatchOnUriPrefix()) {
             pathSpec = pathSpec.endsWith("/") ? pathSpec + "*" : pathSpec + "/*";
         }
-        context.addFilter(filterHolder, pathSpec, 0);
+        context.addFilter(filterHolder, pathSpec, null);
         LOG.debug("using multipart filter implementation " + filter.getClass().getName() + " for path " + pathSpec);
     }
 


### PR DESCRIPTION
Jetty no longer has a ServletContextHandler.addFilter(String,String,int) method in 8.x versions. I looked at Jetty's FilterMapping.setDispatcherTypes() method and it appears to me that, calling ServletContextHandler.addFilter(String,String,EnumSet<DispatcherType>) with null for the third parameter does the same thing.
