### PR TITLE
Rename authentication test classes to reflect the actual test case.

### DIFF
--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthLoginFailureTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthLoginFailureTest.java
@@ -16,15 +16,13 @@
  */
 package org.apache.camel.component.jcr;
 
-import javax.jcr.Node;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
+import javax.jcr.LoginException;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
-public class AuthTokenLoginFailureTest extends JcrAuthTestBase {
+public class JcrAuthLoginFailureTest extends JcrAuthTestBase {
 
     @Test
     public void testCreateNodeWithAuthentication() throws Exception {
@@ -32,18 +30,8 @@ public class AuthTokenLoginFailureTest extends JcrAuthTestBase {
         Exchange out = template.send("direct:a", exchange);
         assertNotNull(out);
         String uuid = out.getOut().getBody(String.class);
-        assertNotNull("Out body was null; expected JCR node UUID", uuid);
-        Session session = getRepository().login(
-                new SimpleCredentials("admin", "admin".toCharArray()));
-        try {
-            Node node = session.getNodeByIdentifier(uuid);
-            assertNotNull(node);
-            assertEquals(BASE_REPO_PATH + "/node", node.getPath());
-        } finally {
-            if (session != null && session.isLive()) {
-                session.logout();
-            }
-        }
+        assertNull("Expected body to be null, found JCR node UUID", uuid);
+        assertTrue("Wrong exception type", out.getException() instanceof LoginException);
     }
 
     @Override
@@ -55,7 +43,7 @@ public class AuthTokenLoginFailureTest extends JcrAuthTestBase {
                 from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME,
                         constant("node")).setHeader("my.contents.property",
                         body()).to(
-                        "jcr://test:quatloos@repository" + BASE_REPO_PATH);
+                        "jcr://not-a-user:nonexisting-password@repository" + BASE_REPO_PATH);
                 // END SNIPPET: jcr
             }
         };

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthLoginTest.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthLoginTest.java
@@ -16,13 +16,15 @@
  */
 package org.apache.camel.component.jcr;
 
-import javax.jcr.LoginException;
+import javax.jcr.Node;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
-public class JcrAuthTokenWithLoginTest extends JcrAuthTestBase {
+public class JcrAuthLoginTest extends JcrAuthTestBase {
 
     @Test
     public void testCreateNodeWithAuthentication() throws Exception {
@@ -30,8 +32,18 @@ public class JcrAuthTokenWithLoginTest extends JcrAuthTestBase {
         Exchange out = template.send("direct:a", exchange);
         assertNotNull(out);
         String uuid = out.getOut().getBody(String.class);
-        assertNull("Expected body to be null, found JCR node UUID", uuid);
-        assertTrue("Wrong exception type", out.getException() instanceof LoginException);
+        assertNotNull("Out body was null; expected JCR node UUID", uuid);
+        Session session = getRepository().login(
+                new SimpleCredentials("admin", "admin".toCharArray()));
+        try {
+            Node node = session.getNodeByIdentifier(uuid);
+            assertNotNull(node);
+            assertEquals(BASE_REPO_PATH + "/node", node.getPath());
+        } finally {
+            if (session != null && session.isLive()) {
+                session.logout();
+            }
+        }
     }
 
     @Override
@@ -43,7 +55,7 @@ public class JcrAuthTokenWithLoginTest extends JcrAuthTestBase {
                 from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME,
                         constant("node")).setHeader("my.contents.property",
                         body()).to(
-                        "jcr://not-a-user:nonexisting-password@repository" + BASE_REPO_PATH);
+                        "jcr://test:quatloos@repository" + BASE_REPO_PATH);
                 // END SNIPPET: jcr
             }
         };


### PR DESCRIPTION
The JUnit classes test the opposite of what their original names suggest.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
