### PR TITLE
Update to Smack 4.0

### DIFF
--- a/components/camel-xmpp/pom.xml
+++ b/components/camel-xmpp/pom.xml
@@ -47,12 +47,17 @@
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smack</artifactId>
+      <artifactId>smack-tcp</artifactId>
       <version>${smack-version}</version>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smackx</artifactId>
+      <artifactId>smack-resolver-javax</artifactId>
+      <version>${smack-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-extensions</artifactId>
       <version>${smack-version}</version>
     </dependency>
 

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
@@ -25,6 +25,7 @@ import org.apache.camel.impl.DefaultHeaderFilterStrategy;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.util.ObjectHelper;
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +71,7 @@ public class XmppBinding {
                     message.setLanguage(language);
                 } else {
                     try {
-                        message.setProperty(name, value);
+                        JivePropertiesManager.addProperty(message, name, value);
                         LOG.trace("Added property name: {} value: {}", name, value.toString());
                     } catch (IllegalArgumentException iae) {
                         if (LOG.isDebugEnabled()) {
@@ -83,7 +84,7 @@ public class XmppBinding {
         
         String id = exchange.getExchangeId();
         if (id != null) {
-            message.setProperty("exchangeId", id);
+            JivePropertiesManager.addProperty(message, "exchangeId", id);
         }
     }
 
@@ -97,8 +98,8 @@ public class XmppBinding {
     public Map<String, Object> extractHeadersFromXmpp(Message xmppMessage, Exchange exchange) {
         Map<String, Object> answer = new HashMap<String, Object>();
 
-        for (String name : xmppMessage.getPropertyNames()) {
-            Object value = xmppMessage.getProperty(name);
+        for (String name : JivePropertiesManager.getPropertiesNames(xmppMessage)) {
+            Object value = JivePropertiesManager.getProperty(xmppMessage, name);
 
             if (!headerFilterStrategy.applyFilterToExternalHeaders(name, value, exchange)) {
                 answer.put(name, value);

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
@@ -16,7 +16,17 @@
  */
 package org.apache.camel.component.xmpp;
 
-import java.util.Iterator;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
@@ -31,12 +41,16 @@ import org.apache.camel.spi.HeaderFilterStrategyAware;
 import org.apache.camel.util.ObjectHelper;
 import org.jivesoftware.smack.AccountManager;
 import org.jivesoftware.smack.ConnectionConfiguration;
+import org.jivesoftware.smack.ConnectionConfiguration.SecurityMode;
+import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.PacketFilter;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Packet;
 import org.jivesoftware.smack.packet.XMPPError;
+import org.jivesoftware.smack.tcp.XMPPTCPConnection;
 import org.jivesoftware.smackx.muc.MultiUserChat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +78,8 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
     private XMPPConnection connection;
     private boolean testConnectionOnStartup = true;
     private int connectionPollDelay = 10;
+    private boolean useTls = true;
+    private boolean acceptAllCertificates = true; // TODO change to false
 
     public XmppEndpoint() {
     }
@@ -127,22 +143,61 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
         return true;
     }
 
-    public synchronized XMPPConnection createConnection() throws XMPPException {
+    public synchronized XMPPConnection createConnection() throws XMPPException, SmackException, IOException {
 
         if (connection != null && connection.isConnected()) {
             return connection;
         }
 
+        ConnectionConfiguration connectionConfiguration;
         if (connection == null) {
             if (port > 0) {
                 if (getServiceName() == null) {
-                    connection = new XMPPConnection(new ConnectionConfiguration(host, port));
+                    connectionConfiguration = new ConnectionConfiguration(host, port);
                 } else {
-                    connection = new XMPPConnection(new ConnectionConfiguration(host, port, serviceName));
+                    connectionConfiguration = new ConnectionConfiguration(host, port, serviceName);
                 }
             } else {
-                connection = new XMPPConnection(host);
+                connectionConfiguration = new ConnectionConfiguration(host);
             }
+
+            if (useTls) {
+                connectionConfiguration.setSecurityMode(SecurityMode.required);
+            } else {
+                connectionConfiguration.setSecurityMode(SecurityMode.disabled);
+            }
+
+            if (acceptAllCertificates) {
+                // TODO Replace with
+                // org.jivesoftware.smack.util.TLSUtils.acceptAllCertificates(ConnectionConfiguration)
+                // once camel-xmpp uses Smack 4.1
+                SSLContext context;
+                try {
+                    context = SSLContext.getInstance("TLS");
+                    X509TrustManager acceptAllTrustManager = new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] arg0, String arg1)
+                                        throws CertificateException {
+                            // Nothing to do here
+                        }
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] arg0, String arg1)
+                                        throws CertificateException {
+                            // Nothing to do here
+                        }
+                        @Override
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return new X509Certificate[0];
+                        }
+                    };
+                    context.init(null, new TrustManager[] { acceptAllTrustManager }, new SecureRandom());
+                    connectionConfiguration.setCustomSSLContext(context);
+                } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                    throw new IOException(e);
+                }
+
+            }
+            connection = new XMPPTCPConnection(connectionConfiguration);
         }
 
         connection.connect();
@@ -168,7 +223,7 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
                 }
 
                 if (createAccount) {
-                    AccountManager accountManager = new AccountManager(connection);
+                    AccountManager accountManager = AccountManager.getInstance(connection);
                     accountManager.createAccount(user, password);
                 }
                 if (login) {
@@ -194,19 +249,19 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
      * If there is no "@" symbol in the room, find the chat service JID and
      * return fully qualified JID for the room as room@conference.server.domain
      */
-    public String resolveRoom(XMPPConnection connection) throws XMPPException {
+    public String resolveRoom(XMPPConnection connection) throws XMPPException, SmackException {
         ObjectHelper.notEmpty(room, "room");
 
         if (room.indexOf('@', 0) != -1) {
             return room;
         }
 
-        Iterator<String> iterator = MultiUserChat.getServiceNames(connection).iterator();
-        if (!iterator.hasNext()) {
-            throw new XMPPException("Cannot find Multi User Chat service on connection: " + getConnectionMessage(connection));
+        Collection<String> mucServices = MultiUserChat.getServiceNames(connection);
+        if (mucServices.isEmpty()) {
+            throw new SmackException("Cannot find Multi User Chat service on connection: " + getConnectionMessage(connection));
         }
 
-        String chatServer = iterator.next();
+        String chatServer = mucServices.iterator().next();
         LOG.debug("Detected chat server: {}", chatServer);
 
         return room + "@" + chatServer;
@@ -220,17 +275,13 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
         return connection.getHost() + ":" + connection.getPort() + "/" + connection.getServiceName();
     }
 
-    public static String getXmppExceptionLogMessage(XMPPException e) {
+    public static String getXmppExceptionLogMessage(XMPPErrorException e) {
         XMPPError xmppError = e.getXMPPError();
-        Throwable t = e.getWrappedThrowable();
         StringBuilder strBuff = new StringBuilder();
         if (xmppError != null) {
-            strBuff.append("[ ").append(xmppError.getCode()).append(" ] ")
+            strBuff.append("[ ").append(xmppError.getType()).append(" ] ")
                 .append(xmppError.getCondition()).append(" : ")
                 .append(xmppError.getMessage());
-        }
-        if (t != null) {
-            strBuff.append(" ( ").append(e.getWrappedThrowable().getMessage()).append(" )");
         }
         return strBuff.toString();
     }
@@ -339,6 +390,14 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
 
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    public void setUseTls(boolean useTls) {
+        this.useTls = useTls;
+    }
+
+    public void setAcceptAllCertificates(boolean acceptAllCertificates) {
+        this.acceptAllCertificates = acceptAllCertificates;
     }
 
     public String getServiceName() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -391,8 +391,7 @@
     <!-- use slf4j-api 1.6.x to be easy compatible with older Camel releases -->
     <slf4j-api-version>1.6.6</slf4j-api-version>
     <slf4j-version>1.7.7</slf4j-version>
-    <smack-bundle-version>3.2.1_1</smack-bundle-version>
-    <smack-version>3.2.1</smack-version>
+    <smack-version>4.0.5</smack-version>
     <snappy-version>1.1.0.1</snappy-version>
     <snmp4j-version>2.3.0_1</snmp4j-version>
     <solr-bundle-version>4.8.1_1</solr-bundle-version>
@@ -498,7 +497,6 @@
       org.eclipse.jetty.*;version="[7.5,10)",
       com.thoughtworks.xstream.*;version="[1.3,2)",
       org.antlr.stringtemplate.*;version="[3.0,4)",
-      org.jivesoftware.smack.*;version="[3.0,4)",
       org.ccil.cowan.tagsoup.*;version="[1.2,2)",
       org.mortbay.cometd.*;version="[6.1,7)",
       org.slf4j.*;version="[1.6,2)",


### PR DESCRIPTION
Remove Presence Packet listener in XmppConsumer. It never worked, since
the processPacket() method does check if the given Packet is instanceof
Message, so the filtered Presence Packets never got processed.

XMPPError.getCode() is no more. Integer error codes have been deprecated
from XMPP for a while. Use getType() instead.

Use the connection packet reply timeout, instead of the global one in
SmackConfiguration (where the method name was changed to
SmackConfiguration.getDefaultPacketReplyTimeout()).

Use JivePropertiesManager for Packet properties.

Fixes CAMEL-7903