### PR TITLE
CAMEL-8427 Publish scala test jar to expose ScalaTestSupport

### DIFF
--- a/components/camel-scala/pom.xml
+++ b/components/camel-scala/pom.xml
@@ -189,6 +189,21 @@
                     </classpathContainers>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>log4j.properties</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
@davsclaus 

ScalaTestSupport needs to be published so that others can depend on test jar for camel-scala and access this.