### PR TITLE
Remove unused spring-test dependency

### DIFF
--- a/components/camel-spring-javaconfig/pom.xml
+++ b/components/camel-spring-javaconfig/pom.xml
@@ -46,11 +46,7 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-tx</artifactId>
         </exclusion>
-      </exclusions>      
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
Depending on camel-spring-javaconfig causes spring-test to be pulled into my project's compile scope. Spring-test should only be pulled into the test scope. It turns out camel-spring-javaconfig does not even require it for testing so I have removed it completely from that project's pom.