### PR TITLE
CAMEL-7938 - Crypto won't decrypt message with multiple encrypted parts if "our" key isn't the first part

### DIFF
--- a/components/camel-crypto/pom.xml
+++ b/components/camel-crypto/pom.xml
@@ -25,7 +25,6 @@
 	</parent>
 
 	<artifactId>camel-crypto</artifactId>
-	<version>2.11.1-PATCH1</version>
 	<packaging>bundle</packaging>
 	<name>Camel :: Crypto</name>
 	<description>Camel Cryptographic Support</description>
@@ -47,30 +46,11 @@
 			org.apache.camel.spi.DataFormatResolver;dataformat=gpg
 		</camel.osgi.export.service>
 	</properties>
-	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.camel</groupId>
-				<artifactId>camel-package-maven-plugin</artifactId>
-				<version>${parent.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>generate-components-list</goal>
-						</goals>
-						<phase>generate-resources</phase>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-core</artifactId>
-			<version>${parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -97,19 +77,6 @@
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-test-spring</artifactId>
-			<version>${parent.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.camel</groupId>
-			<artifactId>camel-test</artifactId>
-			<version>${parent.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.camel</groupId>
-			<artifactId>camel-spring</artifactId>
-			<version>${parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/components/camel-crypto/pom.xml
+++ b/components/camel-crypto/pom.xml
@@ -25,6 +25,7 @@
 	</parent>
 
 	<artifactId>camel-crypto</artifactId>
+	<version>2.11.1-PATCH1</version>
 	<packaging>bundle</packaging>
 	<name>Camel :: Crypto</name>
 	<description>Camel Cryptographic Support</description>
@@ -46,11 +47,30 @@
 			org.apache.camel.spi.DataFormatResolver;dataformat=gpg
 		</camel.osgi.export.service>
 	</properties>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-package-maven-plugin</artifactId>
+				<version>${parent.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate-components-list</goal>
+						</goals>
+						<phase>generate-resources</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-core</artifactId>
+			<version>${parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -77,6 +97,19 @@
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-test-spring</artifactId>
+			<version>${parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-test</artifactId>
+			<version>${parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring</artifactId>
+			<version>${parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/PGPDataFormat.java
+++ b/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/PGPDataFormat.java
@@ -27,6 +27,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.SignatureException;
 import java.util.Date;
+import java.util.Iterator;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.DataFormat;
@@ -245,7 +246,16 @@ public class PGPDataFormat implements DataFormat {
         }
         IOHelper.close(in);
 
-        PGPPublicKeyEncryptedData pbe = (PGPPublicKeyEncryptedData) enc.get(0);
+//        PGPPublicKeyEncryptedData pbe = (PGPPublicKeyEncryptedData) enc.get(0);
+        PGPPublicKeyEncryptedData pbe = null;
+        Iterator encryptedDataObjects = enc.getEncryptedDataObjects();
+        // iterate through the "encryptedDataObjects" until we find the one that matches our "key"
+        while (pbe == null && encryptedDataObjects.hasNext()) {
+        	PGPPublicKeyEncryptedData encryptedData = (PGPPublicKeyEncryptedData) encryptedDataObjects.next();
+        	if (encryptedData.getKeyID() == key.getKeyID()) {
+        		pbe = encryptedData;
+        	}
+        }
         InputStream encData = pbe.getDataStream(key, "BC");
 
         pgpFactory = new PGPObjectFactory(encData);

--- a/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/PGPDataFormatUtil.java
+++ b/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/PGPDataFormatUtil.java
@@ -160,7 +160,12 @@ public final class PGPDataFormatUtil {
         while (privateKey == null && encryptedDataObjects.hasNext()) {
             encryptedData = (PGPPublicKeyEncryptedData) encryptedDataObjects.next();
             PGPSecretKey pgpSecKey = pgpSec.getSecretKey(encryptedData.getKeyID());
-            privateKey = pgpSecKey.extractPrivateKey(passphrase.toCharArray(), "BC");
+//            privateKey = pgpSecKey.extractPrivateKey(passphrase.toCharArray(), "BC");
+            if (pgpSecKey != null) {
+            	privateKey = pgpSecKey.extractPrivateKey(passphrase.toCharArray(), "BC");
+            } else {
+            	// hopefully we'll have the secret key for one of the next encypredDataObjects
+            }
         }
         return privateKey;
     }


### PR DESCRIPTION
CAMEL-7938 patch.  Note that this patch was made off the last commit in 2.11.x, based on when I actually made the fix.  I'd like to see this fix move into the next possible release, so I wasn't sure which commit to actually make it against.