### PR TITLE
camel-mybatis: added "inputHeader" parameter to use a header value as in...

### DIFF
--- a/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisEndpoint.java
+++ b/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisEndpoint.java
@@ -46,6 +46,8 @@ public class MyBatisEndpoint extends DefaultPollingEndpoint {
     private int maxMessagesPerPoll;
     @UriParam
     private String outputHeader;
+    @UriParam
+    private String inputHeader;
 
     public MyBatisEndpoint() {
     }
@@ -157,4 +159,20 @@ public class MyBatisEndpoint extends DefaultPollingEndpoint {
         this.outputHeader = outputHeader;
     }
 
+	public String getInputHeader() {
+		return inputHeader;
+	}
+
+    /**
+     * User the header value for input parameters instead of the message body.
+     * By default, inputHeader == null and the input parameters are taken from the message body.
+     * If outputHeader is set, the value is used and query parameters will be taken from the
+     * header instead of the body.
+     */
+	public void setInputHeader(String inputHeader) {
+		this.inputHeader = inputHeader;
+	}
+
+    
+    
 }

--- a/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisProducer.java
+++ b/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisProducer.java
@@ -97,7 +97,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doSelectOne(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             LOG.trace("SelectOne: {} using statement: {}", in, statement);
             result = session.selectOne(statement, in);
@@ -111,7 +111,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doSelectList(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             LOG.trace("SelectList: {} using statement: {}", in, statement);
             result = session.selectList(statement, in);
@@ -125,7 +125,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doInsert(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // lets handle arrays or collections of objects
             Iterator<?> iter = ObjectHelper.createIterator(in);
@@ -144,7 +144,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doInsertList(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // just pass in the body as Object and allow MyBatis to iterate using its own foreach statement
             LOG.trace("Inserting: {} using statement: {}", in, statement);
@@ -159,7 +159,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doUpdate(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // lets handle arrays or collections of objects
             Iterator<?> iter = ObjectHelper.createIterator(in);
@@ -178,7 +178,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doUpdateList(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // just pass in the body as Object and allow MyBatis to iterate using its own foreach statement
             LOG.trace("Updating: {} using statement: {}", in, statement);
@@ -193,7 +193,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doDelete(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // lets handle arrays or collections of objects
             Iterator<?> iter = ObjectHelper.createIterator(in);
@@ -212,7 +212,7 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doDeleteList(Exchange exchange, SqlSession session) throws Exception {
         Object result;
-        Object in = exchange.getIn().getBody();
+        Object in = getInput(exchange);
         if (in != null) {
             // just pass in the body as Object and allow MyBatis to iterate using its own foreach statement
             LOG.trace("Deleting: {} using statement: {}", in, statement);
@@ -282,4 +282,13 @@ public class MyBatisProducer extends DefaultProducer {
         return (MyBatisEndpoint) super.getEndpoint();
     }
 
+    private Object getInput(final Exchange exchange) {
+    	final String inputHeader = getEndpoint().getInputHeader();
+    	if(inputHeader != null) {
+    		return exchange.getIn().getHeader(inputHeader);
+    	} else {
+    		return exchange.getIn().getBody();
+    	}
+    }
+    
 }

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithInputAndOutputHeaderTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithInputAndOutputHeaderTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mybatis;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class MyBatisInsertWithInputAndOutputHeaderTest extends MyBatisTestSupport {
+
+	private static final String TEST_CASE_INPUT_HEADER_NAME = "testCaseInputHeader";
+	private static final String TEST_CASE_OUTPUT_HEADER_NAME = "testCaseOutputHeader";
+	private static final String RETAINED_BODY = "not an account";
+	
+    @Test
+    public void testInsert() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().equals(RETAINED_BODY);
+        mock.message(0).header(TEST_CASE_OUTPUT_HEADER_NAME).equals(1);
+
+        Account account = new Account();
+        account.setId(444);
+        account.setFirstName("Willem");
+        account.setLastName("Jiang");
+        account.setEmailAddress("Faraway@gmail.com");
+
+        template.sendBodyAndHeader("direct:start", RETAINED_BODY, TEST_CASE_INPUT_HEADER_NAME, account);
+
+        assertMockEndpointsSatisfied();
+
+        // there should be 3 rows now
+        Integer rows = template.requestBody("mybatis:count?statementType=SelectOne", null, Integer.class);
+        assertEquals("There should be 3 rows", 3, rows.intValue());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                    .to("mybatis:insertAccount?statementType=Insert&inputHeader=" + TEST_CASE_INPUT_HEADER_NAME + "&outputHeader=" + TEST_CASE_OUTPUT_HEADER_NAME)
+                    .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithInputHeaderTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithInputHeaderTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mybatis;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class MyBatisInsertWithInputHeaderTest extends MyBatisTestSupport {
+
+	private static final String TEST_CASE_HEADER_NAME = "testCaseHeader";
+	
+    @Test
+    public void testInsert() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        Account account = new Account();
+        account.setId(444);
+        account.setFirstName("Willem");
+        account.setLastName("Jiang");
+        account.setEmailAddress("Faraway@gmail.com");
+
+        template.sendBodyAndHeader("direct:start", "not an account", TEST_CASE_HEADER_NAME, account);
+
+        assertMockEndpointsSatisfied();
+
+        // there should be 3 rows now
+        Integer rows = template.requestBody("mybatis:count?statementType=SelectOne", null, Integer.class);
+        assertEquals("There should be 3 rows", 3, rows.intValue());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                    .to("mybatis:insertAccount?statementType=Insert&inputHeader=" + TEST_CASE_HEADER_NAME)
+                    .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneWithInputAndOutputHeaderTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneWithInputAndOutputHeaderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mybatis;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class MyBatisSelectOneWithInputAndOutputHeaderTest extends MyBatisTestSupport {
+
+	private static final String TEST_CASE_INPUT_HEADER_NAME = "testCaseInputHeader";
+	private static final String TEST_CASE_OUTPUT_HEADER_NAME = "testCaseOutputHeader";
+	private static final int TEST_ACCOUNT_ID = 456;
+    private static final int TEST_ACCOUNT_ID_BAD = 999;
+	
+    @Test
+    public void testSelectOne() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().equals(TEST_ACCOUNT_ID_BAD);
+        mock.message(0).header(TEST_CASE_OUTPUT_HEADER_NAME).isInstanceOf(Account.class);
+
+        template.sendBodyAndHeader("direct:start", TEST_ACCOUNT_ID_BAD, TEST_CASE_INPUT_HEADER_NAME, TEST_ACCOUNT_ID);
+
+        assertMockEndpointsSatisfied();
+
+        Account account = mock.getReceivedExchanges().get(0).getIn().getHeader(TEST_CASE_OUTPUT_HEADER_NAME, Account.class);
+        assertEquals("Claus", account.getFirstName());
+    }
+
+    @Test
+    public void tesSelectOneNotFound() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().equals(TEST_ACCOUNT_ID);
+        mock.message(0).header(TEST_CASE_OUTPUT_HEADER_NAME).isNull();
+
+        template.sendBodyAndHeader("direct:start", TEST_ACCOUNT_ID, TEST_CASE_INPUT_HEADER_NAME, TEST_ACCOUNT_ID_BAD);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // START SNIPPET: e1
+                from("direct:start")
+                    .to("mybatis:selectAccountById?statementType=SelectOne&inputHeader=" + TEST_CASE_INPUT_HEADER_NAME + "&outputHeader=" + TEST_CASE_OUTPUT_HEADER_NAME)
+                    .to("mock:result");
+                // END SNIPPET: e1
+            }
+        };
+    }
+}

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneWithInputHeaderTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneWithInputHeaderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mybatis;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class MyBatisSelectOneWithInputHeaderTest extends MyBatisTestSupport {
+
+    private static final String TEST_CASE_HEADER_NAME = "testCaseHeader";
+    private static final int TEST_ACCOUNT_ID = 456;
+    private static final int TEST_ACCOUNT_ID_BAD = 999;
+	
+    @Test
+    public void testSelectOne() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isInstanceOf(Account.class);
+
+        template.sendBodyAndHeader("direct:start", TEST_ACCOUNT_ID_BAD, TEST_CASE_HEADER_NAME, TEST_ACCOUNT_ID);
+
+        assertMockEndpointsSatisfied();
+
+        Account account = mock.getReceivedExchanges().get(0).getIn().getBody(Account.class);
+        assertEquals("Claus", account.getFirstName());
+    }
+
+    @Test
+    public void tesSelectOneNotFound() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isNull();
+
+        template.sendBodyAndHeader("direct:start", TEST_ACCOUNT_ID, TEST_CASE_HEADER_NAME, TEST_ACCOUNT_ID_BAD);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // START SNIPPET: e1
+                from("direct:start")
+                    .to("mybatis:selectAccountById?statementType=SelectOne&inputHeader=" + TEST_CASE_HEADER_NAME)
+                    .to("mock:result");
+                // END SNIPPET: e1
+            }
+        };
+    }
+}


### PR DESCRIPTION
...put to the component instead of the body

This way parameters don't need to be set as body before a query. In combination with "outputHeader" you can completely retain the body and don't even take it as a parameter.

Ultimately this reduces the boilderplate of "setBody"/"setHeader" statements even more.