### PR TITLE
Creating objects with custom data types

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
@@ -102,7 +102,7 @@ public class CMISProducer extends DefaultProducer {
     private boolean isFolder(Message message) {
         String baseTypeId = message.getHeader(PropertyIds.OBJECT_TYPE_ID, String.class);
         if (baseTypeId != null) {
-            return baseTypeId.equals(CamelCMISConstants.CMIS_FOLDER);
+            return CamelCMISConstants.CMIS_FOLDER.equals(cmisSessionFacade.getCMISTypeFor(baseTypeId));
         }
         return message.getBody() == null;
     }
@@ -137,7 +137,7 @@ public class CMISProducer extends DefaultProducer {
     private boolean isDocument(Exchange exchange) {
         String baseTypeId = exchange.getIn().getHeader(PropertyIds.OBJECT_TYPE_ID, String.class);
         if (baseTypeId != null) {
-            return baseTypeId.equals(CamelCMISConstants.CMIS_DOCUMENT);
+            return CamelCMISConstants.CMIS_DOCUMENT.equals(cmisSessionFacade.getCMISTypeFor(baseTypeId));
         }
         return exchange.getIn().getBody() != null;
     }

--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -190,10 +190,8 @@ public class CMISSessionFacade {
     }
 
     public boolean isObjectTypeVersionable(String objectType) {
-        ObjectType typeDefinition = session.getTypeDefinition(objectType);
-        ObjectType objectBaseType = typeDefinition.getBaseType();
-        if (CamelCMISConstants.CMIS_DOCUMENT.equals(objectType) 
-                || (objectBaseType != null && CamelCMISConstants.CMIS_DOCUMENT.equals(objectBaseType.getId()))) {
+        if (CamelCMISConstants.CMIS_DOCUMENT.equals(getCMISTypeFor(objectType))) {
+            ObjectType typeDefinition = session.getTypeDefinition(objectType);
             return ((DocumentType)typeDefinition).isVersionable();
         }
         return false;
@@ -203,7 +201,12 @@ public class CMISSessionFacade {
         return buf != null ? session.getObjectFactory()
                 .createContentStream(fileName, buf.length, mimeType, new ByteArrayInputStream(buf)) : null;
     }
-    
+
+    public String getCMISTypeFor(String customOrCMISType) {
+        ObjectType objectBaseType = session.getTypeDefinition(customOrCMISType).getBaseType();
+        return objectBaseType == null ? customOrCMISType : objectBaseType.getId();
+    }
+
     public OperationContext createOperationContext() {
         return session.createOperationContext();
     }

--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.cmis;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
@@ -205,6 +202,10 @@ public class CMISSessionFacade {
     public String getCMISTypeFor(String customOrCMISType) {
         ObjectType objectBaseType = session.getTypeDefinition(customOrCMISType).getBaseType();
         return objectBaseType == null ? customOrCMISType : objectBaseType.getId();
+    }
+
+    public Set<String> getPropertiesFor(String objectType) {
+        return session.getTypeDefinition(objectType).getPropertyDefinitions().keySet();
     }
 
     public OperationContext createOperationContext() {

--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -190,8 +190,10 @@ public class CMISSessionFacade {
     }
 
     public boolean isObjectTypeVersionable(String objectType) {
-        if (CamelCMISConstants.CMIS_DOCUMENT.equals(objectType)) {
-            ObjectType typeDefinition = session.getTypeDefinition(objectType);
+        ObjectType typeDefinition = session.getTypeDefinition(objectType);
+        ObjectType objectBaseType = typeDefinition.getBaseType();
+        if (CamelCMISConstants.CMIS_DOCUMENT.equals(objectType) 
+                || (objectBaseType != null && CamelCMISConstants.CMIS_DOCUMENT.equals(objectBaseType.getId()))) {
             return ((DocumentType)typeDefinition).isVersionable();
         }
         return false;


### PR DESCRIPTION
I had a problem. cmis producer had created an custom typed object with an empty body and with an empty metadata fields. This pull request fixes a problem.