### PR TITLE
Camel 6809 - rabbitmq.EXCHANGE_NAME header used in preference to uri exchange name

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
@@ -20,20 +20,19 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.Executors;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.impl.DefaultProducer;
-import org.apache.camel.util.ObjectHelper;
-
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultProducer;
+import org.apache.camel.util.ObjectHelper;
 
 public class RabbitMQProducer extends DefaultProducer {
 
     private final Connection conn;
     private final Channel channel;
 
-    public RabbitMQProducer(final RabbitMQEndpoint endpoint) throws IOException {
+    public RabbitMQProducer(RabbitMQEndpoint endpoint) throws IOException {
         super(endpoint);
         this.conn = endpoint.connect(Executors.newSingleThreadExecutor());
         this.channel = conn.createChannel();
@@ -50,7 +49,7 @@ public class RabbitMQProducer extends DefaultProducer {
     }
 
     @Override
-    public void process(final Exchange exchange) throws Exception {
+    public void process(Exchange exchange) throws Exception {
         String exchangeName = getEndpoint().getExchangeName();
         if (ObjectHelper.isEmpty(exchangeName)) {
             throw new IllegalArgumentException("ExchangeName is not provided in the endpoint: " + getEndpoint());
@@ -63,7 +62,7 @@ public class RabbitMQProducer extends DefaultProducer {
         channel.basicPublish(exchangeName, key, properties.build(), messageBodyBytes);
     }
 
-    AMQP.BasicProperties.Builder buildProperties(final Exchange exchange) {
+    AMQP.BasicProperties.Builder buildProperties(Exchange exchange) {
         AMQP.BasicProperties.Builder properties = new AMQP.BasicProperties.Builder();
 
         final Object contentType = exchange.getIn().getHeader(RabbitMQConstants.CONTENT_TYPE);

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.camel.component.rabbitmq;
 
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -31,9 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
+import static org.junit.Assert.assertEquals;
 
 public class RabbitMQProducerTest {
 
@@ -42,6 +43,7 @@ public class RabbitMQProducerTest {
     private Message message = new DefaultMessage();
     private Connection conn = Mockito.mock(Connection.class);
     private Channel channel = Mockito.mock(Channel.class);
+    
     @Before
     public void before() throws IOException {
         Mockito.when(exchange.getIn()).thenReturn(message);


### PR DESCRIPTION
Pull request relating to Jira feature

https://issues.apache.org/jira/browse/CAMEL-6809
