### PR TITLE
CAMEL-7833 Added convenience method ReactiveCamel.to(...)

### DIFF
--- a/components/camel-rx/src/main/java/org/apache/camel/rx/ReactiveCamel.java
+++ b/components/camel-rx/src/main/java/org/apache/camel/rx/ReactiveCamel.java
@@ -92,6 +92,20 @@ public class ReactiveCamel {
         }
     }
 
+    /**
+     * Convenience method for creating CamelOperator instances
+     */
+    public CamelOperator to(String uri) throws Exception {
+        return new CamelOperator(camelContext, uri);
+    }
+
+    /**
+     * Convenience method for creating CamelOperator instances
+     */
+    public CamelOperator to(Endpoint endpoint) throws Exception {
+        return new CamelOperator(endpoint);
+    }
+
     public CamelContext getCamelContext() {
         return camelContext;
     }


### PR DESCRIPTION
Added convenience method ReactiveCamel.to(String uri) and ReactiveCamel.to(Endpoint endpoint) for nicer DSL experience.

Changed the unit test to further highlight the idea of creating (Camel-like) routes with RX.