### PR TITLE
Fix for CAMEL-7600

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/loadbalancer/QueueLoadBalancer.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/loadbalancer/QueueLoadBalancer.java
@@ -36,7 +36,8 @@ public abstract class QueueLoadBalancer extends LoadBalancerSupport {
         if (!list.isEmpty()) {
             Processor processor = chooseProcessor(list, exchange);
             if (processor == null) {
-                throw new IllegalStateException("No processors could be chosen to process " + exchange);
+                Exception e = new IllegalStateException("No processors could be chosen to process " + exchange);
+                exchange.setException(e);
             } else {
                 if (processor instanceof AsyncProcessor) {
                     AsyncProcessor async = (AsyncProcessor) processor;


### PR DESCRIPTION
Fixed QueueLoadBalancer issue when callback is not executed when processor is not found.
