### PR TITLE
CAMEL-8332: Additional features for camel-dozer component

### DIFF
--- a/components/camel-dozer/pom.xml
+++ b/components/camel-dozer/pom.xml
@@ -45,7 +45,16 @@
             <groupId>net.sf.dozer</groupId>
             <artifactId>dozer</artifactId>
         </dependency>
-
+        <dependency>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+          <version>${javax.el-api-version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.web</groupId>
+          <artifactId>javax.el</artifactId>
+          <version>${javax.el-version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerComponent.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerComponent.java
@@ -16,26 +16,54 @@
  */
 package org.apache.camel.component.dozer;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
+import org.apache.camel.converter.dozer.DozerBeanMapperConfiguration;
 import org.apache.camel.impl.UriEndpointComponent;
+import org.apache.camel.util.ReflectionHelper;
+import org.dozer.config.GlobalSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DozerComponent extends UriEndpointComponent {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(DozerComponent.class);
 
     public DozerComponent() {
         super(DozerEndpoint.class);
+        initDozerSettings();
     }
     
     public DozerComponent(CamelContext context) {
         super(context, DozerEndpoint.class);
+        initDozerSettings();
     }
-
+    
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         DozerConfiguration config = new DozerConfiguration();
         config.setName(remaining);
+        config.setMappingConfiguration(getAndRemoveOrResolveReferenceParameter(
+                parameters, "mappingConfiguration", DozerBeanMapperConfiguration.class));
         setProperties(config, parameters);
+        
+        // Validate endpoint parameters
+        if (config.getTargetModel() == null) {
+            throw new IllegalArgumentException("The targetModel parameter is required for dozer endpoints");
+        }
         return new DozerEndpoint(uri, this, config);
+    }
+    
+    private void initDozerSettings() {
+        try {
+            GlobalSettings settings = GlobalSettings.getInstance();
+            LOG.info("Configuring GlobalSettings to enable EL");
+            Field field = settings.getClass().getDeclaredField("elEnabled");
+            ReflectionHelper.setField(field, settings, true);
+        } catch (NoSuchFieldException nsfEx) {
+            throw new IllegalStateException("Failed to enable EL in global Dozer settings", nsfEx);
+        }
     }
 }

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerConfiguration.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.dozer;
 
+import org.apache.camel.converter.dozer.DozerBeanMapperConfiguration;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
@@ -37,10 +38,12 @@ public class DozerConfiguration {
     private String unmarshalId;
     @UriParam
     private String sourceModel;
-    @UriParam
+    @UriParam @Metadata(required = "true")
     private String targetModel;
     @UriParam(defaultValue = DEFAULT_MAPPING_FILE)
     private String mappingFile;
+    @UriParam
+    private DozerBeanMapperConfiguration mappingConfiguration;
     
     public DozerConfiguration() {
         setMappingFile(DEFAULT_MAPPING_FILE);
@@ -92,5 +95,13 @@ public class DozerConfiguration {
 
     public void setMappingFile(String mappingFile) {
         this.mappingFile = mappingFile;
+    }
+    
+    public DozerBeanMapperConfiguration getMappingConfiguration() {
+        return mappingConfiguration;
+    }
+
+    public void setMappingConfiguration(DozerBeanMapperConfiguration mappingConfiguration) {
+        this.mappingConfiguration = mappingConfiguration;
     }
 }

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/ExpressionMapper.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/ExpressionMapper.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.dozer;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
+import org.apache.camel.spi.Language;
+
+/**
+ * Provides support for mapping a Camel expression to a target field in a 
+ * mapping.  Expressions have the following format:
+ * <br><br>
+ * [language]:[expression]
+ * <br><br>
+ */
+public class ExpressionMapper extends BaseConverter {
+    
+    private ThreadLocal<Exchange> currentExchange = new ThreadLocal<Exchange>();
+    
+    @Override
+    public Object convert(Object existingDestinationFieldValue, 
+            Object sourceFieldValue, 
+            Class<?> destinationClass,
+            Class<?> sourceClass) {
+        try {
+            if (currentExchange.get() == null) {
+                throw new IllegalStateException(
+                        "Current exchange has not been set for ExpressionMapper");
+            }
+            // Resolve the language being used for this expression and evaluate
+            Exchange exchange = currentExchange.get();
+            Language expLang = exchange.getContext().resolveLanguage(getLanguagePart());
+            Expression exp = expLang.createExpression(getExpressionPart());
+            return exp.evaluate(exchange, destinationClass);
+        } finally {
+            done();
+        }
+    }
+    
+    /**
+     * Used as the source field for Dozer mappings. 
+     */
+    public String getExpression() {
+        return getParameter();
+    }
+    
+    /**
+     * The actual expression, without the language prefix.
+     */
+    public String getExpressionPart() {
+        return getParameter().substring(getParameter().indexOf(":") + 1);
+    }
+    
+    /**
+     * The expression language used for this mapping.
+     */
+    public String getLanguagePart() {
+        return getParameter().substring(0, getParameter().indexOf(":"));
+    }
+    
+    /**
+     * Sets the Camel exchange reference for this mapping.  The exchange 
+     * reference is stored in a thread-local which is cleaned up after the 
+     * mapping has been performed via the done() method.
+     * @param exchange
+     */
+    public void setCurrentExchange(Exchange exchange) {
+        currentExchange.set(exchange);
+    }
+    
+    @Override
+    public void done() {
+        super.done();
+        currentExchange.set(null);
+    }
+}

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/VariableMapper.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/VariableMapper.java
@@ -20,7 +20,7 @@ package org.apache.camel.component.dozer;
  * Used to map literal values (e.g. "ACME" or "ABC-123") to a field in the 
  * target object.
  */
-public class LiteralMapper extends BaseConverter {
+public class VariableMapper extends BaseConverter {
      
     @Override
     public Object convert(Object existingDestinationFieldValue, 

--- a/components/camel-dozer/src/main/java/org/apache/camel/converter/dozer/DozerTypeConverterLoader.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/converter/dozer/DozerTypeConverterLoader.java
@@ -228,7 +228,7 @@ public class DozerTypeConverterLoader extends ServiceSupport implements CamelCon
      * @param configuration  the dozer bean mapper configuration.
      * @return the created mapper
      */
-    protected DozerBeanMapper createDozerBeanMapper(DozerBeanMapperConfiguration configuration) {
+    public static DozerBeanMapper createDozerBeanMapper(DozerBeanMapperConfiguration configuration) {
         DozerBeanMapper mapper;
         if (configuration.getMappingFiles() != null) {
             mapper = new DozerBeanMapper(configuration.getMappingFiles());

--- a/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/DozerComponentTest.java
+++ b/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/DozerComponentTest.java
@@ -49,4 +49,16 @@ public class DozerComponentTest {
         Assert.assertEquals(TARGET_MODEL, config.getTargetModel());
         Assert.assertEquals(DOZER_CONFIG_PATH, config.getMappingFile());
     }
+    
+    @Test
+    public void requiredTargetModelMissing() throws Exception {
+        DozerComponent comp = new DozerComponent();
+        comp.setCamelContext(new DefaultCamelContext());
+        try {
+            comp.createEndpoint("dozer:noTargetModel?mappingFile=mapping.xml");
+            Assert.fail("targetModel is a required parameter");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+    }
 }

--- a/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/ExpressionMappingTest.java
+++ b/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/ExpressionMappingTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.dozer;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.dozer.example.abc.ABCOrder;
+import org.apache.camel.component.dozer.example.xyz.XYZOrder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class ExpressionMappingTest {
+    
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint resultEndpoint;
+    
+    @Produce(uri = "direct:start")
+    private ProducerTemplate startEndpoint;
+    
+    @Autowired
+    private CamelContext camelContext;
+    
+    @After
+    public void tearDown() {
+        resultEndpoint.reset();
+    }
+    
+    @Test
+    public void testExpressionMapping() throws Exception {
+        resultEndpoint.expectedMessageCount(1);
+        final String headerName = "customerNumber";
+        final String headerVal = "CAFE-123";
+        ABCOrder abcOrder = new ABCOrder();
+        // Header value should be mapped to custId in target model
+        startEndpoint.sendBodyAndHeader(abcOrder, headerName, headerVal);
+        // check results
+        resultEndpoint.assertIsSatisfied();
+        XYZOrder result = resultEndpoint.getExchanges().get(0).getIn().getBody(XYZOrder.class);
+        Assert.assertEquals(headerVal, result.getCustId());
+    }
+}

--- a/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/VariableMappingTest.java
+++ b/components/camel-dozer/src/test/java/org/apache/camel/component/dozer/VariableMappingTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-public class LiteralMappingTest {
+public class VariableMappingTest {
     
     @EndpointInject(uri = "mock:result")
     private MockEndpoint resultEndpoint;
@@ -61,7 +61,7 @@ public class LiteralMappingTest {
         resultEndpoint.assertIsSatisfied();
         XYZOrder result = resultEndpoint.getExchanges().get(0).getIn().getBody(XYZOrder.class);
         Assert.assertEquals(result.getPriority(), "GOLD");
-        Assert.assertEquals(result.getCustId(), "LITERAL_CUST_ID");
-        Assert.assertEquals(result.getOrderId(), "LITERAL_ORDER_ID");
+        Assert.assertEquals("ACME-SALES", result.getCustId());
+        Assert.assertEquals("W123-EG", result.getOrderId());
     }
 }

--- a/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/ExpressionMappingTest-context.xml
+++ b/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/ExpressionMappingTest-context.xml
@@ -19,7 +19,7 @@
 
    <!-- Camel route -->
    <camelContext xmlns="http://camel.apache.org/schema/spring">
-    <endpoint uri="dozer:java2java?mappingFile=org/apache/camel/component/dozer/literalMapping.xml&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder" id="java2java"/>
+    <endpoint uri="dozer:java2java?mappingFile=org/apache/camel/component/dozer/expressionMapping.xml&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder&amp;sourceModel=org.apache.camel.component.dozer.example.abc.ABCOrder" id="java2java"/>
     <route>
         <from uri="direct:start"/>
         <to ref="java2java"/>

--- a/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/VariableMappingTest-context.xml
+++ b/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/VariableMappingTest-context.xml
@@ -18,20 +18,12 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:camel="http://camel.apache.org/schema/spring" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
    <!-- Camel route -->
-    <camelContext xmlns="http://camel.apache.org/schema/spring">
-	  <endpoint uri="dozer:java2java?mappingConfiguration=#mapConfig&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder" id="java2java"/>
-	  <route>
-	      <from uri="direct:start"/>
-	      <to ref="java2java"/>
-	      <to uri="mock:result"/>
-	  </route>
-    </camelContext>
-    
-    <bean id="mapConfig" class="org.apache.camel.converter.dozer.DozerBeanMapperConfiguration">
-      <property name="mappingFiles">
-        <list>
-          <value>org/apache/camel/component/dozer/customMapping.xml</value>
-        </list>
-      </property>
-    </bean>
+   <camelContext xmlns="http://camel.apache.org/schema/spring">
+    <endpoint uri="dozer:java2java?mappingFile=org/apache/camel/component/dozer/variableMapping.xml&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder&amp;sourceModel=org.apache.camel.component.dozer.example.abc.ABCOrder" id="java2java"/>
+    <route>
+        <from uri="direct:start"/>
+        <to ref="java2java"/>
+        <to uri="mock:result"/>
+    </route>
+</camelContext>
 </beans>

--- a/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/XmlToJsonTest-context.xml
+++ b/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/XmlToJsonTest-context.xml
@@ -19,7 +19,7 @@
 
    <!-- Camel route -->
    <camelContext xmlns="http://camel.apache.org/schema/spring">
-    <endpoint uri="dozer:xml2json?mappingFile=org/apache/camel/component/dozer/dozerBeanMapping.xml&amp;marshalId=myjson&amp;unmarshalId=myjaxb&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder" id="xml2json"/>
+    <endpoint uri="dozer:xml2json?mappingFile=org/apache/camel/component/dozer/dozerBeanMapping.xml&amp;marshalId=myjson&amp;unmarshalId=myjaxb&amp;targetModel=org.apache.camel.component.dozer.example.xyz.XYZOrder&amp;sourceModel=org.apache.camel.component.dozer.example.abc.ABCOrder" id="xml2json"/>
     <dataFormats>
         <json library="Jackson" id="myjson"/>
         <jaxb contextPath="org.apache.camel.component.dozer.example.abc" id="myjaxb"/>

--- a/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/expressionMapping.xml
+++ b/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/expressionMapping.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<mappings xmlns="http://dozer.sourceforge.net" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://dozer.sourceforge.net http://dozer.sourceforge.net/schema/beanmapping.xsd">
+    <mapping>
+        <class-a>org.apache.camel.component.dozer.example.abc.ABCOrder</class-a>
+        <class-b>org.apache.camel.component.dozer.example.xyz.XYZOrder</class-b>
+        <field>
+            <a>header.status</a>
+            <b>priority</b>
+        </field>
+        <field>
+            <a>header.orderNum</a>
+            <b>orderId</b>
+        </field>
+    </mapping>
+    <mapping>
+        <class-a>org.apache.camel.component.dozer.ExpressionMapper</class-a>
+        <class-b>org.apache.camel.component.dozer.example.xyz.XYZOrder</class-b>
+        <field custom-converter-id="_expressionMapping" custom-converter-param="simple:\${header.customerNumber}">
+            <a>expression</a>
+            <b>custId</b>
+        </field>
+    </mapping>
+</mappings>

--- a/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/variableMapping.xml
+++ b/components/camel-dozer/src/test/resources/org/apache/camel/component/dozer/variableMapping.xml
@@ -16,6 +16,12 @@
   limitations under the License.
 -->
 <mappings xmlns="http://dozer.sourceforge.net" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://dozer.sourceforge.net http://dozer.sourceforge.net/schema/beanmapping.xsd">
+    <configuration>
+        <variables>
+            <variable name="CUST_ID">ACME-SALES</variable>
+            <variable name="ORDER_ID">W123-EG</variable>
+        </variables>
+    </configuration>
     <mapping>
         <class-a>org.apache.camel.component.dozer.example.abc.ABCOrder</class-a>
         <class-b>org.apache.camel.component.dozer.example.xyz.XYZOrder</class-b>
@@ -29,13 +35,13 @@
         </field>
     </mapping>
     <mapping>
-        <class-a>org.apache.camel.component.dozer.LiteralMapper</class-a>
+        <class-a>org.apache.camel.component.dozer.VariableMapper</class-a>
         <class-b>org.apache.camel.component.dozer.example.xyz.XYZOrder</class-b>
-        <field custom-converter-id="_literalMapping" custom-converter-param="LITERAL_CUST_ID">
+        <field custom-converter-id="_variableMapping" custom-converter-param="${CUST_ID}">
             <a>literal</a>
             <b>custId</b>
         </field>
-        <field custom-converter-id="_literalMapping" custom-converter-param="LITERAL_ORDER_ID">
+        <field custom-converter-id="_variableMapping" custom-converter-param="${ORDER_ID}">
             <a>literal</a>
             <b>orderId</b>
         </field>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -316,6 +316,8 @@
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle dependency='true'>mvn:commons-collections/commons-collections/${commons-collections-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-beanutils/${commons-beanutils-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:javax.el/javax.el-api/${javax.el-api-version}</bundle>
+    <bundle dependency='true'>mvn:org.glassfish.web/javax.el/${javax.el-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-dozer/${project.version}</bundle>
   </feature>
   <feature name='camel-dropbox' version='${project.version}' resolver='(obr)' start-level='50'>


### PR DESCRIPTION
This commit includes the following changes:
* Added a new converter which allows the user to evaluate an expression using Camel language support and assign it to an output field.
* Enabled javax.el support to allow variables to be used in mappings.
* Users can specify the name of a DozerBeanMapperConfiguration bean instead of a Dozer mapping file to allow for fine-grained configuration of the Dozer environment.
* The sourceModel option is actually used now and targetModel is marked as required.