### PR TITLE
CAMEL-7883 : Validator XSD decoding issue with non UTF-8 imported XSD

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/validator/DefaultLSResourceResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/component/validator/DefaultLSResourceResolver.java
@@ -117,8 +117,7 @@ public class DefaultLSResourceResolver implements LSResourceResolver {
         
         @Override
         public Reader getCharacterStream() {
-            InputStream is = getByteStream();
-            return camelContext.getTypeConverter().convertTo(Reader.class, is);
+            return null;
         }
 
         @Override

--- a/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorIncludeEncodingRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorIncludeEncodingRouteTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.validator;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.Processor;
+import org.apache.camel.ValidationException;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+/**
+ *
+ */
+public class ValidatorIncludeEncodingRouteTest extends ContextTestSupport {
+
+    protected MockEndpoint validEndpoint;
+    protected MockEndpoint finallyEndpoint;
+    protected MockEndpoint invalidEndpoint;
+
+    public void testValidMessage() throws Exception {
+        validEndpoint.expectedMessageCount(1);
+        finallyEndpoint.expectedMessageCount(1);
+        
+        String body = "<t:text xmlns:t=\"org.text\">\n"
+                + "  <t:sentence>J'aime les camélidés</t:sentence>\n"
+                + "</t:text>";
+
+        template.sendBody("direct:start", body);
+
+        MockEndpoint.assertIsSatisfied(validEndpoint, invalidEndpoint, finallyEndpoint);
+    }
+
+    
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        validEndpoint = resolveMandatoryEndpoint("mock:valid", MockEndpoint.class);
+        invalidEndpoint = resolveMandatoryEndpoint("mock:invalid", MockEndpoint.class);
+        finallyEndpoint = resolveMandatoryEndpoint("mock:finally", MockEndpoint.class);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                    .doTry()
+                        .to("validator:org/apache/camel/component/validator/text.xsd")
+                        .to("mock:valid")
+                    .doCatch(NumberFormatException.class)
+                 .process(new Processor() {
+                    
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+System.err.println("helo " + exchange.getException());                        
+                    }
+                })
+                        .to("mock:invalid")
+                    .doFinally()
+                        .to("mock:finally")
+                    .end();
+            }
+        };
+    }
+
+}

--- a/camel-core/src/test/resources/org/apache/camel/component/validator/sentence.xsd
+++ b/camel-core/src/test/resources/org/apache/camel/component/validator/sentence.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<xs:schema attributeFormDefault="unqualified"
+	elementFormDefault="qualified" targetNamespace="org.text.sentence"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="sentence">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-zA-Zé' ]*" />
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/camel-core/src/test/resources/org/apache/camel/component/validator/text.xsd
+++ b/camel-core/src/test/resources/org/apache/camel/component/validator/text.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<xs:schema attributeFormDefault="unqualified"
+	elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:p="org.text" targetNamespace="org.text" xmlns:s="org.text.sentence">
+	<xs:import schemaLocation="sentence.xsd" namespace="org.text.sentence" />
+	<xs:element name="text" type="p:textType">
+	</xs:element>
+	<xs:complexType name="textType">
+		<xs:sequence>
+			<xs:element type="s:sentence" name="sentence" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Let SAX do a good guess for XSD encoding (it uses XSD prolog) instead of using a converter that may not fit.
