### PR TITLE
Removed clearing of field 'Name' to allow upserts with custom external I...

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/AbstractSObjectBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/AbstractSObjectBase.java
@@ -45,7 +45,6 @@ public class AbstractSObjectBase extends AbstractDTOBase {
         Id = null;
         OwnerId = null;
         IsDeleted = null;
-        Name = null;
         CreatedDate = null;
         CreatedById = null;
         LastModifiedDate = null;


### PR DESCRIPTION
Hi,

The component "camel-salesforce" doesn't allow upserts with a custom external ID. 

We have a data model with a new field 'ExternalID__c' which is the external ID, and where 'Name' is a simple mandatory field.
So when we want to insert a new object with an upsert operation on field "ExternalID__c", the field 'Name' is cleared, causing a Salesforce error :

...
.to("salesforce:upsertSObject?sObjectName=Account&sObjectIdName=ExternalID__c");

=> 

[{"errorCode":"REQUIRED_FIELD_MISSING","message":"Required fields are missing: [Name]","fields":["Name"]}], statusCode: 400}]

Moreover, we also want to update the field 'Name', which is currently not possible.

I suggest you to remove the clearing of field 'Name' during the upsert.

Thanks.

Manuel
