### PR TITLE
CAMEL-8483: Removed readPreference from the list of invalid options for camel consumer endpoints

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -153,8 +153,8 @@ public class MongoDbEndpoint extends DefaultEndpoint {
             }
         } else if (role == 'C') {
             if (!ObjectHelper.isEmpty(operation) || !ObjectHelper.isEmpty(writeConcern) || writeConcernRef != null
-                    || readPreference != null || dynamicity || invokeGetLastError) {
-                throw new IllegalArgumentException("operation, writeConcern, writeConcernRef, readPreference, dynamicity, invokeGetLastError "
+                   || dynamicity || invokeGetLastError) {
+                throw new IllegalArgumentException("operation, writeConcern, writeConcernRef, dynamicity, invokeGetLastError "
                         + "options cannot appear on a consumer endpoint");
             }
 


### PR DESCRIPTION
Hi,
This one is about the issue https://issues.apache.org/jira/browse/CAMEL-8483, also discussed here:
http://camel.465427.n5.nabble.com/MongoDB-Consumer-Endpoint-ReadPreference-cannot-be-set-tc5764015.html

I simply removed the "readPreference" option from the list of invalid options, which should allow you to define MongoDB consumer endpoints with a non-default readPreference (for example to consume data from a tailable consumer by reading from the secondary hosts in a MongoDB replica set).

This is my first GitHub commit/Pull request, so I hope I didn't break anything :).

Best regards,
Joerg