### PR TITLE
CAMEL-8293: Be more override-friendly in CamelTestSupport by returning i...

### DIFF
--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTestSupport.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTestSupport.java
@@ -51,6 +51,7 @@ import org.apache.camel.management.JmxSystemPropertyKeys;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.spi.Language;
+import org.apache.camel.spi.Registry;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
 import org.junit.After;
@@ -489,7 +490,7 @@ public abstract class CamelTestSupport extends TestSupport {
         return context;
     }
 
-    protected JndiRegistry createRegistry() throws Exception {
+    protected Registry createRegistry() throws Exception {
         return new JndiRegistry(createJndiContext());
     }
 

--- a/components/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
@@ -65,7 +65,7 @@ public class CamelTestSupportTest extends CamelTestSupport {
     protected JndiRegistry createRegistry() throws Exception {
         called = true;
 
-        JndiRegistry jndi = super.createRegistry();
+        JndiRegistry jndi = (JndiRegistry) super.createRegistry();
         jndi.bind("beer", "yes");
         return jndi;
     }


### PR DESCRIPTION
...nterface type instead of concrete impl