### PR TITLE
CAMEL-7833 Use Camel endpoints inside RX sequence

### DIFF
--- a/components/camel-rx/src/main/java/org/apache/camel/rx/CamelOperator.java
+++ b/components/camel-rx/src/main/java/org/apache/camel/rx/CamelOperator.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.rx;
 
 import org.apache.camel.CamelContext;

--- a/components/camel-rx/src/main/java/org/apache/camel/rx/CamelOperator.java
+++ b/components/camel-rx/src/main/java/org/apache/camel/rx/CamelOperator.java
@@ -1,0 +1,79 @@
+package org.apache.camel.rx;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Producer;
+import org.apache.camel.util.ServiceHelper;
+import rx.Observable;
+import rx.Subscriber;
+
+public class CamelOperator implements Observable.Operator<Message, Message> {
+
+    private Producer producer;
+
+    public CamelOperator(CamelContext context, String uri) throws Exception {
+        this(context.getEndpoint(uri));
+    }
+
+    public CamelOperator(Endpoint endpoint) throws Exception {
+        this.producer = endpoint.createProducer();
+        ServiceHelper.startService(producer);
+    }
+
+    @Override
+    public Subscriber<? super Message> call(final Subscriber<? super Message> s) {
+        return new Subscriber<Message>(s) {
+            @Override
+            public void onCompleted() {
+                try {
+                    ServiceHelper.stopService(producer);
+                } catch (Exception e) {
+                    throw new RuntimeCamelRxException(e);
+                } finally {
+                    producer = null;
+                }
+                if (!s.isUnsubscribed()) {
+                    s.onCompleted();
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                Exchange exchange = producer.createExchange();
+                exchange.setException(e);
+                process(exchange);
+                if (!s.isUnsubscribed()) {
+                    s.onError(e);
+                }
+            }
+
+            @Override
+            public void onNext(Message item) {
+                if (!s.isUnsubscribed()) {
+                    s.onNext(process(item));
+                }
+            }
+        };
+    }
+
+    private Exchange process(Exchange exchange) {
+        try {
+            producer.process(exchange);
+            if (exchange.hasOut()) {
+                exchange.setIn(exchange.getOut());
+                exchange.setOut(null);
+            }
+        } catch (Exception e) {
+            throw new RuntimeCamelRxException(e);
+        }
+        return exchange;
+    }
+
+    private Message process(Message message) {
+        Exchange exchange = producer.createExchange();
+        exchange.setIn(message);
+        return process(exchange).getIn();
+    }
+}

--- a/components/camel-rx/src/test/java/org/apache/camel/rx/CamelOperatorTest.java
+++ b/components/camel-rx/src/test/java/org/apache/camel/rx/CamelOperatorTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.rx;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Message;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+
+/**
+ */
+public class CamelOperatorTest extends RxTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelOperatorTest.class);
+
+    @Test
+    public void testCamelOperator() throws Exception {
+        final MockEndpoint mockEndpoint1 = camelContext.getEndpoint("mock:results1", MockEndpoint.class);
+        final MockEndpoint mockEndpoint2 = camelContext.getEndpoint("mock:results2", MockEndpoint.class);
+        final MockEndpoint mockEndpoint3 = camelContext.getEndpoint("mock:results3", MockEndpoint.class);
+        mockEndpoint1.expectedMessageCount(2);
+        mockEndpoint2.expectedMessageCount(1);
+        mockEndpoint3.expectedMessageCount(1);
+
+        Observable<Message> result = reactiveCamel.toObservable("direct:start")
+            .lift(new CamelOperator(camelContext, "mock:results1"))
+            .lift(new CamelOperator(camelContext, "log:foo"))
+            .debounce(1, TimeUnit.SECONDS)
+            .lift(new CamelOperator(mockEndpoint2));
+        reactiveCamel.sendTo(result, "mock:results3");
+
+        // Send two test messages
+        producerTemplate.sendBody("direct:start", "<test/>");
+        producerTemplate.sendBody("direct:start", "<test/>");
+
+        mockEndpoint1.assertIsSatisfied();
+        mockEndpoint2.assertIsSatisfied();
+        mockEndpoint3.assertIsSatisfied();
+    }
+}


### PR DESCRIPTION
CamelOperator class allows us to use Camel endpoints inside an RX sequence, like so:

```
Observable<Message> in = reactiveCamel.toObservable("direct:start")
   .lift(new CamelOperator(camelContext, "xslt:something.xsl"))
   .lift(new CamelOperator(anotherEndpoint));
```
