### PR TITLE
Improve Exception handling and logging in SJMS:

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
@@ -139,7 +139,7 @@ public final class JmsMessageHelper {
                 break;
             }
         } catch (Exception e) {
-            LOGGER.error("Error creating a message of type: " + messageType.toString());
+            LOGGER.error("Error creating a message of type: {}", messageType, e);
             throw e;
         }
         if (messageHeaders != null && !messageHeaders.isEmpty()) {
@@ -317,9 +317,7 @@ public final class JmsMessageHelper {
         try {
             message.setJMSType(type);
         } catch (JMSException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Error setting the message type: {}", type);
-            }
+            LOGGER.debug("Error setting the message type: {}", type, e);
         }
     }
 
@@ -335,9 +333,7 @@ public final class JmsMessageHelper {
         try {
             message.setJMSCorrelationID(correlationId);
         } catch (JMSException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Error setting the correlationId: {}", correlationId);
-            }
+            LOGGER.debug("Error setting the correlationId: {}", correlationId, e);
         }
     }
 

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/producer/InOnlyProducer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/producer/InOnlyProducer.java
@@ -74,7 +74,7 @@ public class InOnlyProducer extends SjmsProducer {
 
             answer = new MessageProducerResources(session, messageProducer, commitStrategy);
         } catch (Exception e) {
-            log.error("Unable to create the MessageProducer: " + e.getLocalizedMessage());
+            log.error("Unable to create the MessageProducer", e);
         } finally {
             if (conn != null) {
                 getConnectionResource().returnConnection(conn);
@@ -123,7 +123,7 @@ public class InOnlyProducer extends SjmsProducer {
                 producer.getMessageProducer().send(message);
             }
         } catch (Exception e) {
-            exchange.setException(new Exception("Unable to complete sending the message: " + e.getLocalizedMessage()));
+            exchange.setException(new Exception("Unable to complete sending the message: ", e));
         } finally {
             if (producer != null) {
                 getProducers().returnObject(producer);


### PR DESCRIPTION
Changed Logger calls to include the caught exception as well, so that
stacktraces are no longer swallowed. Same for wrapping exceptions.
