### PR TITLE
CAMEL-7406: Avoid NPE when password empty in JCR endpoint URI

### DIFF
--- a/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrEndpoint.java
+++ b/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrEndpoint.java
@@ -56,7 +56,7 @@ public class JcrEndpoint extends DefaultEndpoint {
                 String[] creds = uri.getUserInfo().split(":");
                 if (creds != null) {
                     String username = creds[0];
-                    String password = creds.length > 1 ? creds[1] : null;
+                    String password = creds.length > 1 ? creds[1] : "";
                     this.credentials = new SimpleCredentials(username, password.toCharArray());
                 }
             }


### PR DESCRIPTION
Signed-off-by: Gregor Zurowski gregor@zurowski.org
