### PR TITLE
fix CAMEL-7450: CsvDataFormat unable to setup header when useMaps=true

### DIFF
--- a/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvDataFormat.java
+++ b/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvDataFormat.java
@@ -131,16 +131,25 @@ public class CsvDataFormat implements DataFormat {
         try {
             reader = IOHelper.buffered(new InputStreamReader(inputStream, IOHelper.getCharsetName(exchange)));
             CSVParser parser = new CSVParser(reader, strategy);
-
+            if (skipFirstLine) {
+                // read one line ahead and skip it
+                parser.getLine();
+            }
             CsvLineConverter<?> lineConverter;
             if (useMaps) {
-                lineConverter = CsvLineConverters.getMapLineConverter(parser.getLine());
+                final CSVField[] fields = this.config.getFields();
+                final String[] fieldS;
+                if (fields != null && fields.length > 0) {
+                    fieldS = new String[fields.length];
+                    for (int i = 0; i < fields.length; i++) {
+                        fieldS[i] = fields[i].getName();
+                    }
+                } else {
+                    fieldS = parser.getLine();
+                }
+                lineConverter = CsvLineConverters.getMapLineConverter(fieldS);
             } else {
                 lineConverter = CsvLineConverters.getListConverter();
-                if (skipFirstLine) {
-                    // read one line ahead and skip it
-                    parser.getLine();
-                }
             }
 
             @SuppressWarnings({"unchecked", "rawtypes"}) CsvIterator<?> csvIterator = new CsvIterator(parser, reader, lineConverter);

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvUnmarshalMapLineTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvUnmarshalMapLineTest.java
@@ -32,6 +32,12 @@ public class CsvUnmarshalMapLineTest extends CamelSpringTestSupport {
 
     @EndpointInject(uri = "mock:result")
     private MockEndpoint result;
+    
+    @EndpointInject(uri = "mock:result2")
+    private MockEndpoint result2;
+
+    @EndpointInject(uri = "mock:result3")
+    private MockEndpoint result3;
 
     @SuppressWarnings("unchecked")
     @Test
@@ -64,6 +70,46 @@ public class CsvUnmarshalMapLineTest extends CamelSpringTestSupport {
 
         List<?> body = result.getReceivedExchanges().get(0).getIn().getBody(List.class);
         assertEquals(0, body.size());
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCsvUnMarshalWithoutHeader() throws Exception {
+        result2.expectedMessageCount(1);
+
+        // the first line contains the column names which we intend to skip
+        template.sendBody("direct:start2", "123|Camel in Action|1\n124|ActiveMQ in Action|2");
+
+        assertMockEndpointsSatisfied();
+
+        List<Map<String, String>> body = result2.getReceivedExchanges().get(0).getIn().getBody(List.class);
+        assertEquals(2, body.size());
+        assertEquals("123", body.get(0).get("MyOrderId"));
+        assertEquals("Camel in Action", body.get(0).get("MyItem"));
+        assertEquals("1", body.get(0).get("MyAmount"));
+        assertEquals("124", body.get(1).get("MyOrderId"));
+        assertEquals("ActiveMQ in Action", body.get(1).get("MyItem"));
+        assertEquals("2", body.get(1).get("MyAmount"));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCsvUnMarshalWithCustomHeader() throws Exception {
+        result3.expectedMessageCount(1);
+
+        // the first line contains the column names which we intend to skip
+        template.sendBody("direct:start3", "OrderId|Item|Amount\n123|Camel in Action|1\n124|ActiveMQ in Action|2");
+
+        assertMockEndpointsSatisfied();
+
+        List<Map<String, String>> body = result3.getReceivedExchanges().get(0).getIn().getBody(List.class);
+        assertEquals(2, body.size());
+        assertEquals("123", body.get(0).get("MyOrderId"));
+        assertEquals("Camel in Action", body.get(0).get("MyItem"));
+        assertEquals("1", body.get(0).get("MyAmount"));
+        assertEquals("124", body.get(1).get("MyOrderId"));
+        assertEquals("ActiveMQ in Action", body.get(1).get("MyItem"));
+        assertEquals("2", body.get(1).get("MyAmount"));
     }
 
     @Override

--- a/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvUnmarshalMapLineSpringTest-context.xml
+++ b/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvUnmarshalMapLineSpringTest-context.xml
@@ -28,5 +28,42 @@
       </unmarshal>
       <to uri="mock:result" />
     </route>
+
+	<!-- skipFirstLine="false" since there's no heder into the CSV (let's use 
+		confugured one) -->
+	<route>
+		<from uri="direct:start2" />
+		<unmarshal>
+			<!-- make use of a configuration to setup map headers -->
+			<csv delimiter="|" useMaps="true" configRef="csvConfig" />
+		</unmarshal>
+		<to uri="mock:result2" />
+	</route>
+
+	<!-- skip first line since we want to use our custom header -->
+	<route>
+		<from uri="direct:start3" />
+		<unmarshal>
+			<!-- make use of a configuration to setup map headers -->
+			<csv delimiter="|" useMaps="true" skipFirstLine="true" configRef="csvConfig" />
+		</unmarshal>
+		<to uri="mock:result3" />
+	</route>
   </camelContext>
+
+	<bean id="csvConfig" class="org.apache.commons.csv.writer.CSVConfig">
+		<property name="fields">
+			<list>
+				<bean class="org.apache.commons.csv.writer.CSVField">
+					<property name="name" value="MyOrderId" />
+				</bean>
+				<bean class="org.apache.commons.csv.writer.CSVField">
+					<property name="name" value="MyItem" />
+				</bean>
+				<bean class="org.apache.commons.csv.writer.CSVField">
+					<property name="name" value="MyAmount" />
+				</bean>
+			</list>
+		</property>
+	</bean>
 </beans>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-7450

Hi all,
seems that it is impossible to setup the header of a csv when using a map.
It is always used the first line of the CSV file.
Using this configuration in conjunction with my patch I'm currently able to do so (also having the skipFirstLine flag working with useMaps="true")
Configuration:
https://github.com/ccancellieri/camel_poc/blob/master/src/main/resources/META-INF/spring/camel-context.xml

Is this acceptable for you?
