### PR TITLE
CAMEL-8595 AWS SNS add messageStructure property configuration

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsConfiguration.java
@@ -44,6 +44,8 @@ public class SnsConfiguration implements Cloneable {
     private String topicArn;
     @UriParam
     private String policy;
+    @UriParam
+    private String messageStructure;
 
     public void setAmazonSNSEndpoint(String awsSNSEndpoint) {
         this.amazonSNSEndpoint = awsSNSEndpoint;
@@ -108,7 +110,15 @@ public class SnsConfiguration implements Cloneable {
     public void setPolicy(String policy) {
         this.policy = policy;
     }
-    
+
+    public String getMessageStructure() {
+        return messageStructure;
+    }
+
+    public void setMessageStructure(String messageStructure) {
+        this.messageStructure = messageStructure;
+    }
+
     @Override
     public String toString() {
         return "SnsConfiguration[topicName=" + topicName
@@ -118,6 +128,7 @@ public class SnsConfiguration implements Cloneable {
             + ", subject=" + subject
             + ", topicArn=" + topicArn
             + ", policy=" + policy
+            + ", messageStructure=" + messageStructure
             + "]";
     }
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsConstants.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsConstants.java
@@ -24,4 +24,5 @@ public interface SnsConstants {
     
     String MESSAGE_ID = "CamelAwsSnsMessageId";
     String SUBJECT = "CamelAwsSnsSubject";
+    String MESSAGE_STRUCTURE ="CamelAwsSnsMessageStructure";
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsProducer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sns/SnsProducer.java
@@ -42,10 +42,12 @@ public class SnsProducer extends DefaultProducer {
 
     public void process(Exchange exchange) throws Exception {
         PublishRequest request = new PublishRequest();
+
         request.setTopicArn(getConfiguration().getTopicArn());
-        request.setMessage(exchange.getIn().getBody(String.class));
         request.setSubject(determineSubject(exchange));
-        
+        request.setMessageStructure(determineMessageStructure(exchange));
+        request.setMessage(exchange.getIn().getBody(String.class));
+
         LOG.trace("Sending request [{}] from exchange [{}]...", request, exchange);
         
         PublishResult result = getEndpoint().getSNSClient().publish(request);
@@ -73,6 +75,15 @@ public class SnsProducer extends DefaultProducer {
         }
         
         return subject;
+    }
+
+    private String determineMessageStructure(Exchange exchange) {
+        String structure = exchange.getIn().getHeader(SnsConstants.MESSAGE_STRUCTURE, String.class);
+        if (structure == null) {
+            structure = getConfiguration().getMessageStructure();
+        }
+
+        return structure;
     }
     
     protected SnsConfiguration getConfiguration() {


### PR DESCRIPTION
Json message body support added as a new feature.
on the URI configuration "..&messageStructure=json"
or on the message header add (SnsConstans.MESSAGE_STRUCTURE,"json") key-value