### PR TITLE
VERACODE-986: fix of CWE ID 404 improper resource shutdown or release in FileInputStreamCache

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
@@ -83,6 +83,7 @@ public class FileInputStreamCache extends InputStream implements StreamCache {
                 long i = fc.transferTo(pos, len - pos, out);
                 pos += i;
             }
+            fc.close();
             s.close();
         } else {
             IOHelper.copy(getInputStream(), os);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-7075

During Veracode scan of our application we discover issue in Camel. Please review our fix and apply it in future versions.

Quote from Veracode report below:
Improper Resource Shutdown or Release (CWE ID 404)(1 flaw)
Description
The application fails to release (or incorrectly releases) a system resource before it is made available for re-use. This
condition often occurs with resources such as database connections or file handles. Most unreleased resource issues
result in general software reliability problems, but if an attacker can intentionally trigger a resource leak, it may be
possible to launch a denial of service attack by depleting the resource pool.
Effort to Fix: 2 - Implementation error. Fix is approx. 6-50 lines of code. 1 day to fix.
Recommendations
When a resource is created or allocated, the developer is responsible for properly releasing the resource as well as
accounting for all potential paths of expiration or invalidation. Ensure that all code paths properly release resources.
.../FileInputStreamCache.java line 86
