### PR TITLE
Fix for CAMEL-7748 Test was failing because of change in returning json ...

### DIFF
--- a/components/camel-twitter/src/test/java/org/apache/camel/component/twitter/UriConfigurationTest.java
+++ b/components/camel-twitter/src/test/java/org/apache/camel/component/twitter/UriConfigurationTest.java
@@ -74,8 +74,8 @@ public class UriConfigurationTest extends Assert {
         String json = compConf.createParameterJsonSchema();
         assertNotNull(json);
 
-        assertTrue(json.contains("\"accessToken\": { \"type\": \"java.lang.String\" }"));
-        assertTrue(json.contains("\"consumerKey\": { \"type\": \"java.lang.String\" }"));
+        assertTrue(json.contains("\"accessToken\": { \"type\": \"string\" }"));
+        assertTrue(json.contains("\"consumerKey\": { \"type\": \"string\" }"));
     }
 
     @Test


### PR DESCRIPTION
...schema object types.    
