### PR TITLE
camel-jetty - added option to quickly enable CORS

### DIFF
--- a/components/camel-jetty/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -76,6 +76,7 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.servlets.MultiPartFilter;
 import org.eclipse.jetty.util.component.Container;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -171,6 +172,7 @@ public class JettyHttpComponent extends HttpComponent implements RestConsumerFac
                                                               Boolean.class, true);
         Filter multipartFilter = resolveAndRemoveReferenceParameter(parameters, "multipartFilterRef", Filter.class);
         List<Filter> filters = resolveAndRemoveReferenceListParameter(parameters, "filtersRef", Filter.class);
+        Boolean enableCors = getAndRemoveParameter(parameters, "enableCORS", Boolean.class, false);
         Long continuationTimeout = getAndRemoveParameter(parameters, "continuationTimeout", Long.class);
         Boolean useContinuation = getAndRemoveParameter(parameters, "useContinuation", Boolean.class);
         HeaderFilterStrategy headerFilterStrategy = resolveAndRemoveReferenceParameter(parameters, "headerFilterStrategy", HeaderFilterStrategy.class);
@@ -262,6 +264,12 @@ public class JettyHttpComponent extends HttpComponent implements RestConsumerFac
         if (multipartFilter != null) {
             endpoint.setMultipartFilter(multipartFilter);
             endpoint.setEnableMultipartFilter(true);
+        }
+        if (enableCors) {
+            if (filters == null){
+                filters = new ArrayList<Filter>(1);
+            }
+            filters.add(new CrossOriginFilter());
         }
         if (filters != null) {
             endpoint.setFilters(filters);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/EnableCORSTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/EnableCORSTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Test;
+
+public class EnableCORSTest extends BaseJettyTest {
+
+    @Test
+    public void testCORSdisabled() throws Exception {
+        HttpClient httpclient = new HttpClient();
+        HttpMethod httpMethod = new GetMethod("http://localhost:" + getPort() + "/test1");
+        httpMethod.addRequestHeader("Origin", "http://localhost:9000");
+        httpMethod.addRequestHeader("Referer", "http://localhost:9000");
+
+        int status = httpclient.executeMethod(httpMethod);
+
+        assertEquals("Get a wrong response status", 200, status);
+
+        Header responseHeader = httpMethod.getResponseHeader("Access-Control-Allow-Credentials");
+        assertNull("Access-Control-Allow-Credentials HEADER should not be set", responseHeader);
+    }
+
+
+    @Test
+    public void testCORSenabled() throws Exception {
+        HttpClient httpclient = new HttpClient();
+        HttpMethod httpMethod = new GetMethod("http://localhost:" + getPort2() + "/test2");
+        httpMethod.addRequestHeader("Origin", "http://localhost:9000");
+        httpMethod.addRequestHeader("Referer", "http://localhost:9000");
+
+
+        int status = httpclient.executeMethod(httpMethod);
+
+        assertEquals("Get a wrong response status", 200, status);
+
+        Header responseHeader = httpMethod.getResponseHeader("Access-Control-Allow-Credentials");
+        assertTrue("CORS not enabled", Boolean.valueOf(responseHeader.getValue()));
+
+
+    }
+
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("jetty://http://localhost:{{port}}/test1?enableCORS=false").transform(simple("OK"));
+                from("jetty://http://localhost:{{port2}}/test2?enableCORS=true").transform(simple("OK"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
While connecting to a jetty endpoint from a development web server running on a different port, AJAX calls, fail due to CORS restrictions. 

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS

camel-jetty component can be already be configured providing a list of Filters with:

``` java
       List<Filter> list = new ArrayList<Filter>() ;
        list.add(new org.eclipse.jetty.servlets.CrossOriginFilter());
```

and using already existing `filtersRef` option.

The code in the PR adds a simpler boolean option that enables just the CORS filter, for quicker access of the functionality, ideal for development time.
