### PR TITLE
Camel-8024 Camel-sjms improvement to JMSMessageHelper

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
@@ -123,7 +123,8 @@ public final class JmsMessageHelper {
                 break;
             case Text:
                 TextMessage textMessage = session.createTextMessage();
-                textMessage.setText((String) payload);
+                String convertedText = typeConverter.convertTo(String.class, payload);
+                textMessage.setText(convertedText);
                 answer = textMessage;
                 break;
             case Stream:
@@ -384,7 +385,7 @@ public final class JmsMessageHelper {
             } else if (Collection.class.isInstance(payload)) {
                 answer = JmsMessageType.Map;
             } else if (InputStream.class.isInstance(payload)) {
-                answer = JmsMessageType.Stream;
+                answer = JmsMessageType.Bytes;
             } else if (ByteBuffer.class.isInstance(payload)) {
                 answer = JmsMessageType.Bytes;
             } else if (File.class.isInstance(payload)) {
@@ -392,6 +393,10 @@ public final class JmsMessageHelper {
             } else if (Reader.class.isInstance(payload)) {
                 answer = JmsMessageType.Bytes;
             } else if (String.class.isInstance(payload)) {
+                answer = JmsMessageType.Text;
+            } else if (char[].class.isInstance(payload)) {
+                answer = JmsMessageType.Text;
+            } else if (Character.class.isInstance(payload)) {
                 answer = JmsMessageType.Text;
             } else if (Serializable.class.isInstance(payload)) {
                 answer = JmsMessageType.Object;


### PR DESCRIPTION
Hi,

This PR is related to: https://issues.apache.org/jira/browse/CAMEL-8024

as Aaron Whiteside noted in the ticket https://issues.apache.org/jira/browse/CAMEL-7949 that patch breaks byte[] support.

I think I've fixed that and improved JMSMessageHelper.

Andrea
