### PR TITLE
don't clear attachments when points to same reference

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
@@ -151,12 +151,16 @@ public abstract class MessageSupport implements Message {
                 getHeaders().putAll(that.getHeaders());
             }
         }
-        
-        if (hasAttachments()) {
-            getAttachments().clear();
-        }
-        if (that.hasAttachments()) {
-            getAttachments().putAll(that.getAttachments());
+
+        //if attachments are the same on IN and OUT, don't perform clear()
+        boolean sameAttachmentsInstance = false;
+        if (hasAttachments() && that.hasAttachments() && getAttachments() == that.getAttachments()) {
+            if (hasAttachments()) {
+                getAttachments().clear();
+            }
+            if (that.hasAttachments()) {
+                getAttachments().putAll(that.getAttachments());
+            }
         }
     }
 


### PR DESCRIPTION
If an error was thrown, and the IN message has the same reference for attachments as OUT message, they shouldn't be cleared.
