### PR TITLE
CAMEL-6698: Component camel-cache to support non-serializable objects

### DIFF
--- a/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheConfiguration.java
+++ b/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheConfiguration.java
@@ -52,6 +52,8 @@ public class CacheConfiguration implements Cloneable {
     private CacheEventListenerRegistry eventListenerRegistry = new CacheEventListenerRegistry();
     @UriParam
     private CacheLoaderRegistry cacheLoaderRegistry = new CacheLoaderRegistry();
+    @UriParam
+    private boolean objectCache;
 
     public CacheConfiguration() {
     }
@@ -109,6 +111,14 @@ public class CacheConfiguration implements Cloneable {
             // remove leading if any given as fromString uses LRU, LFU or FIFO
             policy = policy.replace("MemoryStoreEvictionPolicy.", "");
             setMemoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.fromString(policy));
+        }
+        if (cacheSettings.containsKey("objectCache")){
+            setObjectCache(Boolean.valueOf((String) cacheSettings.get("objectCache")));
+        }
+
+        if (isObjectCache()
+                && (isOverflowToDisk() || isDiskPersistent())) {
+            throw new IllegalArgumentException("Unable to create object cache with disk access");
         }
     }
     
@@ -209,4 +219,11 @@ public class CacheConfiguration implements Cloneable {
         return cacheLoaderRegistry;
     }
 
+    public boolean isObjectCache() {
+        return objectCache;
+    }
+
+    public void setObjectCache(boolean objectCache) {
+        this.objectCache = objectCache;
+    }
 }

--- a/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheProducer.java
+++ b/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheProducer.java
@@ -125,6 +125,8 @@ public class CacheProducer extends DefaultProducer {
             throw new CacheException("Body cannot be null for operation " + cacheOperation);
         } else if (body instanceof Serializable) {
             element = new Element(key, body);
+        } else if (config.isObjectCache()) {
+            element = new Element(key, body);
         } else {
             InputStream is = exchange.getContext().getTypeConverter().mandatoryConvertTo(InputStream.class, body);
             // Read InputStream into a byte[] buffer

--- a/components/camel-cache/src/test/java/org/apache/camel/component/cache/ObjectCacheProducerTest.java
+++ b/components/camel-cache/src/test/java/org/apache/camel/component/cache/ObjectCacheProducerTest.java
@@ -1,0 +1,128 @@
+package org.apache.camel.component.cache;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class ObjectCacheProducerTest extends CamelTestSupport {
+
+
+//    protected String ehcacheConfigurationPath() {
+//        return "src/test/resources/test-object-ehcache.xml";
+//    }
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @EndpointInject(uri = "mock:ObjectCacheProducerTest.result")
+    protected MockEndpoint resultEndpoint;
+
+    @EndpointInject(uri = "mock:ObjectCacheProducerTest.cacheException")
+    protected MockEndpoint cacheExceptionEndpoint;
+
+    /**
+     * Test storing 3 elements into object cache then retrieving them back.
+     * We allow cache to store maximum of 2 values to check that overflow to disk not happened (it is not
+     * allowed in ehcache object cache (not serializable cache)).
+     *
+     * @throws Exception
+     * @see net.sf.ehcache.Element for information about object cache operations in ehcache
+     */
+    @Test
+    public void testAddingMultipleDataInCacheAndGettingBack() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            public void configure() {
+                onException(Exception.class).
+                        handled(true).
+                        to("log:LOGGER").
+                        to("mock:ObjectCacheProducerTest.cacheException");
+
+                from("direct:a").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_ADD)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2");
+                from("direct:aGet").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_GET)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2").
+                        choice().when(header(CacheConstants.CACHE_ELEMENT_WAS_FOUND).isNotNull()).
+                        to("mock:ObjectCacheProducerTest.result").end();
+
+                from("direct:b").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_ADD)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson_2")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2");
+                from("direct:bGet").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_GET)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson_2")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2").
+                        choice().when(header(CacheConstants.CACHE_ELEMENT_WAS_FOUND).isNotNull()).
+                        to("mock:ObjectCacheProducerTest.result").end();
+
+                from("direct:c").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_ADD)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson_3")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2");
+                from("direct:cGet").
+                        setHeader(CacheConstants.CACHE_OPERATION, constant(CacheConstants.CACHE_OPERATION_GET)).
+                        setHeader(CacheConstants.CACHE_KEY, constant("Ralph_Waldo_Emerson_3")).
+                        to("cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false&maxElementsInMemory=2").
+                        choice().when(header(CacheConstants.CACHE_ELEMENT_WAS_FOUND).isNotNull()).
+                        to("mock:ObjectCacheProducerTest.result").end();
+            }
+        });
+        context.setTracing(true);
+        context.start();
+        resultEndpoint.expectedMessageCount(2);
+        cacheExceptionEndpoint.expectedMessageCount(0);
+        log.debug("------------Beginning CacheProducer Add and Get Test---------------");
+
+        log.debug("Putting data into cache");
+        sendNonSerializedData("direct:a", newPoetry("Ralph Waldo Emerson", "Brahma"));
+        sendNonSerializedData("direct:b", newPoetry("Ralph Waldo Emerson", "The Rhodora"));
+        sendNonSerializedData("direct:c", newPoetry("Ralph Waldo Emerson", "Concord Hymn"));
+
+        log.debug("Retrieving data from cache");
+        sendEmptyBody("direct:aGet");
+        sendEmptyBody("direct:bGet");
+        sendEmptyBody("direct:cGet");
+
+        cacheExceptionEndpoint.assertIsSatisfied();
+        resultEndpoint.assertIsSatisfied();
+    }
+
+    private void sendNonSerializedData(String endpoint, final PoetryNotSerializable notSerializable) throws Exception {
+        template.send(endpoint, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+
+                // Set the property of the charset encoding
+                exchange.setProperty(Exchange.CHARSET_NAME, "UTF-8");
+                Message in = exchange.getIn();
+                in.setBody(notSerializable);
+            }
+        });
+    }
+
+    private void sendEmptyBody(String endpoint) {
+        template.send(endpoint, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setBody(null);
+            }
+        });
+    }
+
+    private PoetryNotSerializable newPoetry(String poet, String poem) {
+        PoetryNotSerializable poetry = new PoetryNotSerializable();
+        poetry.setPoet(poet);
+        poetry.setPoem(poem);
+        return poetry;
+
+    }
+}

--- a/components/camel-cache/src/test/java/org/apache/camel/component/cache/PoetryNotSerializable.java
+++ b/components/camel-cache/src/test/java/org/apache/camel/component/cache/PoetryNotSerializable.java
@@ -1,0 +1,20 @@
+package org.apache.camel.component.cache;
+
+public class PoetryNotSerializable {
+
+    private String poet;
+    private String poem;
+
+    public String getPoet() {
+        return poet;
+    }
+    public void setPoet(String poet) {
+        this.poet = poet;
+    }
+    public String getPoem() {
+        return poem;
+    }
+    public void setPoem(String poem) {
+        this.poem = poem;
+    }
+}


### PR DESCRIPTION
Ability to store non-serialiable objects into ehcache cache - i called it objectCache. What i modified:
- new configuration param to turn on non-serializable cache - objectCache
- validation to not allow to create object cache which will use object serialization (overflowToDisk and diskPersistence) - overflowToDisk is default
- storing object into cache without using type converters

Things to consider:
```java
else if (body instanceof Serializable) {
   element = new Element(key, body);
 } else if (config.isObjectCache()) {
   element = new Element(key, body);
}

```
can be optimized to 
```java
else if (body instanceof Serializable || config.isObjectCache()) {
  element = new Element(key, body);
 } 
```
as the same contructor using java.lang.Object will  be taken as body is of java.lang.Object

Usage 
To use object cache you have to set objectCache param and disable disk cach i.e.
```
cache://TestCache1?objectCache=true&overflowToDisk=false&diskPersistent=false
```