### PR TITLE
CAMEL-7662 MQTTProducerTest fails once enables it

### DIFF
--- a/components/camel-mqtt/pom.xml
+++ b/components/camel-mqtt/pom.xml
@@ -80,8 +80,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkMode>perTest</forkMode>
-                    <!--CAMEL-7662 disabling the assertion this time-->
-                    <enableAssertions>false</enableAssertions>
                 </configuration>
             </plugin>
              <plugin>


### PR DESCRIPTION
The assertion expects MQTT publish/disconnect call to be submitted as a async task, i.e. enqueued in a dispatch queue
