### PR TITLE
CAMEL-8355 Dynamicity flag on Mongodb endpoint run a dropIndex() command on specified collection

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -214,7 +214,6 @@ public class MongoDbEndpoint extends DefaultEndpoint {
      * @param collection
      */
     public void ensureIndex(DBCollection collection, List<DBObject> dynamicIndex) {
-        collection.dropIndexes();
         if (dynamicIndex != null && !dynamicIndex.isEmpty()) {
             for (DBObject index : dynamicIndex) {
                 LOG.debug("create BDObject Index {}", index);


### PR DESCRIPTION
Hi all,

This PR is related to the following issue:
https://issues.apache.org/jira/browse/CAMEL-8355

Thanks.

Bye,
Andrea