### PR TITLE
added possibility to use filename header withing zip aggregation

### DIFF
--- a/components/camel-zipfile/src/main/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategy.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategy.java
@@ -55,6 +55,14 @@ public class ZipAggregationStrategy implements AggregationStrategy {
     public ZipAggregationStrategy() {
         this(false, false);
     }
+
+    /**
+     * @param preserveFolderStructure if true, the folder structure is preserved when the source is
+     * a type of {@link GenericFileMessage}.  If used with a file, use recursive=true.
+     */
+    public ZipAggregationStrategy(boolean preserveFolderStructure) {
+        this(preserveFolderStructure, false);
+    }
     
     /**
      * @param preserveFolderStructure if true, the folder structure is preserved when the source is

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithFilenameHeaderTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithFilenameHeaderTest.java
@@ -67,7 +67,7 @@ public class AggregationStrategyWithFilenameHeaderTest extends CamelTestSupport 
                 final ZipEntry entry = entries.nextElement();
                 assertTrue("Zip entry file name should be on of: " + FILE_NAMES, FILE_NAMES.contains(entry.getName()));                
             }
-            assertEquals("Zip file should contains " + FILE_NAMES.size() + " files", FILE_NAMES.size(), fileCount);
+            assertEquals("Zip file should contain " + FILE_NAMES.size() + " files", FILE_NAMES.size(), fileCount);
         } finally {
             IOHelper.close(file);
         }

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithPreservationTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithPreservationTest.java
@@ -78,7 +78,7 @@ public class AggregationStrategyWithPreservationTest extends CamelTestSupport {
             public void configure() throws Exception {
                 // Unzip file and Split it according to FileEntry
                 from("file:src/test/resources/org/apache/camel/aggregate/zipfile/data?consumer.delay=1000&noop=true&recursive=true")
-                    .aggregate(new ZipAggregationStrategy(true, false))
+                    .aggregate(new ZipAggregationStrategy(true))
                         .constant(true)
                         .completionFromBatchConsumer()
                         .eagerCheckCompletion()


### PR DESCRIPTION
when aggregating byte arrays using a zipaggregationstrategy within a multicast the messageid will be the same resulting in an error because the filename will be duplicate.