### PR TITLE
VERACODE-658: fix of CWE ID 404 improper resource shutdown or release in QuartzComponent

### DIFF
--- a/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzComponent.java
+++ b/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzComponent.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.imageio.stream.FileImageOutputStream;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.StartupListener;
@@ -435,7 +436,13 @@ public class QuartzComponent extends DefaultComponent implements StartupListener
                 answer.load(is);
             } catch (IOException e) {
                 throw new SchedulerException("Error loading Quartz properties file from classpath: " + getPropertiesFile(), e);
-            }
+            } finally {
+                 try {
+                     is.close();
+                 } catch (IOException ex) {
+                     LOG.warn("Error closing quartz.properties input stream");
+                 }
+              }
         }
         return answer;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-7088

During Veracode scan of our application we discover issue with security in Camel. Please review our fix and apply it in future versions.
Quote from Veracode report below:

Improper Resource Shutdown or Release (CWE ID 404)(1 flaw)
Description
The application fails to release (or incorrectly releases) a system resource before it is made available for re-use. This
condition often occurs with resources such as database connections or file handles. Most unreleased resource issues
result in general software reliability problems, but if an attacker can intentionally trigger a resource leak, it may be
possible to launch a denial of service attack by depleting the resource pool.
Effort to Fix: 2 - Implementation error. Fix is approx. 6-50 lines of code. 1 day to fix.
Recommendations
When a resource is created or allocated, the developer is responsible for properly releasing the resource as well as
accounting for all potential paths of expiration or invalidation. Ensure that all code paths properly release resources.
Instances found via Static Scan
.../QuartzComponent.java line 436
