### PR TITLE
Fix CAMEL-7680 : Throw NPE when stopping if transport client is used

### DIFF
--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -97,7 +97,9 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
             LOG.info("Leaving ElasticSearch cluster " + configuration.getClusterName());
         }
         client.close();
-        node.close();
+        if (node != null) {
+            node.close();
+        }
         super.doStop();
     }
 


### PR DESCRIPTION
Protecting an unassigned field when component is stopped
