### PR TITLE
Fix for CAMEL-8452: Camel route model - Preserve {{ }} placeholders 

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -2463,6 +2463,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         doWithDefinedClassLoader(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
+//                Runnable propertyPlaceholdersChangeReverter = ProcessorDefinitionHelper.createPropertyPlaceholdersChangeReverter();
                 try {
                     doStartCamel();
                     return null;
@@ -2471,6 +2472,8 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
                     EventHelper.notifyCamelContextStartupFailed(DefaultCamelContext.this, e);
                     // rethrow cause
                     throw e;
+                } finally {
+//                    propertyPlaceholdersChangeReverter.run();
                 }
             }
         });

--- a/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
@@ -85,6 +85,7 @@ public class DataFormatDefinition extends IdentifiedType {
 
     public DataFormat getDataFormat(RouteContext routeContext) {
         if (dataFormat == null) {
+            Runnable propertyPlaceholdersChangeReverter = ProcessorDefinitionHelper.createPropertyPlaceholdersChangeReverter();
 
             // resolve properties before we create the data format
             try {
@@ -92,14 +93,17 @@ public class DataFormatDefinition extends IdentifiedType {
             } catch (Exception e) {
                 throw new IllegalArgumentException("Error resolving property placeholders on data format: " + this, e);
             }
-
-            dataFormat = createDataFormat(routeContext);
-            if (dataFormat != null) {
-                configureDataFormat(dataFormat, routeContext.getCamelContext());
-            } else {
-                throw new IllegalArgumentException(
-                        "Data format '" + (dataFormatName != null ? dataFormatName : "<null>") + "' could not be created. "
-                                + "Ensure that the data format is valid and the associated Camel component is present on the classpath");
+            try {
+                dataFormat = createDataFormat(routeContext);
+                if (dataFormat != null) {
+                    configureDataFormat(dataFormat, routeContext.getCamelContext());
+                } else {
+                    throw new IllegalArgumentException(
+                            "Data format '" + (dataFormatName != null ? dataFormatName : "<null>") + "' could not be created. "
+                                    + "Ensure that the data format is valid and the associated Camel component is present on the classpath");
+                }
+            } finally {
+                propertyPlaceholdersChangeReverter.run();
             }
         }
         return dataFormat;

--- a/camel-core/src/main/java/org/apache/camel/model/InterceptSendToEndpointDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/InterceptSendToEndpointDefinition.java
@@ -87,6 +87,7 @@ public class InterceptSendToEndpointDefinition extends OutputDefinition<Intercep
     public Processor createProcessor(final RouteContext routeContext) throws Exception {
         // create the detour
         final Processor detour = this.createChildProcessor(routeContext, true);
+        final String matchURI = getUri();
 
         // register endpoint callback so we can proxy the endpoint
         routeContext.getCamelContext().addRegisterEndpointCallback(new EndpointStrategy() {
@@ -94,7 +95,7 @@ public class InterceptSendToEndpointDefinition extends OutputDefinition<Intercep
                 if (endpoint instanceof InterceptSendToEndpoint) {
                     // endpoint already decorated
                     return endpoint;
-                } else if (getUri() == null || matchPattern(routeContext.getCamelContext(), uri, getUri())) {
+                } else if (matchURI == null || matchPattern(routeContext.getCamelContext(), uri, matchURI)) {
                     // only proxy if the uri is matched decorate endpoint with our proxy
                     // should be false by default
                     boolean skip = getSkipSendToOriginalEndpoint() != null && getSkipSendToOriginalEndpoint();
@@ -116,7 +117,7 @@ public class InterceptSendToEndpointDefinition extends OutputDefinition<Intercep
         List<ProcessorDefinition<?>> outputs = route.getOutputs();
         outputs.remove(this);
 
-        return new InterceptEndpointProcessor(uri, detour);
+        return new InterceptEndpointProcessor(matchURI, detour);
     }
 
     /**

--- a/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesRouteIdTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesRouteIdTest.java
@@ -30,7 +30,7 @@ public class PropertiesRouteIdTest extends ContextTestSupport {
         assertNotNull("Route with name Camel should exist", context.getRoute("Camel"));
 
         String id = context.getRouteDefinition("Camel").getOutputs().get(0).getId();
-        assertEquals("Cheese", id);
+        assertEquals("{{cool.other.name}}", id);
     }
 
     @Override


### PR DESCRIPTION
We preserve just the uri property of ProcessorDefinitions before we create the associated Processor and restore the original value after the the processor is created.

We can probably target more properties to be preserved/restored as the need arrises.