### PR TITLE
CAMEL-7419 - Configure endpoints with many options in the DSL using a mix of url and properties

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/UriOption.java
+++ b/camel-core/src/main/java/org/apache/camel/model/UriOption.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+/**
+ * Represents an XML &lt;option&gt; element within a &lt;from/&gt; or a &lt;to/&gt; element
+ *
+ * @version
+ */
+@XmlRootElement(name = "option")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UriOption {
+    @XmlAttribute
+    private String key;
+    @XmlValue
+    private String value;
+
+    public UriOption() {
+    }
+
+    public UriOption(String key, String value) {
+        setKey(key);
+        setValue(value);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    // Utility methods
+    // -----------------------------------------------------------------------
+    protected static Map<String, Object> transformOptions(List<UriOption> options) {
+        if (options == null) {
+            return null;
+        }
+
+        Map<String, Object> result = new HashMap<String, Object>();
+        for (UriOption option : options) {
+            result.put(option.getKey(), option.getValue());
+        }
+        return result;
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 /**
  * URI utilities.
  *
- * @version 
+ * @version
  */
 public final class URISupport {
 
@@ -44,15 +44,15 @@ public final class URISupport {
     // First capture group is the key, second is the value.
     private static final Pattern SECRETS = Pattern.compile("([?&][^=]*(?:passphrase|password|secretKey)[^=]*)=([^&]*)",
             Pattern.CASE_INSENSITIVE);
-    
+
     // Match the user password in the URI as second capture group
     // (applies to URI with authority component and userinfo token in the form "user:password").
     private static final Pattern USERINFO_PASSWORD = Pattern.compile("(.*://.*:)(.*)(@)");
-    
+
     // Match the user password in the URI path as second capture group
     // (applies to URI path with authority component and userinfo token in the form "user:password").
     private static final Pattern PATH_USERINFO_PASSWORD = Pattern.compile("(.*:)(.*)(@)");
-    
+
     private static final String CHARSET = "UTF-8";
 
     private URISupport() {
@@ -76,12 +76,12 @@ public final class URISupport {
         }
         return sanitized;
     }
-    
+
     /**
      * Removes detected sensitive information (such as passwords) from the
      * <em>path part</em> of an URI (that is, the part without the query
      * parameters or component prefix) and returns the result.
-     * 
+     *
      * @param path the URI path to sanitize
      * @return null if the path is null, otherwise the sanitized path
      */
@@ -426,6 +426,25 @@ public final class URISupport {
             s = null;
         }
         return createURIWithQuery(originalURI, s);
+    }
+
+    /**
+     * Appends the given parameters to the given URI.
+     * <p/>
+     * It keeps the original parameters and if a new parameter is already defined in
+     * {@code originalURI}, it will be replaced by its value in {@code newParameters}.
+     *
+     * @param originalURI the original URI
+     * @param newParameters the parameters to add
+     * @return the URI with all the parameters
+     * @throws URISyntaxException is thrown if the uri syntax is invalid
+     * @throws UnsupportedEncodingException is thrown if encoding error
+     */
+    public static String appendParametersToURI(String originalURI, Map<String, Object> newParameters) throws URISyntaxException, UnsupportedEncodingException {
+        URI uri = new URI(normalizeUri(originalURI));
+        Map<String, Object> parameters = parseParameters(uri);
+        parameters.putAll(newParameters);
+        return createRemainingURI(uri, parameters).toString();
     }
 
     /**

--- a/camel-core/src/main/resources/org/apache/camel/model/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/jaxb.index
@@ -83,6 +83,7 @@ TransactedDefinition
 TransformDefinition
 TryDefinition
 UnmarshalDefinition
+UriOption
 ValidateDefinition
 WhenDefinition
 WireTapDefinition

--- a/camel-core/src/test/java/org/apache/camel/model/UriOptionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/model/UriOptionTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import junit.framework.TestCase;
+
+public class UriOptionTest extends TestCase {
+    public void testTransformOptions() {
+        List<UriOption> list = Arrays.asList(new UriOption("foo", "123"), new UriOption("bar", "456"));
+
+        Map<String, Object> map = UriOption.transformOptions(list);
+
+        assertEquals(2, map.size());
+        assertEquals("123", map.get("foo"));
+        assertEquals("456", map.get("bar"));
+    }
+
+    public void testTransformOptionsWithNull() {
+        assertNull(UriOption.transformOptions(null));
+    }
+
+    public void testTransformOptionsWithDuplicate() {
+        List<UriOption> list = Arrays.asList(new UriOption("foo", "123"), new UriOption("foo", "456"));
+
+        Map<String, Object> map = UriOption.transformOptions(list);
+
+        assertEquals(1, map.size());
+        assertEquals("456", map.get("foo"));
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -48,12 +48,12 @@ public class URISupportTest extends ContextTestSupport {
         out1 = URISupport.normalizeUri("seda:foo?concurrentConsumer=2");
         out2 = URISupport.normalizeUri("seda:foo");
         assertNotSame(out1, out2);
-        
+
         out1 = URISupport.normalizeUri("foo:?test=1");
         out2 = URISupport.normalizeUri("foo://?test=1");
         assertEquals("foo://?test=1", out2);
         assertEquals(out1, out2);
-        
+
     }
 
     public void testNormalizeEndpointUriNoParam() throws Exception {
@@ -94,9 +94,9 @@ public class URISupportTest extends ContextTestSupport {
         assertEquals(out1, out2);
         assertTrue("Should have //", out1.startsWith("http://"));
         assertTrue("Should have //", out2.startsWith("http://"));
-        
+
     }
-    
+
     public void testNormalizeIPv6HttpEndpoint() throws Exception {
         String result = URISupport.normalizeUri("http://[2a00:8a00:6000:40::1413]:30300/test");
         assertEquals("http://[2a00:8a00:6000:40::1413]:30300/test", result);
@@ -212,13 +212,13 @@ public class URISupportTest extends ContextTestSupport {
         String expected = "jt400://GEORGE:xxxxxx@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.DTAQ";
         assertEquals(expected, URISupport.sanitizeUri(uri));
     }
-    
+
     public void testSanitizePathWithUserInfo() {
         String path = "GEORGE:HARRISON@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
         String expected = "GEORGE:xxxxxx@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
         assertEquals(expected, URISupport.sanitizePath(path));
     }
-    
+
     public void testSanitizePathWithoutSensitiveInfoIsUnchanged() {
         String path = "myhost:8080/mypath";
         assertEquals(path, URISupport.sanitizePath(path));
@@ -288,4 +288,27 @@ public class URISupportTest extends ContextTestSupport {
         assertEquals("somechat", map.get("serviceName"));
     }
 
+    public void testAppendParameterToUriWithoutParameters() throws Exception {
+        Map<String, Object> newParameters = new HashMap<String, Object>();
+        newParameters.put("foo", "123");
+        String newUri = URISupport.appendParametersToURI("direct:foo", newParameters);
+
+        assertEquals("direct://foo?foo=123", newUri);
+    }
+
+    public void testAppendParameterToUri() throws Exception {
+        Map<String, Object> newParameters = new HashMap<String, Object>();
+        newParameters.put("bar", "456");
+        String newUri = URISupport.appendParametersToURI("direct:foo?foo=123", newParameters);
+
+        assertEquals("direct://foo?foo=123&bar=456", newUri);
+    }
+
+    public void testAppendParameterToUriAndReplaceExistingOne() throws Exception {
+        Map<String, Object> newParameters = new HashMap<String, Object>();
+        newParameters.put("foo", "456");
+        String newUri = URISupport.appendParametersToURI("direct:foo?foo=123", newParameters);
+
+        assertEquals("direct://foo?foo=456", newUri);
+    }
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/ComponentUriWithOptionsTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/ComponentUriWithOptionsTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import org.apache.camel.component.seda.SedaEndpoint;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class ComponentUriWithOptionsTest extends SpringTestSupport {
+    public void testUriOptionsOnFromTag() {
+        SedaEndpoint input = resolveMandatoryEndpoint("seda:input", SedaEndpoint.class);
+
+        assertEquals(1, input.getSize());
+    }
+
+    public void testUriOptionsOnToTag() {
+        SedaEndpoint output = resolveMandatoryEndpoint("seda:output", SedaEndpoint.class);
+
+        assertEquals(2, output.getSize());
+    }
+
+    public void testUriOptionsOnInOutTag() {
+        SedaEndpoint inOut = resolveMandatoryEndpoint("seda:inOut", SedaEndpoint.class);
+
+        assertEquals(3, inOut.getSize());
+    }
+
+    public void testUriOptionsOnInOnlyTag() {
+        SedaEndpoint inOnly = resolveMandatoryEndpoint("seda:inOnly", SedaEndpoint.class);
+
+        assertEquals(4, inOnly.getSize());
+    }
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/componentUriWithOptions.xml");
+    }
+}

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/componentUriWithOptions.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/componentUriWithOptions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <!-- START SNIPPET: example -->
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+
+        <route>
+            <from uri="seda:input">
+                <option key="size">1</option>
+            </from>
+            <to uri="seda:output">
+                <option key="size">2</option>
+            </to>
+            <inOut uri="seda:inOut">
+                <option key="size">3</option>
+            </inOut>
+           <inOnly uri="seda:inOnly">
+                <option key="size">4</option>
+            </inOnly>
+        </route>
+
+    </camelContext>
+    <!-- END SNIPPET: example -->
+
+</beans>


### PR DESCRIPTION
I'm using the following XML representation:
```xml
<from uri="timer:foo">
    <option key="repeatCount">10</option>
</from>
```
It's only available when creating a `FromDefinition` from XML, if you're using the Java DSL you can use `URISupportcreateRemainingURI()` in order to create your very long URI.
It's handled by `<from />`, `<to />`, `<inOut />` and `<inOnly />`.