### PR TITLE
fix for incorrect patch for 6767. Messages sould be acked only when the channel is NOT autoAck

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -122,7 +122,7 @@ public class RabbitMQConsumer extends DefaultConsumer {
                 consumer.getProcessor().process(exchange);
 
                 long deliveryTag = envelope.getDeliveryTag();
-                if (consumer.endpoint.isAutoAck()) {
+                if (!consumer.endpoint.isAutoAck()) {
                     log.trace("Acknowledging receipt [delivery_tag={}]", deliveryTag);
                     channel.basicAck(deliveryTag, false);
                 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-6767
