### PR TITLE
Explicit in character encoding in SPI resources 

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
 public class AnnotationTypeConverterLoader implements TypeConverterLoader {
     public static final String META_INF_SERVICES = "META-INF/services/org/apache/camel/TypeConverter";
     private static final Logger LOG = LoggerFactory.getLogger(AnnotationTypeConverterLoader.class);
+    private static final Charset UTF8 = Charset.forName("UTF-8");
     protected PackageScanClassResolver resolver;
     protected Set<Class<?>> visitedClasses = new HashSet<Class<?>>();
     protected Set<String> visitedURIs = new HashSet<String>();
@@ -214,7 +215,7 @@ public class AnnotationTypeConverterLoader implements TypeConverterLoader {
                 // remember we have visited this uri so we wont read it twice
                 visitedURIs.add(path);
                 LOG.debug("Loading file {} to retrieve list of packages, from url: {}", META_INF_SERVICES, url);
-                BufferedReader reader = IOHelper.buffered(new InputStreamReader(url.openStream()));
+                BufferedReader reader = IOHelper.buffered(new InputStreamReader(url.openStream(), UTF8));
                 try {
                     while (true) {
                         String line = reader.readLine();


### PR DESCRIPTION
Java ServiceLocator requires SPI resources to be encoded in UTF8 according to http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html.
