### PR TITLE
CAMEL-7073: Overwrite org.restlet.http.headers in response instead of ad...

### DIFF
--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
@@ -274,8 +274,7 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
 
         // set HTTP headers so we return these in the response
         if (!series.isEmpty()) {
-            Series<Header> httpHeaders = (Series<Header>) response.getAttributes().get(HeaderConstants.ATTRIBUTE_HEADERS);
-            httpHeaders.addAll(series);
+            response.getAttributes().put(HeaderConstants.ATTRIBUTE_HEADERS, series);
         }
     }
 

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletPostFormTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletPostFormTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.restlet;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @version 
+ */
+public class RestletPostFormTest extends RestletTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("restlet:http://localhost:" + portNum + "/users?restletMethod=POST")
+                    .process(new PostProcessor());
+            }
+        };
+    }
+    
+    class PostProcessor implements Processor {
+        public void process(Exchange exchange) throws Exception {   
+            assertEquals("bar", exchange.getIn().getHeader("foo", String.class));
+        }
+    }
+    
+    @Test
+    public void testPostBody() throws Exception {
+        HttpUriRequest method = new HttpPost("http://localhost:" + portNum + "/users");
+
+        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        urlParameters.add(new BasicNameValuePair("foo", "bar"));
+
+        ((HttpEntityEnclosingRequestBase)method).setEntity(new UrlEncodedFormEntity(urlParameters));
+
+        HttpResponse response = doExecute(method);
+        
+        assertHttpResponse(response, 200, "text/plain");
+    }
+}


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-7073. Don't copy request headers into the response.

Includes unit test which fails if content-type header from request is copied into the response headers.
