### PR TITLE
Adding feature for stax reader to turn off xml namespace awareness

### DIFF
--- a/components/camel-stax/src/main/java/org/apache/camel/component/stax/StAXBuilder.java
+++ b/components/camel-stax/src/main/java/org/apache/camel/component/stax/StAXBuilder.java
@@ -44,4 +44,24 @@ public final class StAXBuilder {
     public static <T> Expression stax(String clazzName) {
         return new StAXJAXBIteratorExpression<T>(clazzName);
     }
+
+    /**
+     * Creates a {@link org.apache.camel.component.stax.StAXJAXBIteratorExpression}.
+     *
+     * @param clazz the class which has JAXB annotations to bind POJO.
+     * @param isNamespaceAware sets the namespace awareness of the xml reader
+     */
+    public static <T> Expression stax(Class<T> clazz, boolean isNamespaceAware) {
+        return new StAXJAXBIteratorExpression<T>(clazz, isNamespaceAware);
+    }
+
+    /**
+     * Creates a {@link org.apache.camel.component.stax.StAXJAXBIteratorExpression}.
+     *
+     * @param clazzName the FQN name of the class which has JAXB annotations to bind POJO.
+     * @param isNamespaceAware sets the namespace awareness of the xml reader
+     */
+    public static <T> Expression stax(String clazzName, boolean isNamespaceAware) {
+        return new StAXJAXBIteratorExpression<T>(clazzName, isNamespaceAware);
+    }
 }


### PR DESCRIPTION
There is an issue with the default stax XMLEventReader that makes unmarshalling xml's result in null values when the xml has a top-level namespace that defines a xmltype that does not match the tag name of the object to be unmarshalled. With how camel-stax is written, the only way around it is to change the source xml file, which seems like an unnecessary harsh penalty for all the quirky xml files out there. Therefore, I propose a solution to have the xml reader ignore namespaces and thereby making the reader a lot more flexible.
