### PR TITLE
CAMEL-6507 - Add aggregat to mongo component

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbOperation.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbOperation.java
@@ -33,6 +33,9 @@ public enum MongoDbOperation {
     // delete operations
     remove, 
     
+    //aggregat
+    aggregat,
+    
     // others
     getDbStats, 
     getColStats, 

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbOperationsTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbOperationsTest.java
@@ -17,12 +17,14 @@
 package org.apache.camel.component.mongodb;
 
 import java.util.Formatter;
+import java.util.List;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.WriteResult;
 import com.mongodb.util.JSON;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 
 import org.junit.Test;
@@ -157,6 +159,23 @@ public class MongoDbOperationsTest extends AbstractMongoDbTest {
     }
     
     @Test
+    public void testAgregat() throws Exception {
+    	// Test that the collection has 0 documents in it
+    	assertEquals(0, testCollection.count());
+    	pumpDataIntoTestCollection();
+
+    	// Repeat ten times, obtain 10 batches of 100 results each time
+    	Object result = template.requestBody("direct:aggregat",
+    			"[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}},{ $group: { _id: \"$scientist\", count: { $sum: 1 }} } ]");
+    	assertTrue("Result is not of type List", result instanceof List);
+    	
+    	@SuppressWarnings("unchecked")
+    	List<DBObject> resultList = (List<DBObject>) result;
+    	assertListSize("Result does not contain 2 elements", resultList, 2);
+    	//TODO Add more asserts
+    }
+    
+    @Test
     public void testDbStats() throws Exception {
         assertEquals(0, testCollection.count());
         Object result = template.requestBody("direct:getDbStats", "irrelevantBody");
@@ -210,6 +229,7 @@ public class MongoDbOperationsTest extends AbstractMongoDbTest {
                 from("direct:save").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=save&writeConcern=SAFE");
                 from("direct:update").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=update&writeConcern=SAFE");
                 from("direct:remove").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=remove&writeConcern=SAFE");
+                from("direct:aggregat").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregat&writeConcern=SAFE");
                 from("direct:getDbStats").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=getDbStats");
                 from("direct:getColStats").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=getColStats");
 


### PR DESCRIPTION
Hi,

I just add the ability to use aggregat in camel-mongo-db route.

Now you can declare a route to aggregate : from(...).to("mongodb:myDb?database=test&collection=test&operation=aggregat&dynamicity=true");

The body should contain a valid Mongo pipeline for example { $match : {"name" : "my product"}},{ $group: { _id: "$name" ,total: { $sum: "$price" } } }

P-Alban
