### PR TITLE
Only persist changes when no exceptions occurred.

### DIFF
--- a/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrProducer.java
+++ b/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrProducer.java
@@ -72,8 +72,8 @@ public class JcrProducer extends DefaultProducer {
                 throw new RuntimeException("Unsupported operation: " + operation);
             }
 
-        } finally {
             session.save();
+        } finally {
             if (session != null && session.isLive()) {
                 session.logout();
             }


### PR DESCRIPTION
Move session.save() call into try block, so no partial changes are
persisted if any exceptions occur during component operations.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
