### PR TITLE
ZooKeeperProducer does not stop ZooKeeper threads if Camel context ist stopped

### DIFF
--- a/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ConnectionHolder.java
+++ b/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ConnectionHolder.java
@@ -85,7 +85,9 @@ public class ConnectionHolder implements Watcher {
 
     public void closeConnection() {
         try {
-            zookeeper.close();
+            if (zookeeper != null) {
+                zookeeper.close();
+            }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Shutting down connection to Zookeeper cluster {}", configuration.getConnectString());
             }

--- a/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ZooKeeperComponent.java
+++ b/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ZooKeeperComponent.java
@@ -56,9 +56,12 @@ public class ZooKeeperComponent extends DefaultComponent {
     }
 
     private void extractConfigFromUri(String remaining, ZooKeeperConfiguration config) throws URISyntaxException {
-        URI u = new URI(remaining);
-        config.addZookeeperServer(u.getHost() + (u.getPort() != -1 ? ":" + u.getPort() : ""));
-        config.setPath(u.getPath());
+        URI fullUri = new URI(remaining);
+        String[] hosts = fullUri.getAuthority().split(",");
+        for (String host : hosts) {
+            config.addZookeeperServer(host.trim());
+        }
+        config.setPath(fullUri.getPath());
     }
 
     public ZooKeeperConfiguration getConfiguration() {

--- a/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ZookeeperProducer.java
+++ b/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/ZookeeperProducer.java
@@ -101,6 +101,15 @@ public class ZookeeperProducer extends DefaultProducer {
         }
     }
 
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        if (log.isTraceEnabled()) {
+            log.trace(String.format("Shutting down zookeeper producer of '%s'", configuration.getPath()));
+        }
+        zkm.shutdown();
+    }
+
     private void asynchronouslyDeleteNode(ZooKeeper connection, ProductionContext context) {
         if (log.isDebugEnabled()) {
             log.debug(format("Deleting node '%s', not waiting for confirmation", context.node));


### PR DESCRIPTION
Added overloaded doStop() method to shutdown ZooKeeperConnectionManager