### PR TITLE
Improved javadoc for expectedMessageCount.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
@@ -434,8 +434,12 @@ public class MockEndpoint extends DefaultEndpoint implements BrowsableEndpoint {
      * Specifies the expected number of message exchanges that should be
      * received by this endpoint
      *
+     * If you want to assert that <b>exactly</b> n messages arrives to this mock
+     * endpoint, then see also the {@link #setAssertPeriod(long)} method for further details.
+     *
      * @param expectedCount the number of message exchanges that should be
      *                expected by this endpoint
+     * @see #setAssertPeriod(long)
      */
     public void expectedMessageCount(int expectedCount) {
         setExpectedMessageCount(expectedCount);


### PR DESCRIPTION
The javadoc for `expectedMessageCount` really should match up with setExpectedMessageCount since the side effect of calling `setAssertPeriod` is so important.
