### PR TITLE
CAMEL-7875 Method for adding objects to Registry

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/CompositeRegistry.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/CompositeRegistry.java
@@ -107,6 +107,13 @@ public class CompositeRegistry implements Registry {
         return answer;
     }
 
+    @Override
+    public void add(String name, Object object) {
+        if (null != registryList.get(0)) {
+            registryList.get(0).add(name, object);
+        }
+    }
+
     public Object lookup(String name) {
         return lookupByName(name);
     }

--- a/camel-core/src/main/java/org/apache/camel/impl/JndiRegistry.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/JndiRegistry.java
@@ -107,6 +107,11 @@ public class JndiRegistry implements Registry {
         return answer;
     }
 
+    @Override
+    public void add(String name, Object object) {
+        bind(name, object);
+    }
+
     public Object lookup(String name) {
         return lookupByName(name);
     }

--- a/camel-core/src/main/java/org/apache/camel/impl/PropertyPlaceholderDelegateRegistry.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/PropertyPlaceholderDelegateRegistry.java
@@ -74,6 +74,11 @@ public class PropertyPlaceholderDelegateRegistry implements Registry {
         return delegate.findByType(type);
     }
 
+    @Override
+    public void add(String name, Object object) {
+        delegate.add(name, object);
+    }
+
     public Object lookup(String name) {
         return lookupByName(name);
     }

--- a/camel-core/src/main/java/org/apache/camel/impl/SimpleRegistry.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/SimpleRegistry.java
@@ -72,6 +72,11 @@ public class SimpleRegistry extends HashMap<String, Object> implements Registry 
         return result;
     }
 
+    @Override
+    public void add(String name, Object object) {
+        put(name, object);
+    }
+
     public Object lookup(String name) {
         return lookupByName(name);
     }

--- a/camel-core/src/main/java/org/apache/camel/spi/Registry.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/Registry.java
@@ -62,6 +62,14 @@ public interface Registry {
     <T> Set<T> findByType(Class<T> type);
 
     /**
+     * Adds a service in the registry.
+     *
+     * @param name the name of the service
+     * @param object the service object to add
+     */
+    void add(String name, Object object);
+
+    /**
      * Looks up a service in the registry based purely on name,
      * returning the service or <tt>null</tt> if it could not be found.
      *
@@ -95,5 +103,4 @@ public interface Registry {
      */
     @Deprecated
     <T> Map<String, T> lookupByType(Class<T> type);
-
 }

--- a/camel-core/src/test/java/org/apache/camel/impl/CompositeRegistryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/CompositeRegistryTest.java
@@ -34,6 +34,7 @@ public class CompositeRegistryTest {
         registry = new CompositeRegistry();
         registry.addRegistry(sr2);
         registry.addRegistry(sr1);
+        registry.add("direct", "something");
     }
     
     @Test
@@ -41,6 +42,10 @@ public class CompositeRegistryTest {
         Object result = registry.lookupByNameAndType("name", String.class);
         assertNotNull(result);
         assertEquals("Get a wrong result", result, "12");
+
+        result = registry.lookup("direct");
+        assertNotNull(result);
+        assertEquals("something", result);
         
         result = registry.lookup("test", Integer.class);
         assertNull(result);

--- a/camel-core/src/test/java/org/apache/camel/impl/JndiRegistryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/JndiRegistryTest.java
@@ -30,10 +30,12 @@ public class JndiRegistryTest extends TestCase {
         JndiRegistry jndi = new JndiRegistry(JndiTest.createInitialContext());
         jndi.bind("foo", new SimpleLanguage());
         jndi.bind("bar", "Hello bar");
+        jndi.add("direct", "something");
 
         assertEquals("Hello bar", jndi.lookup("bar"));
         assertEquals("Hello bar", jndi.lookupByName("bar"));
         assertEquals("Hello bar", jndi.lookupByNameAndType("bar", String.class));
+        assertEquals("something", jndi.lookup("direct"));
         assertNull(jndi.lookup("unknown"));
         assertNull(jndi.lookupByName("unknown"));
 

--- a/camel-core/src/test/java/org/apache/camel/impl/SimpleRegistryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/SimpleRegistryTest.java
@@ -29,10 +29,12 @@ public class SimpleRegistryTest extends TestCase {
         registry = new SimpleRegistry();
         registry.put("a", "b");
         registry.put("c", 1);
+        registry.add("direct", "something");
     }
 
     public void testLookupByName() {
         assertEquals("b", registry.lookupByName("a"));
+        assertEquals("something", registry.lookup("direct"));
     }
 
     public void testLookupByWrongName() {
@@ -56,10 +58,10 @@ public class SimpleRegistryTest extends TestCase {
     
     public void testLookupByType() {
         Map<?, ?> map = registry.findByTypeWithName(String.class);
-        assertEquals(1, map.size());
+        assertEquals(2, map.size());
         assertEquals("b", map.get("a"));
         map = registry.findByTypeWithName(Object.class);
-        assertEquals(2, map.size());
+        assertEquals(3, map.size());
         assertEquals("b", map.get("a"));
         assertEquals(1, map.get("c"));
     }

--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiBeanRegistry.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiBeanRegistry.java
@@ -90,6 +90,11 @@ public class CdiBeanRegistry implements Registry {
     }
 
     @Override
+    public void add(String name, Object object) {
+        // not implemented
+    }
+
+    @Override
     public Object lookup(String name) {
         return lookupByName(name);
     }


### PR DESCRIPTION
Having a write method in Registry interface simplifies configuring Camel routes in CamelTestSupport unit tests where a registry reference is not available and when you would like to configure beans required by the components inside route builder's configure method.

This change eliminates the need to pass registry references around. If your code can see its CamelContext you'll have uniform write access to its registry.
