### PR TITLE
Improved JMX handling on ActiveMQ broker for tests

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SimpleJmsComponentTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SimpleJmsComponentTest.java
@@ -34,7 +34,7 @@ public class SimpleJmsComponentTest extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=true");
+                ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
                 SjmsComponent component = new SjmsComponent();
                 component.setConnectionFactory(connectionFactory);
                 getContext().addComponent("sjms", component);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/AsyncConsumerFalseTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/AsyncConsumerFalseTest.java
@@ -46,7 +46,7 @@ public class AsyncConsumerFalseTest extends CamelTestSupport {
         camelContext.addComponent("async", new MyAsyncComponent());
 
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(
-                "vm://broker?broker.persistent=false");
+                "vm://broker?broker.persistent=false&broker.useJmx=false");
         SjmsComponent component = new SjmsComponent();
         component.setConnectionFactory(connectionFactory);
         camelContext.addComponent("sjms", component);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/AsyncConsumerInOutTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/AsyncConsumerInOutTest.java
@@ -50,7 +50,7 @@ public class AsyncConsumerInOutTest extends CamelTestSupport {
         camelContext.addComponent("async", new MyAsyncComponent());
 
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(
-                "vm://broker?broker.persistent=false");
+                "vm://broker?broker.persistent=false&broker.useJmx=false");
         SjmsComponent component = new SjmsComponent();
         component.setConnectionFactory(connectionFactory);
         camelContext.addComponent("sjms", component);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyTopicDurableConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyTopicDurableConsumerTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class InOnlyTopicDurableConsumerTest extends CamelTestSupport {
     
     private static final String CONNECTION_ID = "test-connection-1";
-    private static final String BROKER_URI = "vm://durable.broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://durable.broker?broker.persistent=false&broker.useJmx=false";
     
     @Override
     protected boolean useJmx() {

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/jms/ConnectionFactoryResourceTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/jms/ConnectionFactoryResourceTest.java
@@ -34,7 +34,7 @@ public class ConnectionFactoryResourceTest {
 
     @Before
     public void setup() {
-        connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false");
+        connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
     }
 
     @After

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/jms/SessionPoolTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/jms/SessionPoolTest.java
@@ -36,7 +36,7 @@ public class SessionPoolTest {
 
     @Before
     public void setup() {
-        connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false");
+        connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
     }
 
     @After

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/JmsTestSupport.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/JmsTestSupport.java
@@ -56,10 +56,10 @@ public class JmsTestSupport extends CamelTestSupport {
     @Override
     protected void doPreSetup() throws Exception {
         deleteDirectory("target/activemq-data");
-
-        brokerUri = "tcp://localhost:" + AvailablePortFinder.getNextAvailable(33333);
-
         broker = new BrokerService();
+        final int port = AvailablePortFinder.getNextAvailable(33333);
+        brokerUri = "tcp://localhost:" + port;
+        broker.getManagementContext().setConnectorPort(AvailablePortFinder.getNextAvailable(port + 1));
         configureBroker(broker);
         startBroker();
     }

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedConcurrentMultipleConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedConcurrentMultipleConsumerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
  */
 public class BatchTransactedConcurrentMultipleConsumerTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://btcmc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btcmc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedConcurrentMultipleRouteConsumersTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedConcurrentMultipleRouteConsumersTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class BatchTransactedConcurrentMultipleRouteConsumersTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://btcmrc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btcmrc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedQueueConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedQueueConsumerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class BatchTransactedQueueConsumerTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedQueueProducerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedQueueProducerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  * for a Queue Producer.
  */
 public class BatchTransactedQueueProducerTest extends BatchTransactedProducerSupport {
-    private static final String BROKER_URI = "vm://btqpt_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btqpt_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * Verify that after processing a {@link BatchMessage} twice with 30

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicConsumerMultipleRouteTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicConsumerMultipleRouteTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class BatchTransactedTopicConsumerMultipleRouteTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://bttcmr_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://bttcmr_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicConsumerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class BatchTransactedTopicConsumerTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://bttc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://bttc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicProducerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/BatchTransactedTopicProducerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  * for a Topic Producer.
  */
 public class BatchTransactedTopicProducerTest extends BatchTransactedProducerSupport {
-    private static final String BROKER_URI = "vm://bttpt_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://bttpt_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * Verify that after processing a {@link BatchMessage} twice with 30

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedConcurrentConsumersTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedConcurrentConsumersTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
  */
 public class TransactedConcurrentConsumersTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedConsumersMultipleRouteTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedConsumersMultipleRouteTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
  */
 public class TransactedConsumersMultipleRouteTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://btqc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedQueueConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedQueueConsumerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 public class TransactedQueueConsumerTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://tqc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://tqc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedQueueProducerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedQueueProducerTest.java
@@ -61,7 +61,7 @@ public class TransactedQueueProducerTest extends CamelTestSupport {
      */
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=true");
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
         CamelContext camelContext = super.createCamelContext();
         SjmsComponent component = new SjmsComponent();
         component.setConnectionFactory(connectionFactory);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedTopicConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedTopicConsumerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 public class TransactedTopicConsumerTest extends TransactedConsumerSupport {
     
-    private static final String BROKER_URI = "vm://ttc_test_broker?broker.persistent=false&broker.useJmx=true";
+    private static final String BROKER_URI = "vm://ttc_test_broker?broker.persistent=false&broker.useJmx=false";
 
     /**
      * We want to verify that when consuming from a single destination with

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedTopicProducerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedTopicProducerTest.java
@@ -62,7 +62,7 @@ public class TransactedTopicProducerTest extends CamelTestSupport {
      */
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=true");
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
         ConnectionFactoryResource connectionResource = new ConnectionFactoryResource();
         connectionResource.setConnectionFactory(connectionFactory);
         connectionResource.setClientId("test-connection-1");


### PR DESCRIPTION
Disabled jmx for tests that don't need to use it and also add
AvailablePortFinder to dinamically assing JMX connector port when
needed.
