### PR TITLE
Added @PreConsumed annotation

### DIFF
--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -69,11 +69,6 @@
       <artifactId>geronimo-jpa_2.0_spec</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>14.0</version>
-    </dependency>
     
     <!-- test dependencies -->
     <dependency>


### PR DESCRIPTION
Added @PreConsumed annotation to camel-jpa. Allows the state change caused by the record being consumed to be available further down the route.
