### PR TITLE
Specifying criteria for count operation in MongoDB component

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
@@ -338,7 +338,13 @@ public class MongoDbProducer extends DefaultProducer {
 
     protected void doCount(Exchange exchange) throws Exception {
         DBCollection dbCol = calculateCollection(exchange);
-        Long answer = Long.valueOf(dbCol.count());
+        DBObject query = exchange.getIn().getBody(DBObject.class);
+        Long answer;
+        if (query == null){
+            answer = Long.valueOf(dbCol.count());    
+        } else {
+            answer = Long.valueOf(dbCol.count(query));    
+        }
         Message resultMessage = prepareResponseMessage(exchange, MongoDbOperation.count);
         resultMessage.setBody(answer);
     }


### PR DESCRIPTION
In current version count operation in Camel MongoDB component can return only total amount of documents in collection. Now you can specify criteria as DBObject in message body and operation will return the amount of documents matching this criteria. To get total amount of documents, you should invoke count operation without any value in message body.
