### PR TITLE
CAMEL-8265 camel-hipchat component to integrate with Hipchat

### DIFF
--- a/apache-camel/pom.xml
+++ b/apache-camel/pom.xml
@@ -305,6 +305,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-hipchat</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-hl7</artifactId>
     </dependency>
     <dependency>

--- a/apache-camel/src/main/descriptors/common-bin.xml
+++ b/apache-camel/src/main/descriptors/common-bin.xml
@@ -88,6 +88,7 @@
         <include>org.apache.camel:camel-hbase</include>
         <include>org.apache.camel:camel-hdfs</include>
         <include>org.apache.camel:camel-hdfs2</include>
+        <include>org.apache.camel:camel-hipchat</include>
         <include>org.apache.camel:camel-http</include>
         <include>org.apache.camel:camel-http4</include>
         <include>org.apache.camel:camel-ibatis</include>

--- a/components/camel-hipchat/pom.xml
+++ b/components/camel-hipchat/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>components</artifactId>
+    <version>2.15-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-hipchat</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>Camel :: Hipchat</name>
+  <description>Camel Hipchat Component</description>
+
+  <properties>
+    <camel.osgi.export.pkg>org.apache.camel.component.hipchat.*</camel.osgi.export.pkg>
+    <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=hipchat</camel.osgi.export.service>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient4-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson2-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson2-version}</version>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>${log4j-version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymockclassextension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest-version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatApiConstants.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatApiConstants.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+/**
+ * List of constants specifically used for invoking Hipchat API
+ */
+interface HipchatApiConstants {
+    String URI_PATH_ROOM_NOTIFY = "/v2/room/%s/notification";
+    String URI_PATH_USER_MESSAGE = "/v2/user/%s/message";
+    String URI_PATH_USER_LATEST_PRIVATE_CHAT = "/v2/user/%s/history/latest";
+    String API_MESSAGE_COLOR = "color";
+    String API_MESSAGE_FORMAT = "message_format";
+    String API_MESSAGE = "message";
+    String API_DATE = "date";
+    String API_ITEMS = "items";
+    String API_MESSAGE_NOTIFY = "notify";
+    String AUTH_TOKEN_PREFIX = "?auth_token=";
+    String DEFAULT_MAX_RESULT = "max-results=1";
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatComponent.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatComponent.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.UriEndpointComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents the component that manages {@link HipchatEndpoint}. Hipchat is an Atlassian software for team chat.
+ *
+ * The hipchat component uses the OAuth2 Hipchat API to produce/consume messages. For more details about Hipchat API
+ * @see <a href="https://www.hipchat.com/docs/apiv2/auth">Hipchat API</a>. You can get the Oauth2 auth token
+ * at @see <a href="https://www.hipchat.com/account/api">Hipchat Auth Token</a>. The messages produced and consumed
+ * would be from/to owner of the provided auth token.
+ */
+public class HipchatComponent extends UriEndpointComponent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HipchatComponent.class);
+
+    public HipchatComponent() {
+        super(HipchatEndpoint.class);
+    }
+
+    public HipchatComponent(CamelContext context) {
+        super(context, HipchatEndpoint.class);
+    }
+
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        HipchatEndpoint endpoint = getHipchatEndpoint(uri);
+        setProperties(endpoint.getConfiguration(), parameters);
+        if (endpoint.getConfiguration().getAuthToken() == null) {
+            throw new HipchatException("OAuth 2 auth token must be specified");
+        }
+        parseUri(uri, endpoint);
+        LOG.info("Using Hipchat API URL: " + endpoint.getConfiguration().hipChatUrl());
+        return endpoint;
+    }
+
+    private void parseUri(String uri, HipchatEndpoint endpoint) throws URISyntaxException {
+        URI hipChatUri = new URI(uri);
+        if (hipChatUri.getHost() != null) {
+            endpoint.getConfiguration().setHost(hipChatUri.getHost());
+            if (hipChatUri.getPort() != -1) {
+                endpoint.getConfiguration().setPort(hipChatUri.getPort());
+            }
+        }
+    }
+
+    protected HipchatEndpoint getHipchatEndpoint(String uri) {
+        return new HipchatEndpoint(uri, this);
+    }
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConfiguration.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConfiguration.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import org.apache.camel.spi.UriParam;
+import org.apache.camel.spi.UriParams;
+import org.apache.camel.spi.UriPath;
+
+@UriParams
+public class HipchatConfiguration {
+    @UriPath
+    private String host = HipchatConstants.DEFAULT_HOST;
+    @UriPath
+    private Integer port = HipchatConstants.DEFAULT_PORT;
+    @UriParam
+    private String protocol = HipchatConstants.DEFAULT_PROTOCOL;
+    @UriParam
+    private String authToken;
+    @UriParam
+    private String consumeUsers;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    public String getConsumeUsers() {
+        return consumeUsers;
+    }
+
+    public void setConsumeUsers(String consumeUsers) {
+        this.consumeUsers = consumeUsers;
+    }
+
+    public String hipChatUrl() {
+        return getProtocol() + "://" + getHost() + ":" + getPort();
+    }
+
+    public String[] consumableUsers() {
+        return consumeUsers != null ? consumeUsers.split(",") : new String[0];
+    }
+
+    public String withAuthToken(String urlPath) {
+        return urlPath + HipchatApiConstants.AUTH_TOKEN_PREFIX + getAuthToken();
+    }
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConstants.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConstants.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+public interface HipchatConstants {
+
+    String DEFAULT_HOST = "api.hipchat.com";
+    int DEFAULT_PORT = 80;
+    String DEFAULT_PROTOCOL = "http";
+    String TO_USER = "HipchatToUser";
+    String TO_USER_RESPONSE_STATUS = "HipchatToUserResponseStatus";
+    String FROM_USER = "HipchatFromUser";
+    String FROM_USER_RESPONSE_STATUS = "HipchatFromUserResponseStatus";
+    String MESSAGE_DATE = "HipchatMessageDate";
+    String TO_ROOM = "HipchatToRoom";
+    String TO_ROOM_RESPONSE_STATUS = "HipchatToRoomResponseStatus";
+    String TRIGGER_NOTIFY = "HipchatTriggerNotification";
+    String MESSAGE_FORMAT = "HipchatMessageFormat";
+    String MESSAGE_BACKGROUND_COLOR = "HipchatMessageBackgroundColor";
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConsumer.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatConsumer.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.IOException;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.impl.ScheduledPollConsumer;
+import org.apache.camel.util.URISupport;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Hipchat consumer consumes messages from a list of users.
+ */
+public class HipchatConsumer extends ScheduledPollConsumer {
+    public static final long DEFAULT_CONSUMER_DELAY = 5 * 1000;
+    private static final Logger LOG = LoggerFactory.getLogger(HipchatConsumer.class);
+    private static final MapType MAP_TYPE = TypeFactory.defaultInstance().constructMapType(Map.class, String.class, Object.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();
+
+    public HipchatConsumer(HipchatEndpoint endpoint, Processor processor) {
+        super(endpoint, processor);
+    }
+
+    @Override
+    protected int poll() throws Exception {        
+        int messageCount = 0;
+        for (String user : getConfig().consumableUsers()) {
+            Exchange exchange = getEndpoint().createExchange();
+            processExchangeForUser(user, exchange);
+            messageCount++;
+        }
+        return messageCount;
+    }
+
+    private void processExchangeForUser(String user, Exchange exchange) throws Exception {
+        String urlPath = String.format(getMostRecentMessageUrl(), user);
+        LOG.debug("Polling HipChat Api " + urlPath + " for new messages at " + Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime());
+        HttpGet httpGet = new HttpGet(getConfig().hipChatUrl() + urlPath);
+        CloseableHttpResponse response = executeGet(httpGet);
+        exchange.getIn().setHeader(HipchatConstants.FROM_USER, user);
+        processApiResponse(exchange, response);
+    }
+
+    private void processApiResponse(Exchange exchange, CloseableHttpResponse response) throws Exception {
+        try {
+            Map<String, Object> jsonMap = MAPPER.readValue(response.getEntity().getContent(), MAP_TYPE);
+            LOG.debug("Hipchat response " + response + ", json: " + MAPPER.writeValueAsString(jsonMap));
+            if (jsonMap != null && jsonMap.size() > 0) {
+                List<Map<String, Object>> items = (List<Map<String, Object>>) jsonMap.get(HipchatApiConstants.API_ITEMS);
+                if (items != null && items.size() > 0) {
+                    try {
+                        Map<String, Object> item = items.get(0);
+                        String date = (String) item.get(HipchatApiConstants.API_DATE);
+                        String message = (String) item.get(HipchatApiConstants.API_MESSAGE);
+                        LOG.debug("Setting exchange body: " + message + ", header " + HipchatConstants.MESSAGE_DATE + ": " + date);
+                        exchange.getIn().setHeader(HipchatConstants.FROM_USER_RESPONSE_STATUS, response.getStatusLine());
+                        exchange.getIn().setHeader(HipchatConstants.MESSAGE_DATE, date);
+                        exchange.getIn().setBody(message);
+                        getProcessor().process(exchange);
+                    } catch (Exception e) {
+                        throw new HipchatException("Error parsing Json response from Hipchat API", e);
+                    }
+                }
+            }
+        } finally {
+            response.close();
+        }
+    }
+
+    protected CloseableHttpResponse executeGet(HttpGet httpGet) throws IOException {
+        return HTTP_CLIENT.execute(httpGet);
+    }
+
+    private String getMostRecentMessageUrl() {
+        return getConfig().withAuthToken(HipchatApiConstants.URI_PATH_USER_LATEST_PRIVATE_CHAT) + "&" + HipchatApiConstants.DEFAULT_MAX_RESULT;
+    }
+
+    private HipchatConfiguration getConfig() {
+        return getEndpoint().getConfiguration();
+    }
+
+    @Override
+    public HipchatEndpoint getEndpoint() {
+        return (HipchatEndpoint)super.getEndpoint();
+    }
+
+    @Override
+    public String toString() {
+        return "HipchatConsumer[" + URISupport.sanitizeUri(getEndpoint().getEndpointUri()) + "]";
+    }
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatEndpoint.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatEndpoint.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.impl.DefaultEndpoint;
+import org.apache.camel.impl.ScheduledPollEndpoint;
+import org.apache.camel.spi.UriEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a Hipchat endpoint.
+ */
+@UriEndpoint(scheme = "hipchat", consumerClass = HipchatConsumer.class, label = "api,cloud")
+public class HipchatEndpoint extends ScheduledPollEndpoint {
+
+    private HipchatConfiguration configuration;
+
+    public HipchatEndpoint(String uri, HipchatComponent component) {
+        super(uri, component);
+        configuration = new HipchatConfiguration();
+    }
+
+    public Producer createProducer() throws Exception {
+        return new HipchatProducer(this);
+    }
+
+    public Consumer createConsumer(Processor processor) throws Exception {
+        HipchatConsumer consumer =  new HipchatConsumer(this, processor);
+        //Default delay of 500 millis is too often and would result in Rate Limit error's from
+        //HipChat API as per https://www.hipchat.com/docs/apiv2/rate_limiting. End user can override using
+        //consumer.delay parameter
+        consumer.setDelay(HipchatConsumer.DEFAULT_CONSUMER_DELAY);
+        configureConsumer(consumer);
+        return consumer;
+    }
+
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public HipchatConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatException.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatException.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+public class HipchatException extends Exception {
+
+    public HipchatException(String message, Exception e) {
+        super(message, e);
+    }
+
+    public HipchatException(String message) {
+        super(message);
+    }
+}

--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatProducer.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatProducer.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.IOException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultProducer;
+import org.apache.camel.util.URISupport;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Hipchat producer to send message to a user and/or a room.
+ */
+public class HipchatProducer extends DefaultProducer {
+    private static final Logger LOG = LoggerFactory.getLogger(HipchatProducer.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();
+
+    public HipchatProducer(HipchatEndpoint endpoint) {
+        super(endpoint);
+    }
+
+    public void process(Exchange exchange) throws Exception {
+        Message message = getMessageForResponse(exchange);
+        String user = exchange.getIn().getHeader(HipchatConstants.TO_USER, String.class);
+        if (user != null) {
+            message.setHeader(HipchatConstants.TO_USER_RESPONSE_STATUS, sendUserMessage(user, exchange));
+        }
+        String room = exchange.getIn().getHeader(HipchatConstants.TO_ROOM, String.class);
+        if (room != null) {
+            message.setHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS, sendRoomMessage(room, exchange));
+        }
+    }
+
+    private StatusLine sendRoomMessage(String room, Exchange exchange) throws IOException, InvalidPayloadException {
+        String urlPath = String.format(getConfig().withAuthToken(HipchatApiConstants.URI_PATH_ROOM_NOTIFY), room);
+        String backGroundColor = exchange.getIn().getHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, String.class);
+        Map<String, String> jsonParam = getCommonHttpPostParam(exchange);
+        if (backGroundColor != null) {
+            jsonParam.put(HipchatApiConstants.API_MESSAGE_COLOR, backGroundColor);
+        }
+        LOG.info("Sending message to room: " + room + ", " + MAPPER.writeValueAsString(jsonParam));
+        StatusLine statusLine = post(urlPath, jsonParam);
+        LOG.debug("Response status for send room message: " + statusLine);
+        return statusLine;
+    }
+
+    private StatusLine sendUserMessage(String user, Exchange exchange) throws IOException, InvalidPayloadException {
+        String urlPath = String.format(getConfig().withAuthToken(HipchatApiConstants.URI_PATH_USER_MESSAGE), user);
+        Map<String, String> jsonParam = getCommonHttpPostParam(exchange);
+        LOG.info("Sending message to user: " + user + ", " + MAPPER.writeValueAsString(jsonParam));
+        StatusLine statusLine = post(urlPath, jsonParam);
+        LOG.debug("Response status for send user message: " + statusLine);
+        return statusLine;
+    }
+
+    private Map<String, String> getCommonHttpPostParam(Exchange exchange) throws InvalidPayloadException {
+        String format = exchange.getIn().getHeader(HipchatConstants.MESSAGE_FORMAT, "text", String.class);
+        String notify = exchange.getIn().getHeader(HipchatConstants.TRIGGER_NOTIFY, String.class);
+        Map<String, String> jsonMap = new HashMap<String, String>(4);
+        jsonMap.put(HipchatApiConstants.API_MESSAGE, exchange.getIn().getMandatoryBody(String.class));
+        if (notify != null) {
+            jsonMap.put(HipchatApiConstants.API_MESSAGE_NOTIFY, notify);
+        }
+        jsonMap.put(HipchatApiConstants.API_MESSAGE_FORMAT, format);
+        return jsonMap;
+    }
+
+    protected StatusLine post(String urlPath, Map<String, String> postParam) throws IOException {
+        HttpPost httpPost = new HttpPost(getConfig().hipChatUrl() + urlPath);
+        httpPost.setEntity(new StringEntity(MAPPER.writeValueAsString(postParam), ContentType.APPLICATION_JSON));
+        CloseableHttpResponse closeableHttpResponse = HTTP_CLIENT.execute(httpPost);
+        try {
+            return closeableHttpResponse.getStatusLine();
+        } finally {
+            closeableHttpResponse.close();
+        }
+    }
+
+    private Message getMessageForResponse(final Exchange exchange) {
+        if (exchange.getPattern().isOutCapable()) {
+            Message out = exchange.getOut();
+            out.copyFrom(exchange.getIn());
+            return out;
+        }
+        return exchange.getIn();
+    }
+
+    private HipchatConfiguration getConfig() {
+        return getEndpoint().getConfiguration();
+    }
+
+    @Override
+    public HipchatEndpoint getEndpoint() {
+        return (HipchatEndpoint)super.getEndpoint();
+    }
+
+    @Override
+    public String toString() {
+        return "HipchatProducer[" + URISupport.sanitizeUri(getEndpoint().getEndpointUri()) + "]";
+    }
+}

--- a/components/camel-hipchat/src/main/resources/META-INF/LICENSE.txt
+++ b/components/camel-hipchat/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/components/camel-hipchat/src/main/resources/META-INF/NOTICE.txt
+++ b/components/camel-hipchat/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/components/camel-hipchat/src/main/resources/META-INF/services/org/apache/camel/component/hipchat
+++ b/components/camel-hipchat/src/main/resources/META-INF/services/org/apache/camel/component/hipchat
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+class=org.apache.camel.component.hipchat.HipchatComponent

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentConsumerTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentConsumerTest.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.http.HttpEntity;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HipchatComponentConsumerTest extends CamelTestSupport {
+    private CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+
+    @EndpointInject(uri = "hipchat://?authToken=anything&consumeUsers=@AUser")
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void sendInOnly() throws Exception {
+        result.expectedMessageCount(1);
+        String expectedResponse = "{\n"
+                +
+                "  \"items\" : [\n"
+                +
+                "    {\n"
+                +
+                "      \"date\" : \"2015-01-19T22:07:11.030740+00:00\",\n"
+                +
+                "      \"from\" : {\n"
+                +
+                "        \"id\" : 1647095,\n"
+                +
+                "        \"links\" : {\n"
+                +
+                "          \"self\" : \"https://api.hipchat.com/v2/user/1647095\"\n"
+                +
+                "        },\n"
+                +
+                "        \"mention_name\" : \"notifier\",\n"
+                +
+                "        \"name\" : \"Message Notifier\"\n"
+                +
+                "      },\n"
+                +
+                "      \"id\" : \"6567c6f7-7c1b-43cf-bed0-792b1d092919\",\n"
+                +
+                "      \"mentions\" : [ ],\n"
+                +
+                "      \"message\" : \"Unit test Alert\",\n"
+                +
+                "      \"type\" : \"message\"\n"
+                +
+                "    }\n"
+                +
+                "  ],\n"
+                +
+                "  \"links\" : {\n"
+                +
+                "    \"self\" : \"https://api.hipchat.com/v2/user/%40ShreyasPurohit/history/latest\"\n"
+                +
+                "  },\n"
+                +
+                "  \"maxResults\" : 1,\n"
+                +
+                "  \"startIndex\" : 0\n"
+                +
+                "}";
+        HttpEntity mockHttpEntity = mock(HttpEntity.class);
+        when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(expectedResponse.getBytes(StandardCharsets.UTF_8)));
+        when(closeableHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, ""));
+
+        assertMockEndpointsSatisfied();
+
+        assertCommonResultExchange(result.getExchanges().get(0));
+    }
+
+    //TODO
+    @Test
+    public void sendInOnlyMultipleUsers() throws Exception {
+        result.expectedMessageCount(1);
+        String expectedResponse = "{\n"
+                +
+                "  \"items\" : [\n"
+                +
+                "    {\n"
+                +
+                "      \"date\" : \"2015-01-19T22:07:11.030740+00:00\",\n"
+                +
+                "      \"from\" : {\n"
+                +
+                "        \"id\" : 1647095,\n"
+                +
+                "        \"links\" : {\n"
+                +
+                "          \"self\" : \"https://api.hipchat.com/v2/user/1647095\"\n"
+                +
+                "        },\n"
+                +
+                "        \"mention_name\" : \"notifier\",\n"
+                +
+                "        \"name\" : \"Message Notifier\"\n"
+                +
+                "      },\n"
+                +
+                "      \"id\" : \"6567c6f7-7c1b-43cf-bed0-792b1d092919\",\n"
+                +
+                "      \"mentions\" : [ ],\n"
+                +
+                "      \"message\" : \"Unit test Alert\",\n"
+                +
+                "      \"type\" : \"message\"\n"
+                +
+                "    }\n"
+                +
+                "  ],\n"
+                +
+                "  \"links\" : {\n"
+                +
+                "    \"self\" : \"https://api.hipchat.com/v2/user/%40ShreyasPurohit/history/latest\"\n"
+                +
+                "  },\n"
+                +
+                "  \"maxResults\" : 1,\n"
+                +
+                "  \"startIndex\" : 0\n"
+                +
+                "}";
+        HttpEntity mockHttpEntity = mock(HttpEntity.class);
+        when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(expectedResponse.getBytes(StandardCharsets.UTF_8)));
+        when(closeableHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, ""));
+
+        assertMockEndpointsSatisfied();
+
+        assertCommonResultExchange(result.getExchanges().get(0));
+    }
+
+    @Test
+    public void sendInOnlyNoResponse() throws Exception {
+        result.expectedMessageCount(0);
+        HttpEntity mockHttpEntity = mock(HttpEntity.class);
+        when(mockHttpEntity.getContent()).thenReturn(null);
+        when(closeableHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, ""));
+
+        assertMockEndpointsSatisfied();
+    }
+
+    private void assertCommonResultExchange(Exchange resultExchange) {
+        assertIsInstanceOf(String.class, resultExchange.getIn().getBody());
+        assertEquals("Unit test Alert", resultExchange.getIn().getBody(String.class));
+        assertEquals("@AUser", resultExchange.getIn().getHeader(HipchatConstants.FROM_USER));
+        assertEquals("2015-01-19T22:07:11.030740+00:00", resultExchange.getIn().getHeader(HipchatConstants.MESSAGE_DATE));
+        assertNotNull(resultExchange.getIn().getHeader(HipchatConstants.FROM_USER_RESPONSE_STATUS));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        final CamelContext context = super.createCamelContext();
+        HipchatComponent component = new HipchatComponent(context) {
+            @Override
+            protected HipchatEndpoint getHipchatEndpoint(String uri) {
+                return new HipchatEPSuccessTestSupport(uri, this, null, closeableHttpResponse);
+            }
+        };
+        context.addComponent("hipchat", component);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("hipchat://?authToken=anything&consumeUsers=@AUser")
+                        .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentMultipleUsersTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentMultipleUsersTest.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.http.HttpEntity;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HipchatComponentMultipleUsersTest extends CamelTestSupport {
+    private CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+
+    @EndpointInject(uri = "hipchat://?authToken=anything&consumeUsers=@AUser")
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void sendInOnlyMultipleUsers() throws Exception {
+        result.expectedMessageCount(2);
+        result.expectedHeaderValuesReceivedInAnyOrder(HipchatConstants.FROM_USER, Arrays.asList(new String[]{"@AUser", "@BUser"}));
+        final String expectedResponse = "{\n"
+                +
+                "  \"items\" : [\n"
+                +
+                "    {\n"
+                +
+                "      \"date\" : \"2015-01-19T22:07:11.030740+00:00\",\n"
+                +
+                "      \"from\" : {\n"
+                +
+                "        \"id\" : 1647095,\n"
+                +
+                "        \"links\" : {\n"
+                +
+                "          \"self\" : \"https://api.hipchat.com/v2/user/1647095\"\n"
+                +
+                "        },\n"
+                +
+                "        \"mention_name\" : \"notifier\",\n"
+                +
+                "        \"name\" : \"Message Notifier\"\n"
+                +
+                "      },\n"
+                +
+                "      \"id\" : \"6567c6f7-7c1b-43cf-bed0-792b1d092919\",\n"
+                +
+                "      \"mentions\" : [ ],\n"
+                +
+                "      \"message\" : \"Unit test Alert\",\n"
+                +
+                "      \"type\" : \"message\"\n"
+                +
+                "    }\n"
+                +
+                "  ],\n"
+                +
+                "  \"links\" : {\n"
+                +
+                "    \"self\" : \"https://api.hipchat.com/v2/user/%40ShreyasPurohit/history/latest\"\n"
+                +
+                "  },\n"
+                +
+                "  \"maxResults\" : 1,\n"
+                +
+                "  \"startIndex\" : 0\n"
+                +
+                "}";
+        HttpEntity mockHttpEntity = mock(HttpEntity.class);
+        when(mockHttpEntity.getContent()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return new ByteArrayInputStream(expectedResponse.getBytes(StandardCharsets.UTF_8));
+            }
+        });
+        when(closeableHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, ""));
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        final CamelContext context = super.createCamelContext();
+        HipchatComponent component = new HipchatComponent(context) {
+            @Override
+            protected HipchatEndpoint getHipchatEndpoint(String uri) {
+                return new HipchatEPSuccessTestSupport(uri, this, null, closeableHttpResponse);
+            }
+        };
+        context.addComponent("hipchat", component);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("hipchat://?authToken=anything&consumeUsers=@AUser,@BUser")
+                        .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentProducerTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentProducerTest.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.http.StatusLine;
+import org.junit.Test;
+
+public class HipchatComponentProducerTest extends CamelTestSupport {
+    @EndpointInject(uri = "direct:start")
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    private PostCallback callback = new PostCallback();
+
+    @Test
+    public void sendInOnly() throws Exception {
+        result.expectedMessageCount(1);
+
+        Exchange exchange = template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "CamelUnitTest");
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "CamelUnitTestUser");
+                exchange.getIn().setBody("This is my unit test message.");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+
+        assertCommonResultExchange(result.getExchanges().get(0));
+        assertNullExchangeHeader(result.getExchanges().get(0));
+
+        assertResponseMessage(exchange.getIn());
+    }
+
+    @Test
+    public void sendInOut() throws Exception {
+        result.expectedMessageCount(1);
+
+        Exchange exchange = template.send("direct:start", ExchangePattern.InOut, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "CamelUnitTest");
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "CamelUnitTestUser");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, "CamelUnitTestBkColor");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_FORMAT, "CamelUnitTestFormat");
+                exchange.getIn().setHeader(HipchatConstants.TRIGGER_NOTIFY, "CamelUnitTestNotify");
+                exchange.getIn().setBody("This is my unit test message.");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+
+        assertCommonResultExchange(result.getExchanges().get(0));
+        assertRemainingResultExchange(result.getExchanges().get(0));
+
+        assertResponseMessage(exchange.getIn());
+
+    }
+
+    @Test
+    public void sendInOutRoomOnly() throws Exception {
+        result.expectedMessageCount(1);
+
+        Exchange exchange = template.send("direct:start", ExchangePattern.InOut, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "CamelUnitTest");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, "CamelUnitTestBkColor");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_FORMAT, "CamelUnitTestFormat");
+                exchange.getIn().setHeader(HipchatConstants.TRIGGER_NOTIFY, "CamelUnitTestNotify");
+                exchange.getIn().setBody("This is my unit test message.");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+        Exchange resultExchange = result.getExchanges().get(0);
+        assertIsInstanceOf(String.class, resultExchange.getIn().getBody());
+        assertEquals("This is my unit test message.", resultExchange.getIn().getBody(String.class));
+        assertEquals("CamelUnitTest", resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.TO_USER));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS));
+        assertNotNull(resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS));
+
+        assertRemainingResultExchange(result.getExchanges().get(0));
+
+        assertEquals(204, exchange.getIn().getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+        assertNotNull(callback);
+        assertNotNull(callback.called);
+        assertEquals("This is my unit test message.", callback.called.get(HipchatApiConstants.API_MESSAGE));
+        assertEquals("CamelUnitTestBkColor", callback.called.get(HipchatApiConstants.API_MESSAGE_COLOR));
+        assertEquals("CamelUnitTestFormat", callback.called.get(HipchatApiConstants.API_MESSAGE_FORMAT));
+        assertEquals("CamelUnitTestNotify", callback.called.get(HipchatApiConstants.API_MESSAGE_NOTIFY));
+    }
+
+    @Test
+    public void sendInOutUserOnly() throws Exception {
+        result.expectedMessageCount(1);
+
+        Exchange exchange = template.send("direct:start", ExchangePattern.InOut, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "CamelUnitTest");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, "CamelUnitTestBkColor");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_FORMAT, "CamelUnitTestFormat");
+                exchange.getIn().setHeader(HipchatConstants.TRIGGER_NOTIFY, "CamelUnitTestNotify");
+                exchange.getIn().setBody("This is my unit test message.");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+        Exchange resultExchange = result.getExchanges().get(0);
+        assertIsInstanceOf(String.class, resultExchange.getIn().getBody());
+        assertEquals("This is my unit test message.", resultExchange.getIn().getBody(String.class));
+        assertEquals("CamelUnitTest", resultExchange.getIn().getHeader(HipchatConstants.TO_USER));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS));
+        assertNotNull(resultExchange.getIn().getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS));
+
+        assertRemainingResultExchange(result.getExchanges().get(0));
+
+        assertEquals(204, exchange.getIn().getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+        assertNotNull(callback);
+        assertNotNull(callback.called);
+        assertEquals("This is my unit test message.", callback.called.get(HipchatApiConstants.API_MESSAGE));
+        assertNull(callback.called.get(HipchatApiConstants.API_MESSAGE_COLOR));
+        assertEquals("CamelUnitTestFormat", callback.called.get(HipchatApiConstants.API_MESSAGE_FORMAT));
+        assertEquals("CamelUnitTestNotify", callback.called.get(HipchatApiConstants.API_MESSAGE_NOTIFY));
+    }
+
+    private void assertNullExchangeHeader(Exchange resultExchange) {
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.FROM_USER));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.MESSAGE_FORMAT));
+        assertNull(resultExchange.getIn().getHeader(HipchatConstants.TRIGGER_NOTIFY));
+    }
+
+    private void assertRemainingResultExchange(Exchange resultExchange) {
+        assertEquals("CamelUnitTestBkColor", resultExchange.getIn().getHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR));
+        assertEquals("CamelUnitTestFormat", resultExchange.getIn().getHeader(HipchatConstants.MESSAGE_FORMAT));
+        assertEquals("CamelUnitTestNotify", resultExchange.getIn().getHeader(HipchatConstants.TRIGGER_NOTIFY));
+    }
+
+    private void assertResponseMessage(Message message) {
+        assertEquals(204, message.getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+        assertEquals(204, message.getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+    }
+
+    private void assertCommonResultExchange(Exchange resultExchange) {
+        assertIsInstanceOf(String.class, resultExchange.getIn().getBody());
+        assertEquals("This is my unit test message.", resultExchange.getIn().getBody(String.class));
+        assertEquals("CamelUnitTest", resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM));
+        assertEquals("CamelUnitTestUser", resultExchange.getIn().getHeader(HipchatConstants.TO_USER));
+        assertNotNull(resultExchange.getIn().getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS));
+        assertNotNull(resultExchange.getIn().getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        final CamelContext context = super.createCamelContext();
+        HipchatComponent component = new HipchatComponent(context) {
+            @Override
+            protected HipchatEndpoint getHipchatEndpoint(String uri) {
+                return new HipchatEPSuccessTestSupport(uri, this, callback, null);
+            }
+        };
+        context.addComponent("hipchat", component);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .to("hipchat://?authToken=anything")
+                        .to("mock:result");
+            }
+        };
+    }
+
+    public static class PostCallback {
+        public Map<String, String> called;
+        public void call(Map<String, String> postParam) {
+            this.called = postParam;
+        }
+    }
+
+
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatComponentTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import org.apache.camel.CamelContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HipchatComponentTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testAuthTokenMandatory() throws Exception {
+        HipchatComponent component = new HipchatComponent(Mockito.mock(CamelContext.class));
+        expectedException.expect(IllegalArgumentException.class);
+        component.createEndpoint("", "", new HashMap<String, Object>());
+    }
+
+    @Test
+    public void testUriParseNoPort() throws Exception {
+        HipchatComponent component = new HipchatComponent(Mockito.mock(CamelContext.class));
+        HashMap<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("authToken", "token");
+        parameters.put("protocol", "https");
+        HipchatEndpoint endpoint = (HipchatEndpoint)component.createEndpoint("hipchat://localhost?authToken=token&protocol=https", "localhost", parameters);
+        assertEquals("localhost", endpoint.getConfiguration().getHost());
+        assertEquals(new Integer(80), endpoint.getConfiguration().getPort());
+        assertEquals("https", endpoint.getConfiguration().getProtocol());
+        assertEquals("token", endpoint.getConfiguration().getAuthToken());
+        assertEquals("https://localhost:80", endpoint.getConfiguration().hipChatUrl());
+        assertEquals("/a?auth_token=token", endpoint.getConfiguration().withAuthToken("/a"));
+    }
+
+    @Test
+    public void testUriParseFull() throws Exception {
+        HipchatComponent component = new HipchatComponent(Mockito.mock(CamelContext.class));
+        HashMap<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("authToken", "token");
+        parameters.put("protocol", "https");
+        parameters.put("consumeUsers", "@auser,@buser");
+        HipchatEndpoint endpoint = (HipchatEndpoint)component.createEndpoint("hipchat://localhost:8080?authToken=token&protocol=https@consumeUsers=@auser,@buser", "localhost:8080", parameters);
+        assertEquals("localhost", endpoint.getConfiguration().getHost());
+        assertEquals(new Integer(8080), endpoint.getConfiguration().getPort());
+        assertEquals("https", endpoint.getConfiguration().getProtocol());
+        assertEquals("token", endpoint.getConfiguration().getAuthToken());
+        assertEquals("https://localhost:8080", endpoint.getConfiguration().hipChatUrl());
+        assertEquals("/a?auth_token=token", endpoint.getConfiguration().withAuthToken("/a"));
+        assertEquals(2, endpoint.getConfiguration().consumableUsers().length);
+        assertTrue(Arrays.asList(endpoint.getConfiguration().consumableUsers()).contains("@auser"));
+        assertTrue(Arrays.asList(endpoint.getConfiguration().consumableUsers()).contains("@buser"));
+    }
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatEPSuccessTestSupport.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatEPSuccessTestSupport.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.message.BasicStatusLine;
+
+public class HipchatEPSuccessTestSupport extends HipchatEndpoint {
+    private HipchatComponentProducerTest.PostCallback callback;
+    private CloseableHttpResponse closeableHttpResponse;
+
+    public HipchatEPSuccessTestSupport(
+            String uri,
+            HipchatComponent component,
+            HipchatComponentProducerTest.PostCallback callback,
+            CloseableHttpResponse consumerResponse) {
+        super(uri, component);
+        this.callback = callback;
+        this.closeableHttpResponse = consumerResponse;
+    }
+
+    public Producer createProducer() throws Exception {
+        return new HipchatProducer(this) {
+            @Override
+            protected StatusLine post(String urlPath, Map<String, String> postParam) throws IOException {
+                callback.call(postParam);
+                return new BasicStatusLine(new ProtocolVersion("any", 1, 1), 204, "");
+            }
+        };
+    }
+
+    @Override
+    public Consumer createConsumer(Processor processor) throws Exception {
+        return new HipchatConsumer(this, processor) {
+            @Override
+            protected CloseableHttpResponse executeGet(HttpGet httpGet) throws IOException {
+                return closeableHttpResponse;
+            }
+        };
+    }
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatEndpointTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatEndpointTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HipchatEndpointTest {
+    @Test
+    public void testCreateConsumer() throws Exception {
+        HipchatComponent component = new HipchatComponent(Mockito.mock(CamelContext.class));
+        HipchatEndpoint endpoint = new HipchatEndpoint("hipchat://?authKey=token", component);
+        HipchatConsumer consumer = (HipchatConsumer)endpoint.createConsumer(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+
+            }
+        });
+
+        Assert.assertEquals(5000, consumer.getDelay());
+    }
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatConsumerIntegrationTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatConsumerIntegrationTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat.integration;
+
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Predicate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.hipchat.HipchatConstants;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.http.StatusLine;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Must be manually tested. Provide your own auth key, user, & room from https://www.hipchat.com/docs/apiv2/auth")
+public class HipchatConsumerIntegrationTest extends CamelTestSupport {
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void sendInOnly() throws Exception {
+        result.expectedMessageCount(1);
+        result.expectedMessagesMatches(new Predicate() {
+            @Override
+            public boolean matches(Exchange exchange) {
+                StatusLine status = (StatusLine)exchange.getIn().getHeader(HipchatConstants.FROM_USER_RESPONSE_STATUS);
+                return 200 == status.getStatusCode();
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                String hipchatEndpointUri = "hipchat://?authToken=XXXX&consumeUsers=@ShreyasPurohit&delay=1000";
+
+                from(hipchatEndpointUri)
+                    .idempotentConsumer(
+                        simple("${in.header.HipchatMessageDate} ${in.header.HipchatFromUser}"),
+                        MemoryIdempotentRepository.memoryIdempotentRepository(200)
+                    )
+                    .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatProducerIntegrationTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatProducerIntegrationTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat.integration;
+
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.hipchat.HipchatConstants;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.http.StatusLine;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Must be manually tested. Provide your own auth key, user, & room from https://www.hipchat.com/docs/apiv2/auth")
+public class HipchatProducerIntegrationTest extends CamelTestSupport {
+    @EndpointInject(uri = "direct:start")
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void sendInOnly() throws Exception {
+        result.expectedMessageCount(2);
+
+        Exchange exchange1 = template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "Developer");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_FORMAT, "text");
+                exchange.getIn().setHeader(HipchatConstants.TRIGGER_NOTIFY, "true");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, "green");
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "@ShreyasPurohit");
+                exchange.getIn().setBody("Integration test Alert");
+            }
+        });
+
+        Exchange exchange2 = template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "Developer");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_FORMAT, "html");
+                exchange.getIn().setHeader(HipchatConstants.TRIGGER_NOTIFY, "false");
+                exchange.getIn().setHeader(HipchatConstants.MESSAGE_BACKGROUND_COLOR, "red");
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "@ShreyasPurohit");
+                exchange.getIn().setBody("<b>Integration test Alert</b>");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+
+        assertResponseMessage(exchange1.getIn());
+        assertResponseMessage(exchange2.getIn());
+
+    }
+
+    private void assertResponseMessage(Message message) {
+        assertEquals(204, message.getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+        assertEquals(204, message.getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS, StatusLine.class).getStatusCode());
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                String hipchatEndpointUri = "hipchat://?authToken=XXXX";
+
+                from("direct:start")
+                        .to(hipchatEndpointUri)
+                        .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/components/camel-hipchat/src/test/resources/log4j.properties
+++ b/components/camel-hipchat/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+#
+# The logging properties used
+#
+log4j.rootLogger=INFO, out
+
+# uncomment the following line to turn on Camel debugging
+#log4j.logger.org.apache.camel=DEBUG
+log4j.logger.org.apache.camel.component.hipchat=DEBUG
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+#log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -112,6 +112,7 @@
     <module>camel-hbase</module>
     <module>camel-hdfs</module>
     <module>camel-hdfs2</module>
+    <module>camel-hipchat</module>
     <module>camel-hl7</module>
     <module>camel-ibatis</module>
     <module>camel-ical</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -881,6 +881,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
+        <artifactId>camel-hipchat</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -635,6 +635,14 @@
     <bundle>mvn:org.apache.camel/camel-hdfs2/${project.version}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.hadoop-client/${hadoop2-bundle-version}</bundle>
   </feature>
+  <feature name='camel-hipchat' version='${project.version}' resolver='(obr)' start-level='50'>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
+    <feature version='${project.version}'>camel-core</feature>
+    <bundle>mvn:org.apache.camel/camel-hipchat/${project.version}</bundle>
+  </feature>
   <feature name='camel-hl7' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature version='${project.version}'>camel-netty4</feature>


### PR DESCRIPTION
@davsclaus @WillemJiang 

Creates a new camel-hipchat component that can integrate with Hipchat. Following functionality are supported.
1. Send message to User and/or Room
2. Send text/html message with background color when supported
3. Notify the user/room of a new message
4. Consume latest message from user's using scheduled poll

Following things have been done as per http://camel.apache.org/add-new-component-guide.html
1. Jira: CAMEL-8265
2. All dependencies used where already present in apache camel. No new dependency added, hence no new license needs to be evaluated.
3. This PR
4. camel-hipchat component added to components pom modules section
5a. Every added source and resource contains the Apache license header.
5b. Component has an adequate test coverage.
5c. Build with checkstyle to ensure the sources are conform with the Apache Camel coding rules
5d. Producer log output is adequate on the INFO log level, the consumer is at DEBUG level as it is a polling consumer.
6. All dependencies used in this component already exist in Camel and hence they should already be OSGI compliant.
7. New feature added to platforms/karaf/features.
8. Submitted ICLA to get approval to edit wiki when this PR is merged.
9. Run maven clean install from new component directory
10. Add new component to parent/pom.xml and apache-camel/src/main/descriptors/common-bin.xml

Thing's I could not do:
1. mvn clean install -Pvalidate could not complete due to not related error:
[ERROR] Failed to execute goal org.apache.karaf.tooling:features-maven-plugin:2.4.1:validate (validate) on project apache-camel: Unable to validate F:
\Projects\Java\camel\platforms\karaf\features\target\classes\features.xml: Could not transfer artifact org.apache.cxf.karaf:apache-cxf:xml:features:3.
0.3 from/to google.script.repo (http://scriptengines.googlecode.com/svn/m2-repo/): No connector available to access repository google.script.repo (htt
p://scriptengines.googlecode.com/svn/m2-repo/) of type default using the available factories WagonRepositoryConnectorFactory
[ERROR] org.apache.cxf.karaf:apache-cxf:xml:3.0.3