### PR TITLE
Fix for CAMEL-7529 Modify HeaderFilterStrategyComponent to extend UriEnd...

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/HeaderFilterStrategyComponent.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/HeaderFilterStrategyComponent.java
@@ -21,15 +21,16 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.HeaderFilterStrategyAware;
 
-public abstract class HeaderFilterStrategyComponent extends DefaultComponent implements HeaderFilterStrategyAware {
+public abstract class HeaderFilterStrategyComponent extends UriEndpointComponent implements HeaderFilterStrategyAware {
     
     private HeaderFilterStrategy headerFilterStrategy;
     
-    public HeaderFilterStrategyComponent() {
+    public HeaderFilterStrategyComponent(Class<? extends Endpoint> endpointClass) {
+        super(endpointClass);
     }
 
-    public HeaderFilterStrategyComponent(CamelContext context) {
-        super(context);
+    public HeaderFilterStrategyComponent(CamelContext context, Class<? extends Endpoint> endpointClass) {
+        super(context, endpointClass);
     }
     
     public HeaderFilterStrategy getHeaderFilterStrategy() {

--- a/camel-core/src/test/java/org/apache/camel/impl/HeaderFilterStrategyComponentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/HeaderFilterStrategyComponentTest.java
@@ -33,6 +33,10 @@ public class HeaderFilterStrategyComponentTest extends TestCase {
 
     private static class MyComponent extends HeaderFilterStrategyComponent {
 
+        public MyComponent(Class<? extends Endpoint> endpointClass) {
+            super(endpointClass);
+        }
+
         protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
             return null;
         }
@@ -64,7 +68,7 @@ public class HeaderFilterStrategyComponentTest extends TestCase {
     }
 
     public void testHeaderFilterStrategyComponent() {
-        MyComponent comp = new MyComponent();
+        MyComponent comp = new MyComponent(MyEndpoint.class);
         assertNull(comp.getHeaderFilterStrategy());
 
         HeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
@@ -74,7 +78,7 @@ public class HeaderFilterStrategyComponentTest extends TestCase {
     }
 
     public void testHeaderFilterStrategyAware() {
-        MyComponent comp = new MyComponent();
+        MyComponent comp = new MyComponent(MyEndpoint.class);
         assertNull(comp.getHeaderFilterStrategy());
 
         HeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();

--- a/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcComponent.java
+++ b/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcComponent.java
@@ -48,6 +48,10 @@ public class AhcComponent extends HeaderFilterStrategyComponent {
     private AhcBinding binding;
     private SSLContextParameters sslContextParameters;
 
+    public AhcComponent() {
+        super(AhcEndpoint.class);
+    }
+
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         String addressUri = createAddressUri(uri, remaining);

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfComponent.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfComponent.java
@@ -33,10 +33,11 @@ public class CxfComponent extends HeaderFilterStrategyComponent {
     Boolean allowStreaming;
     
     public CxfComponent() {
+        super(CxfEndpoint.class);
     }
 
     public CxfComponent(CamelContext context) {
-        super(context);
+        super(context, CxfEndpoint.class);
     }
     
     public void setAllowStreaming(Boolean b) {

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/cxfbean/CxfBeanComponent.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/cxfbean/CxfBeanComponent.java
@@ -33,7 +33,11 @@ import org.apache.camel.impl.HeaderFilterStrategyComponent;
 public class CxfBeanComponent extends HeaderFilterStrategyComponent {
 
     private Map<String, CxfBeanEndpoint> endpoints = new HashMap<String, CxfBeanEndpoint>();
-        
+
+    public CxfBeanComponent() {
+        super(CxfBeanEndpoint.class);
+    }
+
     @Override
     protected Endpoint createEndpoint(String uri, String remaining,
             Map<String, Object> parameters) throws Exception {

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsComponent.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsComponent.java
@@ -36,10 +36,11 @@ import org.apache.cxf.jaxrs.AbstractJAXRSFactoryBean;
 public class CxfRsComponent extends HeaderFilterStrategyComponent {
 
     public CxfRsComponent() {
+        super(CxfRsEndpoint.class);
     }
     
     public CxfRsComponent(CamelContext context) {
-        super(context);
+        super(context, CxfRsEndpoint.class);
     }
 
     @Override

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
@@ -48,6 +48,10 @@ public class HttpComponent extends HeaderFilterStrategyComponent {
     protected HttpBinding httpBinding;
     protected HttpConfiguration httpConfiguration;
 
+    public HttpComponent() {
+        super(HttpEndpoint.class);
+    }
+
     /**
      * Connects the URL specified on the endpoint to the specified processor.
      *

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpComponent.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpComponent.java
@@ -73,6 +73,10 @@ public class HttpComponent extends HeaderFilterStrategyComponent {
     // It's MILLISECONDS, the default value is always keep alive
     protected long connectionTimeToLive = -1;
 
+    public HttpComponent() {
+        super(HttpEndpoint.class);
+    }
+
     /**
      * Connects the URL specified on the endpoint to the specified processor.
      *

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
@@ -75,6 +75,7 @@ public class RestletComponent extends HeaderFilterStrategyComponent {
     public RestletComponent(Component component) {
         // Allow the Component to be injected, so that the RestletServlet may be
         // configured within a webapp
+        super(RestletEndpoint.class);
         this.component = component;
     }
 


### PR DESCRIPTION
...pointComponent instead of DefaultComponent.  This is needed to expose component options in components where XXXComponent.java extended HeaderFilterStrategyComponent rather than DefaultComponent.
