### PR TITLE
First part of CAMEL-7482, update log messages on timeout

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultShutdownStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultShutdownStrategy.java
@@ -195,11 +195,11 @@ public class DefaultShutdownStrategy extends ServiceSupport implements ShutdownS
 
             // if set, stop processing and return false to indicate that the shutdown is aborting
             if (!forceShutdown && abortAfterTimeout) {
-                LOG.warn("Timeout occurred. Aborting the shutdown now.");
+                LOG.warn("Timeout occurred. Aborting the shutdown now.  Some resources may still be running.");
                 return false;
             } else {
                 if (forceShutdown || shutdownNowOnTimeout) {
-                    LOG.warn("Timeout occurred. Forcing the routes to be shutdown now.");
+                    LOG.warn("Timeout occurred. Forcing the routes to be shutdown now.  Some resources may still be running.");
                     // force the routes to shutdown now
                     shutdownRoutesNow(routesOrdered);
 
@@ -210,7 +210,7 @@ public class DefaultShutdownStrategy extends ServiceSupport implements ShutdownS
                         }
                     }
                 } else {
-                    LOG.warn("Timeout occurred. Will ignore shutting down the remainder routes.");
+                    LOG.warn("Timeout occurred. Will ignore shutting down the remainder routes. Some resources may still be running.");
                 }
             }
         } finally {


### PR DESCRIPTION
Update the warn messages that are logged when the graceful timeout is hit to let people know some resources may still be running.
