### PR TITLE
CAMEL-6934 enabling dns addresses to not get cached

### DIFF
--- a/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Configuration.java
+++ b/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Configuration.java
@@ -53,6 +53,7 @@ public class Mina2Configuration implements Cloneable {
     private boolean autoStartTls = true;
     private int maximumPoolSize = 16; // 16 is the default mina setting
     private boolean orderedThreadPoolExecutor = true;
+    private boolean cachedAddress = true;
 
     /**
      * Returns a copy of this configuration
@@ -263,7 +264,19 @@ public class Mina2Configuration implements Cloneable {
     public void setOrderedThreadPoolExecutor(boolean orderedThreadPoolExecutor) {
         this.orderedThreadPoolExecutor = orderedThreadPoolExecutor;
     }
-    
+
+    public void setCachedAddress(boolean shouldCacheAddress){
+        this.cachedAddress = shouldCacheAddress;
+    }
+
+    public boolean getCachedAddress(){
+        return this.cachedAddress;
+    }
+
+    public boolean isCachedAddress(){
+        return this.getCachedAddress();
+    }
+
     // here we just shows the option setting of host, port, protocol 
     public String getUriString() {
         return "mina2:" + getProtocol() + ":" + getHost() + ":" + getPort();

--- a/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Producer.java
+++ b/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Producer.java
@@ -251,6 +251,9 @@ public class Mina2Producer extends DefaultProducer implements ServicePoolAware {
     }
 
     private void openConnection() {
+        if(this.address == null || !this.configuration.isCachedAddress()){
+            setSocketAddress(this.configuration.getProtocol());
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating connector to address: {} using connector: {} timeout: {} millis.", new Object[]{address, connector, timeout});
         }
@@ -444,6 +447,16 @@ public class Mina2Producer extends DefaultProducer implements ServicePoolAware {
             for (IoFilter ioFilter : filters) {
                 filterChain.addLast(ioFilter.getClass().getCanonicalName(), ioFilter);
             }
+        }
+    }
+
+    private void setSocketAddress(String protocol){
+        if(protocol.equals("tcp")){
+            this.address = new InetSocketAddress(configuration.getHost(), configuration.getPort());
+        }else if(configuration.isDatagramProtocol()){
+            this.address = new InetSocketAddress(configuration.getHost(), configuration.getPort());
+        }else if(protocol.equals("vm")){
+            this.address = new VmPipeAddress(configuration.getPort());
         }
     }
 


### PR DESCRIPTION
CAMEL-6934 camel-mina2 change. Enables a new SocketAddress to be created if the new config value of cachedAddress is set to false everytime openConnection is called. This allows DNS changes to be picked up without having to restart.
