### PR TITLE
CAMEL-7503 PAYLOAD Producer select first available operation if OPERATION_NAME is not specified

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfProducer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfProducer.java
@@ -330,6 +330,7 @@ public class CxfProducer extends DefaultProducer implements AsyncProcessor {
     private BindingOperationInfo getBindingOperationInfo(Exchange ex) {
         CxfEndpoint endpoint = (CxfEndpoint)this.getEndpoint();
         BindingOperationInfo answer = null;
+        LOG.info("If '{}' header is not specified, the Producer will pick up the first available operation", CxfConstants.OPERATION_NAME);
         String lp = ex.getIn().getHeader(CxfConstants.OPERATION_NAME, String.class);
         if (lp == null) {
             lp = endpoint.getDefaultOperationName();


### PR DESCRIPTION
Hi,

This PR is related to https://issues.apache.org/jira/browse/CAMEL-7503

I just added an info log line.

Bye,
Andrea
