### PR TITLE
CAMEL-7067: Use message headers instead of exchange properties.

### DIFF
--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/AuthTokenLoginFailureTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/AuthTokenLoginFailureTest.java
@@ -54,8 +54,8 @@ public class AuthTokenLoginFailureTest extends JcrAuthTestBase {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: jcr
-                from("direct:a").setProperty(JcrConstants.JCR_NODE_NAME,
-                        constant("node")).setProperty("my.contents.property",
+                from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME,
+                        constant("node")).setHeader("my.contents.property",
                         body()).to(
                         "jcr://test:quatloos@repository" + BASE_REPO_PATH);
                 // END SNIPPET: jcr

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthTokenWithLoginTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthTokenWithLoginTest.java
@@ -39,8 +39,8 @@ public class JcrAuthTokenWithLoginTest extends JcrAuthTestBase {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: jcr
-                from("direct:a").setProperty(JcrConstants.JCR_NODE_NAME,
-                        constant("node")).setProperty("my.contents.property",
+                from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME,
+                        constant("node")).setHeader("my.contents.property",
                         body()).to(
                         "jcr://not-a-user:nonexisting-password@repository" + BASE_REPO_PATH);
                 // END SNIPPET: jcr

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrGetNodeByIdTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrGetNodeByIdTest.java
@@ -53,8 +53,8 @@ public class JcrGetNodeByIdTest extends JcrRouteTestSupport {
     @Test
     public void testJcrProducer() throws Exception {
         result.expectedMessageCount(1);
-        result.expectedPropertyReceived("my.contents.property", CONTENT);
-        result.expectedPropertyReceived("content.approved", APPROVED);
+        result.expectedHeaderReceived("my.contents.property", CONTENT);
+        result.expectedHeaderReceived("content.approved", APPROVED);
 
         Exchange exchange = createExchangeWithBody(identifier);
         template.send("direct:a", exchange);

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrNodePathCreationTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrNodePathCreationTest.java
@@ -65,8 +65,8 @@ public class JcrNodePathCreationTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: jcr
-                from("direct:a").setProperty(JcrConstants.JCR_NODE_NAME, constant("node/with/path"))
-                    .setProperty("my.contents.property", body()).to("jcr://user:pass@repository/home/test");
+                from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME, constant("node/with/path"))
+                    .setHeader("my.contents.property", body()).to("jcr://user:pass@repository/home/test");
                 // END SNIPPET: jcr
             }
         };

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrProducerSubNodeTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrProducerSubNodeTest.java
@@ -41,7 +41,7 @@ public class JcrProducerSubNodeTest extends JcrRouteTestSupport {
         try {
             // create node
             Exchange exchange1 = ExchangeBuilder.anExchange(context)
-                .withProperty(JcrConstants.JCR_NODE_NAME, "node")
+                .withHeader(JcrConstants.JCR_NODE_NAME, "node")
                 .build();
             Exchange out1 = template.send("direct:a", exchange1);
             assertNotNull(out1);
@@ -53,7 +53,7 @@ public class JcrProducerSubNodeTest extends JcrRouteTestSupport {
             
             // create sub node
             Exchange exchange2 = ExchangeBuilder.anExchange(context)
-                .withProperty(JcrConstants.JCR_NODE_NAME, "node/subnode")
+                .withHeader(JcrConstants.JCR_NODE_NAME, "node/subnode")
                 .build();
             Exchange out2 = template.send("direct:a", exchange2);
             assertNotNull(out2);

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrProducerTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrProducerTest.java
@@ -58,8 +58,8 @@ public class JcrProducerTest extends JcrRouteTestSupport {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: jcr-create-node
-                from("direct:a").setProperty(JcrConstants.JCR_NODE_NAME, constant("node"))
-                        .setProperty("my.contents.property", body())
+                from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME, constant("node"))
+                        .setHeader("my.contents.property", body())
                         .to("jcr://user:pass@repository/home/test");
                 // END SNIPPET: jcr-create-node
             }


### PR DESCRIPTION
Refactor jcr-component to use message headers instead of exchange properties as data source for properties in target JCR nodes, see: https://issues.apache.org/jira/browse/CAMEL-7067.
