### PR TITLE
Mybatis component can accept an InputStream for configuration

### DIFF
--- a/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisComponent.java
+++ b/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisComponent.java
@@ -35,6 +35,7 @@ public class MyBatisComponent extends UriEndpointComponent {
 
     private SqlSessionFactory sqlSessionFactory;
     private String configurationUri = "SqlMapConfig.xml";
+    private InputStream configurationInputStream;
 
     public MyBatisComponent() {
         super(MyBatisEndpoint.class);
@@ -48,12 +49,18 @@ public class MyBatisComponent extends UriEndpointComponent {
     }
 
     protected SqlSessionFactory createSqlSessionFactory() throws IOException {
-        ObjectHelper.notNull(configurationUri, "configurationUri", this);
-        InputStream is = ResourceHelper.resolveMandatoryResourceAsInputStream(getCamelContext().getClassResolver(), configurationUri);
+
+        if(configurationInputStream == null) {
+
+            ObjectHelper.notNull(configurationUri, "configurationUri", this);
+            configurationInputStream = ResourceHelper.resolveMandatoryResourceAsInputStream(getCamelContext().getClassResolver(), configurationUri);
+
+        }
         try {
-            return new SqlSessionFactoryBuilder().build(is);
+            return new SqlSessionFactoryBuilder().build(configurationInputStream);
         } finally {
-            IOHelper.close(is);
+            IOHelper.close(configurationInputStream);
+            configurationInputStream = null;
         }
     }
 
@@ -63,6 +70,14 @@ public class MyBatisComponent extends UriEndpointComponent {
 
     public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
         this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    public InputStream getConfigurationInputStream() {
+        return configurationInputStream;
+    }
+
+    public void setConfigurationInputStream(InputStream configurationInputStream) {
+        this.configurationInputStream = configurationInputStream;
     }
 
     public String getConfigurationUri() {

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisComponentConfigurationAndDocumentationTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.ComponentConfiguration;
 import org.apache.camel.EndpointConfiguration;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.util.ResourceHelper;
 import org.junit.Test;
 
 public class MyBatisComponentConfigurationAndDocumentationTest extends CamelTestSupport {
@@ -29,6 +30,23 @@ public class MyBatisComponentConfigurationAndDocumentationTest extends CamelTest
     @Override
     public boolean isUseRouteBuilder() {
         return false;
+    }
+
+    @Test
+    public void testProvideInputStream() throws Exception {
+        MyBatisComponent comp = context.getComponent(COMPONENT_NAME, MyBatisComponent.class);
+         comp.setConfigurationInputStream(ResourceHelper.resolveMandatoryResourceAsInputStream(context().getClassResolver(), "SqlMapConfig.xml"));
+        EndpointConfiguration conf = comp.createConfiguration("mybatis:insertAccount?statementType=Insert&maxMessagesPerPoll=5");
+
+        assertEquals("Insert", conf.getParameter("statementType"));
+        assertEquals("5", conf.getParameter("maxMessagesPerPoll"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"maxMessagesPerPoll\": { \"type\": \"int\" }"));
+        assertTrue(json.contains("\"statement\": { \"type\": \"java.lang.String\" }"));
     }
 
     @Test


### PR DESCRIPTION
In my current project we're using YAML for configuration, and have a utility that converts YAML to XML for Mybatis... I'd like the option of providing an inputstream for configuration instead of only an XML file reference.

My changes add the option of setting an inputstream for configuring the component. In my particular use case, I have a set of JAXB annotated classes return their XML equivalent value as an inputstream into this component.
