### PR TITLE
CAMEL-5829

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -29,6 +29,7 @@ import org.apache.camel.Component;
 import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.ExpressionIllegalSyntaxException;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.impl.ScheduledPollEndpoint;
@@ -132,6 +133,8 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
     protected long readLockCheckInterval = 1000;
     @UriParam
     protected long readLockTimeout = 10000;
+    @UriParam
+    protected LoggingLevel readLockLoggingLevel = LoggingLevel.WARN;
     @UriParam
     protected long readLockMinLength = 1;
     @UriParam
@@ -596,6 +599,14 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
         this.readLockTimeout = readLockTimeout;
     }
 
+    public LoggingLevel getReadLockLoggingLevel() {
+        return readLockLoggingLevel;
+    }
+
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
+        this.readLockLoggingLevel = readLockLoggingLevel;
+    }
+
     public long getReadLockMinLength() {
         return readLockMinLength;
     }
@@ -820,6 +831,7 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
             params.put("readLockTimeout", readLockTimeout);
         }
         params.put("readLockMinLength", readLockMinLength);
+        params.put("readLockLoggingLevel", readLockLoggingLevel);
 
         return params;
     }

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileExclusiveReadLockStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileExclusiveReadLockStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 
 /**
  * Strategy for acquiring exclusive read locks for files to be consumed. After
@@ -88,5 +89,16 @@ public interface GenericFileExclusiveReadLockStrategy<T> {
      * @param checkInterval interval in millis
      */
     void setCheckInterval(long checkInterval);
+
+    /**
+     * Sets logging level used when a read lock could not be acquired.
+     * <p/>
+     * Logging level used when a read lock could not be acquired.
+     * <p/>
+     * The default logging level is WARN
+     * @param readLockLoggingLevel LoggingLevel
+     */
+    void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel);
+
 
 }

--- a/camel-core/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
@@ -19,8 +19,10 @@ package org.apache.camel.component.file.strategy;
 import java.io.File;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.util.CamelLogger;
 import org.apache.camel.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +36,9 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
     private long timeout;
     private long checkInterval = 1000;
     private long minLength = 1;
+    private LoggingLevel readLockLoggingLevel = LoggingLevel.WARN;
 
+    @Override
     public boolean acquireExclusiveReadLock(GenericFileOperations<File> operations, GenericFile<File> file, Exchange exchange) throws Exception {
         // must call super
         if (!super.acquireExclusiveReadLock(operations, file, exchange)) {
@@ -55,7 +59,8 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
             if (timeout > 0) {
                 long delta = watch.taken();
                 if (delta > timeout) {
-                    LOG.warn("Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
+                    CamelLogger.log(LOG, readLockLoggingLevel,
+                            "Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
                     // we could not get the lock within the timeout period, so return false
                     return false;
                 }
@@ -101,6 +106,7 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
         return timeout;
     }
 
+    @Override
     public void setTimeout(long timeout) {
         this.timeout = timeout;
     }
@@ -109,8 +115,14 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
         return checkInterval;
     }
 
+    @Override
     public void setCheckInterval(long checkInterval) {
         this.checkInterval = checkInterval;
+    }
+
+    @Override
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
+        this.readLockLoggingLevel = readLockLoggingLevel;
     }
 
     public long getMinLength() {

--- a/camel-core/src/main/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategy.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.file.strategy;
 import java.io.File;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 public class MarkerFileExclusiveReadLockStrategy implements GenericFileExclusiveReadLockStrategy<File> {
     private static final transient Logger LOG = LoggerFactory.getLogger(MarkerFileExclusiveReadLockStrategy.class);
 
+    @Override
     public void prepareOnStartup(GenericFileOperations<File> operations, GenericFileEndpoint<File> endpoint) {
         String dir = endpoint.getConfiguration().getDirectory();
         File file = new File(dir);
@@ -51,6 +53,7 @@ public class MarkerFileExclusiveReadLockStrategy implements GenericFileExclusive
         }
     }
 
+    @Override
     public boolean acquireExclusiveReadLock(GenericFileOperations<File> operations,
                                             GenericFile<File> file, Exchange exchange) throws Exception {
         String lockFileName = getLockFileName(file);
@@ -64,6 +67,7 @@ public class MarkerFileExclusiveReadLockStrategy implements GenericFileExclusive
         return acquired;
     }
 
+    @Override
     public void releaseExclusiveReadLock(GenericFileOperations<File> operations,
                                          GenericFile<File> file, Exchange exchange) throws Exception {
         String lockFileName = exchange.getProperty(Exchange.FILE_LOCK_FILE_NAME, getLockFileName(file), String.class);
@@ -78,11 +82,18 @@ public class MarkerFileExclusiveReadLockStrategy implements GenericFileExclusive
         }
     }
 
+    @Override
     public void setTimeout(long timeout) {
         // noop
     }
 
+    @Override
     public void setCheckInterval(long checkInterval) {
+        // noop
+    }
+
+    @Override
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
         // noop
     }
 

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerBridgeRouteExceptionHandlerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerBridgeRouteExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.JndiRegistry;
 
@@ -107,6 +108,11 @@ public class FileConsumerBridgeRouteExceptionHandlerTest extends ContextTestSupp
 
         @Override
         public void setCheckInterval(long checkInterval) {
+            // noop
+        }
+
+        @Override
+        public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
             // noop
         }
 

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCustomExceptionHandlerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCustomExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -164,6 +165,11 @@ public class FileConsumerCustomExceptionHandlerTest extends ContextTestSupport {
 
         @Override
         public void setCheckInterval(long checkInterval) {
+            // noop
+        }
+
+        @Override
+        public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
             // noop
         }
 

--- a/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockLoggingLevelTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockLoggingLevelTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.strategy;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class FileChangedReadLockLoggingLevelTest extends FileChangedReadLockTest {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("file:target/changed/in?readLock=changed&readLockLoggingLevel=DEBUG").to("file:target/changed/out", "mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/FtpChangedExclusiveReadLockStrategy.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/FtpChangedExclusiveReadLockStrategy.java
@@ -19,10 +19,12 @@ package org.apache.camel.component.file.remote.strategy;
 import java.util.List;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExclusiveReadLockStrategy;
 import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.util.CamelLogger;
 import org.apache.camel.util.StopWatch;
 import org.apache.commons.net.ftp.FTPFile;
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ public class FtpChangedExclusiveReadLockStrategy implements GenericFileExclusive
     private static final transient Logger LOG = LoggerFactory.getLogger(FtpChangedExclusiveReadLockStrategy.class);
     private long timeout;
     private long checkInterval = 5000;
+    private LoggingLevel readLockLoggingLevel = LoggingLevel.WARN;
     private long minLength = 1;
     private boolean fastExistsCheck;
 
@@ -54,7 +57,8 @@ public class FtpChangedExclusiveReadLockStrategy implements GenericFileExclusive
             if (timeout > 0) {
                 long delta = watch.taken();
                 if (delta > timeout) {
-                    LOG.warn("Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
+                    CamelLogger.log(LOG, readLockLoggingLevel,
+                            "Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
                     // we could not get the lock within the timeout period, so return false
                     return false;
                 }
@@ -123,6 +127,7 @@ public class FtpChangedExclusiveReadLockStrategy implements GenericFileExclusive
         return timeout;
     }
 
+    @Override
     public void setTimeout(long timeout) {
         this.timeout = timeout;
     }
@@ -131,8 +136,14 @@ public class FtpChangedExclusiveReadLockStrategy implements GenericFileExclusive
         return checkInterval;
     }
 
+    @Override
     public void setCheckInterval(long checkInterval) {
         this.checkInterval = checkInterval;
+    }
+
+    @Override
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
+        this.readLockLoggingLevel = readLockLoggingLevel;
     }
 
     public long getMinLength() {

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/SftpChangedExclusiveReadLockStrategy.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/SftpChangedExclusiveReadLockStrategy.java
@@ -20,10 +20,12 @@ import java.util.List;
 
 import com.jcraft.jsch.ChannelSftp;
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExclusiveReadLockStrategy;
 import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.util.CamelLogger;
 import org.apache.camel.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,7 @@ public class SftpChangedExclusiveReadLockStrategy implements GenericFileExclusiv
     private static final transient Logger LOG = LoggerFactory.getLogger(SftpChangedExclusiveReadLockStrategy.class);
     private long timeout;
     private long checkInterval = 5000;
+    private LoggingLevel readLockLoggingLevel = LoggingLevel.WARN;
     private long minLength = 1;
     private boolean fastExistsCheck;
 
@@ -54,7 +57,8 @@ public class SftpChangedExclusiveReadLockStrategy implements GenericFileExclusiv
             if (timeout > 0) {
                 long delta = watch.taken();
                 if (delta > timeout) {
-                    LOG.warn("Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
+                    CamelLogger.log(LOG, readLockLoggingLevel,
+                            "Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
                     // we could not get the lock within the timeout period, so return false
                     return false;
                 }
@@ -123,6 +127,7 @@ public class SftpChangedExclusiveReadLockStrategy implements GenericFileExclusiv
         return timeout;
     }
 
+    @Override
     public void setTimeout(long timeout) {
         this.timeout = timeout;
     }
@@ -131,8 +136,14 @@ public class SftpChangedExclusiveReadLockStrategy implements GenericFileExclusiv
         return checkInterval;
     }
 
+    @Override
     public void setCheckInterval(long checkInterval) {
         this.checkInterval = checkInterval;
+    }
+
+    @Override
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
+        this.readLockLoggingLevel = readLockLoggingLevel;
     }
 
     public long getMinLength() {

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpChangedReadLockLoggingLevelTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpChangedReadLockLoggingLevelTest.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote;
+
+/**
+ *
+ */
+public class FtpChangedReadLockLoggingLevelTest extends FtpChangedReadLockTest {
+
+    protected String getFtpUrl() {
+        return super.getFtpUrl() + "&readLockLoggingLevel=DEBUG";
+    }
+}


### PR DESCRIPTION
Adding readLockLoggingLevel to allow to configure logging level of read lock strategy.

More details on https://issues.apache.org/jira/browse/CAMEL-5829
