### PR TITLE
Update camel-core/src/main/java/org/apache/camel/management/DefaultManag...

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/management/DefaultManagementAgent.java
+++ b/camel-core/src/main/java/org/apache/camel/management/DefaultManagementAgent.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultManagementAgent extends ServiceSupport implements ManagementAgent, CamelContextAware {
 
     public static final String DEFAULT_DOMAIN = "org.apache.camel";
-    public static final String DEFAULT_HOST = "localhost";
+    public static final String DEFAULT_HOST = "0.0.0.0";
     public static final int DEFAULT_REGISTRY_PORT = 1099;
     public static final int DEFAULT_CONNECTION_PORT = -1;
     public static final String DEFAULT_SERVICE_URL_PATH = "/jmxrmi/camel";
@@ -332,28 +332,8 @@ public class DefaultManagementAgent extends ServiceSupport implements Management
 
     protected void createMBeanServer() {
         String hostName;
-        boolean canAccessSystemProps = true;
-        try {
-            // we'll do it this way mostly to determine if we should lookup the hostName
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPropertiesAccess();
-            }
-        } catch (SecurityException se) {
-            canAccessSystemProps = false;
-        }
 
-        if (canAccessSystemProps) {
-            try {
-                hostName = InetAddress.getLocalHost().getHostName();
-            } catch (UnknownHostException uhe) {
-                LOG.info("Cannot determine localhost name. Using default: " + DEFAULT_REGISTRY_PORT, uhe);
-                hostName = DEFAULT_HOST;
-            }
-        } else {
-            hostName = DEFAULT_HOST;
-        }
-
+        hostName = DEFAULT_HOST;
         server = findOrCreateMBeanServer();
 
         try {


### PR DESCRIPTION
...ementAgent.java

https://issues.apache.org/jira/browse/CAMEL-5127?page=com.atlassian.jira.plugin.system.issuetabpanels:all-tabpanel

serviceUrl in JMX remote connection should use 0.0.0.0 instead of localhost

DEFAULT_HOST updated to 0.0.0.0 as requested by change request.

createMBeanServer() updated to remove code attempting to lookup hostname as we will always use 0.0.0.0 now

NB: Where multiple network cards exist, the utilisation of 0.0.0.0 may result in any network card being used.
