### PR TITLE
CAMEL-7479: Make unit tests run with any JVM system locale

### DIFF
--- a/components/camel-jaxb/src/test/java/org/apache/camel/converter/jaxb/JaxbDataFormatSchemaValidationSpringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/converter/jaxb/JaxbDataFormatSchemaValidationSpringTest.java
@@ -76,7 +76,7 @@ public class JaxbDataFormatSchemaValidationSpringTest extends CamelSpringTestSup
             assertIsInstanceOf(IOException.class, cause);
             assertTrue(cause.getMessage().contains("javax.xml.bind.MarshalException"));
             assertTrue(cause.getMessage().contains("org.xml.sax.SAXParseException"));
-            assertTrue(cause.getMessage().contains("Invalid content was found"));
+            assertTrue(cause.getMessage().contains("cvc-complex-type.2.4.a"));
         }
     }
 
@@ -119,7 +119,7 @@ public class JaxbDataFormatSchemaValidationSpringTest extends CamelSpringTestSup
             assertIsInstanceOf(IOException.class, cause);
             assertTrue(cause.getMessage().contains("javax.xml.bind.UnmarshalException"));
             assertTrue(cause.getMessage().contains("org.xml.sax.SAXParseException"));
-            assertTrue(cause.getMessage().contains("The content of element 'person' is not complete"));
+            assertTrue(cause.getMessage().contains("cvc-complex-type.2.4.b"));
         }
     }
 

--- a/components/camel-jaxb/src/test/java/org/apache/camel/converter/jaxb/JaxbDataFormatSchemaValidationTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/converter/jaxb/JaxbDataFormatSchemaValidationTest.java
@@ -75,7 +75,7 @@ public class JaxbDataFormatSchemaValidationTest extends CamelTestSupport {
             assertIsInstanceOf(IOException.class, cause);
             assertTrue(cause.getMessage().contains("javax.xml.bind.MarshalException"));
             assertTrue(cause.getMessage().contains("org.xml.sax.SAXParseException"));
-            assertTrue(cause.getMessage().contains("Invalid content was found"));
+            assertTrue(cause.getMessage().contains("cvc-complex-type.2.4.a"));
         }
     }
 
@@ -118,7 +118,7 @@ public class JaxbDataFormatSchemaValidationTest extends CamelTestSupport {
             assertIsInstanceOf(IOException.class, cause);
             assertTrue(cause.getMessage().contains("javax.xml.bind.UnmarshalException"));
             assertTrue(cause.getMessage().contains("org.xml.sax.SAXParseException"));
-            assertTrue(cause.getMessage().contains("The content of element 'person' is not complete"));
+            assertTrue(cause.getMessage().contains("cvc-complex-type.2.4.b"));
         }
     }
 


### PR DESCRIPTION
Use SAX validation error code instead of the localized error message in
assert statements, so that the tests run with any JVM system locale.

Signed-off-by: Gregor Zurowski gregor@zurowski.org
