### PR TITLE
CAMEL-8226 Deprecated feature dataSourceRef not working correctly

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlComponent.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlComponent.java
@@ -51,9 +51,8 @@ public class SqlComponent extends UriEndpointComponent {
         }
 
         //TODO cmueller: remove the 'dataSourceRef' lookup in Camel 3.0
-        if (dataSource == null) {
-            String dataSourceRef = getAndRemoveParameter(parameters, "dataSourceRef", String.class);
-            if (dataSourceRef != null) {
+        String dataSourceRef = getAndRemoveParameter(parameters, "dataSourceRef", String.class);
+        if (dataSource == null && dataSourceRef != null) {
                 dataSource = CamelContextHelper.mandatoryLookup(getCamelContext(), dataSourceRef, DataSource.class);
             }
         }


### PR DESCRIPTION
If you try to create more than one of endpoint from SqlComponent with specifying dataSourceRef option, it doesn't remove dataSourceRef option from URL on 2nd attempt as dataSource object is already populated on 1st attempt, causes org.apache.camel.ResolveEndpointFailedException