### PR TITLE
CAMEL-7446: Fix m2e lifecycle configuration problem

### DIFF
--- a/components/camel-web/pom.xml
+++ b/components/camel-web/pom.xml
@@ -538,8 +538,8 @@
                                 </pluginExecution>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
-                                        <groupId>org.fusesource.scalate</groupId>
-                                        <artifactId>maven-scalate-plugin_2.10</artifactId>
+                                        <groupId>org.scalatra.scalate</groupId>
+                                        <artifactId>maven-scalate-plugin_2.11</artifactId>
                                         <versionRange>${scalate-version}</versionRange>
                                         <goals>
                                             <goal>precompile</goal>


### PR DESCRIPTION
Fix m2e lifecycle configuration problems caused by missing lifecycle
mapping details in maven-scalate-plugin_2.11.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
