### PR TITLE
[Minor] Maven POM cleanup, reduce warnings

### DIFF
--- a/components/camel-ahc-ws/pom.xml
+++ b/components/camel-ahc-ws/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty-version}</version>
       <scope>test</scope>
     </dependency>
     

--- a/components/camel-atmosphere-websocket/pom.xml
+++ b/components/camel-atmosphere-websocket/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-servlet_3.0_spec</artifactId>
-          <version>${geronimo-servlet-spec-version}</version>
         </dependency>
 
         <!--  atmosphere -->
@@ -106,7 +105,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${jetty-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
@@ -94,7 +93,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
         <configuration>
           <goalPrefix>camel-salesforce</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
Remove version specification from dependencies that override with the
same version as defined by parent.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
