### PR TITLE
CAMEL-7672 copy message headers that do not begin with 'camel' into STOMP frame headers

### DIFF
--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.stomp;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.camel.Consumer;
@@ -120,6 +121,16 @@ public class StompEndpoint extends DefaultEndpoint {
 
     protected void send(Message message) {
         final StompFrame frame = new StompFrame(SEND);
+        Map<String,Object> headerMap = message.getHeaders();
+        for ( String key : headerMap.keySet() ) {
+            if ( ! key.toLowerCase().startsWith( "camel" ) ) {
+                Object val = headerMap.get( key );
+                if ( val!=null ) {
+                    frame.addHeader( new AsciiBuffer( key ), 
+                                     StompFrame.encodeHeader( val.toString() ) );
+                }
+            }
+        }
         frame.addHeader(DESTINATION, StompFrame.encodeHeader(destination));
         frame.content(utf8(message.getBody().toString()));
         connection.getDispatchQueue().execute(new Task() {


### PR DESCRIPTION
CAMEL-7672 copy message headers that do not begin with 'camel' into STOMP frame headers