### PR TITLE
Fixes CAMEL-6716: ServiceInterfaceStrategy fails to create with interface containing multiple methods without parameters

### DIFF
--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ServiceInterfaceStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ServiceInterfaceStrategy.java
@@ -158,14 +158,16 @@ public class ServiceInterfaceStrategy implements ElementNameStrategy {
             MethodInfo info = analyzeMethod(method);
             for (int i = 0; i < info.getIn().length; i++) {
                 TypeInfo ti = info.getIn()[i];
-                if (inTypeNameToQName.containsKey(ti.getTypeName())
-                    && (!(ti.getTypeName().equals("javax.xml.ws.Holder")))
-                    && (!(inTypeNameToQName.get(ti.getTypeName()).equals(ti.getElName())))) {
-                    LOG.warn("Ambiguous QName mapping. The type [ "
-                                                    + ti.getTypeName()
-                                                    + " ] is already mapped to a QName in this context.");
-                    continue;
-                }
+				if (inTypeNameToQName.containsKey(ti.getTypeName())) {
+					if (ti.getTypeName() != null) {
+						if (!(ti.getTypeName().equals("javax.xml.ws.Holder")) && (!(inTypeNameToQName.get(ti.getTypeName()).equals(ti.getElName())))) {
+							LOG.warn("Ambiguous QName mapping. The type [ "
+									+ ti.getTypeName()
+									+ " ] is already mapped to a QName in this context.");
+							continue;
+						}
+					}
+				}
                 inTypeNameToQName.put(ti.getTypeName(), ti.getElName());
             }
             if (info.getSoapAction() != null && !"".equals(info.getSoapAction())) {

--- a/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/ServiceInterfaceStrategyTest.java
+++ b/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/ServiceInterfaceStrategyTest.java
@@ -50,6 +50,10 @@ public class ServiceInterfaceStrategyTest extends Assert {
         QName elName3 = strategy.findQNameForSoapActionOrType("http://customerservice.example.com/getAllCustomers",
                 null);
         assertNull(elName3);
+        
+        QName elName4 = strategy.findQNameForSoapActionOrType("http://customerservice.example.com/getAllAmericanCustomers",
+                null);
+        assertNull(elName4);
 
         try {
             elName = strategy.findQNameForSoapActionOrType("test", Class.class);

--- a/components/camel-soap/src/test/java/org/apache/camel/dataformat/soap/CustomerServiceImpl.java
+++ b/components/camel-soap/src/test/java/org/apache/camel/dataformat/soap/CustomerServiceImpl.java
@@ -18,6 +18,7 @@ package org.apache.camel.dataformat.soap;
 
 import com.example.customerservice.Customer;
 import com.example.customerservice.CustomerService;
+import com.example.customerservice.GetAllAmericanCustomersResponse;
 import com.example.customerservice.GetAllCustomersResponse;
 import com.example.customerservice.GetCustomersByName;
 import com.example.customerservice.GetCustomersByNameResponse;
@@ -66,6 +67,18 @@ public class CustomerServiceImpl implements CustomerService {
         GetAllCustomersResponse response = new GetAllCustomersResponse();
         Customer customer = new Customer();
         customer.setName("Smith");
+        customer.setRevenue(100000);
+        response.getReturn().add(customer);
+        return response;
+    }
+    
+    /**
+     * This method is to test a call without input parameter
+     */
+    public GetAllAmericanCustomersResponse getAllAmericanCustomers() {
+    	GetAllAmericanCustomersResponse response = new GetAllAmericanCustomersResponse();
+        Customer customer = new Customer();
+        customer.setName("Schmitz");
         customer.setRevenue(100000);
         response.getReturn().add(customer);
         return response;

--- a/components/camel-soap/src/test/resources/org/apache/camel/dataformat/soap/CustomerService.wsdl
+++ b/components/camel-soap/src/test/resources/org/apache/camel/dataformat/soap/CustomerService.wsdl
@@ -73,6 +73,18 @@
                         minOccurs="0"></xs:element>
                 </xs:sequence>
             </xs:complexType>
+            
+            <xs:element name="getAllAmericanCustomers">
+            </xs:element>
+            <xs:element name="getAllAmericanCustomersResponse" type="tns:getAllAmericanCustomersResponse">
+            </xs:element>
+
+            <xs:complexType name="getAllAmericanCustomersResponse">
+                <xs:sequence>
+                    <xs:element name="return" type="tns:customer" maxOccurs="unbounded"
+                        minOccurs="0"></xs:element>
+                </xs:sequence>
+            </xs:complexType>
 
             <xs:element name="saveCustomer" type="tns:saveCustomer">
             </xs:element>
@@ -100,7 +112,12 @@
     </wsdl:message>
     <wsdl:message name="getAllCustomersResponse">
         <wsdl:part name="parameters" element="tns:getAllCustomersResponse"></wsdl:part>
+    </wsdl:message>   
+	<wsdl:message name="getAllAmericanCustomers">
     </wsdl:message>
+    <wsdl:message name="getAllAmericanCustomersResponse">
+        <wsdl:part name="parameters" element="tns:getAllAmericanCustomersResponse"></wsdl:part>
+    </wsdl:message>   
     <wsdl:message name="saveCustomerRequest">
         <wsdl:part name="parameters" element="tns:saveCustomer"></wsdl:part>
     </wsdl:message>
@@ -118,6 +135,10 @@
         <wsdl:operation name="getAllCustomers">
             <wsdl:input message="tns:getAllCustomers"></wsdl:input>
             <wsdl:output message="tns:getAllCustomersResponse"></wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getAllAmericanCustomers">
+            <wsdl:input message="tns:getAllAmericanCustomers"></wsdl:input>
+            <wsdl:output message="tns:getAllAmericanCustomersResponse"></wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="saveCustomer">
             <wsdl:input message="tns:saveCustomerRequest"></wsdl:input>
@@ -152,6 +173,12 @@
                 <soap:body use="literal" />
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="getAllAmericanCustomers">
+            <soap:operation soapAction="http://customerservice.example.com/getAllAmericanCustomers" />
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="saveCustomer">
             <soap:operation soapAction="http://customerservice.example.com/saveCustomer" />
             <wsdl:input>
@@ -168,3 +195,4 @@
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>
+


### PR DESCRIPTION
Hi all,

This pull request is related to:
https://issues.apache.org/jira/browse/CAMEL-6716

I've added a second method without parameter in the customerservice.wsdl and add an assert in the **testServiceInterfaceStrategyWithClient** method of **ServiceInterfaceStrategyTest** Test class.

Hope this should be useful and it will be merged.

P.S.: I've closed the other pull request and submitted this new one.
