### PR TITLE
[master][CAMEL-8247] AWS S3 Producer does not use ObjectMetaData when exchange is a File

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
@@ -179,6 +179,7 @@ public class S3Producer extends DefaultProducer {
         if (obj instanceof File) {
             filePayload = (File) obj;
             putObjectRequest = new PutObjectRequest(getConfiguration().getBucketName(), determineKey(exchange), filePayload);
+            putObjectRequest.setMetadata(objectMetadata);
         } else {
             putObjectRequest = new PutObjectRequest(getConfiguration().getBucketName(),
                 determineKey(exchange), exchange.getIn().getMandatoryBody(InputStream.class), objectMetadata);


### PR DESCRIPTION
@WillemJiang @davsclaus 
The S3 Producer component does not take the ObjectMetaData set into account when the type of the exchange is a File. It does takes it into account when the exchange in an InputStream. This is a serious problem because a lot of S3 metadata set in camel headers are not considered at all.