### PR TITLE
CAMEL-8185: Changed parameter of scr reference event methods

### DIFF
--- a/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
+++ b/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
@@ -42,9 +42,9 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.ExplicitCamelContextNameStrategy;
 import org.apache.camel.impl.SimpleRegistry;
 import org.apache.camel.model.ModelCamelContext;
-import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.util.ReflectionHelper;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -221,12 +221,12 @@ public abstract class AbstractCamelRunner implements Runnable {
         return context;
     }
 
-    protected void gotCamelComponent(final ComponentResolver componentResolver) {
+    protected void gotCamelComponent(final ServiceReference serviceReference) {
         log.trace("Got a new Camel Component.");
         runWithDelay(this);
     }
 
-    protected void lostCamelComponent(final ComponentResolver componentResolver) {
+    protected void lostCamelComponent(final ServiceReference serviceReference) {
         log.trace("Lost a Camel Component.");
     }
 


### PR DESCRIPTION
Modified the default bind/unbind scr reference method parameter from a ComponentResolver to a ServiceReference to avoid the possibility of an argument type mismatch exception. This can occur if multiple versions of Camel are installed (such as JBoss Fuse 6.1) and have registered their own versions of services within the OSGi ServiceRegistry. 

Since these methods do not utilize the ComponentResolver themselves, moving to a ServiceReference does not change the functionality of the component and the end user can define bind/unbind methods of their own.