### PR TITLE
Fix unit test, so it runs on all platforms

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/processor/interceptor/DefaultTraceEventMessageTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/interceptor/DefaultTraceEventMessageTest.java
@@ -76,7 +76,7 @@ public class DefaultTraceEventMessageTest extends ContextTestSupport {
         exchange.getIn().setBody(new File("target/test"));
         DefaultTraceEventMessage em = new DefaultTraceEventMessage(new Date(), null, exchange);
         
-        assertEquals("Get a wrong body string", "[Body is file based: target/test]", em.getBody());
+        assertEquals("Get a wrong body string", "[Body is file based: target" + File.separator + "test]", em.getBody());
         
         exchange.getIn().setBody(new ByteArrayInputStream("target/test".getBytes()));
         em = new DefaultTraceEventMessage(new Date(), null, exchange);


### PR DESCRIPTION
Replace usage of hard-coded Unix file name separator ("/") with
java.io.File.separator constant, so the test also runs on Windows
platforms.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
