### PR TITLE
camel-smpp: CAMEL-8215: update to org.jsmpp / jsmpp v2.1.1

### DIFF
--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>camel-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.jsmpp</artifactId>
+            <groupId>org.jsmpp</groupId>
+            <artifactId>jsmpp</artifactId>
             <version>${jsmpp-version}</version>
         </dependency>
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -269,7 +269,7 @@
     <josql-version>1.5</josql-version>
     <jruby-version>1.7.18</jruby-version>
     <jsendnsca-version>1.3.1</jsendnsca-version>
-    <jsmpp-version>2.1.0_5</jsmpp-version>
+    <jsmpp-version>2.1.1</jsmpp-version>
     <jsch-version>0.1.51</jsch-version>
     <jsch-bundle-version>0.1.51_1</jsch-bundle-version>
     <jsendnsca-bundle-version>1.3.1_3</jsendnsca-bundle-version>


### PR DESCRIPTION
This uses 2.1.1 instead of jumping up to 2.2.0