### PR TITLE
CAMEL-7834 - Camel Docker Component

### DIFF
--- a/components/camel-docker/README.md
+++ b/components/camel-docker/README.md
@@ -1,0 +1,108 @@
+Docker Camel Component
+=======================
+
+Camel component for communicating with Docker.
+
+## Docker Remote API
+
+The Docker Camel component leverages the [docker-java](https://github.com/docker-java/docker-java) via the [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/)
+
+## URI Format
+
+    docker://[operation]?[options]
+
+## Header Strategy
+
+All URI option can be passed as Header properties. Values found in a message header take precedence over URI parameters. A header property takes the form of a URI option prefixed with *CamelDocker* as shown below
+
+| URI Option | Header Property  |
+| ------------- | ---------------- |
+|containerId|CamelDockerContainerId |
+
+## General Options
+
+The following parameters can be used with any invocation of the component
+
+The following options are required
+
+| Option | Header | Description | Default Value |
+|-----------|-----------|-----------------|-------------------|
+| host     | CamelDockerHost | Docker host | localhost |
+| port      | CamelDockerPort | Docker port | 5000 |
+
+The following are additional optional parameters
+
+| Option | Header | Description | Default Value |
+|-----------|-----------|-----------------|-------------------|
+| username | CamelDockerUserName | User name to authenticate with | |
+| password | CamelDockerPassword | Password to authenticate with | |
+| email | CamelDockerEmail | Email address associated with the user | |
+| secure | CamelDockerSecure | Use HTTPS communication | false |
+| requestTimeout | CamelDockerRequestTimeout | Request timeout for response (in seconds) | 30 |
+
+
+## Consumer Operations
+
+| Operation | Options | Description  | Produces |
+| ------------- | ---------------- | ------------- | ---------------- |
+|events| initialRange | Monitor Docker events (Streaming) | Event |
+
+## Producer Operations
+
+The following producer operations are available
+
+### Misc
+| Operation | Options | Description  | Returns |
+| ------------- | ---------------- | ------------- | ---------------- |
+| auth | | Check auth configuration | |
+| info | | System wide information | Info |
+| ping | | Ping the Docker server | | 
+| version | | Show the docker version information | Version |
+
+ 
+### Images
+
+| Operation | Options | Description | Body Content | Returns |
+| ------------- | ---------------- | ------------- | ---------------- | ---------------- |
+| image/list | filter, showAll | List images | | List&lt;Image&gt; |
+| image/create | **repository** | Create an image | InputStream |CreateImageResponse |
+| image/build | noCache, quiet, remove, tag | Build an image from Dockerfile via stdin | InputStream or File | InputStream |
+| image/pull |  **repository**, registry, tag | Pull an image from the registry | |InputStream |
+| image/push | **name** | Push an image on the registry | InputStream |
+| image/search | **term** | Search for images | | List&lt;SearchItem&gt; |
+| image/remove | **imageId**, force, noPrune | Remove an image | | |
+| image/tag | **imageId**, **repository**, **tag**, **force** | Tag an image into a repository | | |	
+| image/inspect | **imageId** | Inspect an image | | InspectImageResponse |
+
+### Containers
+
+| Operation | Options | Description  | Body Content |
+| ------------- | ---------------- | ------------- | ---------------- |
+| container/list | showSize, showAll, before, since, limit, List containers | initialRange | List&lt;Container&gt; |
+| container/create | **imageId**, name, exposedPorts, workingDir, disableNetwork, hostname, user, tty, stdInOpen, stdInOnce, memoryLimit, memorySwap, cpuShares, attachStdIn, attachStdOut, attachStdErr, env, cmd, dns, image, volumes, volumesFrom | Create a container | CreateContainerResponse |
+| container/start | **containerId**, binds, links, lxcConf, portBindings, privileged, publishAllPorts, dns, dnsSearch, volumesFrom, networkMode, devices, restartPolicy, capAdd, capDrop | Start a container | | 
+| container/inspect | **containerId** | Inspect a container  | InspectContainerResponse |
+| container/wait | **containerId** | Wait a container | Integer
+| container/log | **containerId**, stdOut, stdErr, timestamps, followStream, tailAll, tail | Get container logs | InputStream |
+| container/attach | **containerId**, stdOut, stdErr, timestamps, logs, followStream | Attach to a container | InputStream |
+| container/stop | **containerId**, timeout | Stop a container | |
+| container/restart | **containerId**, timeout | Restart a container | |
+| container/diff | **containerId** | Inspect changes on a container | ChangeLog |
+| container/kill | **containerId**, signal, | Kill a container | |
+| container/top | **containerId**, psArgs | List processes running in a container | TopContainerResponse |
+| container/pause | **containerId** | Pause a container | |
+| container/unpause | **containerId** | Unpause a container | |
+| container/commit | **containerId**, repository, message, tag, attachStdIn, attachStdOut, attachStdErr, cmd, disableNetwork, pause, env, exposedPorts, hostname, memory, memorySwap, openStdIn, portSpecs, stdInOnce, tty, user, volumes, hostname | Create a new image from a container's changes | String |
+| container/copyfile | **containerId**, **resource**, hostPath | Copy files or folders from a container | InputStream |
+| container/remove | **containerId**, force, removeVolumes | Remove a container | |
+
+
+## Examples
+
+The following example consumes events from Docker 
+
+    docker://events?host=192.168.59.103&port=2375
+
+The following example queries Docker for system wide information
+
+    docker://info?host=192.168.59.103&port=2375

--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>components</artifactId>
+      <version>2.15-SNAPSHOT</version>
+  </parent>
+    
+  <artifactId>camel-docker</artifactId>
+  <packaging>bundle</packaging>
+  <name>Camel :: Docker</name>
+  <description>Camel Docker Support</description>
+
+
+  <properties>
+    <camel.osgi.export.pkg>org.apache.camel.component.docker.*</camel.osgi.export.pkg>
+    <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=docker</camel.osgi.export.service>
+  	<docker.java.version>0.10.2</docker.java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+
+	<!-- Docker -->
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java</artifactId>
+      <version>${docker.java.version}</version>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+       <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock-version}</version>
+      <scope>test</scope>
+   </dependency>
+   <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock-version}</version>
+      <scope>test</scope>
+   </dependency>
+  </dependencies>
+  
+</project>

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerClientFactory.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerClientFactory.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.apache.camel.Message;
+import org.apache.camel.component.docker.exception.DockerException;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * Methods for communicating with Docker
+ */
+public class DockerClientFactory {
+    
+    
+    /**
+     * Produces a {@link DockerClient} to communicate with Docker
+     * 
+     * @param dockerConfiguration
+     * @param message the Camel message
+     * @return a DockerClient
+     * @throws DockerException
+     */
+    public static DockerClient getDockerClient(DockerConfiguration dockerConfiguration, Message message) throws DockerException {
+        
+        ObjectHelper.notNull(dockerConfiguration, "dockerConfiguration");
+        
+        Integer port = null;
+        String host = null;
+        DockerClient client = null;
+       
+            
+        port = DockerHelper.getProperty(DockerConstants.DOCKER_PORT, dockerConfiguration, message, Integer.class);
+        host = DockerHelper.getProperty(DockerConstants.DOCKER_HOST, dockerConfiguration, message, String.class);
+       
+        int uriPort = port != null ? port : dockerConfiguration.getDefaultPort();
+        String uriHost = host != null ? host : dockerConfiguration.getDefaultHost();
+        
+        String username = DockerHelper.getProperty(DockerConstants.DOCKER_USERNAME, dockerConfiguration, message, String.class);
+        String password = DockerHelper.getProperty(DockerConstants.DOCKER_PASSWORD, dockerConfiguration, message, String.class);
+        String email = DockerHelper.getProperty(DockerConstants.DOCKER_EMAIL, dockerConfiguration, message, String.class);
+        Integer requestTimeout = DockerHelper.getProperty(DockerConstants.DOCKER_API_REQUEST_TIMEOUT, dockerConfiguration, message, Integer.class);
+        String serverAddress = DockerHelper.getProperty(DockerConstants.DOCKER_SERVER_ADDRESS, dockerConfiguration, message, String.class);
+        Boolean secure = DockerHelper.getProperty(DockerConstants.DOCKER_SECURE, dockerConfiguration, message, Boolean.class);
+        
+        
+        DockerClientProfile clientProfile = new DockerClientProfile();
+        clientProfile.setHost(uriHost);
+        clientProfile.setPort(uriPort);
+        clientProfile.setEmail(email);
+        clientProfile.setUsername(username);
+        clientProfile.setPassword(password);
+        clientProfile.setRequestTimeout(requestTimeout);
+        clientProfile.setServerAddress(serverAddress);
+        
+        if(secure != null && secure) {
+            clientProfile.setSecure(secure);
+        }
+        
+        client = dockerConfiguration.getClient(clientProfile);
+        
+        if(client != null) {
+            return client;
+        }
+        
+        DockerClientConfig.DockerClientConfigBuilder configBuilder = new DockerClientConfig.DockerClientConfigBuilder()
+        .withUsername(username)
+        .withPassword(password)
+        .withEmail(email)
+        .withReadTimeout(requestTimeout)
+        .withUri(clientProfile.toUrl());
+        
+        DockerClientConfig config = configBuilder.build();
+        
+        return DockerClientBuilder.getInstance(config).build();
+        
+    }
+
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerClientProfile.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerClientProfile.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.camel.component.docker.exception.DockerException;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * The elements representing a client initiating a connection to Docker
+ */
+public class DockerClientProfile {
+    
+    private String host;
+    private Integer port;
+    private String username;
+    private String password;
+    private String email;
+    private String serverAddress;
+    private Integer requestTimeout;
+    private boolean secure;
+    
+    public String getHost() {
+        return host;
+    }
+    public void setHost(String host) {
+        this.host = host;
+    }
+    public Integer getPort() {
+        return port;
+    }
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    public String getServerAddress() {
+        return serverAddress;
+    }
+    public void setServerAddress(String serverAddress) {
+        this.serverAddress = serverAddress;
+    }
+    
+    public Integer getRequestTimeout() {
+        return requestTimeout;
+    }
+    public void setRequestTimeout(Integer requestTimeout) {
+        this.requestTimeout = requestTimeout;
+    }
+    public boolean isSecure() {
+        return secure;
+    }
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+    public String toUrl() throws DockerException {
+        ObjectHelper.notNull(this.host, "host");
+        ObjectHelper.notNull(this.port, "port");
+        
+        URL uri;
+        String secure = this.secure ? "https" : "http";
+        try {
+            uri = new URL(secure, this.host, this.port, "");
+        } catch (MalformedURLException e) {
+           throw new DockerException(e);
+        }
+
+        return uri.toString();
+        
+    }
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((email == null) ? 0 : email.hashCode());
+        result = prime * result + ((host == null) ? 0 : host.hashCode());
+        result = prime * result + ((password == null) ? 0 : password.hashCode());
+        result = prime * result + ((port == null) ? 0 : port.hashCode());
+        result = prime * result + ((requestTimeout == null) ? 0 : requestTimeout.hashCode());
+        result = prime * result + (secure ? 1231 : 1237);
+        result = prime * result + ((serverAddress == null) ? 0 : serverAddress.hashCode());
+        result = prime * result + ((username == null) ? 0 : username.hashCode());
+        return result;
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DockerClientProfile other = (DockerClientProfile)obj;
+        if (email == null) {
+            if (other.email != null)
+                return false;
+        } else if (!email.equals(other.email))
+            return false;
+        if (host == null) {
+            if (other.host != null)
+                return false;
+        } else if (!host.equals(other.host))
+            return false;
+        if (password == null) {
+            if (other.password != null)
+                return false;
+        } else if (!password.equals(other.password))
+            return false;
+        if (port == null) {
+            if (other.port != null)
+                return false;
+        } else if (!port.equals(other.port))
+            return false;
+        if (requestTimeout == null) {
+            if (other.requestTimeout != null)
+                return false;
+        } else if (!requestTimeout.equals(other.requestTimeout))
+            return false;
+        if (secure != other.secure)
+            return false;
+        if (serverAddress == null) {
+            if (other.serverAddress != null)
+                return false;
+        } else if (!serverAddress.equals(other.serverAddress))
+            return false;
+        if (username == null) {
+            if (other.username != null)
+                return false;
+        } else if (!username.equals(other.username))
+            return false;
+        return true;
+    }
+  
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerComponent.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerComponent.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.util.Map;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.docker.exception.DockerException;
+import org.apache.camel.impl.DefaultComponent;
+
+/**
+ * Represents the component that manages {@link DockerEndpoint}.
+ */
+public class DockerComponent extends DefaultComponent {
+    
+    private DockerConfiguration configuration;
+        
+    public DockerComponent() {
+        
+    }
+    
+    public DockerComponent(DockerConfiguration configuration) {
+        this.configuration = configuration;
+    }
+    
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        
+        DockerConfiguration configuration = getConfiguration();
+        
+        String normalizedRemaining = remaining.replaceAll("/", "");
+        
+        DockerOperation operation = DockerOperation.getDockerOperation(normalizedRemaining);
+        
+        if(operation == null) {
+            throw new DockerException(remaining + " is not a valid operation");
+        }
+        
+        configuration.setOperation(operation);
+        
+        // Validate URI Parameters
+        DockerHelper.validateParameters(operation, parameters);
+        
+        Endpoint endpoint = new DockerEndpoint(uri, this, configuration);
+        setProperties(configuration, parameters);
+        configuration.setParameters(parameters);
+                
+        return endpoint;
+    }
+    
+    protected DockerConfiguration getConfiguration() {
+        if(configuration == null) {
+            configuration = new DockerConfiguration();
+        }
+        
+        return configuration;
+    }
+        
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConfiguration.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConfiguration.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import com.github.dockerjava.api.DockerClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.component.docker.exception.DockerException;
+
+public class DockerConfiguration {
+
+
+    private Map<String, Object> parameters = new HashMap<String, Object>();
+    private Map<DockerClientProfile, DockerClient> clients = new HashMap<DockerClientProfile, DockerClient>();
+
+    private static final String DEFAULT_DOCKER_HOST = "localhost";
+    private static final int DEFAULT_DOCKER_PORT = 5000;
+    
+    private DockerOperation operation;
+
+    public void setClient(DockerClientProfile clientProfile, DockerClient client) {
+        clients.put(clientProfile, client);
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Object> parameters) {
+        this.parameters = parameters;
+    }
+
+    public DockerOperation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(DockerOperation operation) {
+        this.operation = operation;
+    }
+
+    public String getDefaultHost() {
+        return DEFAULT_DOCKER_HOST;
+    }
+
+    public Integer getDefaultPort() {
+        return DEFAULT_DOCKER_PORT;
+    }
+
+    public DockerClient getClient(DockerClientProfile clientProfile) throws DockerException {
+        return clients.get(clientProfile);
+
+    }
+
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConstants.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConstants.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Docker Component constants
+ */
+public class DockerConstants {
+    
+    public static final String DOCKER_PREFIX = "CamelDocker";
+
+    public static final Map<String,Class<?>> DOCKER_DEFAULT_PARAMETERS = new HashMap<String,Class<?>>();
+
+
+    /** Connectivity **/
+    public static final String DOCKER_HOST = "CamelDockerHost";
+    public static final String DOCKER_PORT = "CamelDockerPort";
+    public static final String DOCKER_SECURE = "CamelDockerSecure";
+    public static final String DOCKER_API_REQUEST_TIMEOUT = "CamelDockerRequestTimeout";
+    
+    
+    /** List Images **/
+    public static final String DOCKER_FILTER = "CamelDockerFilter";
+    public static final String DOCKER_SHOW_ALL = "CamelDockerShowAll";
+
+    /** Common **/
+    public static final String DOCKER_CONTAINER_ID = "CamelDockerContainerId";
+    public static final String DOCKER_IMAGE_ID = "CamelDockerImageId";
+
+    /** Auth **/
+    public static final String DOCKER_USERNAME = "CamelDockerUsername";
+    public static final String DOCKER_PASSWORD = "CamelDockerPassword";
+    public static final String DOCKER_EMAIL = "CamelDockerEmail";
+    public static final String DOCKER_SERVER_ADDRESS = "CamelDockerServerAddress";
+    
+    /** Pull **/
+    public static final String DOCKER_REPOSITORY = "CamelDockerRepository";
+    public static final String DOCKER_TAG = "CamelDockerTag";
+    public static final String DOCKER_REGISTRY = "CamelDockerRegistry";
+    
+    /** Push **/
+    public static final String DOCKER_NAME = "CamelDockerName";
+    
+    /** Search **/
+    public static final String DOCKER_TERM = "CamelDockerTerm";
+    
+    /** Remove **/
+    public static final String DOCKER_FORCE = "CamelDockerForce";
+    public static final String DOCKER_NO_PRUNE = "CamelDockerNoPrune";
+    
+    /** Events **/
+    public static final String DOCKER_INITIAL_RANGE = "CamelDockerInitialRange";
+    
+    /** List Container **/
+    public static final String DOCKER_LIMIT = "CamelDockerLimit";
+    public static final String DOCKER_SHOW_SIZE = "CamelDockerShowSize";
+    public static final String DOCKER_SINCE = "CamelDockerSince";
+    public static final String DOCKER_BEFORE = "CamelDockerBefore";
+
+
+    /** Remove Container **/
+    public static final String DOCKER_REMOVE_VOLUMES = "CamelDockerRemoveVolumes";
+
+    /** Attach Container **/
+    public static final String DOCKER_FOLLOW_STREAM = "CamelDockerFollowStream";
+    public static final String DOCKER_STD_OUT = "CamelDockerStdOut";
+    public static final String DOCKER_STD_ERR = "CamelDockerStdErr";
+    public static final String DOCKER_TIMESTAMPS = "CamelDockerTimestamps";
+    public static final String DOCKER_LOGS = "CamelDockerLogs";
+    
+    /** Logs **/
+    public static final String DOCKER_TAIL = "CamelDockerTail";
+    public static final String DOCKER_TAIL_ALL = "CamelDockerTailAll";
+    
+    /** Copy **/
+    public static final String DOCKER_RESOURCE = "CamelDockerResource";
+    public static final String DOCKER_HOST_PATH = "CamelDockerHostPath";
+    
+    /** Stop Container **/
+    public static final String DOCKER_TIMEOUT = "CamelDockerTimeout";
+
+    /** Kill Container **/
+    public static final String DOCKER_SIGNAL = "CamelDockerSignal";
+    
+    /** Top Container **/
+    public static final String DOCKER_PS_ARGS = "CamelDockerPsArgs";
+    
+    /** Build Image **/
+    public static final String DOCKER_NO_CACHE = "CamelDockerNoCache";
+    public static final String DOCKER_QUIET = "CamelDockerQuiet";
+    public static final String DOCKER_REMOVE = "CamelDockerRemove";
+    
+    /** Commit **/
+    public static final String DOCKER_COMMENT = "CamelDockerComment";
+    public static final String DOCKER_MESSAGE = "CamelDockerMessage";
+    public static final String DOCKER_AUTHOR = "CamelDockerAuthor";
+    public static final String DOCKER_ATTACH_STD_ERR = "CamelDockerAttachStdErr";
+    public static final String DOCKER_ATTACH_STD_IN = "CamelDockerAttachStdIn";
+    public static final String DOCKER_ATTACH_STD_OUT = "CamelDockerAttachStdOut";
+    public static final String DOCKER_CMD = "CamelDockerCmd";
+    public static final String DOCKER_DISABLE_NETWORK = "CamelDockerDisableNetwork";
+    public static final String DOCKER_ENV = "CamelDockerEnv";
+    public static final String DOCKER_PAUSE = "CamelDockerPause";
+    public static final String DOCKER_EXPOSED_PORTS = "CamelDockerExposedPorts";
+    public static final String DOCKER_HOSTNAME = "CamelDockerHostname";
+    public static final String DOCKER_MEMORY = "CamelDockerMemory";
+    public static final String DOCKER_MEMORY_SWAP = "CamelDockerMemorySwap";
+    public static final String DOCKER_OPEN_STD_IN = "CamelDockerOpenStdIn";
+    public static final String DOCKER_PORT_SPECS = "CamelDockerPortSpecs";
+    public static final String DOCKER_STD_IN_ONCE = "CamelDockerStdInOnce";
+    public static final String DOCKER_TTY = "CamelDockerTty";
+    public static final String DOCKER_USER = "CamelDockerUser";
+    public static final String DOCKER_VOLUMES = "CamelDockerVolumes";
+    public static final String DOCKER_WORKING_DIR = "CamelDockerWorkingDir";
+
+    /** Create Container **/
+    public static final String DOCKER_MEMORY_LIMIT = "CamelDockerMemoryLimit";    
+    public static final String DOCKER_CPU_SHARES = "CamelDockerCpuShares";
+    public static final String DOCKER_DNS = "CamelDockerDns";
+    public static final String DOCKER_IMAGE = "CamelDockerImage";
+    public static final String DOCKER_STD_IN_OPEN = "CamelDockerStdInOpen";
+    public static final String DOCKER_VOLUMES_FROM = "CamelDockerVolumesFrom";
+    
+    /** Start Container **/
+    public static final String DOCKER_BINDS = "CamelDockerBinds";    
+    public static final String DOCKER_LINKS = "CamelDockerLinks"; 
+    public static final String DOCKER_LXC_CONF = "CamelDockerLxcConf";    
+    public static final String DOCKER_PUBLISH_ALL_PORTS = "CamelDockerPublishAllPorts";
+    public static final String DOCKER_PORT_BINDINGS = "CamelDockerPortBindings"; 
+    public static final String DOCKER_PRIVILEGED = "CamelDockerDnsSearch";    
+    public static final String DOCKER_DNS_SEARCH = "CamelDockerDnsSearch";    
+    public static final String DOCKER_NETWORK_MODE = "CamelNetworkMode";
+    public static final String DOCKER_DEVICES = "CamelDockeDevices";
+    public static final String DOCKER_RESTART_POLICY = "CamelDockerRestartPolicy";
+    public static final String DOCKER_CAP_ADD = "CamelDockerCapAdd";
+    public static final String DOCKER_CAP_DROP = "CamelDockerCapDrop";
+    
+    static {
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_HOST, String.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_PORT, Integer.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_USERNAME, String.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_PASSWORD, String.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_EMAIL, String.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_SERVER_ADDRESS, String.class);
+        DOCKER_DEFAULT_PARAMETERS.put(DOCKER_SECURE, Boolean.class);
+    }
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerEndpoint.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerEndpoint.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.component.docker.consumer.DockerEventsConsumer;
+import org.apache.camel.component.docker.exception.DockerException;
+import org.apache.camel.component.docker.producer.DockerProducer;
+import org.apache.camel.impl.DefaultEndpoint;
+import org.apache.camel.spi.UriEndpoint;
+
+/**
+ * Represents a Docker endpoint.
+ */
+@UriEndpoint(scheme = "docker", consumerClass = DockerEventsConsumer.class)
+public class DockerEndpoint extends DefaultEndpoint {
+
+    private DockerConfiguration configuration;
+
+    public DockerEndpoint() {
+    }
+
+    public DockerEndpoint(String uri, DockerComponent component, DockerConfiguration configuration) {
+        super(uri, component);
+        this.configuration = configuration;
+    }
+
+    public DockerEndpoint(String endpointUri) {
+        super(endpointUri);
+    }
+
+    public Producer createProducer() throws Exception {
+        DockerOperation operation = configuration.getOperation();
+        
+        if(operation != null && operation.canProduce()) {
+            return new DockerProducer(this);
+        }
+        else {
+            throw new DockerException(operation + " is not a valid producer operation");
+        }
+    }
+
+    public Consumer createConsumer(Processor processor) throws Exception {
+
+        DockerOperation operation = configuration.getOperation();
+
+        switch (operation) {
+            case EVENTS:
+                return new DockerEventsConsumer(this, processor);
+            default:
+                throw new DockerException(operation + " is not a valid consumer operation");
+        }
+
+    }
+    
+
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public DockerConfiguration getConfiguration() {
+        return configuration;
+    }
+    
+    @Override
+    public boolean isLenientProperties() {
+        return true;
+    }
+
+ 
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerHelper.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerHelper.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import com.github.dockerjava.api.DockerClientException;
+import com.github.dockerjava.api.model.AuthConfig;
+
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Message;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.commons.lang.BooleanUtils;
+
+/**
+ * Utility methods for Docker Component
+ */
+public class DockerHelper {
+    
+    private static final String STRING_DELIMITER = ";";
+    
+    /**
+     * Validates the URI parameters for a given {@link DockerOperation}
+     * 
+     * @param dockerOperation
+     * @param parameters
+     */
+    public static void validateParameters(DockerOperation dockerOperation, Map<String,Object> parameters) {
+        Map<String,Class<?>> validParamMap = new HashMap<String,Class<?>>();
+        validParamMap.putAll(DockerConstants.DOCKER_DEFAULT_PARAMETERS);
+        validParamMap.putAll(dockerOperation.getParameters());
+        
+        for(String key : parameters.keySet()) {
+            
+            String transformedKey = DockerHelper.transformToHeaderName(key);
+            
+            // Validate URI parameter name
+            if(!validParamMap.containsKey(transformedKey)) {
+                throw new DockerClientException(key + " is not a valid URI parameter");
+            }
+            
+            
+            try {
+                Class<?> parameterClass = validParamMap.get(transformedKey);
+                Object parameterValue = parameters.get(key);
+                
+                if(parameterClass == null || parameterValue == null) {
+                    throw new DockerClientException("Failed to validate parameter type for property " + key);
+                } 
+                
+                if(Integer.class == parameterClass) {
+                    Integer.parseInt((String)parameterValue);
+                }
+                else if(Boolean.class == parameterClass) {
+                    BooleanUtils.toBooleanObject((String)parameterValue, "true", "false", "null");
+                }
+                
+                
+            }
+            catch(Exception e) {
+                throw new DockerClientException("Failed to validate parameter type for property " + key);                    
+            }
+        }
+              
+    }
+    
+    /**
+     * Transforms a Docker Component header value to its' analogous URI parameter
+     * @param name
+     * @return
+     */
+    public static String transformFromHeaderName(String name) {
+        ObjectHelper.notEmpty(name, "name");
+        
+        StringBuilder formattedName = new StringBuilder();
+        
+        String nameSubstring = name.substring(DockerConstants.DOCKER_PREFIX.length());
+        
+        if(nameSubstring.length() > 0) {
+            formattedName.append(nameSubstring.substring(0,1).toLowerCase());
+            formattedName.append(nameSubstring.substring(1));   
+        }
+        
+        return formattedName.toString();
+    }
+
+    /**
+     * Transforms a Docker Component URI parameter to its' analogous header value
+     * @param name
+     * @return
+     */
+    public static String transformToHeaderName(String name) {
+        ObjectHelper.notEmpty(name, "name");
+        
+        StringBuilder formattedName = new StringBuilder(DockerConstants.DOCKER_PREFIX);
+        
+        
+        if(name.length() > 0) {
+            formattedName.append(name.substring(0,1).toUpperCase());
+            formattedName.append(name.substring(1));   
+        }
+        
+        return formattedName.toString();
+    }
+    
+    /**
+     * Attempts to locate a given property name within a URI parameter or the message header. 
+     * A found value in a message header takes precedence over a URI parameter.
+     * 
+     * @param name
+     * @param configuration
+     * @param message
+     * @param clazz
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T getProperty(String name, DockerConfiguration configuration, Message message, Class<T> clazz) {
+        // First attempt to locate property from Message Header, then fallback to Endpoint property
+       
+        if(message != null) {
+            T headerProperty = message.getHeader(name, clazz);
+            
+            if(headerProperty != null) {
+                return headerProperty;
+            }
+        }
+        
+        Object prop = configuration.getParameters().get(transformFromHeaderName(name));
+        
+        if(prop != null) {
+            
+            if(prop.getClass().isAssignableFrom(clazz)) {
+                return (T) prop;
+            }
+            else if(Integer.class == clazz) {
+               return (T) Integer.valueOf((String)prop);
+            }
+            else if(Boolean.class == clazz) {
+                return (T)BooleanUtils.toBooleanObject((String)prop, "true", "false", "null");
+            }
+        }
+        
+        return null;
+        
+        
+    }
+    
+    /**
+     * Attempts to locate a given property which is an array by name within a URI parameter or the message header. 
+     * A found value in a message header takes precedence over a URI parameter.
+     * 
+     * @param name
+     * @param message
+     * @param clazz
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] getArrayProperty(String name, Message message, Class<T> clazz) {
+       
+        if(message != null) {
+            Object header = message.getHeader(name);
+            
+            if(header != null) {
+                if(header.getClass().isAssignableFrom(clazz)) {
+                    
+                    T[] headerArray = (T[])Array.newInstance(clazz, 1);
+                    headerArray[0] = (T) header;
+                    return headerArray;
+                    
+                }
+                
+                if(header.getClass().isArray()) {
+                    if(header.getClass().getDeclaringClass().isAssignableFrom(clazz)) {
+                        return (T[])header;
+                    }
+                }
+            }
+            
+        }
+        
+        return null;
+        
+    }
+    
+    public static AuthConfig getAuthConfig(DockerConfiguration configuration, Message message) {
+        String username = getProperty(DockerConstants.DOCKER_USERNAME, configuration, message, String.class);
+        String password = getProperty(DockerConstants.DOCKER_PASSWORD, configuration, message, String.class);
+
+        ObjectHelper.notNull(username, "username");
+        ObjectHelper.notNull(password, "password");
+        
+        String email = getProperty(DockerConstants.DOCKER_EMAIL, configuration, message, String.class);
+        String serverAddress = getProperty(DockerConstants.DOCKER_SERVER_ADDRESS, configuration, message, String.class);
+
+        
+        AuthConfig authConfig = new AuthConfig();
+        authConfig.setUsername(username);
+        authConfig.setPassword(password);
+        authConfig.setEmail(email);
+        authConfig.setServerAddress(serverAddress);
+        
+        return authConfig;
+    }
+    
+    public static String[] parseDelimitedStringHeader(String headerName, Message message) {
+        
+        
+        Object header = message.getHeader(headerName);
+        
+        if(header != null) {
+            
+            if(header instanceof String) {
+                return ((String) header).split(STRING_DELIMITER);
+            }
+            
+            if(header instanceof String[]) {
+                return((String[]) header);
+            }
+        }
+        
+        
+        return null;
+        
+    }
+    
+    
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerOperation.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerOperation.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Operations the Docker Component supports
+ */
+public enum DockerOperation {
+    
+    EVENTS("events",false,true,
+         DockerConstants.DOCKER_INITIAL_RANGE, Long.class),        
+    AUTH("auth",false,true,
+         DockerConstants.DOCKER_USERNAME, String.class,
+         DockerConstants.DOCKER_PASSWORD, String.class,
+         DockerConstants.DOCKER_EMAIL, String.class,
+         DockerConstants.DOCKER_SERVER_ADDRESS, String.class),
+    INFO("info",false,true),
+    PING("ping",false,true),
+    VERSION("version",false,true),
+    LIST_IMAGES("imagelist",false,true,
+         DockerConstants.DOCKER_FILTER, String.class,
+         DockerConstants.DOCKER_SHOW_ALL, Boolean.class),
+    PULL_IMAGE("imagepull",false,true,
+         DockerConstants.DOCKER_REGISTRY, String.class,
+         DockerConstants.DOCKER_TAG, String.class,
+         DockerConstants.DOCKER_REPOSITORY, String.class),
+    PUSH_IMAGE("imagepush",false,true,
+         DockerConstants.DOCKER_NAME, String.class,
+         DockerConstants.DOCKER_USERNAME, String.class,
+         DockerConstants.DOCKER_PASSWORD, String.class,
+         DockerConstants.DOCKER_EMAIL, String.class,
+         DockerConstants.DOCKER_SERVER_ADDRESS, String.class),
+    CREATE_IMAGE("imagecreate",false,true,
+         DockerConstants.DOCKER_REPOSITORY, String.class),
+    SEARCH_IMAGES("imagesearch",false,true,
+         DockerConstants.DOCKER_TERM, String.class),
+    REMOVE_IMAGE("imageremove",false,true,
+         DockerConstants.DOCKER_IMAGE_ID, String.class,
+         DockerConstants.DOCKER_FORCE, Boolean.class,
+         DockerConstants.DOCKER_NO_PRUNE, String.class),
+    INSPECT_IMAGE("imageinspect",false,true,
+         DockerConstants.DOCKER_IMAGE_ID, String.class,
+         DockerConstants.DOCKER_NO_PRUNE, Boolean.class,
+         DockerConstants.DOCKER_FORCE, Boolean.class),
+    LIST_CONTAINERS("containerlist",false,true,
+         DockerConstants.DOCKER_LIMIT, String.class,
+         DockerConstants.DOCKER_SHOW_ALL, Boolean.class,
+         DockerConstants.DOCKER_SHOW_SIZE, Boolean.class,
+         DockerConstants.DOCKER_BEFORE, String.class,
+         DockerConstants.DOCKER_SINCE, String.class),   
+    WAIT_CONTAINER("containerwait",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class),
+    INSPECT_CONTAINER("inspectcontainer",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class),  
+    REMOVE_CONTAINER("removecontainer",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_FORCE, Boolean.class,
+         DockerConstants.DOCKER_REMOVE_VOLUMES, Boolean.class),
+    ATTACH_CONTAINER("containerattach",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_FOLLOW_STREAM, Boolean.class,
+         DockerConstants.DOCKER_TIMESTAMPS, Boolean.class,
+         DockerConstants.DOCKER_STD_OUT, Boolean.class,
+         DockerConstants.DOCKER_STD_ERR, Boolean.class,
+         DockerConstants.DOCKER_LOGS, Boolean.class), 
+    LOG_CONTAINER("containerlog",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_FOLLOW_STREAM, Boolean.class,
+         DockerConstants.DOCKER_TIMESTAMPS, Boolean.class,
+         DockerConstants.DOCKER_STD_OUT, Boolean.class,
+         DockerConstants.DOCKER_STD_ERR, Boolean.class,
+         DockerConstants.DOCKER_TAIL, Integer.class,
+         DockerConstants.DOCKER_TAIL_ALL, Boolean.class),
+    CONTAINER_COPY_FILE("containercopyfile",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_RESOURCE, String.class,
+         DockerConstants.DOCKER_HOST_PATH, String.class),
+    DIFF_CONTAINER("containerdiff",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class),
+    STOP_CONTAINER("containerstop",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_TIMEOUT, Integer.class),
+    KILL_CONTAINER("containerkill",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_SIGNAL, String.class),
+    RESTART_CONTAINER("containerrestart",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_TIMEOUT, Integer.class),
+    TOP_CONTAINER("containertop",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_TIMEOUT, Integer.class),    
+    TAG_IMAGE("imagetag",false,true,
+         DockerConstants.DOCKER_IMAGE_ID, String.class,
+         DockerConstants.DOCKER_REPOSITORY, String.class,
+         DockerConstants.DOCKER_FORCE, Boolean.class),
+    PAUSE_CONTAINER("containerpause",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class),
+    UNPAUSE_CONTAINER("containerunpause",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class),
+    BUILD_IMAGE("imagebuild",false,true,
+         DockerConstants.DOCKER_NO_CACHE, Boolean.class,
+         DockerConstants.DOCKER_REMOVE, Boolean.class,
+         DockerConstants.DOCKER_QUIET, Boolean.class),
+    COMMIT_CONTAINER("containercommit",false,true,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_REPOSITORY, String.class,
+         DockerConstants.DOCKER_TAG, String.class,
+         DockerConstants.DOCKER_MESSAGE, String.class,
+         DockerConstants.DOCKER_AUTHOR, String.class,
+         DockerConstants.DOCKER_ATTACH_STD_ERR, Boolean.class,
+         DockerConstants.DOCKER_ATTACH_STD_IN, Boolean.class,
+         DockerConstants.DOCKER_ATTACH_STD_OUT, Boolean.class,
+         DockerConstants.DOCKER_PAUSE, Boolean.class,
+         DockerConstants.DOCKER_ENV, String.class,
+         DockerConstants.DOCKER_HOSTNAME, String.class,
+         DockerConstants.DOCKER_MEMORY, Integer.class,
+         DockerConstants.DOCKER_MEMORY_SWAP, Integer.class,
+         DockerConstants.DOCKER_OPEN_STD_IN, Boolean.class,
+         DockerConstants.DOCKER_PORT_SPECS, String.class,
+         DockerConstants.DOCKER_STD_IN_ONCE, Boolean.class,
+         DockerConstants.DOCKER_TTY, Boolean.class,
+         DockerConstants.DOCKER_WORKING_DIR, String.class),
+   CREATE_CONTAINER("containercreate",false,true,
+         DockerConstants.DOCKER_IMAGE_ID, String.class,
+         DockerConstants.DOCKER_NAME, String.class,
+         DockerConstants.DOCKER_WORKING_DIR, String.class,
+         DockerConstants.DOCKER_DISABLE_NETWORK, Boolean.class,
+         DockerConstants.DOCKER_HOSTNAME, String.class,
+         DockerConstants.DOCKER_PORT_SPECS, String.class,
+         DockerConstants.DOCKER_USER, String.class,
+         DockerConstants.DOCKER_TTY, Boolean.class,
+         DockerConstants.DOCKER_STD_IN_OPEN, Boolean.class,
+         DockerConstants.DOCKER_STD_IN_ONCE, Boolean.class,
+         DockerConstants.DOCKER_MEMORY_LIMIT, Long.class,
+         DockerConstants.DOCKER_MEMORY_SWAP, Long.class,
+         DockerConstants.DOCKER_CPU_SHARES, Integer.class,
+         DockerConstants.DOCKER_ATTACH_STD_IN, Boolean.class,
+         DockerConstants.DOCKER_ATTACH_STD_OUT, Boolean.class,
+         DockerConstants.DOCKER_ATTACH_STD_ERR, Boolean.class,
+         DockerConstants.DOCKER_ENV, String.class,
+         DockerConstants.DOCKER_CMD, String.class,
+         DockerConstants.DOCKER_DNS, String.class,
+         DockerConstants.DOCKER_IMAGE, String.class,
+         DockerConstants.DOCKER_VOLUMES_FROM, String.class),   
+    START_CONTAINER("containerstart",false,true,
+         DockerConstants.DOCKER_PUBLISH_ALL_PORTS, Boolean.class,
+         DockerConstants.DOCKER_PRIVILEGED, Boolean.class,
+         DockerConstants.DOCKER_DNS, String.class,
+         DockerConstants.DOCKER_DNS_SEARCH, String.class,
+         DockerConstants.DOCKER_CONTAINER_ID, String.class,
+         DockerConstants.DOCKER_VOLUMES_FROM, String.class,
+         DockerConstants.DOCKER_NETWORK_MODE, String.class,
+         DockerConstants.DOCKER_CAP_ADD, String.class,
+         DockerConstants.DOCKER_CAP_DROP, String.class);
+    
+    
+    private String text;
+    private boolean canConsume, canProduce;
+    private Map<String, Class<?>> parameters;
+    
+    
+    private DockerOperation(String text, boolean canConsume, boolean canProduce, Object... params) {
+        
+        this.text = text;
+        this.canConsume = canConsume;
+        this.canProduce = canProduce;
+        
+        parameters = new HashMap<String,Class<?>>();
+              
+        if(params.length > 0) {
+            
+            if(params.length % 2 != 0) {
+                throw new IllegalArgumentException("Invalid parameter list, "
+                    + "must be of the form 'String name1, Class class1, String name2, Class class2...");
+            }
+            
+            int nParameters = params.length / 2;
+            
+            for(int i = 0; i < nParameters; i++) {
+                parameters.put((String) params[i * 2], (Class<?>) params[i * 2 + 1]);
+            }
+            
+   
+        }
+        
+    }
+    
+    @Override
+    public String toString() {
+        return text;
+    }
+    
+    public boolean canConsume() {
+        return canConsume;
+    }
+    
+    public boolean canProduce() {
+        return canProduce;
+    }
+    
+    public Map<String,Class<?>> getParameters() {
+        return parameters;
+    }
+    
+    public static DockerOperation getDockerOperation(String name) {
+        for(DockerOperation dockerOperation : DockerOperation.values()) {
+            if(dockerOperation.toString().equals(name)) {
+                return dockerOperation;
+            }
+        }
+        
+        return null;
+    }
+
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerEventsConsumer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerEventsConsumer.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.consumer;
+
+import com.github.dockerjava.api.command.EventCallback;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.model.Event;
+
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.component.docker.DockerClientFactory;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerEndpoint;
+import org.apache.camel.component.docker.DockerHelper;
+import org.apache.camel.impl.DefaultConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Docker Consumer for streaming events
+ */
+public class DockerEventsConsumer extends DefaultConsumer implements EventCallback {
+
+    private transient static final Logger LOGGER = LoggerFactory.getLogger(DockerEventsConsumer.class);
+
+    private DockerEndpoint endpoint;
+        
+    private EventsCmd eventsCmd;
+    
+    private ExecutorService eventsExecutorService;
+
+    public DockerEventsConsumer(DockerEndpoint endpoint, Processor processor) throws Exception {
+        super(endpoint, processor);
+        this.endpoint = endpoint;
+              
+    }
+
+    @Override
+    public DockerEndpoint getEndpoint() {
+        return (DockerEndpoint)super.getEndpoint();
+    }
+    
+
+    /**
+     * Determine the point in time to begin streaming events
+     */
+    private long processInitialEvent()  {
+
+        long currentTime = new Date().getTime();
+        
+        Long initialRange = DockerHelper.getProperty(DockerConstants.DOCKER_INITIAL_RANGE, endpoint.getConfiguration(), null, Long.class);
+
+        if (initialRange != null) {
+            currentTime = currentTime - initialRange;
+        } 
+        
+        return currentTime;
+        
+        
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        
+        eventsCmd = DockerClientFactory.getDockerClient(endpoint.getConfiguration(), null).eventsCmd(this);
+        
+        eventsCmd.withSince(String.valueOf(processInitialEvent()));
+        eventsExecutorService =  eventsCmd.exec();
+
+        super.doStart();
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+ 
+        if(eventsExecutorService != null && !eventsExecutorService.isTerminated()) {
+            LOGGER.trace("Stopping Docker events Executor Service");
+            
+            eventsExecutorService.shutdown();
+        }
+
+        super.doStop();
+    }
+       
+
+    @Override
+    public void onEvent(Event event) {
+        
+        LOGGER.debug("Received Docker Event: " + event);
+                
+        final Exchange exchange = getEndpoint().createExchange();
+        Message message = exchange.getIn();
+        message.setBody(event);
+        
+        try {
+            LOGGER.trace("Processing exchange [{}]...", exchange);
+            getAsyncProcessor().process(exchange, new AsyncCallback() {
+                @Override
+                public void done(boolean doneSync) {
+                    LOGGER.trace("Done processing exchange [{}]...", exchange);
+                }
+            });
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+        if (exchange.getException() != null) {
+            getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
+        }
+        
+    }
+
+    @Override
+    public void onException(Throwable throwable) {
+       LOGGER.error("Error Consuming from Docker Events: {}", throwable.getMessage());
+        
+    }
+
+    @Override
+    public void onCompletion(int numEvents) {
+        
+        LOGGER.debug("Docker events connection completed. Events processed : {}", numEvents);
+        
+        eventsCmd.withSince(null);
+        
+        LOGGER.debug("Reestablishing connection with Docker");
+        eventsCmd.exec();
+        
+    }
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/exception/DockerException.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/exception/DockerException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.exception;
+
+/**
+ * Errors occurring during the processing of the Docker component
+ */
+public class DockerException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public DockerException(String message) {
+        super(message);
+    }
+    
+    public DockerException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
@@ -1,0 +1,1411 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.producer;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.DockerCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Device;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.ExposedPorts;
+import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LxcConf;
+import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.Volumes;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.component.docker.DockerClientFactory;
+import org.apache.camel.component.docker.DockerConfiguration;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerEndpoint;
+import org.apache.camel.component.docker.DockerHelper;
+import org.apache.camel.component.docker.DockerOperation;
+import org.apache.camel.component.docker.exception.DockerException;
+import org.apache.camel.impl.DefaultProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Docker producer.
+ */
+public class DockerProducer extends DefaultProducer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerProducer.class);
+    private DockerConfiguration configuration;
+
+    public DockerProducer(DockerEndpoint endpoint) {
+        super(endpoint);
+        this.configuration = endpoint.getConfiguration();
+    }
+
+    public void process(Exchange exchange) throws Exception {
+        
+        DockerCmd<?> dockerCmd = null;
+        
+        Message message = exchange.getIn();
+        DockerClient client = DockerClientFactory.getDockerClient(configuration, message);
+        
+        DockerOperation operation = configuration.getOperation();
+        
+        switch(operation) {
+        
+            case AUTH:
+                dockerCmd = executeAuthRequest(client,message);
+                break;
+            case INFO:
+                dockerCmd = executeInfoRequest(client,message);
+                break;
+            case LIST_IMAGES:
+                dockerCmd = executeListImagesRequest(client,message);
+                break;
+            case PING:
+                dockerCmd = executePingRequest(client,message);
+                break;
+            case VERSION:
+                dockerCmd = executeVersionRequest(client,message);
+                break;
+            case PULL_IMAGE:
+                dockerCmd = executePullImageRequest(client,message);
+                break;
+            case PUSH_IMAGE:
+                dockerCmd = executePushImageRequest(client,message);
+                break;
+            case CREATE_IMAGE:
+                dockerCmd = executeCreateImageRequest(client,message);
+                break;
+            case SEARCH_IMAGES:
+                dockerCmd = executeSearchImageRequest(client,message);
+                break;
+            case REMOVE_IMAGE:
+                dockerCmd = executeRemoveImageRequest(client,message);
+                break;
+            case INSPECT_IMAGE:
+                dockerCmd = executeInspectImageRequest(client,message);
+                break;
+            case LIST_CONTAINERS:
+                dockerCmd = executeListContainersRequest(client,message);
+                break;
+            case REMOVE_CONTAINER:
+                dockerCmd = executeRemoveContainerRequest(client,message);
+                break;
+            case INSPECT_CONTAINER:
+                dockerCmd = executeInspectContainerRequest(client,message);
+                break;
+            case WAIT_CONTAINER:
+                dockerCmd = executeWaitContainerRequest(client,message);
+                break;
+            case ATTACH_CONTAINER:
+                dockerCmd = executeAttachContainerRequest(client,message);
+                break;   
+            case LOG_CONTAINER:
+                dockerCmd = executeLogContainerRequest(client,message);
+                break;
+            case CONTAINER_COPY_FILE:
+                dockerCmd = executeCopyFileContainerRequest(client,message);
+                break; 
+            case DIFF_CONTAINER:
+                dockerCmd = executeDiffContainerRequest(client,message);
+                break; 
+            case STOP_CONTAINER:
+                dockerCmd = executeStopContainerRequest(client,message);
+                break; 
+            case KILL_CONTAINER:
+                dockerCmd = executeKillContainerRequest(client,message);
+                break; 
+            case RESTART_CONTAINER:
+                dockerCmd = executeRestartContainerRequest(client,message);
+                break; 
+            case TOP_CONTAINER:
+                dockerCmd = executeTopContainerRequest(client,message);
+                break; 
+            case TAG_IMAGE:
+                dockerCmd = executeTagImageRequest(client,message);
+                break;
+            case PAUSE_CONTAINER:
+                dockerCmd = executePauseContainerRequest(client,message);
+                break;
+            case UNPAUSE_CONTAINER:
+                dockerCmd = executeUnpauseContainerRequest(client,message);
+                break;
+            case BUILD_IMAGE:
+                dockerCmd = executeBuildImageRequest(client,message);
+                break;
+            case COMMIT_CONTAINER:
+                dockerCmd = executeCommitContainerRequest(client,message);
+                break;
+            case CREATE_CONTAINER:
+                dockerCmd = executeCreateContainerRequest(client,message);
+                break;
+            case START_CONTAINER:
+                dockerCmd = executeStartContainerRequest(client,message);
+                break;
+            default:
+               throw new DockerException("Invalid operation: " + operation);
+        }
+        
+        Object result = dockerCmd.exec();
+        
+        // If request included a response, set as body
+        if(result != null) {
+            exchange.getIn().setBody(result);
+        }
+    
+    }
+    
+    /*********************
+     * Misc Requests
+     ********************/
+    
+    /**
+     * Produces a Authorization request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private AuthCmd executeAuthRequest(DockerClient client, Message message) throws DockerException {
+     
+        LOGGER.debug("Executing Docker Auth Request");
+        
+        return client.authCmd();
+    }
+    
+    /**
+     * Produces a platform information request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private InfoCmd executeInfoRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Info Request");
+        
+        InfoCmd infoCmd = client.infoCmd();
+        
+        return infoCmd;
+
+    }
+    
+    /**
+     * Executes a ping platform request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private PingCmd executePingRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Ping Request");
+        
+        PingCmd pingCmd = client.pingCmd();
+        
+        return pingCmd;
+
+    }
+    
+    /**
+     * Executes a platform version request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private VersionCmd executeVersionRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Version Request");
+        
+        VersionCmd versionCmd = client.versionCmd();
+        
+        return versionCmd;
+
+    }
+    
+    
+    /*********************
+     * Image Requests
+     ********************/
+    
+    
+    
+    /**
+     * Performs a list images request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private ListImagesCmd executeListImagesRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Images List Request");
+        
+        ListImagesCmd listImagesCmd = client.listImagesCmd();
+        
+        String filter = DockerHelper.getProperty(DockerConstants.DOCKER_FILTER,configuration, message, String.class);
+        
+        if(filter != null) {
+            listImagesCmd.withFilter(filter);
+        }
+        
+        Boolean showAll = DockerHelper.getProperty(DockerConstants.DOCKER_SHOW_ALL,configuration, message, Boolean.class);
+        
+        if(showAll != null && showAll) {
+            listImagesCmd.withShowAll(showAll);
+        }
+
+        return listImagesCmd;
+
+    }
+    
+    /**
+     * Performs a create image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private CreateImageCmd executeCreateImageRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Create Image Request");
+        
+        String repository = DockerHelper.getProperty(DockerConstants.DOCKER_REPOSITORY, configuration, message, String.class);
+        
+        InputStream inputStream = message.getBody(InputStream.class);
+        
+        CreateImageCmd createImageCmd = client.createImageCmd(repository, inputStream);
+        
+        return createImageCmd;
+
+    }
+    
+    /**
+     * Produces a build image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private BuildImageCmd executeBuildImageRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Build Image Request");
+        
+        Object body = message.getBody();
+        
+        BuildImageCmd buildImageCmd;
+        
+        if(body != null && body instanceof InputStream) {
+            buildImageCmd = client.buildImageCmd((InputStream) body);
+        }
+        else if (body != null && body instanceof File) {
+            buildImageCmd = client.buildImageCmd((File) body);
+        }
+        else {
+            throw new DockerException("Unable to location source Image");
+        }
+    
+        Boolean noCache = DockerHelper.getProperty(DockerConstants.DOCKER_NO_CACHE,configuration, message, Boolean.class);
+
+        if(noCache != null && noCache) {
+            buildImageCmd.withNoCache();
+        }
+        
+        Boolean quiet = DockerHelper.getProperty(DockerConstants.DOCKER_QUIET,configuration, message, Boolean.class);
+
+        if(quiet != null && quiet) {
+            buildImageCmd.withQuiet();
+        }
+        
+        Boolean remove = DockerHelper.getProperty(DockerConstants.DOCKER_REMOVE,configuration, message, Boolean.class);
+
+        if(remove != null && remove) {
+            buildImageCmd.withRemove();
+        }
+        
+        String tag = DockerHelper.getProperty(DockerConstants.DOCKER_TAG,configuration, message, String.class);
+
+        if(tag != null) {
+            buildImageCmd.withTag(tag);
+        }
+        
+        return buildImageCmd;
+
+    }
+    
+    
+    /**
+     * Produces a pull image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private PullImageCmd executePullImageRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Pull Image Request");
+        
+        String repository = DockerHelper.getProperty(DockerConstants.DOCKER_REPOSITORY, configuration, message, String.class);
+                
+        PullImageCmd pullImageCmd = client.pullImageCmd(repository);
+        
+        String registry = DockerHelper.getProperty(DockerConstants.DOCKER_REGISTRY, configuration, message, String.class);
+        if(registry != null) {
+            pullImageCmd.withRegistry(registry);
+        }
+        
+        String tag = DockerHelper.getProperty(DockerConstants.DOCKER_TAG, configuration, message, String.class);
+        if(tag != null) {
+            pullImageCmd.withTag(tag);
+        }
+        
+        return pullImageCmd;
+
+    }
+    
+    /**
+     * Produces a push image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private PushImageCmd executePushImageRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Push Image Request");
+        
+        String name = DockerHelper.getProperty(DockerConstants.DOCKER_NAME, configuration, message, String.class);
+        
+        PushImageCmd pushImageCmd = client.pushImageCmd(name);  
+   
+        AuthConfig authConfig = getAuthConfig(client);
+    
+        if(authConfig != null) {
+            pushImageCmd.withAuthConfig(authConfig);
+        }
+        
+        return pushImageCmd;
+    
+    }
+    
+    
+    /**
+     * Produces a search image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private SearchImagesCmd executeSearchImageRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Search Image Request");
+        
+        String term = DockerHelper.getProperty(DockerConstants.DOCKER_TERM, configuration, message, String.class);
+        
+        SearchImagesCmd searchImagesCmd = client.searchImagesCmd(term);
+        
+        return searchImagesCmd;
+
+    }
+    
+    
+    /**
+     * Produces a remove image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private RemoveImageCmd executeRemoveImageRequest(DockerClient client, Message message) throws DockerException {
+
+        LOGGER.debug("Executing Docker Remove Image Request");
+        
+        String imageId = DockerHelper.getProperty(DockerConstants.DOCKER_IMAGE_ID, configuration, message, String.class);
+        
+        RemoveImageCmd removeImagesCmd = client.removeImageCmd(imageId);
+        
+        Boolean force = DockerHelper.getProperty(DockerConstants.DOCKER_FORCE, configuration, message, Boolean.class);
+        
+        if(force != null && force) {
+            removeImagesCmd.withForce();
+        }
+        
+        Boolean prune = DockerHelper.getProperty(DockerConstants.DOCKER_NO_PRUNE, configuration, message, Boolean.class);
+        
+        if(prune != null && prune) {
+            removeImagesCmd.withNoPrune();
+        }
+        
+        return removeImagesCmd;
+
+    }
+    
+    /**
+     * Produces a tag image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private TagImageCmd executeTagImageRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Tag Image Request");
+        
+        String imageId = DockerHelper.getProperty(DockerConstants.DOCKER_IMAGE_ID,configuration, message, String.class);
+        
+        String repository = DockerHelper.getProperty(DockerConstants.DOCKER_REPOSITORY,configuration, message, String.class);
+   
+        String tag = DockerHelper.getProperty(DockerConstants.DOCKER_TAG,configuration, message, String.class);
+       
+        TagImageCmd tagImageCmd = client.tagImageCmd(imageId, repository, tag);
+
+        Boolean force = DockerHelper.getProperty(DockerConstants.DOCKER_FORCE,configuration, message, Boolean.class);
+        
+        if(force != null && force) {
+            tagImageCmd.withForce();
+        }
+             
+        return tagImageCmd;
+
+    }
+
+   
+    /**
+     * Produces a inspect image request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private InspectImageCmd executeInspectImageRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Inspect Image Request");
+
+        String imageId = DockerHelper.getProperty(DockerConstants.DOCKER_IMAGE_ID,configuration, message, String.class);
+        
+        InspectImageCmd inspectImageCmd = client.inspectImageCmd(imageId);
+        
+        return inspectImageCmd;
+
+    }
+    
+    /*********************
+     * Container Requests
+     ********************/
+    
+    
+    /**
+     * Produces a list containers request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private ListContainersCmd executeListContainersRequest(DockerClient client, Message message) throws DockerException {
+  
+        LOGGER.debug("Executing Docker List Container Request");
+        
+        ListContainersCmd listContainersCmd = client.listContainersCmd();
+ 
+        Boolean showSize = DockerHelper.getProperty(DockerConstants.DOCKER_SHOW_SIZE, configuration, message, Boolean.class);
+        if(showSize != null && showSize) {
+            listContainersCmd.withShowSize(showSize);
+        }
+        
+        Boolean showAll = DockerHelper.getProperty(DockerConstants.DOCKER_SHOW_ALL, configuration, message, Boolean.class);
+        if(showAll != null && showAll) {
+            listContainersCmd.withShowAll(showAll);
+        }
+       
+        String before = DockerHelper.getProperty(DockerConstants.DOCKER_BEFORE, configuration, message, String.class);
+        if(before != null) {
+            listContainersCmd.withBefore(before);
+        }
+        
+        Integer limit = DockerHelper.getProperty(DockerConstants.DOCKER_LIMIT, configuration, message, Integer.class);
+        if(limit != null) {
+            listContainersCmd.withLimit(limit);
+        }
+        
+        String since = DockerHelper.getProperty(DockerConstants.DOCKER_SINCE, configuration, message, String.class);
+        if(since != null) {
+            listContainersCmd.withSince(since);
+        }
+
+        return listContainersCmd;
+
+    }
+    
+    /**
+     * Produce a create container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private CreateContainerCmd executeCreateContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker List Container Request");
+        
+        String imageId = DockerHelper.getProperty(DockerConstants.DOCKER_IMAGE_ID,configuration, message, String.class);
+        
+        CreateContainerCmd createContainerCmd = client.createContainerCmd(imageId);
+        
+        String name = DockerHelper.getProperty(DockerConstants.DOCKER_NAME,configuration, message, String.class);
+
+        if(name != null) {
+            createContainerCmd.withName(name);
+        }
+
+        ExposedPort[] exposedPorts = DockerHelper.getArrayProperty(DockerConstants.DOCKER_EXPOSED_PORTS, message, ExposedPort.class);
+
+        if(exposedPorts != null) {
+            createContainerCmd.withExposedPorts(exposedPorts);
+        }
+        
+        String workingDir = DockerHelper.getProperty(DockerConstants.DOCKER_WORKING_DIR,configuration, message, String.class);
+
+        if(workingDir != null) {
+            createContainerCmd.withWorkingDir(workingDir);
+        }  
+        
+        Boolean disabledNetwork = DockerHelper.getProperty(DockerConstants.DOCKER_DISABLE_NETWORK,configuration, message, Boolean.class);
+
+        if(disabledNetwork != null && disabledNetwork) {
+            createContainerCmd.withDisableNetwork(disabledNetwork);
+        }
+        
+        String hostName = DockerHelper.getProperty(DockerConstants.DOCKER_HOSTNAME,configuration, message, String.class);
+
+        if(hostName != null) {
+            createContainerCmd.withHostName(hostName);
+        }  
+        
+        String[] portSpecs = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_PORT_SPECS, message);
+
+        if(portSpecs != null) {
+            createContainerCmd.withPortSpecs(portSpecs);
+        }
+        
+        String user = DockerHelper.getProperty(DockerConstants.DOCKER_USER,configuration, message, String.class);
+
+        if(hostName != null) {
+            createContainerCmd.withUser(user);
+        }  
+        
+        Boolean tty = DockerHelper.getProperty(DockerConstants.DOCKER_TTY,configuration, message, Boolean.class);
+
+        if(tty != null && tty) {
+            createContainerCmd.withTty(tty);
+        }
+        
+        Boolean stdInOpen = DockerHelper.getProperty(DockerConstants.DOCKER_STD_IN_OPEN,configuration, message, Boolean.class);
+
+        if(stdInOpen != null && stdInOpen) {
+            createContainerCmd.withStdinOpen(stdInOpen);
+        }
+        
+        Boolean stdInOnce = DockerHelper.getProperty(DockerConstants.DOCKER_STD_IN_ONCE,configuration, message, Boolean.class);
+
+        if(stdInOnce != null && stdInOnce) {
+            createContainerCmd.withStdInOnce(stdInOnce);
+        }
+        
+        Long memoryLimit = DockerHelper.getProperty(DockerConstants.DOCKER_MEMORY_LIMIT,configuration, message, Long.class);
+
+        if(memoryLimit != null) {
+            createContainerCmd.withMemoryLimit(memoryLimit);
+        }
+
+        Long memorySwap = DockerHelper.getProperty(DockerConstants.DOCKER_MEMORY_SWAP,configuration, message, Long.class);
+
+        if(memorySwap != null) {
+            createContainerCmd.withMemorySwap(memorySwap);
+        }
+        
+        Integer cpuShares = DockerHelper.getProperty(DockerConstants.DOCKER_CPU_SHARES,configuration, message, Integer.class);
+
+        if(cpuShares != null) {
+            createContainerCmd.withCpuShares(cpuShares);
+        }
+        
+        Boolean attachStdIn = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_IN,configuration, message, Boolean.class);
+
+        if(attachStdIn != null && attachStdIn) {
+            createContainerCmd.withAttachStdin(attachStdIn);
+        }
+  
+        Boolean attachStdOut = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_OUT,configuration, message, Boolean.class);
+
+        if(attachStdOut != null && attachStdOut) {
+            createContainerCmd.withAttachStdout(attachStdOut);
+        }
+        
+        Boolean attachStdErr = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_ERR,configuration, message, Boolean.class);
+
+        if(attachStdErr != null && attachStdErr) {
+            createContainerCmd.withAttachStderr(attachStdErr);
+        }
+        
+        String[] env = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_ENV, message);
+
+        if(env != null) {
+            createContainerCmd.withEnv(env);
+        }
+        
+        String[] cmd = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_CMD, message);
+
+        if(cmd != null) {
+            createContainerCmd.withCmd(env);
+        }
+        
+        String[] dns = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_DNS, message);
+
+        if(dns != null) {
+            createContainerCmd.withDns(dns);
+        }
+        
+        String image = DockerHelper.getProperty(DockerConstants.DOCKER_IMAGE,configuration, message, String.class);
+
+        if(image != null) {
+            createContainerCmd.withImage(image);
+        }
+        
+        Volume[] volume = DockerHelper.getArrayProperty(DockerConstants.DOCKER_VOLUMES, message, Volume.class);
+
+        if(volume != null) {
+            createContainerCmd.withVolumes(volume);
+        }
+        
+        String[] volumesFrom = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_VOLUMES_FROM, message);
+
+        if(volumesFrom != null) {
+            createContainerCmd.withVolumesFrom(volumesFrom);
+        }
+        
+        return createContainerCmd;
+
+    }
+    
+    /**
+     * Produce a start container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private StartContainerCmd executeStartContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Start Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        StartContainerCmd startContainerCmd = client.startContainerCmd(containerId);
+        
+        Bind[] binds = DockerHelper.getArrayProperty(DockerConstants.DOCKER_BINDS, message, Bind.class);
+
+        if(binds != null) {
+            startContainerCmd.withBinds(binds);
+        }
+        
+        Link[] links = DockerHelper.getArrayProperty(DockerConstants.DOCKER_LINKS, message, Link.class);
+
+        if(links != null) {
+            startContainerCmd.withLinks(links);
+        }
+        
+        LxcConf[] lxcConf = DockerHelper.getArrayProperty(DockerConstants.DOCKER_LXC_CONF, message, LxcConf.class);
+
+        if(lxcConf != null) {
+            startContainerCmd.withLxcConf(lxcConf);
+        }
+        
+        Ports ports = DockerHelper.getProperty(DockerConstants.DOCKER_PORT_BINDINGS,configuration, message, Ports.class);
+
+        if(ports != null) {
+            startContainerCmd.withPortBindings(ports);
+        }
+        
+        Boolean privileged = DockerHelper.getProperty(DockerConstants.DOCKER_PRIVILEGED,configuration, message, Boolean.class);
+
+        if(privileged != null && privileged) {
+            startContainerCmd.withPrivileged(privileged);
+        }
+        
+        Boolean publishAllPorts = DockerHelper.getProperty(DockerConstants.DOCKER_PUBLISH_ALL_PORTS,configuration, message, Boolean.class);
+
+        if(publishAllPorts != null && publishAllPorts) {
+            startContainerCmd.withPublishAllPorts(publishAllPorts);
+        }
+        
+        String[] dns = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_DNS, message);
+
+        if(dns != null) {
+            startContainerCmd.withDns(dns);
+        }
+        
+        String[] dnsSearch = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_DNS_SEARCH, message);
+
+        if(dnsSearch != null) {
+            startContainerCmd.withDnsSearch(dnsSearch);
+        }
+        
+        String volumesFrom = DockerHelper.getProperty(DockerConstants.DOCKER_VOLUMES_FROM,configuration, message, String.class);
+
+        if(volumesFrom != null) {
+            startContainerCmd.withVolumesFrom(volumesFrom);
+        }
+
+        String networkMode = DockerHelper.getProperty(DockerConstants.DOCKER_NETWORK_MODE,configuration, message, String.class);
+
+        if(networkMode != null) {
+            startContainerCmd.withNetworkMode(networkMode);
+        }
+
+        Device[] devices = DockerHelper.getArrayProperty(DockerConstants.DOCKER_DEVICES, message, Device.class);
+
+        if(devices != null) {
+            startContainerCmd.withDevices(devices);
+        }
+        
+        RestartPolicy restartPolicy = DockerHelper.getProperty(DockerConstants.DOCKER_RESTART_POLICY,configuration, message, RestartPolicy.class);
+
+        if(restartPolicy != null) {
+            startContainerCmd.withRestartPolicy(restartPolicy);
+        }
+        
+        String[] capAdd = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_CAP_ADD, message);
+
+        if(capAdd != null) {
+            startContainerCmd.withCapAdd(capAdd);
+        }
+        
+        String[] capDrop = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_CAP_DROP, message);
+
+        if(capDrop != null) {
+            startContainerCmd.withCapDrop(capDrop);
+        }
+        
+        return startContainerCmd;
+
+    }
+    
+    /**
+     * Produce a inspect container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private InspectContainerCmd executeInspectContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Inspect Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        InspectContainerCmd inspectContainerCmd = client.inspectContainerCmd(containerId);
+        
+        return inspectContainerCmd;
+
+    }
+    
+    /**
+     * Produce a wait container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private WaitContainerCmd executeWaitContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Wait Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        WaitContainerCmd waitContainerCmd = client.waitContainerCmd(containerId);
+        
+        return waitContainerCmd;
+
+    }
+    
+    /**
+     * Produce a log container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private LogContainerCmd executeLogContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Log Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+
+        LogContainerCmd logContainerCmd = client.logContainerCmd(containerId);
+
+        Boolean stdOut = DockerHelper.getProperty(DockerConstants.DOCKER_STD_OUT,configuration, message, Boolean.class);
+        
+        if(stdOut != null && stdOut) {
+            logContainerCmd.withStdOut(stdOut);
+        }
+        
+        Boolean stdErr = DockerHelper.getProperty(DockerConstants.DOCKER_STD_ERR,configuration, message, Boolean.class);
+        
+        if(stdErr != null && stdErr) {
+            logContainerCmd.withStdErr(stdErr);
+        }
+        
+        Boolean timestamps = DockerHelper.getProperty(DockerConstants.DOCKER_TIMESTAMPS,configuration, message, Boolean.class);
+        
+        if(timestamps != null && timestamps) {
+            logContainerCmd.withTimestamps(timestamps);
+        }       
+        
+        Boolean followStream = DockerHelper.getProperty(DockerConstants.DOCKER_FOLLOW_STREAM,configuration, message, Boolean.class);
+        
+        if(followStream != null && followStream) {
+            logContainerCmd.withFollowStream(followStream);
+        }    
+        
+        Boolean tailAll = DockerHelper.getProperty(DockerConstants.DOCKER_TAIL_ALL,configuration, message, Boolean.class);
+        
+        if(tailAll != null && tailAll) {
+            logContainerCmd.withTailAll();
+        }
+        
+        Integer tail = DockerHelper.getProperty(DockerConstants.DOCKER_TAIL,configuration, message, Integer.class);
+        
+        if(tailAll != null) {
+            logContainerCmd.withTail(tail);
+        }
+        
+        return logContainerCmd;
+
+    }
+    
+    
+    /**
+     * Produce a attach container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private AttachContainerCmd executeAttachContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Attach Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+
+        AttachContainerCmd attachContainerCmd = client.attachContainerCmd(containerId);
+
+        Boolean stdOut = DockerHelper.getProperty(DockerConstants.DOCKER_STD_OUT,configuration, message, Boolean.class);
+        
+        if(stdOut != null && stdOut) {
+            attachContainerCmd.withStdOut(stdOut);
+        }
+        
+        Boolean stdErr = DockerHelper.getProperty(DockerConstants.DOCKER_STD_ERR,configuration, message, Boolean.class);
+        
+        if(stdErr != null && stdErr) {
+            attachContainerCmd.withStdErr(stdErr);
+        }
+        
+        Boolean logs = DockerHelper.getProperty(DockerConstants.DOCKER_LOGS,configuration, message, Boolean.class);
+        
+        if(logs != null && logs) {
+            attachContainerCmd.withLogs(logs);
+        }
+        
+        Boolean timestamps = DockerHelper.getProperty(DockerConstants.DOCKER_TIMESTAMPS,configuration, message, Boolean.class);
+        
+        if(timestamps != null && timestamps) {
+            attachContainerCmd.withTimestamps(timestamps);
+        }       
+        
+        Boolean followStream = DockerHelper.getProperty(DockerConstants.DOCKER_FOLLOW_STREAM,configuration, message, Boolean.class);
+        
+        if(followStream != null && followStream) {
+            attachContainerCmd.withFollowStream(followStream);
+        }    
+        
+        return attachContainerCmd;
+
+    }
+    
+
+    /**
+     * Produces a stop container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private StopContainerCmd executeStopContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Kill Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        StopContainerCmd stopContainerCmd = client.stopContainerCmd(containerId);
+
+        Integer timeout = DockerHelper.getProperty(DockerConstants.DOCKER_TIMEOUT,configuration, message, Integer.class);
+        
+        if(timeout != null) {
+            stopContainerCmd.withTimeout(timeout);
+        }
+             
+        return stopContainerCmd;
+
+    }
+   
+    
+    /**
+     * Produces a restart container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private RestartContainerCmd executeRestartContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Restart Container Request");
+   
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        RestartContainerCmd restartContainerCmd = client.restartContainerCmd(containerId);
+
+        Integer timeout = DockerHelper.getProperty(DockerConstants.DOCKER_TIMEOUT,configuration, message, Integer.class);
+        
+        if(timeout != null) {
+            restartContainerCmd.withtTimeout(timeout);
+        }
+             
+        return restartContainerCmd;
+
+    }
+    
+    
+    /**
+     * Produces a diff container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private ContainerDiffCmd executeDiffContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Diff Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+
+        ContainerDiffCmd diffContainerCmd = client.containerDiffCmd(containerId);
+        
+        return diffContainerCmd;
+
+    }
+    
+    /**
+     * Produces a kill container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private KillContainerCmd executeKillContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Kill Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        KillContainerCmd killContainerCmd = client.killContainerCmd(containerId);
+
+        String signal = DockerHelper.getProperty(DockerConstants.DOCKER_SIGNAL,configuration, message, String.class);
+        
+        if(signal != null) {
+            killContainerCmd.withSignal(signal);
+        }
+             
+        return killContainerCmd;
+
+    }
+    
+    /**
+     * Produces a top container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private TopContainerCmd executeTopContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Top Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        TopContainerCmd topContainerCmd = client.topContainerCmd(containerId);
+
+        String psArgs = DockerHelper.getProperty(DockerConstants.DOCKER_PS_ARGS,configuration, message, String.class);
+        
+        if(psArgs != null) {
+            topContainerCmd.withPsArgs(psArgs);
+        }
+             
+        return topContainerCmd;
+
+    }
+    
+    
+    /**
+     * Produces a pause container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private PauseContainerCmd executePauseContainerRequest(DockerClient client, Message message) throws DockerException {
+            
+        LOGGER.debug("Executing Docker Pause Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        PauseContainerCmd pauseContainerCmd = client.pauseContainerCmd(containerId);
+        
+        return pauseContainerCmd;
+
+    }
+    
+    /**
+     * Produces a unpause container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private UnpauseContainerCmd executeUnpauseContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Unpause Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        UnpauseContainerCmd unpauseContainerCmd = client.unpauseContainerCmd(containerId);
+        
+        return unpauseContainerCmd;
+
+    }
+    
+    
+    /**
+     * Produces a commit container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private CommitCmd executeCommitContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Commit Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        
+        CommitCmd commitCmd = client.commitCmd(containerId);
+ 
+        String repository = DockerHelper.getProperty(DockerConstants.DOCKER_REPOSITORY,configuration, message, String.class);
+
+        if(repository != null) {
+            commitCmd.withRepository(repository);
+        }
+        
+        String msg = DockerHelper.getProperty(DockerConstants.DOCKER_MESSAGE,configuration, message, String.class);
+
+        if(message != null) {
+            commitCmd.withMessage(msg);
+        }
+        
+        String tag = DockerHelper.getProperty(DockerConstants.DOCKER_TAG,configuration, message, String.class);
+
+        if(tag != null) {
+            commitCmd.withTag(tag);
+        }
+        
+        String author = DockerHelper.getProperty(DockerConstants.DOCKER_TAG,configuration, message, String.class);
+
+        if(author != null) {
+            commitCmd.withAuthor(tag);
+        }       
+
+        Boolean attachStdIn = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_IN,configuration, message, Boolean.class);
+
+        if(attachStdIn != null && attachStdIn) {
+            commitCmd.withAttachStdin();
+        }   
+        
+        Boolean attachStdOut = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_OUT,configuration, message, Boolean.class);
+
+        if(attachStdOut != null && attachStdOut) {
+            commitCmd.withAttachStdout();
+        }   
+
+        Boolean attachStdErr = DockerHelper.getProperty(DockerConstants.DOCKER_ATTACH_STD_ERR,configuration, message, Boolean.class);
+
+        if(attachStdErr != null && attachStdErr) {
+            commitCmd.withAttachStderr();
+        }   
+               
+        String[] cmds = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_CMD, message);
+
+        if(cmds != null) {
+            commitCmd.withCmd(cmds);
+        }
+        
+        Boolean disableNetwork = DockerHelper.getProperty(DockerConstants.DOCKER_DISABLE_NETWORK,configuration, message, Boolean.class);
+
+        if(disableNetwork != null && disableNetwork) {
+            commitCmd.withDisableNetwork(disableNetwork);
+        }   
+        
+        Boolean pause = DockerHelper.getProperty(DockerConstants.DOCKER_PAUSE,configuration, message, Boolean.class);
+
+        if(pause != null && pause) {
+            commitCmd.withPause(pause);
+        }          
+        
+        String[] envs = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_ENV, message);
+
+        if(envs != null) {
+            commitCmd.withEnv(envs);
+        }
+ 
+        ExposedPorts exposedPorts = DockerHelper.getProperty(DockerConstants.DOCKER_EXPOSED_PORTS,configuration, message, ExposedPorts.class);
+
+        if(exposedPorts != null) {
+            commitCmd.withExposedPorts(exposedPorts);
+        }  
+        
+        String hostname = DockerHelper.getProperty(DockerConstants.DOCKER_HOSTNAME,configuration, message, String.class);
+
+        if(hostname != null) {
+            commitCmd.withHostname(hostname);
+        }
+        
+        Integer memory = DockerHelper.getProperty(DockerConstants.DOCKER_MEMORY,configuration, message, Integer.class);
+
+        if(memory != null) {
+            commitCmd.withMemory(memory);
+        }
+
+        Integer memorySwap = DockerHelper.getProperty(DockerConstants.DOCKER_MEMORY_SWAP,configuration, message, Integer.class);
+
+        if(memorySwap != null) {
+            commitCmd.withMemorySwap(memorySwap);
+        }
+        
+        Boolean openStdIn = DockerHelper.getProperty(DockerConstants.DOCKER_OPEN_STD_IN,configuration, message, Boolean.class);
+
+        if(openStdIn != null && openStdIn) {
+            commitCmd.withOpenStdin(openStdIn);
+        }  
+        
+        String[] portSpecs = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_PORT_SPECS, message);
+
+        if(portSpecs != null) {
+            commitCmd.withPortSpecs(portSpecs);
+        }
+        
+        Boolean stdInOnce = DockerHelper.getProperty(DockerConstants.DOCKER_STD_IN_ONCE,configuration, message, Boolean.class);
+
+        if(stdInOnce != null && stdInOnce) {
+            commitCmd.withStdinOnce(stdInOnce);
+        }  
+        
+        Boolean tty = DockerHelper.getProperty(DockerConstants.DOCKER_TTY,configuration, message, Boolean.class);
+
+        if(tty != null && tty) {
+            commitCmd.withTty(tty);
+        }
+        
+        String user = DockerHelper.getProperty(DockerConstants.DOCKER_USER,configuration, message, String.class);
+
+        if(user != null) {
+            commitCmd.withUser(user);
+        }
+        
+        Volumes volumes = DockerHelper.getProperty(DockerConstants.DOCKER_VOLUMES,configuration, message, Volumes.class);
+
+        if(volumes != null) {
+            commitCmd.withVolumes(volumes);
+        }
+        
+        String workingDir = DockerHelper.getProperty(DockerConstants.DOCKER_HOSTNAME,configuration, message, String.class);
+
+        if(workingDir != null) {
+            commitCmd.withWorkingDir(workingDir);
+        }
+        
+        
+        return commitCmd;
+
+    }
+    
+    /**
+     * Produces a copy file/folder from container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private CopyFileFromContainerCmd executeCopyFileContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Copy File/Folder Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+        String resource = DockerHelper.getProperty(DockerConstants.DOCKER_RESOURCE,configuration, message, String.class);
+
+        CopyFileFromContainerCmd copyFileContainerCmd = client.copyFileFromContainerCmd(containerId, resource);
+
+        String hostPath = DockerHelper.getProperty(DockerConstants.DOCKER_HOST_PATH,configuration, message, String.class);
+        
+        if(hostPath != null) {
+            copyFileContainerCmd.withHostPath(hostPath);
+        }
+             
+        return copyFileContainerCmd;
+
+    }
+    
+    /**
+     * Produces a remove container request
+     * 
+     * @param client
+     * @param message
+     * @return
+     * @throws DockerException
+     */
+    private RemoveContainerCmd executeRemoveContainerRequest(DockerClient client, Message message) throws DockerException {
+        
+        LOGGER.debug("Executing Docker Remove Container Request");
+        
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID,configuration, message, String.class);
+
+        RemoveContainerCmd removeContainerCmd = client.removeContainerCmd(containerId);
+
+        Boolean force = DockerHelper.getProperty(DockerConstants.DOCKER_FORCE,configuration, message, Boolean.class);
+        
+        if(force != null && force) {
+            removeContainerCmd.withForce(force);
+        }
+        
+        Boolean removeVolumes = DockerHelper.getProperty(DockerConstants.DOCKER_REMOVE_VOLUMES,configuration, message, Boolean.class);
+        
+        if(removeVolumes != null && removeVolumes) {
+            removeContainerCmd.withRemoveVolumes(removeVolumes);
+        }
+        
+        return removeContainerCmd;
+
+    }
+   
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+    }
+    
+    
+    /**
+     * Attempt to retrieve authorization details from the client
+     * 
+     * @param client
+     * @return
+     */
+    private AuthConfig getAuthConfig(DockerClient client) {
+        
+        AuthConfig authConfig = null;
+        
+        try {
+            authConfig = client.authConfig();
+        }
+        catch(Exception e) {}
+        
+        return authConfig;     
+        
+    }
+
+}

--- a/components/camel-docker/src/main/resources/META-INF/services/org/apache/camel/component/docker
+++ b/components/camel-docker/src/main/resources/META-INF/services/org/apache/camel/component/docker
@@ -1,0 +1,1 @@
+class=org.apache.camel.component.docker.DockerComponent

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerClientProfileTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerClientProfileTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Validates the {@link DockerClientProfile}
+ */
+public class DockerClientProfileTest {
+    
+    @Test
+    public void clientProfileTest() {
+        
+        String host = "host";
+        String email = "docker@camel.apache.org";
+        String username = "user";
+        String password = "password";
+        Integer port = 2241;
+        Integer requestTimeout = 40;
+        boolean secure = true;
+        
+        
+        DockerClientProfile clientProfile1 = new DockerClientProfile();
+        clientProfile1.setHost(host);
+        clientProfile1.setEmail(email);
+        clientProfile1.setUsername(username);
+        clientProfile1.setPassword(password);
+        clientProfile1.setPort(port);
+        clientProfile1.setRequestTimeout(requestTimeout);
+        clientProfile1.setSecure(secure);
+        
+        DockerClientProfile clientProfile2 = new DockerClientProfile();
+        clientProfile2.setHost(host);
+        clientProfile2.setEmail(email);
+        clientProfile2.setUsername(username);
+        clientProfile2.setPassword(password);
+        clientProfile2.setPort(port);
+        clientProfile2.setRequestTimeout(requestTimeout);
+        clientProfile2.setSecure(secure);
+        
+        assertEquals(clientProfile1, clientProfile2);
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerConfigurationTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerConfigurationTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultMessage;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DockerConfigurationTest {
+    
+    private DockerConfiguration configuration;
+    
+    @Before
+    public void setupTest() {
+        configuration = new DockerConfiguration();
+    }
+    
+    @Test
+    public void testPropertyFromHeader() {
+        
+        String host = "camelhost";
+        
+        Message message = new DefaultMessage();
+        message.setHeader(DockerConstants.DOCKER_HOST, host);
+        
+        String configurationProp = DockerHelper.getProperty(DockerConstants.DOCKER_HOST, configuration, message, String.class);
+        assertEquals(host, configurationProp);
+    }
+    
+    @Test
+    public void testPropertyfromEndpointProperties() {
+        String host = "camelhost";
+        
+        Map<String,Object> parameters = new HashMap<String,Object>();
+        parameters.put(DockerHelper.transformFromHeaderName(DockerConstants.DOCKER_HOST), host);
+        configuration.setParameters(parameters);
+        
+        Message message = new DefaultMessage();
+        String configurationProp = DockerHelper.getProperty(DockerConstants.DOCKER_HOST, configuration, message, String.class);
+        assertEquals(host, configurationProp);
+
+
+        
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerHelperTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerHelperTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class DockerHelperTest {
+    
+    @Test
+    public void transformHeaderTestFromHeader() {
+        
+        String headerField = DockerHelper.transformFromHeaderName(DockerConstants.DOCKER_REGISTRY);
+        
+        assertEquals("registry", headerField);
+    }
+    
+    
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/RemoveImageCmdUriTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/RemoveImageCmdUriTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import com.github.dockerjava.api.command.RemoveImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.docker.headers.BaseDockerHeaderTest;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Remove Image Request URI parameters are applied properly
+ */
+public class RemoveImageCmdUriTest extends BaseDockerHeaderTest<RemoveImageCmd> {
+
+    private String imageId = "be29975e0098";
+    private Boolean noPrune = false;
+    private Boolean force = true;
+    
+    @Mock
+    private RemoveImageCmd mockObject;
+    
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            
+            @Override
+            public void configure() throws Exception {
+                from("direct:in").to("docker://"+getOperation().toString()+"?imageId="+imageId+"&noPrune="+noPrune+"&force="+force);
+                
+            }
+        };
+        
+    } 
+    
+    @Test
+    public void removeImageHeaderTest() {
+        
+
+        
+        Map<String,Object> headers = getDefaultParameters();
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).removeImageCmd(imageId);
+        Mockito.verify(mockObject,Mockito.times(0)).withNoPrune();
+        Mockito.verify(mockObject,Mockito.times(1)).withForce();
+
+        
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.removeImageCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.REMOVE_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.AttachContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Attach Container Request headers are applied properly
+ */
+public class AttachContainerCmdHeaderTest extends BaseDockerHeaderTest<AttachContainerCmd> {
+    
+    @Mock
+    private AttachContainerCmd mockObject;
+    
+    @Test
+    public void attachContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        boolean stdOut = true;
+        boolean stdErr = true;
+        boolean followStream = true;
+        boolean logs = true;
+        boolean timestamps = true;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_FOLLOW_STREAM, followStream);
+        headers.put(DockerConstants.DOCKER_STD_OUT, stdOut);
+        headers.put(DockerConstants.DOCKER_STD_ERR, stdErr);
+        headers.put(DockerConstants.DOCKER_TIMESTAMPS, timestamps);
+        headers.put(DockerConstants.DOCKER_LOGS, logs);
+
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).attachContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withFollowStream(Mockito.eq(followStream));
+        Mockito.verify(mockObject,Mockito.times(1)).withLogs(Mockito.eq(logs));
+        Mockito.verify(mockObject,Mockito.times(1)).withStdErr(Mockito.eq(stdErr));
+        Mockito.verify(mockObject,Mockito.times(1)).withStdOut(Mockito.eq(stdOut));
+        Mockito.verify(mockObject,Mockito.times(1)).withTimestamps(Mockito.eq(timestamps));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.attachContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.ATTACH_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AuthCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AuthCmdHeaderTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.AuthCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerClientProfile;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Authentication Request headers are parsed properly
+ */
+public class AuthCmdHeaderTest extends BaseDockerHeaderTest<AuthCmd> {
+    
+    @Mock
+    private AuthCmd mockObject;
+    
+    private String userName = "jdoe";
+    private String password = "password";
+    private String email = "jdoe@example.com";
+    private String serverAddress = "http://docker.io/v1";
+    
+    @Test
+    public void authHeaderTest() {
+        String userName = "jdoe";
+        String password = "password";
+        String email = "jdoe@example.com";
+        String serverAddress = "http://docker.io/v1";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_USERNAME, userName);
+        headers.put(DockerConstants.DOCKER_PASSWORD, password);
+        headers.put(DockerConstants.DOCKER_EMAIL, email);
+        headers.put(DockerConstants.DOCKER_SERVER_ADDRESS, serverAddress);
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).authCmd();
+        
+    }
+    
+    @Override
+    public DockerClientProfile getClientProfile() {
+       DockerClientProfile clientProfile = super.getClientProfile();
+       clientProfile.setEmail(email);
+       clientProfile.setPassword(password);
+       clientProfile.setUsername(userName);
+       clientProfile.setServerAddress(serverAddress);
+       
+       return clientProfile;
+       
+    }
+
+
+
+    @Override
+    protected void setupMocks() {
+       Mockito.when(dockerClient.authCmd()).thenReturn(mockObject);
+        
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+       return DockerOperation.AUTH;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.DockerClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.docker.DockerClientProfile;
+import org.apache.camel.component.docker.DockerComponent;
+import org.apache.camel.component.docker.DockerConfiguration;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public abstract class BaseDockerHeaderTest<T> extends CamelTestSupport {
+    
+    @Mock
+    protected DockerClient dockerClient;
+        
+    protected DockerConfiguration dockerConfiguration;    
+    
+    @Mock
+    T mockObject;
+    
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            
+            @Override
+            public void configure() throws Exception {
+                from("direct:in").to("docker://"+getOperation().toString());
+                
+            }
+        };
+        
+    }   
+    
+    @Before
+    public void setupTest() {
+        setupMocks();
+    }
+    
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        dockerConfiguration = new DockerConfiguration();
+        dockerConfiguration.setParameters(getDefaultParameters());
+        
+        
+        dockerConfiguration.setClient(getClientProfile(), dockerClient);
+        
+        DockerComponent dockerComponent = new DockerComponent(dockerConfiguration);
+        camelContext.addComponent("docker", dockerComponent);
+        
+
+        
+        return camelContext;
+    }
+    
+    
+    protected String getHost() {
+        return "localhost";
+    }
+    
+    protected Integer getPort() {
+        return 5000;
+    }
+    
+    protected String getEmail() {
+        return "docker@camel.apache.org";
+    }
+    
+    public T getMockObject() {
+        return mockObject;
+    }
+    
+    protected Map<String,Object> getDefaultParameters() {
+        Map<String,Object> parameters = new HashMap<String,Object>();
+        parameters.put(DockerConstants.DOCKER_HOST, getHost());
+        parameters.put(DockerConstants.DOCKER_PORT, getPort());
+        parameters.put(DockerConstants.DOCKER_EMAIL, getEmail());
+
+        return parameters;
+    }
+    
+    protected DockerClientProfile getClientProfile() {
+        DockerClientProfile clientProfile = new DockerClientProfile();
+        clientProfile.setHost(getHost());
+        clientProfile.setPort(getPort());
+        clientProfile.setEmail(getEmail());
+        
+        return clientProfile;
+
+    }
+    
+    
+    protected abstract void setupMocks();
+    
+    protected abstract DockerOperation getOperation();
+         
+    
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BuildImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BuildImageCmdHeaderTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.BuildImageCmd;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Build Image Request headers are parsed properly
+ */
+public class BuildImageCmdHeaderTest extends BaseDockerHeaderTest<BuildImageCmd> {
+    
+    @Mock
+    private BuildImageCmd mockObject;
+    
+    @Mock
+    private InputStream inputStream;
+    
+    @Mock
+    private File file;
+    
+    private String repository = "docker/empty";
+    private boolean quiet = true;
+    private boolean noCache = true;
+    private boolean remove = true;
+    private String tag = "1.0";
+    
+    @Test
+    public void buildImageFromInputStreamHeaderTest() {
+        
+        template.sendBodyAndHeaders("direct:in", inputStream,getHeaders());
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).buildImageCmd(Mockito.any(InputStream.class));
+        Mockito.verify(mockObject,Mockito.times(1)).withQuiet();
+        Mockito.verify(mockObject,Mockito.times(1)).withNoCache();
+        Mockito.verify(mockObject,Mockito.times(1)).withRemove();
+        Mockito.verify(mockObject,Mockito.times(1)).withTag(tag);
+        
+    }
+    
+    @Test
+    public void buildImageFromFileHeaderTest() {
+        
+        template.sendBodyAndHeaders("direct:in", file,getHeaders());
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).buildImageCmd(Mockito.any(File.class));
+        Mockito.verify(mockObject,Mockito.times(1)).withQuiet();
+        Mockito.verify(mockObject,Mockito.times(1)).withNoCache();
+        Mockito.verify(mockObject,Mockito.times(1)).withRemove();
+        Mockito.verify(mockObject,Mockito.times(1)).withTag(tag);
+        
+    }
+    
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.buildImageCmd(Mockito.any(InputStream.class))).thenReturn(mockObject);
+        Mockito.when(dockerClient.buildImageCmd(Mockito.any(File.class))).thenReturn(mockObject);
+
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.BUILD_IMAGE;
+    }
+    
+    private Map<String,Object> getHeaders() {
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_REPOSITORY, repository);
+        headers.put(DockerConstants.DOCKER_QUIET, quiet);
+        headers.put(DockerConstants.DOCKER_NO_CACHE, noCache);
+        headers.put(DockerConstants.DOCKER_TAG, tag);
+        headers.put(DockerConstants.DOCKER_REMOVE, remove);
+        
+        return headers;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CopyFileContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CopyFileContainerCmdHeaderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Copy File from Container Request headers are applied properly
+ */
+public class CopyFileContainerCmdHeaderTest extends BaseDockerHeaderTest<CopyFileFromContainerCmd> {
+    
+    @Mock
+    private CopyFileFromContainerCmd mockObject;
+    
+    @Test
+    public void copyFileFromContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        String resource = "/test";
+        String hostPath = "/test/test2";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_RESOURCE, resource);
+        headers.put(DockerConstants.DOCKER_HOST_PATH, hostPath);
+
+
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).copyFileFromContainerCmd(containerId, resource);
+        Mockito.verify(mockObject,Mockito.times(1)).withHostPath(Mockito.eq(hostPath));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.copyFileFromContainerCmd(Mockito.anyString(), Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.CONTAINER_COPY_FILE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateContainerCmdHeaderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Create Container Request headers are parsed properly
+ */
+public class CreateContainerCmdHeaderTest extends BaseDockerHeaderTest<CreateContainerCmd> {
+
+    
+    @Mock
+    private CreateContainerCmd mockObject;
+    
+    @Test
+    public void createContainerHeaderTest() {
+        
+        String imageId = "be29975e0098";
+        ExposedPort tcp22 = ExposedPort.tcp(22);
+
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_IMAGE_ID, imageId);
+        headers.put(DockerConstants.DOCKER_EXPOSED_PORTS, tcp22);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).createContainerCmd(imageId);
+        Mockito.verify(mockObject,Mockito.times(1)).withExposedPorts(Mockito.any(ExposedPort.class));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.createContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.CREATE_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateImageCmdHeaderTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.CreateImageCmd;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Create Image Request headers are parsed properly
+ */
+public class CreateImageCmdHeaderTest extends BaseDockerHeaderTest<CreateImageCmd> {
+    
+    @Mock
+    private CreateImageCmd mockObject;
+    
+    @Test
+    public void createImageHeaderTest() {
+        
+        String repository = "docker/empty";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_REPOSITORY, repository);
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).createImageCmd(Mockito.eq(repository), Mockito.any(InputStream.class));
+        
+
+        
+    }
+    
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.createImageCmd(Mockito.anyString(), Mockito.any(InputStream.class))).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.CREATE_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/DiffContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/DiffContainerCmdHeaderTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Container Diff Request headers are parsed properly
+ */
+public class DiffContainerCmdHeaderTest extends BaseDockerHeaderTest<ContainerDiffCmd> {
+
+    @Mock
+    private ContainerDiffCmd mockObject;
+    
+    @Test
+    public void containerDiffHeaderTest() {
+                
+        String containerId = "9c09acd48a25";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).containerDiffCmd(containerId);
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.containerDiffCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.DIFF_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InfoCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InfoCmdHeaderTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.InfoCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Info Request headers are parsed properly
+ */
+public class InfoCmdHeaderTest extends BaseDockerHeaderTest<InfoCmd> {
+
+    @Mock
+    private InfoCmd mockObject;
+    
+    @Test
+    public void listImageHeaderTest() {
+                
+        Map<String,Object> headers = getDefaultParameters();
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).infoCmd();
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.infoCmd()).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.INFO;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectContainerCmdHeaderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.InspectContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Inspect Container Request headers are applied properly
+ */
+public class InspectContainerCmdHeaderTest extends BaseDockerHeaderTest<InspectContainerCmd> {
+    
+    @Mock
+    private InspectContainerCmd mockObject;
+    
+    @Test
+    public void inspectContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).inspectContainerCmd(containerId);
+
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.inspectContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.INSPECT_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectImageCmdHeaderTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.InspectImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Inspect Image Request headers are parsed properly
+ */
+public class InspectImageCmdHeaderTest extends BaseDockerHeaderTest<InspectImageCmd> {
+
+    @Mock
+    private InspectImageCmd mockObject;
+    
+    @Test
+    public void listImageHeaderTest() {
+        
+        String imageId = "be29975e0098";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_IMAGE_ID, imageId);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).inspectImageCmd(Mockito.eq(imageId));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.inspectImageCmd(Mockito.anyString())).thenReturn(mockObject);
+
+        
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+       return DockerOperation.INSPECT_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/KillContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/KillContainerCmdHeaderTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.KillContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Kill Container Request headers are applied properly
+ */
+public class KillContainerCmdHeaderTest extends BaseDockerHeaderTest<KillContainerCmd> {
+    
+    @Mock
+    private KillContainerCmd mockObject;
+    
+    @Test
+    public void stopContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        String signal = "signal";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_SIGNAL, signal);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).killContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withSignal(Mockito.eq(signal));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.killContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.KILL_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListContainersCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListContainersCmdHeaderTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.ListContainersCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates List Containers Request headers are applied properly
+ */
+public class ListContainersCmdHeaderTest extends BaseDockerHeaderTest<ListContainersCmd> {
+    
+    @Mock
+    private ListContainersCmd mockObject;
+    
+    @Test
+    public void listContainerHeaderTest() {
+        
+        boolean showSize = true;
+        boolean showAll = true;
+        int limit = 2;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_LIMIT, limit);
+        headers.put(DockerConstants.DOCKER_SHOW_ALL, showAll);
+        headers.put(DockerConstants.DOCKER_SHOW_SIZE, showSize);
+
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).listContainersCmd();
+        Mockito.verify(mockObject,Mockito.times(1)).withShowAll(Mockito.eq(showAll));
+        Mockito.verify(mockObject,Mockito.times(1)).withShowSize(Mockito.eq(showSize));
+        Mockito.verify(mockObject,Mockito.times(1)).withLimit(Mockito.eq(limit));
+
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.listContainersCmd()).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.LIST_CONTAINERS;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListImagesCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListImagesCmdHeaderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.ListImagesCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates List Image Request headers are parsed properly
+ */
+public class ListImagesCmdHeaderTest extends BaseDockerHeaderTest<ListImagesCmd> {
+
+    
+    @Mock
+    private ListImagesCmd mockObject;
+    
+    @Test
+    public void listImageHeaderTest() {
+        
+        String filter = "filter";
+        Boolean showAll = true;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_FILTER, filter);
+        headers.put(DockerConstants.DOCKER_SHOW_ALL, showAll);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).listImagesCmd();
+        Mockito.verify(mockObject,Mockito.times(1)).withFilter(Mockito.eq(filter));
+        Mockito.verify(mockObject,Mockito.times(1)).withShowAll(Mockito.eq(showAll));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.listImagesCmd()).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.LIST_IMAGES;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.LogContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Log Container Request headers are applied properly
+ */
+public class LogContainerCmdHeaderTest extends BaseDockerHeaderTest<LogContainerCmd> {
+    
+    @Mock
+    private LogContainerCmd mockObject;
+    
+    @Test
+    public void logContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        boolean stdOut = true;
+        boolean stdErr = true;
+        boolean followStream = true;
+        boolean timestamps = true;
+        boolean tailAll = true;
+        int tail = 5;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_FOLLOW_STREAM, followStream);
+        headers.put(DockerConstants.DOCKER_STD_OUT, stdOut);
+        headers.put(DockerConstants.DOCKER_STD_ERR, stdErr);
+        headers.put(DockerConstants.DOCKER_TIMESTAMPS, timestamps);
+        headers.put(DockerConstants.DOCKER_TAIL, tail);
+        headers.put(DockerConstants.DOCKER_TAIL_ALL, tailAll);
+
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).logContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withFollowStream(Mockito.eq(followStream));
+        Mockito.verify(mockObject,Mockito.times(1)).withTail(Mockito.eq(tail));
+        Mockito.verify(mockObject,Mockito.times(1)).withTailAll();
+        Mockito.verify(mockObject,Mockito.times(1)).withStdErr(Mockito.eq(stdErr));
+        Mockito.verify(mockObject,Mockito.times(1)).withStdOut(Mockito.eq(stdOut));
+        Mockito.verify(mockObject,Mockito.times(1)).withTimestamps(Mockito.eq(timestamps));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.logContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.LOG_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PauseContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PauseContainerCmdHeaderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.PauseContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Pause Container Request headers are applied properly
+ */
+public class PauseContainerCmdHeaderTest extends BaseDockerHeaderTest<PauseContainerCmd> {
+    
+    @Mock
+    private PauseContainerCmd mockObject;
+    
+    @Test
+    public void pauseHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).pauseContainerCmd(containerId);
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.pauseContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.PAUSE_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PingCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PingCmdHeaderTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.PingCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Ping Request headers are parsed properly
+ */
+public class PingCmdHeaderTest extends BaseDockerHeaderTest<PingCmd> {
+
+    @Mock
+    private PingCmd mockObject;
+    
+    @Test
+    public void pingHeaderTest() {
+                
+        Map<String,Object> headers = getDefaultParameters();
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).pingCmd();
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.pingCmd()).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.PING;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.PullImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Pull Image Request headers are applied properly
+ */
+public class PullImageCmdHeaderTest extends BaseDockerHeaderTest<PullImageCmd> {
+    
+    @Mock
+    private PullImageCmd mockObject;
+    
+    @Test
+    public void pullImageHeaderTest() {
+        
+        String repository = "docker/empty";
+        String tag = "1.0";
+        String registry = "registry";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_REPOSITORY, repository);
+        headers.put(DockerConstants.DOCKER_TAG, tag);
+        headers.put(DockerConstants.DOCKER_REGISTRY, registry);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).pullImageCmd(repository);
+        Mockito.verify(mockObject,Mockito.times(1)).withTag(Mockito.eq(tag));
+        Mockito.verify(mockObject,Mockito.times(1)).withRegistry(Mockito.eq(registry));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.pullImageCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.PULL_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.PushImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerClientProfile;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Push Image Request headers are applied properly
+ */
+public class PushImageCmdHeaderTest extends BaseDockerHeaderTest<PushImageCmd> {
+    
+    @Mock
+    private PushImageCmd mockObject;
+    
+    private String userName = "jdoe";
+    private String password = "password";
+    private String email = "jdoe@example.com";
+    private String serverAddress = "http://docker.io/v1";
+    private String name = "imagename";
+
+    
+    @Test
+    public void pushImageHeaderTest() {
+        
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_USERNAME, userName);
+        headers.put(DockerConstants.DOCKER_PASSWORD, password);
+        headers.put(DockerConstants.DOCKER_EMAIL, email);
+        headers.put(DockerConstants.DOCKER_SERVER_ADDRESS, serverAddress);
+        headers.put(DockerConstants.DOCKER_NAME, name);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).pushImageCmd(name);
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.pushImageCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.PUSH_IMAGE;
+    }
+    
+    @Override
+    public DockerClientProfile getClientProfile() {
+       DockerClientProfile clientProfile = super.getClientProfile();
+       clientProfile.setEmail(email);
+       clientProfile.setPassword(password);
+       clientProfile.setUsername(userName);
+       clientProfile.setServerAddress(serverAddress);
+       
+       return clientProfile;
+       
+    }
+
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveContainerCmdHeaderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Remove Container Request headers are applied properly
+ */
+public class RemoveContainerCmdHeaderTest extends BaseDockerHeaderTest<RemoveContainerCmd> {
+    
+    @Mock
+    private RemoveContainerCmd mockObject;
+    
+    @Test
+    public void removeContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        boolean force = true;
+        boolean removeVolumes = true;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_FORCE, force);
+        headers.put(DockerConstants.DOCKER_REMOVE_VOLUMES, removeVolumes);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).removeContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withForce(Mockito.eq(force));
+        Mockito.verify(mockObject,Mockito.times(1)).withRemoveVolumes(Mockito.eq(removeVolumes));
+
+
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.removeContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.REMOVE_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveImageCmdHeaderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.RemoveImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Remove Image Request headers are applied properly
+ */
+public class RemoveImageCmdHeaderTest extends BaseDockerHeaderTest<RemoveImageCmd> {
+
+    @Mock
+    private RemoveImageCmd mockObject;
+    
+    @Test
+    public void removeImageHeaderTest() {
+        
+        String imageId = "be29975e0098";
+        Boolean noPrune = false;
+        Boolean force = true;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_IMAGE_ID, imageId);
+        headers.put(DockerConstants.DOCKER_NO_PRUNE, noPrune);
+        headers.put(DockerConstants.DOCKER_FORCE, force);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).removeImageCmd(imageId);
+        Mockito.verify(mockObject,Mockito.times(0)).withNoPrune();
+        Mockito.verify(mockObject,Mockito.times(1)).withForce();
+
+        
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.removeImageCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.REMOVE_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RestartContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RestartContainerCmdHeaderTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.RestartContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Restart Container Request headers are applied properly
+ */
+public class RestartContainerCmdHeaderTest extends BaseDockerHeaderTest<RestartContainerCmd> {
+    
+    @Mock
+    private RestartContainerCmd mockObject;
+    
+    @Test
+    public void restartContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        int timeout = 50;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_TIMEOUT, timeout);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).restartContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withtTimeout(Mockito.eq(timeout));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.restartContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.RESTART_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/SearchImagesCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/SearchImagesCmdHeaderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.SearchImagesCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Search Image Request headers are applied properly
+ */
+public class SearchImagesCmdHeaderTest extends BaseDockerHeaderTest<SearchImagesCmd> {
+
+    @Mock
+    private SearchImagesCmd mockObject;
+    
+    @Test
+    public void searchImagesHeaderTest() {
+        
+        String term = "dockerTerm";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_TERM, term);
+
+        template.sendBodyAndHeaders("direct:in", "",headers);
+
+        Mockito.verify(dockerClient,Mockito.times(1)).searchImagesCmd(Mockito.eq(term));
+        
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.searchImagesCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.SEARCH_IMAGES;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StopContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StopContainerCmdHeaderTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.StopContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Stop Container Request headers are applied properly
+ */
+public class StopContainerCmdHeaderTest extends BaseDockerHeaderTest<StopContainerCmd> {
+    
+    @Mock
+    private StopContainerCmd mockObject;
+    
+    @Test
+    public void stopContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        int timeout = 50;
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_TIMEOUT, timeout);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).stopContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withTimeout(Mockito.eq(timeout));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.stopContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.STOP_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TagImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TagImageCmdHeaderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.TagImageCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Tag Image Request headers are applied properly
+ */
+public class TagImageCmdHeaderTest extends BaseDockerHeaderTest<TagImageCmd> {
+    
+    @Mock
+    private TagImageCmd mockObject;
+    
+    @Test
+    public void topImageHeaderTest() {
+        
+        String imageId = "be29975e0098";
+        String repository = "docker/empty";
+        String tag = "1.0";
+        boolean force = true;
+        
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_IMAGE_ID, imageId);
+        headers.put(DockerConstants.DOCKER_REPOSITORY, repository);
+        headers.put(DockerConstants.DOCKER_TAG, tag);
+        headers.put(DockerConstants.DOCKER_FORCE, force);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).tagImageCmd(imageId, repository, tag);
+        Mockito.verify(mockObject,Mockito.times(1)).withForce();
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.tagImageCmd(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.TAG_IMAGE;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TopContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TopContainerCmdHeaderTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.TopContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Top Container Request headers are applied properly
+ */
+public class TopContainerCmdHeaderTest extends BaseDockerHeaderTest<TopContainerCmd> {
+    
+    @Mock
+    private TopContainerCmd mockObject;
+    
+    @Test
+    public void topContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        String psArgs = "aux";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+        headers.put(DockerConstants.DOCKER_PS_ARGS, psArgs);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).topContainerCmd(containerId);
+        Mockito.verify(mockObject,Mockito.times(1)).withPsArgs(Mockito.eq(psArgs));
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.topContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.TOP_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/UnpauseContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/UnpauseContainerCmdHeaderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Unpause Container Request headers are applied properly
+ */
+public class UnpauseContainerCmdHeaderTest extends BaseDockerHeaderTest<UnpauseContainerCmd> {
+    
+    @Mock
+    private UnpauseContainerCmd mockObject;
+    
+    @Test
+    public void unpauseHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).unpauseContainerCmd(containerId);
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.unpauseContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.UNPAUSE_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/VersionCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/VersionCmdHeaderTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.VersionCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Version Request headers are parsed properly
+ */
+public class VersionCmdHeaderTest extends BaseDockerHeaderTest<VersionCmd> {
+
+    @Mock
+    private VersionCmd mockObject;
+    
+    @Test
+    public void pingHeaderTest() {
+                
+        Map<String,Object> headers = getDefaultParameters();
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+        
+        Mockito.verify(dockerClient,Mockito.times(1)).versionCmd();
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.versionCmd()).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.VERSION;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/WaitContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/WaitContainerCmdHeaderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.headers;
+
+import com.github.dockerjava.api.command.WaitContainerCmd;
+
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerOperation;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Validates Wait Container Request headers are applied properly
+ */
+public class WaitContainerCmdHeaderTest extends BaseDockerHeaderTest<WaitContainerCmd> {
+    
+    @Mock
+    private WaitContainerCmd mockObject;
+    
+    @Test
+    public void waitContainerHeaderTest() {
+        
+        String containerId = "9c09acd48a25";
+        
+        Map<String,Object> headers = getDefaultParameters();
+        headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
+
+        
+        template.sendBodyAndHeaders("direct:in", "",headers);
+                
+        Mockito.verify(dockerClient,Mockito.times(1)).waitContainerCmd(containerId);
+        
+    }
+
+    @Override
+    protected void setupMocks() {
+        Mockito.when(dockerClient.waitContainerCmd(Mockito.anyString())).thenReturn(mockObject);
+    }
+
+    @Override
+    protected DockerOperation getOperation() {
+        return DockerOperation.WAIT_CONTAINER;
+    }
+
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/it/DockerProducerTestIT.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/it/DockerProducerTestIT.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.it;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+/**
+ * Integration test listing images on Docker Platform
+ */
+public class DockerProducerTestIT extends CamelTestSupport {
+
+    private String host = "192.168.59.103";
+    private String port = "2376";
+    
+    @Test
+    public void testDocker() throws Exception {
+        template.sendBody("direct:in", "");
+        
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMinimumMessageCount(1);       
+        
+        assertMockEndpointsSatisfied(60, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:in")
+                .to("docker://imagelist?host="+host+"&port="+port)
+                .log("${body}")
+                  .to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-docker/src/test/resources/log4j.properties
+++ b/components/camel-docker/src/test/resources/log4j.properties
@@ -1,0 +1,14 @@
+#
+# The logging properties used
+#
+log4j.rootLogger=INFO, out
+
+# uncomment the following line to turn on Camel debugging
+#log4j.logger.org.apache.camel=DEBUG
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+#log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -81,6 +81,7 @@
     <module>camel-csv</module>
     <module>camel-disruptor</module>
     <module>camel-dns</module>
+    <module>camel-docker</module>
     <module>camel-dozer</module>
     <module>camel-dropbox</module>
     <module>camel-eclipse</module>


### PR DESCRIPTION
Created a Docker component for Camel. Includes the functionality requested in [CAMEL-7834](https://issues.apache.org/jira/browse/CAMEL-7834) to consume events and includes the majority of the functionality as documented in the [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/)
