### PR TITLE
New FileExist option for File component: TryRename

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileExist.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileExist.java
@@ -23,5 +23,5 @@ package org.apache.camel.component.file;
  */
 public enum GenericFileExist {
 
-    Override, Append, Fail, Ignore, Move
+    Override, Append, Fail, Ignore, Move, TryRename
 }

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistTryRenameTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistTryRenameTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import java.util.Locale;
+
+import junit.framework.TestResult;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.TestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+/**
+ * @version 
+ */
+public class FileProducerFileExistTryRenameTest extends ContextTestSupport {
+
+   @Override
+    protected void setUp() throws Exception {
+        deleteDirectory("target/file");
+        super.setUp();
+        template.sendBodyAndHeader("file://target/file", "Hello World", Exchange.FILE_NAME, "hello.txt");
+    }
+   
+
+    public void testIgnore() throws Exception {
+
+        // Does not work on Windows
+        if(TestSupport.isPlatform("windows"))
+            return;
+        
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedBodiesReceived("Bye World");
+        mock.expectedFileExists("target/file/hello.txt", "Bye World");
+
+        template.sendBodyAndHeader("file://target/file?fileExist=TryRename&tempPrefix=tmp", "Bye World", Exchange.FILE_NAME, "hello.txt");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("file://target/file?noop=true&delay=1000").convertBodyTo(String.class).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
This patch introduces a new FileExist option for File component which works great when using on an FTP producer:
the producer won't check if the file exists (sometime this is taking a long time) on the destination endpoint and simply rename it after the temporary file has been deployed. Most of FTP server implementation will overwrite the final file in case this already exists.
