### PR TITLE
Fix the KafkaConsumer to put the message in the body

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
@@ -111,6 +111,7 @@ public class KafkaEndpoint extends DefaultEndpoint {
         message.setHeader(KafkaConstants.PARTITION, mm.partition());
         message.setHeader(KafkaConstants.TOPIC, mm.topic());
         message.setHeader(KafkaConstants.KEY, new String(mm.key()));
+        message.setBody(mm.message());
         exchange.setIn(message);
 
         return exchange;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerIT.java
@@ -79,6 +79,7 @@ public class KafkaConsumerIT extends CamelTestSupport {
     @Test
     public void kaftMessageIsConsumedByCamel() throws InterruptedException, IOException {
         to.expectedMessageCount(5);
+        to.expectedBodiesReceived("message-0","message-1","message-2","message-3","message-4" );
         for (int k = 0; k < 5; k++) {
             String msg = "message-" + k;
             KeyedMessage<String, String> data = new KeyedMessage<String, String>(TOPIC, "1", msg);


### PR DESCRIPTION
Right now, the consumer would create an exchange for each received message.
However, it didn't filled the exchange body with the received message content.

Right now, it is set as an array of bytes but in the future we could use the Consumer decoder class to convert the content in the right type.
