### PR TITLE
Add a type converter for java.sql.Timestamp

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/SQLConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/SQLConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.converter;
+
+import java.sql.Timestamp;
+
+import org.apache.camel.Converter;
+
+/**
+ * Date and time related converters.
+ */
+@Converter
+public final class SQLConverter {
+
+    /**
+     * Utility classes should not have a public constructor.
+     */
+    private SQLConverter() {
+    }
+
+    @Converter
+    public static Timestamp toTimestamp(Long l) {
+        return l != null ? new Timestamp(l) : null;
+    }
+    
+    @Converter
+    public static Long toLong(Timestamp ts) {
+        return ts != null ? ts.getTime() : null;
+    }
+}


### PR DESCRIPTION
This makes it easy to convert JMSTimestamp to a value that can be inserted into a database.