### PR TITLE
Camel 6137 Send siteCommand(s) without uploading files

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -113,91 +113,93 @@ public class GenericFileProducer<T> extends DefaultProducer {
         try {
             preWriteCheck();
 
-            // should we write to a temporary name and then afterwards rename to real target
-            boolean writeAsTempAndRename = ObjectHelper.isNotEmpty(endpoint.getTempFileName());
-            String tempTarget = null;
-            // remember if target exists to avoid checking twice
-            Boolean targetExists = null;
-            if (writeAsTempAndRename) {
-                // compute temporary name with the temp prefix
-                tempTarget = createTempFileName(exchange, target);
+            if (isUploadFile()) {
+                // should we write to a temporary name and then afterwards rename to real target
+                boolean writeAsTempAndRename = ObjectHelper.isNotEmpty(endpoint.getTempFileName());
+                String tempTarget = null;
+                // remember if target exists to avoid checking twice
+                Boolean targetExists = null;
+                if (writeAsTempAndRename) {
+                    // compute temporary name with the temp prefix
+                    tempTarget = createTempFileName(exchange, target);
 
-                log.trace("Writing using tempNameFile: {}", tempTarget);
+                    log.trace("Writing using tempNameFile: {}", tempTarget);
 
-                // cater for file exists option on the real target as
-                // the file operations code will work on the temp file
+                    // cater for file exists option on the real target as
+                    // the file operations code will work on the temp file
 
-                // if an existing file already exists what should we do?
-                targetExists = operations.existsFile(target);
-                if (targetExists) {
-                    if (endpoint.getFileExist() == GenericFileExist.Ignore) {
-                        // ignore but indicate that the file was written
-                        log.trace("An existing file already exists: {}. Ignore and do not override it.", target);
-                        return;
-                    } else if (endpoint.getFileExist() == GenericFileExist.Fail) {
-                        throw new GenericFileOperationFailedException("File already exist: " + target + ". Cannot write new file.");
-                    } else if (endpoint.isEagerDeleteTargetFile() && endpoint.getFileExist() == GenericFileExist.Override) {
-                        // we override the target so we do this by deleting it so the temp file can be renamed later
-                        // with success as the existing target file have been deleted
-                        log.trace("Eagerly deleting existing file: {}", target);
-                        if (!operations.deleteFile(target)) {
-                            throw new GenericFileOperationFailedException("Cannot delete file: " + target);
+                    // if an existing file already exists what should we do?
+                    targetExists = operations.existsFile(target);
+                    if (targetExists) {
+                        if (endpoint.getFileExist() == GenericFileExist.Ignore) {
+                            // ignore but indicate that the file was written
+                            log.trace("An existing file already exists: {}. Ignore and do not override it.", target);
+                            return;
+                        } else if (endpoint.getFileExist() == GenericFileExist.Fail) {
+                            throw new GenericFileOperationFailedException("File already exist: " + target + ". Cannot write new file.");
+                        } else if (endpoint.isEagerDeleteTargetFile() && endpoint.getFileExist() == GenericFileExist.Override) {
+                            // we override the target so we do this by deleting it so the temp file can be renamed later
+                            // with success as the existing target file have been deleted
+                            log.trace("Eagerly deleting existing file: {}", target);
+                            if (!operations.deleteFile(target)) {
+                                throw new GenericFileOperationFailedException("Cannot delete file: " + target);
+                            }
+                        }
+                    }
+
+                    // delete any pre existing temp file
+                    if (operations.existsFile(tempTarget)) {
+                        log.trace("Deleting existing temp file: {}", tempTarget);
+                        if (!operations.deleteFile(tempTarget)) {
+                            throw new GenericFileOperationFailedException("Cannot delete file: " + tempTarget);
                         }
                     }
                 }
 
-                // delete any pre existing temp file
-                if (operations.existsFile(tempTarget)) {
-                    log.trace("Deleting existing temp file: {}", tempTarget);
-                    if (!operations.deleteFile(tempTarget)) {
-                        throw new GenericFileOperationFailedException("Cannot delete file: " + tempTarget);
+                // write/upload the file
+                writeFile(exchange, tempTarget != null ? tempTarget : target);
+
+                // if we did write to a temporary name then rename it to the real
+                // name after we have written the file
+                if (tempTarget != null) {
+
+                    // if we should not eager delete the target file then do it now just before renaming
+                    if (!endpoint.isEagerDeleteTargetFile() && targetExists
+                            && endpoint.getFileExist() == GenericFileExist.Override) {
+                        // we override the target so we do this by deleting it so the temp file can be renamed later
+                        // with success as the existing target file have been deleted
+                        log.trace("Deleting existing file: {}", target);
+                        if (!operations.deleteFile(target)) {
+                            throw new GenericFileOperationFailedException("Cannot delete file: " + target);
+                        }
+                    }
+
+                    // now we are ready to rename the temp file to the target file
+                    log.trace("Renaming file: [{}] to: [{}]", tempTarget, target);
+                    boolean renamed = operations.renameFile(tempTarget, target);
+                    if (!renamed) {
+                        throw new GenericFileOperationFailedException("Cannot rename file from: " + tempTarget + " to: " + target);
                     }
                 }
-            }
 
-            // write/upload the file
-            writeFile(exchange, tempTarget != null ? tempTarget : target);
+                // any done file to write?
+                if (endpoint.getDoneFileName() != null) {
+                    String doneFileName = endpoint.createDoneFileName(target);
+                    ObjectHelper.notEmpty(doneFileName, "doneFileName", endpoint);
 
-            // if we did write to a temporary name then rename it to the real
-            // name after we have written the file
-            if (tempTarget != null) {
+                    // create empty exchange with empty body to write as the done file
+                    Exchange empty = new DefaultExchange(exchange);
+                    empty.getIn().setBody("");
 
-                // if we should not eager delete the target file then do it now just before renaming
-                if (!endpoint.isEagerDeleteTargetFile() && targetExists
-                        && endpoint.getFileExist() == GenericFileExist.Override) {
-                    // we override the target so we do this by deleting it so the temp file can be renamed later
-                    // with success as the existing target file have been deleted
-                    log.trace("Deleting existing file: {}", target);
-                    if (!operations.deleteFile(target)) {
-                        throw new GenericFileOperationFailedException("Cannot delete file: " + target);
+                    log.trace("Writing done file: [{}]", doneFileName);
+                    // delete any existing done file
+                    if (operations.existsFile(doneFileName)) {
+                        if (!operations.deleteFile(doneFileName)) {
+                            throw new GenericFileOperationFailedException("Cannot delete existing done file: " + doneFileName);
+                        }
                     }
+                    writeFile(empty, doneFileName);
                 }
-
-                // now we are ready to rename the temp file to the target file
-                log.trace("Renaming file: [{}] to: [{}]", tempTarget, target);
-                boolean renamed = operations.renameFile(tempTarget, target);
-                if (!renamed) {
-                    throw new GenericFileOperationFailedException("Cannot rename file from: " + tempTarget + " to: " + target);
-                }
-            }
-
-            // any done file to write?
-            if (endpoint.getDoneFileName() != null) {
-                String doneFileName = endpoint.createDoneFileName(target);
-                ObjectHelper.notEmpty(doneFileName, "doneFileName", endpoint);
-
-                // create empty exchange with empty body to write as the done file
-                Exchange empty = new DefaultExchange(exchange);
-                empty.getIn().setBody("");
-
-                log.trace("Writing done file: [{}]", doneFileName);
-                // delete any existing done file
-                if (operations.existsFile(doneFileName)) {
-                    if (!operations.deleteFile(doneFileName)) {
-                        throw new GenericFileOperationFailedException("Cannot delete existing done file: " + doneFileName);
-                    }
-                }
-                writeFile(empty, doneFileName);
             }
 
             // let's store the name we really used in the header, so end-users
@@ -208,6 +210,15 @@ public class GenericFileProducer<T> extends DefaultProducer {
         }
 
         postWriteCheck();
+    }
+
+    /**
+     * Override if required. Files are actually sent / returns true by default
+     *
+     * @return <tt>true</tt> to send files, <tt>false</tt> to skip sending files.
+     */
+    protected boolean isUploadFile() {
+        return true;
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -111,7 +111,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
         log.trace("Processing file: {} for exchange: {}", target, exchange);
 
         try {
-            preWriteCheck();
+            preWriteCheck(exchange);
 
             if (isUploadFile()) {
                 // should we write to a temporary name and then afterwards rename to real target
@@ -232,7 +232,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
     /**
      * Perform any actions that need to occur before we write such as connecting to an FTP server etc.
      */
-    public void preWriteCheck() throws Exception {
+    public void preWriteCheck(Exchange exchange) throws Exception {
         // nothing needed to check
     }
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
@@ -172,7 +172,8 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
 
     public void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException {
         if (configuration.getSiteCommand() != null) {
-            List<String> siteOutput = new ArrayList<String>();
+            final boolean captureOutput = exchange != null && configuration.isSiteCommandCapture();
+            final List<String> siteOutput = new ArrayList<String>();
             // commands can be separated using new line
             Iterator<?> it = ObjectHelper.createIterator(endpoint.getConfiguration().getSiteCommand(), "\n");
             while (it.hasNext()) {
@@ -182,9 +183,9 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
                 if (command != null) {
                     boolean result = sendSiteCommand(command);
 
-                    if (configuration.isSiteCommandCapture()) {
+                    if (captureOutput) {
                         String reply = getFtpClient().getReplyString();
-                        siteOutput.add(reply);
+                        siteOutput.add( reply );
                     }
 
                     if (!result) {
@@ -192,7 +193,7 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
                     }
                 }
             }
-            if (configuration.isSiteCommandCapture()) {
+            if ( captureOutput ) {
                 exchange.getIn().setBody(siteOutput);
             }
         }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConfiguration.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConfiguration.java
@@ -47,6 +47,7 @@ public abstract class RemoteFileConfiguration extends GenericFileConfiguration {
     private int soTimeout;
     private boolean throwExceptionOnConnectFailed;
     private String siteCommand;
+    private boolean siteCommandCapture = false;
     private boolean stepwise = true;
     private PathSeparator separator = PathSeparator.Auto;
     private boolean streamDownload;
@@ -57,7 +58,7 @@ public abstract class RemoteFileConfiguration extends GenericFileConfiguration {
     public RemoteFileConfiguration(URI uri) {
         configure(uri);
     }
-    
+
     @Override
     public boolean needToNormalize() {
         return false;
@@ -230,6 +231,25 @@ public abstract class RemoteFileConfiguration extends GenericFileConfiguration {
         this.siteCommand = siteCommand;
     }
 
+    public boolean isSiteCommandCapture() {
+        return siteCommandCapture;
+    }
+
+    /**
+     * Capture the output of the site commands. The output of the site commands will be returned
+     * in the exchange's body as a List<String> with the output of each executed site command
+     * as a list element in order of execution. The order of execution is defined by the order
+     * of the site commands in the siteCommand option (each separated by a newline character).
+     * If false, the body remains untouched.
+     * <p/>
+     * The default is false.
+     *
+     * @param siteCommandCapture if true, capture site command output.
+     */
+    public void setSiteCommandCapture(boolean siteCommandCapture) {
+        this.siteCommandCapture = siteCommandCapture;
+    }
+
     public boolean isStepwise() {
         return stepwise;
     }
@@ -261,7 +281,7 @@ public abstract class RemoteFileConfiguration extends GenericFileConfiguration {
     public void setSeparator(PathSeparator separator) {
         this.separator = separator;
     }
-    
+
     public boolean isStreamDownload() {
         return streamDownload;
     }
@@ -271,7 +291,7 @@ public abstract class RemoteFileConfiguration extends GenericFileConfiguration {
      * the remote files are streamed to the route as they are read.  When set to false, the remote files
      * are loaded into memory before being sent into the route.
      *
-     * @param streamDownload 
+     * @param streamDownload
      */
     public void setStreamDownload(boolean streamDownload) {
         this.streamDownload = streamDownload;

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
@@ -55,6 +55,7 @@ public abstract class RemoteFileConsumer<T> extends GenericFileConsumer<T> {
             } else {
                 connectIfNecessary();
             }
+            getOperations().sendSiteCommands( getEndpoint().getConfiguration(), null );
         } catch (Exception e) {
             loggedIn = false;
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
@@ -38,6 +38,7 @@ public abstract class RemoteFileEndpoint<T> extends GenericFileEndpoint<T> {
     private boolean disconnect;
     private boolean fastExistsCheck;
     private boolean download = true;
+    private boolean upload = true;
 
     public RemoteFileEndpoint() {
         // no args constructor for spring bean endpoint configuration
@@ -207,5 +208,13 @@ public abstract class RemoteFileEndpoint<T> extends GenericFileEndpoint<T> {
 
     public void setDownload(boolean download) {
         this.download = download;
+    }
+
+    public boolean isUpload() {
+        return this.upload;
+    }
+
+    public void setUpload(boolean upload) {
+        this.upload = upload;
     }
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileOperations.java
@@ -71,9 +71,11 @@ public interface RemoteFileOperations<T> extends GenericFileOperations<T> {
      * configuration option siteCommand. If option siteCommandCapture is true,
      * the output of each site command will be captured and returned as a List<String>
      * in the body.
+     * <p/>
+     * Works with the producer only.
      *
      * @param configuration the configuration
-     * @param exchange the exchange
+     * @param exchange the exchange; if null, output will not be captured
      * @throws GenericFileOperationFailedException can be thrown
      */
     void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException;

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileOperations.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file.remote;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileOperations;
 
@@ -65,4 +66,15 @@ public interface RemoteFileOperations<T> extends GenericFileOperations<T> {
      */
     boolean sendSiteCommand(String command) throws GenericFileOperationFailedException;
 
+    /**
+     * Sends the site commands to the remote server which are specified in the
+     * configuration option siteCommand. If option siteCommandCapture is true,
+     * the output of each site command will be captured and returned as a List<String>
+     * in the body.
+     *
+     * @param configuration the configuration
+     * @param exchange the exchange
+     * @throws GenericFileOperationFailedException can be thrown
+     */
+    void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException;
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileProducer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileProducer.java
@@ -89,7 +89,7 @@ public class RemoteFileProducer<T> extends GenericFileProducer<T> implements Ser
     }
 
     @Override
-    public void preWriteCheck() throws Exception {
+    public void preWriteCheck(Exchange exchange) throws Exception {
         // before writing send a noop to see if the connection is alive and works
         boolean noop = false;
         if (loggedIn) {
@@ -114,6 +114,7 @@ public class RemoteFileProducer<T> extends GenericFileProducer<T> implements Ser
                 } else {
                     connectIfNecessary();
                 }
+                getOperations().sendSiteCommands(getEndpoint().getConfiguration(), exchange);
             } catch (Exception e) {
                 loggedIn = false;
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileProducer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileProducer.java
@@ -137,6 +137,11 @@ public class RemoteFileProducer<T> extends GenericFileProducer<T> implements Ser
     }
 
     @Override
+    protected boolean isUploadFile() {
+        return getEndpoint().isUpload();
+    }
+
+    @Override
     protected void doStart() throws Exception {
         log.debug("Starting");
         // do not connect when component starts, just wait until we process as we will

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -867,4 +867,9 @@ public class SftpOperations implements RemoteFileOperations<ChannelSftp.LsEntry>
         // is not implemented
         return true;
     }
+
+    @Override
+    public void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException {
+        throw new GenericFileOperationFailedException("Operation 'site ..' not supported by the sftp: protocol");
+    }
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -870,6 +870,6 @@ public class SftpOperations implements RemoteFileOperations<ChannelSftp.LsEntry>
 
     @Override
     public void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException {
-        throw new GenericFileOperationFailedException("Operation 'site ..' not supported by the sftp: protocol");
+        // is not implemented
     }
 }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpProducerSiteCommandTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpProducerSiteCommandTest.java
@@ -17,11 +17,15 @@
 package org.apache.camel.component.file.remote;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.converter.IOConverter;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 
 public class FtpProducerSiteCommandTest extends FtpServerTestSupport {
 
@@ -34,26 +38,48 @@ public class FtpProducerSiteCommandTest extends FtpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from( "direct:callSiteCommandWithoutUpload" )
-                        .to( "ftp://admin@localhost:" + getPort() + "/site?password=admin&siteCommand=STAT&upload=false" );
+                from("direct:callSiteCommandWithoutUpload")
+                        .to("ftp://admin@localhost:" + getPort() + "/site?password=admin&siteCommand=STAT&upload=false");
+
+                from("direct:callSiteCommandAndCaptureOutput")
+                        .inOut("ftp://admin@localhost:" + getPort() + "/site?password=admin&siteCommand=STAT&upload=false&siteCommandCapture=true");
+
+                from("direct:callTwoSiteCommands")
+                        .inOut("ftp://admin@localhost:" + getPort() + "/site?password=admin&siteCommand=STAT%0AZONE&upload=false&siteCommandCapture=true");
             }
         };
     }
 
     @Test
     public void testSiteCommandWithoutUploadingFile() throws Exception {
-        template.sendBodyAndHeader( "direct:callSiteCommandWithoutUpload", "Hello world", Exchange.FILE_NAME, "hello.txt" );
+        template.sendBodyAndHeader("direct:callSiteCommandWithoutUpload", "Hello world", Exchange.FILE_NAME, "hello.txt");
 
-        File file = new File( FTP_ROOT_DIR + "/site/hello.txt" );
-        assertFalse( "No file should be uploaded", file.exists() );
+        File file = new File(FTP_ROOT_DIR + "/site/hello.txt");
+        assertFalse("No file should be uploaded", file.exists());
+    }
+
+    @Test
+    public void testCaptureSiteCommandOutput() throws Exception {
+        List<String> output = template.requestBody("direct:callSiteCommandAndCaptureOutput", null, List.class);
+
+        assertThat("Body should contain one line of site command output", output.size(), is(1));
+        assertThat("Site command output should start with response code 200", output.get(0), startsWith("200"));
+    }
+
+    @Test
+    public void testCallsTwoSiteCommands() throws Exception {
+        List<String> output = template.requestBody("direct:callTwoSiteCommands", null, List.class);
+        System.out.println(output.get(0));
+        System.out.println(output.get(1));
+        assertThat("Body should contain one line of site command output", output.size(), is(2));
     }
 
     @Test
     public void testSiteCommand() throws Exception {
-        sendFile( getFtpUrl(), "Hello World", "hello.txt" );
+        sendFile(getFtpUrl(), "Hello World", "hello.txt");
 
-        File file = new File( FTP_ROOT_DIR + "/site/hello.txt" );
-        assertTrue( "The uploaded file should exist", file.exists() );
-        assertEquals( "Hello World", IOConverter.toString( file, null ) );
+        File file = new File(FTP_ROOT_DIR + "/site/hello.txt");
+        assertTrue("The uploaded file should exist", file.exists());
+        assertEquals("Hello World", IOConverter.toString(file, null));
     }
 }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpServerTestSupport.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpServerTestSupport.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 public abstract class FtpServerTestSupport extends BaseServerTestSupport {
 
     protected static final String FTP_ROOT_DIR = "./target/res/home";
-    protected static final File USERS_FILE = new File("./src/test/resources/users.properties");
+    protected static final File USERS_FILE = new File(FtpServerTestSupport.class.getResource( "/users.properties" ).getFile());
     protected static final String DEFAULT_LISTENER = "default";
 
     protected FtpServer ftpServer;

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/jsch/ScpOperations.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/jsch/ScpOperations.java
@@ -215,7 +215,7 @@ public class ScpOperations implements RemoteFileOperations<ScpFile> {
 
     @Override
     public void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException {
-        throw new GenericFileOperationFailedException("Operation 'site ..' not supported by the scp: protocol");
+        // TODO: not really used, maybe implement at a later time
     }
 
     private Session createSession(ScpConfiguration config) {

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/jsch/ScpOperations.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/jsch/ScpOperations.java
@@ -212,7 +212,12 @@ public class ScpOperations implements RemoteFileOperations<ScpFile> {
         // TODO: not really used, maybe implement at a later time
         return true;
     }
-    
+
+    @Override
+    public void sendSiteCommands(RemoteFileConfiguration configuration, Exchange exchange) throws GenericFileOperationFailedException {
+        throw new GenericFileOperationFailedException("Operation 'site ..' not supported by the scp: protocol");
+    }
+
     private Session createSession(ScpConfiguration config) {
         ObjectHelper.notNull(config, "ScpConfiguration");
         try {


### PR DESCRIPTION
CAMEL-6137
==========

Part 1
------
- Added a new option "upload" to the producer which works according to option "download" in the FTP consumer: If false, no file will be uploaded, no temporary file will be created, no done file will be created, but the Exchange.FILE_NAME_PRODUCED header will be set. Defaults to true.
- Since I wanted the "upload" option to work similar as the "download" option, I added an isUploadFile() method to the GenericFileProducer in camel-core. This is the only change in camel-core.

Part 2
------
- Added a new option "siteCommandCapture" to the RemoteFileConfiguration: if true, the output of the site commands will be returned in the exchange's body as a List<String> with the output of each executed site command as a list element in order of execution. If false, the body remains untouched. Defaults to false.

The default behaviour remains as before.