### PR TITLE
CAMEL-8054: jpa shared entity manager

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaComponent.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaComponent.java
@@ -37,6 +37,7 @@ public class JpaComponent extends UriEndpointComponent {
     private EntityManagerFactory entityManagerFactory;
     private PlatformTransactionManager transactionManager;
     private boolean joinTransaction = true;
+    private boolean sharedEntityManager = false;
 
     public JpaComponent() {
         super(JpaEndpoint.class);
@@ -60,6 +61,19 @@ public class JpaComponent extends UriEndpointComponent {
         this.transactionManager = transactionManager;
     }
 
+    public boolean isSharedEntityManager() {
+        return sharedEntityManager;
+    }
+
+    /**
+     * Whether to use spring's SharedEntityManager for the consumer/producer. 
+	 * Note in most cases joinTransaction should be set to false as this is not an EXTENDED EntityManager.
+     * @param sharedEntityManager enables by default for all endpoints
+     */
+    public void setSharedEntityManager(boolean sharedEntityManager) {
+        this.sharedEntityManager = sharedEntityManager;
+    }
+
     // Implementation methods
     //-------------------------------------------------------------------------
 
@@ -67,6 +81,7 @@ public class JpaComponent extends UriEndpointComponent {
     protected Endpoint createEndpoint(String uri, String path, Map<String, Object> options) throws Exception {
         JpaEndpoint endpoint = new JpaEndpoint(uri, this);
         endpoint.setJoinTransaction(isJoinTransaction());
+        endpoint.setSharedEntityManager(isSharedEntityManager());
 
         // lets interpret the next string as a class
         if (ObjectHelper.isNotEmpty(path)) {
@@ -146,4 +161,5 @@ public class JpaComponent extends UriEndpointComponent {
     public void setJoinTransaction(boolean joinTransaction) {
         this.joinTransaction = joinTransaction;
     }
+
 }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
@@ -91,6 +91,10 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
         shutdownRunningTask = null;
         pendingExchanges = 0;
 
+        //get a fresh entity manager if closed
+        final EntityManager entityManager = createEntityManager();
+    
+        try {
         Object messagePolled = transactionTemplate.execute(new TransactionCallback<Object>() {
             public Object doInTransaction(TransactionStatus status) {
                 if (getEndpoint().isJoinTransaction()) {
@@ -145,6 +149,10 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
         });
 
         return getEndpoint().getCamelContext().getTypeConverter().convertTo(int.class, messagePolled);
+        } catch (PersistenceException e) {
+            closeEntityManager();
+            throw e;
+        }
     }
 
 
@@ -482,11 +490,7 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-        if (getEndpoint().isSharedEntityManager())
-            this.entityManager = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
-        else
-            this.entityManager = entityManagerFactory.createEntityManager();
-        LOG.trace("Created EntityManager {} on {}", entityManager, this);
+		createEntityManager(); //trigger creation 
     }
 
     @Override
@@ -497,9 +501,31 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
     @Override
     protected void doShutdown() throws Exception {
         super.doShutdown();
-        if (entityManager != null) {
-            this.entityManager.close();
-            LOG.trace("Closed EntityManager {} on {}", entityManager, this);
+		closeEntityManager();
+    }
+
+    public void closeEntityManager() {
+        if (entityManager == null) {
+            return;
         }
+        try {
+            entityManager.close();
+        }
+        catch (Exception e) {
+            LOG.warn("Error closing entity manager", e);
+        }
+        LOG.trace("closed the EntityManager {} on {}", entityManager, this);
+        entityManager = null;
+    }
+
+    protected synchronized EntityManager createEntityManager() {
+        if (entityManager == null) {
+	        if (getEndpoint().isSharedEntityManager())
+	            this.entityManager = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
+	        else
+	            this.entityManager = entityManagerFactory.createEntityManager();
+	        LOG.trace("Created EntityManager {} on {}", entityManager, this);
+		}
+		return this.entityManager;
     }
 }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
+
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -39,6 +40,7 @@ import org.apache.camel.util.CastUtils;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -480,7 +482,10 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-        this.entityManager = entityManagerFactory.createEntityManager();
+        if (getEndpoint().isSharedEntityManager())
+            this.entityManager = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
+        else
+            this.entityManager = entityManagerFactory.createEntityManager();
         LOG.trace("Created EntityManager {} on {}", entityManager, this);
     }
 
@@ -492,7 +497,9 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
     @Override
     protected void doShutdown() throws Exception {
         super.doShutdown();
-        this.entityManager.close();
-        LOG.trace("Closed EntityManager {} on {}", entityManager, this);
+        if (entityManager != null) {
+            this.entityManager.close();
+            LOG.trace("Closed EntityManager {} on {}", entityManager, this);
+        }
     }
 }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaEndpoint.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaEndpoint.java
@@ -36,6 +36,7 @@ import org.apache.camel.util.IntrospectionSupport;
 import org.apache.camel.util.ObjectHelper;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalEntityManagerFactoryBean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -66,6 +67,7 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
     private boolean joinTransaction = true;
     @UriParam
     private boolean usePassedInEntityManager;
+    private boolean sharedEntityManager = false;
 
     public JpaEndpoint() {
     }
@@ -261,6 +263,16 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
         this.usePassedInEntityManager = usePassedIn;
     }
 
+    public boolean isSharedEntityManager() {
+        return sharedEntityManager;
+    }
+
+    public void setSharedEntityManager(boolean sharedEntityManager) {
+        this.sharedEntityManager = sharedEntityManager;
+//        if (sharedEntityManager)
+//            this.joinTransaction = false;
+    }
+
     // Implementation methods
     // -------------------------------------------------------------------------
 
@@ -287,7 +299,10 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
      */
     @Deprecated
     protected EntityManager createEntityManager() {
-        return getEntityManagerFactory().createEntityManager();
+        if (sharedEntityManager)
+            return SharedEntityManagerCreator.createSharedEntityManager(getEntityManagerFactory());
+        else
+            return getEntityManagerFactory().createEntityManager();
     }
 
     protected TransactionTemplate createTransactionTemplate() {
@@ -317,5 +332,6 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
             }
         };
     }
+
 
 }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaEndpoint.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaEndpoint.java
@@ -67,6 +67,7 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
     private boolean joinTransaction = true;
     @UriParam
     private boolean usePassedInEntityManager;
+    @UriParam
     private boolean sharedEntityManager = false;
 
     public JpaEndpoint() {
@@ -267,6 +268,10 @@ public class JpaEndpoint extends ScheduledPollEndpoint {
         return sharedEntityManager;
     }
 
+    /**
+     * Whether to use spring's SharedEntityManager for the consumer/producer. Sets joinTransaction=false 
+     * @param sharedEntityManager
+     */
     public void setSharedEntityManager(boolean sharedEntityManager) {
         this.sharedEntityManager = sharedEntityManager;
 //        if (sharedEntityManager)

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaHelper.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaHelper.java
@@ -20,6 +20,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.camel.Exchange;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
 
 /**
  * Helper for JPA.
@@ -36,10 +37,11 @@ public final class JpaHelper {
      * @param entityManagerFactory     the entity manager factory (mandatory)
      * @param usePassedInEntityManager whether to use an existing {@link javax.persistence.EntityManager} which has been stored
      *                                 on the exchange in the header with key {@link org.apache.camel.component.jpa.JpaConstants#ENTITY_MANAGER}
+     * @param useSharedEntityManager   whether to use SharedEntityManagerCreator if not already passed in                             
      * @return the entity manager (is never null)
      */
     public static EntityManager getTargetEntityManager(Exchange exchange, EntityManagerFactory entityManagerFactory,
-                                                       boolean usePassedInEntityManager) {
+                                                       boolean usePassedInEntityManager, boolean useSharedEntityManager) {
         EntityManager em = null;
 
         // favor using entity manager provided as a header from the end user
@@ -52,6 +54,10 @@ public final class JpaHelper {
             em = exchange.getProperty(JpaConstants.ENTITY_MANAGER, EntityManager.class);
         }
 
+        if (em == null && useSharedEntityManager) {
+            em = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
+        }
+        
         if (em == null) {
             // create a new entity manager
             em = entityManagerFactory.createEntityManager();

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
@@ -53,11 +53,12 @@ public class JpaProducer extends DefaultProducer {
     }
 
     public void process(final Exchange exchange) {
-        // resolve the entity manager before evaluating the expression
-        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, getEndpoint().isUsePassedInEntityManager());
         final Object values = expression.evaluate(exchange, Object.class);
 
         if (values != null) {
+        	// resolve the entity manager before evaluating the expression
+        	final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, getEndpoint().isUsePassedInEntityManager());
+        	
             transactionTemplate.execute(new TransactionCallback<Object>() {
                 public Object doInTransaction(TransactionStatus status) {
                     if (getEndpoint().isJoinTransaction()) {

--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
@@ -50,6 +50,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
     private final EntityManagerFactory entityManagerFactory;
     private final TransactionTemplate transactionTemplate;
     private boolean joinTransaction = true;
+    private boolean sharedEntityManager = false;
 
     public JpaMessageIdRepository(EntityManagerFactory entityManagerFactory, String processorName) {
         this(entityManagerFactory, createTransactionTemplate(entityManagerFactory), processorName);
@@ -83,7 +84,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
 
     @Override
     public boolean add(final Exchange exchange, final String messageId) {
-        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true);
+        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager);
 
         // Run this in single transaction.
         Boolean rc = transactionTemplate.execute(new TransactionCallback<Boolean>() {
@@ -118,7 +119,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
 
     @Override
     public boolean contains(final Exchange exchange, final String messageId) {
-        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true);
+        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager);
 
         // Run this in single transaction.
         Boolean rc = transactionTemplate.execute(new TransactionCallback<Boolean>() {
@@ -147,7 +148,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
 
     @Override
     public boolean remove(final Exchange exchange, final String messageId) {
-        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true);
+        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager);
 
         Boolean rc = transactionTemplate.execute(new TransactionCallback<Boolean>() {
             public Boolean doInTransaction(TransactionStatus status) {
@@ -203,6 +204,10 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
         this.joinTransaction = joinTransaction;
     }
 
+    public void setSharedEntityManager(boolean sharedEntityManager) {
+        this.sharedEntityManager = sharedEntityManager;
+    }
+    
     @Override
     protected void doStart() throws Exception {
         // noop
@@ -212,4 +217,5 @@ public class JpaMessageIdRepository extends ServiceSupport implements ExchangeId
     protected void doStop() throws Exception {
         // noop
     }
+
 }

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaRouteSharedEntityManagerTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaRouteSharedEntityManagerTest.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.jpa;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.examples.SendEmail;
+import org.apache.camel.spring.SpringRouteBuilder;
+import org.junit.Test;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.orm.jpa.LocalEntityManagerFactoryBean;
+
+/**
+ * @version 
+ */
+public class JpaRouteSharedEntityManagerTest extends AbstractJpaTest {
+    protected static final String SELECT_ALL_STRING = "select x from " + SendEmail.class.getName() + " x";
+    private CountDownLatch latch = new CountDownLatch(1);
+    
+    @Test
+    public void testRouteJpaShared() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        int countStart = getBrokerCount();
+        assertThat("brokerCount", countStart, equalTo(1));
+
+        template.sendBody("direct:startShared", new SendEmail("one@somewhere.org"));
+        // start route
+        context.startRoute("jpaShared");
+
+        // not the cleanest way to check the number of open connections
+        int countEnd = getBrokerCount();
+        assertThat("brokerCount", countEnd, equalTo(1));
+        
+        latch.countDown();
+
+        assertMockEndpointsSatisfied();
+    }
+
+    private int getBrokerCount() {
+        LocalEntityManagerFactoryBean entityManagerFactory = applicationContext.getBean("&entityManagerFactory", LocalEntityManagerFactoryBean.class);
+
+        //uses Spring EL so we don't need to reference the classes
+        StandardEvaluationContext context = new StandardEvaluationContext(entityManagerFactory);
+        context.setBeanResolver(new BeanFactoryResolver(applicationContext));
+        SpelExpressionParser parser = new SpelExpressionParser();
+        Expression expression = parser.parseExpression("nativeEntityManagerFactory.brokerFactory.openBrokers"); 
+        List<?> brokers = expression.getValue(context, List.class);
+
+        return brokers.size();
+    }
+    
+    @Test
+    public void testRouteJpaNotShared() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:startNotshared", new SendEmail("one@somewhere.org"));
+
+        int countStart = getBrokerCount();
+        assertThat("brokerCount", countStart, equalTo(1));
+
+        // start route
+        context.startRoute("jpaOwn");
+
+        // not the cleanest way to check the number of open connections
+        int countEnd = getBrokerCount();
+        assertThat("brokerCount", countEnd, equalTo(2));
+        
+        latch.countDown();
+
+        assertMockEndpointsSatisfied();
+    }    
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new SpringRouteBuilder() {
+            public void configure() {
+                from("direct:startNotshared").to("jpa://" + SendEmail.class.getName() + "?");
+                from("direct:startShared").to("jpa://" + SendEmail.class.getName() + "?sharedEntityManager=true&joinTransaction=false");
+                from("jpa://" + SendEmail.class.getName() + "?sharedEntityManager=true&joinTransaction=false").routeId("jpaShared").autoStartup(false).process(new LatchProcessor()).to("mock:result");
+                from("jpa://" + SendEmail.class.getName() + "?sharedEntityManager=false").routeId("jpaOwn").autoStartup(false).process(new LatchProcessor()).to("mock:result");
+            }
+        };
+    }
+
+    @Override
+    protected String routeXml() {
+        return "org/apache/camel/processor/jpa/springJpaRouteTest.xml";
+    }
+
+    @Override
+    protected String selectAllString() {
+        return SELECT_ALL_STRING;
+    }
+    
+    private class LatchProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            latch.await(2, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
When using JpaTransactionManager it "Binds a JPA EntityManager from the specified factory to the thread". Meaning that on top of the EntityManager created for each JpaConsumer, each time it creates a new EntityManager.

New property:
sharedEntityManager - whether to use spring's SharedEntityManager for the consumer/producer. Sets joinTransaction=false

Also added as a property to the JpaComponent.