### PR TITLE
CAMEL-4427: Enable support for joining channels named "#"

### DIFF
--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcChannel.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcChannel.java
@@ -31,7 +31,6 @@ public final class IrcChannel {
     public void setName(String name) {
         if (name == null || name.isEmpty()) {
             name = "";
-            return;
         }
         this.name = name.startsWith("#") || name.startsWith("&") ? name : "#" + name;
     }


### PR DESCRIPTION
This is suggested fix to a comment I left on: https://issues.apache.org/jira/browse/CAMEL-4427
