### PR TITLE
CAMEL-7184 Ensure that QFJ consumers have their engines initialized

### DIFF
--- a/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/QuickfixjConsumer.java
+++ b/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/QuickfixjConsumer.java
@@ -31,6 +31,12 @@ public class QuickfixjConsumer extends DefaultConsumer {
         super(endpoint, processor);
     }
 
+    @Override
+    protected void doStart() throws Exception {
+        ((QuickfixjEndpoint)getEndpoint()).ensureInitialized();
+        super.doStart();
+    }
+
     public void onExchange(Exchange exchange) throws Exception {
         if (isStarted()) {
             try {

--- a/components/camel-quickfix/src/test/java/org/apache/camel/component/quickfixj/QuickfixjConsumerTest.java
+++ b/components/camel-quickfix/src/test/java/org/apache/camel/component/quickfixj/QuickfixjConsumerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.quickfixj;
 
-import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
@@ -37,7 +36,7 @@ import quickfix.field.TargetCompID;
 public class QuickfixjConsumerTest {
     private Exchange mockExchange;
     private Processor mockProcessor;
-    private Endpoint mockEndpoint;
+    private QuickfixjEndpoint mockEndpoint;
     private Message inboundFixMessage;
     
     @Before
@@ -54,7 +53,7 @@ public class QuickfixjConsumerTest {
         Mockito.when(mockCamelMessage.getBody(quickfix.Message.class)).thenReturn(inboundFixMessage);
         
         mockProcessor = Mockito.mock(Processor.class);        
-        mockEndpoint = Mockito.mock(Endpoint.class);
+        mockEndpoint = Mockito.mock(QuickfixjEndpoint.class);
         Mockito.when(mockEndpoint.createExchange(ExchangePattern.InOnly)).thenReturn(mockExchange);  
     }
     
@@ -71,6 +70,7 @@ public class QuickfixjConsumerTest {
         Mockito.verifyZeroInteractions(mockProcessor);
         
         consumer.start();
+        Mockito.verify(mockEndpoint).ensureInitialized();
         Assert.assertThat(consumer.isStarted(), CoreMatchers.is(true));
         
         consumer.onExchange(mockExchange);

--- a/components/camel-quickfix/src/test/resources/org/apache/camel/component/quickfixj/QuickfixjSpringTest-context.xml
+++ b/components/camel-quickfix/src/test/resources/org/apache/camel/component/quickfixj/QuickfixjSpringTest-context.xml
@@ -35,11 +35,8 @@
             </filter>
         </route>
         <route>
-            <from uri="lazyQuickfix:example"/>
-            <filter>
-                <simple>${in.header.EventCategory} == 'AppMessageReceived'</simple>
-                <to uri="log:test"/>
-            </filter>
+            <from uri="vm:test"/>
+            <to uri="lazyQuickfix:example"/>
         </route>
     </camelContext>
 
@@ -60,7 +57,7 @@
         <property name="lazyCreateEngines" value="true" />
         <property name="configurations">
             <util:map>
-                <entry key="example" value-ref="quickfixjConfiguration"/>
+                <entry key="example" value-ref="lazyQuickfixjConfiguration"/>
             </util:map>
         </property>
         <property name="messageFactory">
@@ -96,5 +93,34 @@
         </property>
     </bean>
     <!-- END SNIPPET: e1 -->
+
+    <!-- lazy quickfix settings -->
+    <bean id="lazyQuickfixjConfiguration" class="org.apache.camel.component.quickfixj.QuickfixjConfiguration">
+        <property name="defaultSettings">
+            <util:map>
+                <entry key="SocketConnectProtocol" value="VM_PIPE"/>
+                <entry key="SocketAcceptProtocol" value="VM_PIPE"/>
+                <entry key="UseDataDictionary" value="N"/>
+            </util:map>
+        </property>
+        <property name="sessionSettings">
+            <util:map>
+                <entry key="FIX.4.2:INITIATOR->ACCEPTOR">
+                    <util:map>
+                        <entry key="ConnectionType" value="initiator"/>
+                        <entry key="SocketConnectHost" value="localhost"/>
+                        <entry key="SocketConnectPort" value="5001"/>
+                    </util:map>
+                </entry>
+                <entry key="FIX.4.2:ACCEPTOR->INITIATOR">
+                    <util:map>
+                        <entry key="ConnectionType" value="acceptor"/>
+                        <entry key="SocketAcceptPort" value="5001"/>
+                    </util:map>
+                </entry>
+            </util:map>
+        </property>
+    </bean>
+    <!-- END SNIPPET: e2 -->
 
 </beans>


### PR DESCRIPTION
A case for QFJ consumers - they should have their engines initialized and started when starting consumers
