### PR TITLE
[CAMEL-8184] Added support to set custom headers to AWS-S3

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Constants.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Constants.java
@@ -37,4 +37,5 @@ public interface S3Constants {
     String CANNED_ACL          = "CamelAwsS3CannedAcl";
     String ACL                 = "CamelAwsS3Acl";
     String USER_METADATA       = "CamelAwsS3UserMetadata";
+    String S3_HEADERS          = "CamelAwsS3Headers";
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Endpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Endpoint.java
@@ -157,7 +157,8 @@ public class S3Endpoint extends ScheduledPollEndpoint {
         message.setHeader(S3Constants.CONTENT_ENCODING, objectMetadata.getContentEncoding());
         message.setHeader(S3Constants.CONTENT_DISPOSITION, objectMetadata.getContentDisposition());
         message.setHeader(S3Constants.CACHE_CONTROL, objectMetadata.getCacheControl());
-        
+        message.setHeader(S3Constants.S3_HEADERS, objectMetadata.getRawMetadata());
+
         return exchange;
     }
 

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
@@ -262,6 +262,13 @@ public class S3Producer extends DefaultProducer {
             objectMetadata.setUserMetadata(userMetadata);
         }
 
+        Map<String, String> s3Headers = CastUtils.cast(exchange.getIn().getHeader(S3Constants.S3_HEADERS, Map.class));
+        if (s3Headers != null) {
+            for(Map.Entry<String, String> entry : s3Headers.entrySet()) {
+                objectMetadata.setHeader(entry.getKey(), entry.getValue());
+            }
+        }
+
         return objectMetadata;
     }
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/s3/S3ComponentFileTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/s3/S3ComponentFileTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.aws.s3;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStream;
+import java.util.Map;
 
 import com.amazonaws.services.s3.model.PutObjectRequest;
 
@@ -137,6 +138,7 @@ public class S3ComponentFileTest extends CamelTestSupport {
         assertNull(resultExchange.getIn().getHeader(S3Constants.CONTENT_MD5));
         assertNull(resultExchange.getIn().getHeader(S3Constants.CACHE_CONTROL));
         assertNull(resultExchange.getIn().getHeader(S3Constants.USER_METADATA));
+        assertEquals(0, resultExchange.getIn().getHeader(S3Constants.S3_HEADERS, Map.class).size());
     }
 
     private void assertResponseMessage(Message message) {


### PR DESCRIPTION
@davsclaus 

This is especially needed to send encryption headers to S3 among others (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html). I did try to upgrade the AWS SDK to 1.9.3 which has Header constants, but that breaks the DynamoDB which would need to be upgraded to v2. I will work on it as I get time, but for now this is a solution.

Since, this is my first pull request, please let me know if I need to do/submit anything else. Thanks.