### PR TITLE
VERACODE-648: fix of CWE ID470 in AnnotationTypeConverterLoader using ObjectHelper.loadClass for class loading

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
@@ -165,9 +165,6 @@ public class AnnotationTypeConverterLoader implements TypeConverterLoader {
                 Class<?> clazz = null;
                 for (ClassLoader loader : resolver.getClassLoaders()) {
                     try {
-                        if(name == null || name.isEmpty()){
-                            throw new ClassNotFoundException("Invalid class name [" + name + "]");
-                        }
                         clazz = ObjectHelper.loadClass(name, loader);
                         LOG.trace("Loaded {} as class {}", name, clazz);
                         classes.add(clazz);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-7072

During Veracode scan of our application we discover issue with security in Camel. Please review our fix and apply it in future versions. 

Quote from Veracode report below:
Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection') (CWE ID470)(1 flaw)
Description
A call uses reflection in an unsafe manner. An attacker can specify the class name to be instantiated, which may
create unexpected control flow paths through the application. Depending on how reflection is being used, the attack
vector may allow the attacker to bypass security checks or otherwise cause the application to behave in an unexpected
manner. Even if the object does not implement the specified interface and a ClassCastException is thrown, the
constructor of the user-supplied class name will have already executed.
Effort to Fix: 2 - Implementation error. Fix is approx. 6-50 lines of code. 1 day to fix.
Recommendations
Validate the class name against a combination of white and black lists to ensure that only expected behavior is
produced.
Instances found via Static Scan
Module # Class # Module Location Fix By Flaw Id
.../AnnotationTypeConverterLoader.java - line 168
