### PR TITLE
CAMEL-8572 Upgrade AWS SDK java version and add support for DynamoDB v2

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
@@ -19,13 +19,12 @@ package org.apache.camel.component.aws.ddb;
 import java.util.Collection;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.ExpectedAttributeValue;
-import com.amazonaws.services.dynamodb.model.Key;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 public abstract class AbstractDdbCommand {
     protected DdbConfiguration configuration;
@@ -81,8 +80,8 @@ public abstract class AbstractDdbCommand {
         msg.setHeader(headerKey, value);
     }
 
-    protected Key determineKey() {
-        return exchange.getIn().getHeader(DdbConstants.KEY, Key.class);
+    protected Map<String, AttributeValue> determineKey() {
+        return exchange.getIn().getHeader(DdbConstants.KEY, Map.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
@@ -19,12 +19,12 @@ package org.apache.camel.component.aws.ddb;
 import java.util.Collection;
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 
 public abstract class AbstractDdbCommand {
     protected DdbConfiguration configuration;

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.BatchGetItemRequest;
-import com.amazonaws.services.dynamodb.model.BatchGetItemResult;
-import com.amazonaws.services.dynamodb.model.KeysAndAttributes;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 
 public class BatchGetItemsCommand extends AbstractDdbCommand {
     public BatchGetItemsCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+
+import org.apache.camel.Exchange;
 
 public class BatchGetItemsCommand extends AbstractDdbCommand {
     public BatchGetItemsCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConfiguration.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 import org.apache.camel.spi.UriPath;
-
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 
 @UriParams
 public class DdbConfiguration {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConfiguration.java
@@ -16,11 +16,12 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 import org.apache.camel.spi.UriPath;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 
 @UriParams
 public class DdbConfiguration {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConstants.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbConstants.java
@@ -28,8 +28,10 @@ public interface DdbConstants {
     String CONSUMED_CAPACITY = "CamelAwsDdbConsumedCapacity";
     String COUNT = "CamelAwsDdbCount";
     String CREATION_DATE = "CamelAwsDdbCreationDate";
-    String EXACT_COUNT = "CamelAwsDdbExactCount";
-    String HASH_KEY_VALUE = "CamelAwsDdbHashKeyValue";
+    // Removed from DynamoDB v1 to v2
+    // String EXACT_COUNT = "CamelAwsDdbExactCount";
+    // Removed from DynamoDB v1 to v2
+    // String HASH_KEY_VALUE = "CamelAwsDdbHashKeyValue";
     String ITEM = "CamelAwsDdbItem";
     String ITEMS = "CamelAwsDdbItems";
     String ITEM_COUNT = "CamelAwsDdbTableItemCount";
@@ -37,6 +39,8 @@ public interface DdbConstants {
     String MESSAGE_ID = "CamelAwsDdbMessageId";
     String NEXT_TOKEN = "CamelAwsDdbNextToken";
     String KEY = "CamelAwsDdbKey";
+    // Added from DynamoDB v1 to v2
+    String KEY_CONDITIONS = "CamelAwsDdbKeyConditions";
     String KEY_SCHEMA = "CamelAwsDdbKeySchema";
     String LAST_EVALUATED_KEY = "CamelAwsDdbLastEvaluatedKey";
     String LIMIT = "CamelAwsDdbLimit";
@@ -46,7 +50,8 @@ public interface DdbConstants {
     String RETURN_VALUES = "CamelAwsDdbReturnValues";
     String SCANNED_COUNT = "CamelAwsDdbScannedCount";
     String SCAN_INDEX_FORWARD = "CamelAwsDdbScanIndexForward";
-    String SCAN_RANGE_KEY_CONDITION = "CamelAwsDdbScanRangeKeyCondition";
+    // Removed from DynamoDB v1 to v2
+    // String SCAN_RANGE_KEY_CONDITION = "CamelAwsDdbScanRangeKeyCondition";
     String SCAN_FILTER = "CamelAwsDdbScanFilter";
     String START_KEY = "CamelAwsDdbStartKey";
     String TABLE_NAME = "CamelAwsDdbTableName";

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbEndpoint.java
@@ -16,18 +16,6 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Component;
-import org.apache.camel.Consumer;
-import org.apache.camel.Processor;
-import org.apache.camel.Producer;
-import org.apache.camel.impl.ScheduledPollEndpoint;
-import org.apache.camel.spi.UriEndpoint;
-import org.apache.camel.spi.UriParam;
-import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -40,6 +28,18 @@ import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.dynamodbv2.model.TableStatus;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.impl.ScheduledPollEndpoint;
+import org.apache.camel.spi.UriEndpoint;
+import org.apache.camel.spi.UriParam;
+import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Defines the <a href="http://aws.amazon.com/dynamodb/">AWS DynamoDB endpoint</a>

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DdbEndpoint.java
@@ -16,19 +16,6 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.AmazonDynamoDBClient;
-import com.amazonaws.services.dynamodb.model.CreateTableRequest;
-import com.amazonaws.services.dynamodb.model.DescribeTableRequest;
-import com.amazonaws.services.dynamodb.model.KeySchema;
-import com.amazonaws.services.dynamodb.model.KeySchemaElement;
-import com.amazonaws.services.dynamodb.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodb.model.ResourceNotFoundException;
-import com.amazonaws.services.dynamodb.model.TableDescription;
-import com.amazonaws.services.dynamodb.model.TableStatus;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.Consumer;
@@ -40,6 +27,19 @@ import org.apache.camel.spi.UriParam;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.amazonaws.services.dynamodbv2.model.TableStatus;
 
 /**
  * Defines the <a href="http://aws.amazon.com/dynamodb/">AWS DynamoDB endpoint</a>
@@ -114,10 +114,10 @@ public class DdbEndpoint extends ScheduledPollEndpoint {
 
     private TableDescription createTable(String tableName) {
         CreateTableRequest createTableRequest = new CreateTableRequest().withTableName(tableName)
-                .withKeySchema(new KeySchema(
+                .withKeySchema(
                         new KeySchemaElement().withAttributeName(
                                 configuration.getKeyAttributeName())
-                                .withAttributeType(configuration.getKeyAttributeType())))
+                                .withKeyType(configuration.getKeyAttributeType()))
                 .withProvisionedThroughput(
                         new ProvisionedThroughput().withReadCapacityUnits(configuration.getReadCapacity())
                                 .withWriteCapacityUnits(configuration.getWriteCapacity()));

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteItemCommand.java
@@ -16,14 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import java.util.Map;
-
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
+
+import org.apache.camel.Exchange;
 
 public class DeleteItemCommand extends AbstractDdbCommand {
     public DeleteItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteItemCommand.java
@@ -16,11 +16,14 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.DeleteItemRequest;
-import com.amazonaws.services.dynamodb.model.DeleteItemResult;
+import java.util.Map;
 
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
 
 public class DeleteItemCommand extends AbstractDdbCommand {
     public DeleteItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.DeleteTableRequest;
-import com.amazonaws.services.dynamodb.model.TableDescription;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
 public class DeleteTableCommand extends AbstractDdbCommand {
     public DeleteTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration,

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+import org.apache.camel.Exchange;
 
 public class DeleteTableCommand extends AbstractDdbCommand {
     public DeleteTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration,

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DescribeTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DescribeTableCommand.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.DescribeTableRequest;
-import com.amazonaws.services.dynamodb.model.DescribeTableResult;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 
 public class DescribeTableCommand extends AbstractDdbCommand {
     public DescribeTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration,

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DescribeTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DescribeTableCommand.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 
 public class DescribeTableCommand extends AbstractDdbCommand {
     public DescribeTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration,

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/GetItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/GetItemCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.GetItemRequest;
-import com.amazonaws.services.dynamodb.model.GetItemResult;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 
 public class GetItemCommand extends AbstractDdbCommand {
     public GetItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/GetItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/GetItemCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+
+import org.apache.camel.Exchange;
 
 public class GetItemCommand extends AbstractDdbCommand {
     public GetItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/PutItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/PutItemCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.PutItemRequest;
-import com.amazonaws.services.dynamodb.model.PutItemResult;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+import com.amazonaws.services.dynamodbv2.model.PutItemResult;
 
 public class PutItemCommand extends AbstractDdbCommand {
     public PutItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/PutItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/PutItemCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemResult;
+
+import org.apache.camel.Exchange;
 
 public class PutItemCommand extends AbstractDdbCommand {
     public PutItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.Condition;
-import com.amazonaws.services.dynamodb.model.Key;
-import com.amazonaws.services.dynamodb.model.QueryRequest;
-import com.amazonaws.services.dynamodb.model.QueryResult;
+import java.util.Map;
 
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
 
 public class QueryCommand extends AbstractDdbCommand {
     public QueryCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {
@@ -35,41 +35,32 @@ public class QueryCommand extends AbstractDdbCommand {
         QueryResult result = ddbClient.query(new QueryRequest()
                 .withTableName(determineTableName())
                 .withAttributesToGet(determineAttributeNames())
-                .withCount(determineExactCount())
                 .withConsistentRead(determineConsistentRead())
                 .withExclusiveStartKey(determineStartKey())
-                .withHashKeyValue(determineHashKeyValue())
+                .withKeyConditions(determineKeyConditions())
+                .withExclusiveStartKey(determineStartKey())
                 .withLimit(determineLimit())
-                .withRangeKeyCondition(determineRangeKeyCondition())
                 .withScanIndexForward(determineScanIndexForward()));
 
         addToResult(DdbConstants.ITEMS, result.getItems());
         addToResult(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
-        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacityUnits());
+        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
         addToResult(DdbConstants.COUNT, result.getCount());
     }
 
-    private Key determineStartKey() {
-        return exchange.getIn().getHeader(DdbConstants.START_KEY, Key.class);
+    private  Map<String, AttributeValue> determineStartKey() {
+        return exchange.getIn().getHeader(DdbConstants.START_KEY, Map.class);
     }
 
     private Boolean determineScanIndexForward() {
         return exchange.getIn().getHeader(DdbConstants.SCAN_INDEX_FORWARD, Boolean.class);
     }
 
-    private Condition determineRangeKeyCondition() {
-        return exchange.getIn().getHeader(DdbConstants.SCAN_RANGE_KEY_CONDITION, Condition.class);
+    private Map determineKeyConditions() {
+        return exchange.getIn().getHeader(DdbConstants.KEY_CONDITIONS, Map.class);
     }
 
     private Integer determineLimit() {
         return exchange.getIn().getHeader(DdbConstants.LIMIT, Integer.class);
-    }
-
-    private AttributeValue determineHashKeyValue() {
-        return exchange.getIn().getHeader(DdbConstants.HASH_KEY_VALUE, AttributeValue.class);
-    }
-
-    private Boolean determineExactCount() {
-        return exchange.getIn().getHeader(DdbConstants.EXACT_COUNT, Boolean.class);
     }
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.amazonaws.services.dynamodbv2.model.QueryResult;
+
+import org.apache.camel.Exchange;
 
 public class QueryCommand extends AbstractDdbCommand {
     public QueryCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
+
+import org.apache.camel.Exchange;
 
 public class ScanCommand extends AbstractDdbCommand {
     public ScanCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.Condition;
-import com.amazonaws.services.dynamodb.model.ScanRequest;
-import com.amazonaws.services.dynamodb.model.ScanResult;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
 
 public class ScanCommand extends AbstractDdbCommand {
     public ScanCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {
@@ -38,7 +38,7 @@ public class ScanCommand extends AbstractDdbCommand {
 
         addToResult(DdbConstants.ITEMS, result.getItems());
         addToResult(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
-        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacityUnits());
+        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
         addToResult(DdbConstants.COUNT, result.getCount());
         addToResult(DdbConstants.SCANNED_COUNT, result.getScannedCount());
     }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateItemCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
+
+import org.apache.camel.Exchange;
 
 public class UpdateItemCommand extends AbstractDdbCommand {
     public UpdateItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateItemCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateItemCommand.java
@@ -18,12 +18,12 @@ package org.apache.camel.component.aws.ddb;
 
 import java.util.Map;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.AttributeValueUpdate;
-import com.amazonaws.services.dynamodb.model.UpdateItemRequest;
-import com.amazonaws.services.dynamodb.model.UpdateItemResult;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 
 public class UpdateItemCommand extends AbstractDdbCommand {
     public UpdateItemCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateTableCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import com.amazonaws.services.dynamodb.AmazonDynamoDB;
-import com.amazonaws.services.dynamodb.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodb.model.UpdateTableRequest;
-
 import org.apache.camel.Exchange;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 
 public class UpdateTableCommand extends AbstractDdbCommand {
     public UpdateTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/UpdateTableCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import org.apache.camel.Exchange;
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
+
+import org.apache.camel.Exchange;
 
 public class UpdateTableCommand extends AbstractDdbCommand {
     public UpdateTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration, Exchange exchange) {

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/AmazonDDBClientMock.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/AmazonDDBClientMock.java
@@ -165,11 +165,10 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
         List<Map<String, AttributeValue>> p = new ArrayList<Map<String, AttributeValue>>();
         p.add(getAttributes());
         responseMap.put("DOMAIN1", p);
-        Map<String,AttributeValue> keysMap = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> keysMap = new HashMap<String, AttributeValue>();
         keysMap.put("1", new AttributeValue("UNPROCESSED_KEY"));
         Map<String, KeysAndAttributes> unprocessedKeys = new HashMap<String, KeysAndAttributes>();
-        unprocessedKeys.put("DOMAIN1", new KeysAndAttributes().withKeys(
-        		keysMap));
+        unprocessedKeys.put("DOMAIN1", new KeysAndAttributes().withKeys(keysMap));
 
         return new BatchGetItemResult()
                 .withResponses(responseMap)
@@ -182,7 +181,7 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
         this.scanRequest = scanRequest;
         ConsumedCapacity consumed = new ConsumedCapacity();
         consumed.setCapacityUnits(1.0);
-        Map<String,AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
         lastEvaluatedKey.put("1", new AttributeValue("LAST_KEY"));
         return new ScanResult()
                 .withConsumedCapacity(consumed)
@@ -198,7 +197,7 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
         this.queryRequest = queryRequest;
         ConsumedCapacity consumed = new ConsumedCapacity();
         consumed.setCapacityUnits(1.0);
-        Map<String,AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
         lastEvaluatedKey.put("1", new AttributeValue("LAST_KEY"));
         return new QueryResult()
                 .withConsumedCapacity(consumed)

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/AmazonDDBClientMock.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/AmazonDDBClientMock.java
@@ -16,44 +16,45 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.dynamodb.AmazonDynamoDBClient;
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.BatchGetItemRequest;
-import com.amazonaws.services.dynamodb.model.BatchGetItemResult;
-import com.amazonaws.services.dynamodb.model.BatchResponse;
-import com.amazonaws.services.dynamodb.model.CreateTableRequest;
-import com.amazonaws.services.dynamodb.model.CreateTableResult;
-import com.amazonaws.services.dynamodb.model.DeleteItemRequest;
-import com.amazonaws.services.dynamodb.model.DeleteItemResult;
-import com.amazonaws.services.dynamodb.model.DeleteTableRequest;
-import com.amazonaws.services.dynamodb.model.DeleteTableResult;
-import com.amazonaws.services.dynamodb.model.DescribeTableRequest;
-import com.amazonaws.services.dynamodb.model.DescribeTableResult;
-import com.amazonaws.services.dynamodb.model.GetItemRequest;
-import com.amazonaws.services.dynamodb.model.GetItemResult;
-import com.amazonaws.services.dynamodb.model.Key;
-import com.amazonaws.services.dynamodb.model.KeySchema;
-import com.amazonaws.services.dynamodb.model.KeySchemaElement;
-import com.amazonaws.services.dynamodb.model.KeysAndAttributes;
-import com.amazonaws.services.dynamodb.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodb.model.PutItemRequest;
-import com.amazonaws.services.dynamodb.model.PutItemResult;
-import com.amazonaws.services.dynamodb.model.QueryRequest;
-import com.amazonaws.services.dynamodb.model.QueryResult;
-import com.amazonaws.services.dynamodb.model.ResourceNotFoundException;
-import com.amazonaws.services.dynamodb.model.ScanRequest;
-import com.amazonaws.services.dynamodb.model.ScanResult;
-import com.amazonaws.services.dynamodb.model.TableDescription;
-import com.amazonaws.services.dynamodb.model.TableStatus;
-import com.amazonaws.services.dynamodb.model.UpdateItemRequest;
-import com.amazonaws.services.dynamodb.model.UpdateItemResult;
-import com.amazonaws.services.dynamodb.model.UpdateTableRequest;
-import com.amazonaws.services.dynamodb.model.UpdateTableResult;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
+import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+import com.amazonaws.services.dynamodbv2.model.PutItemResult;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.amazonaws.services.dynamodbv2.model.TableStatus;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
+import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
+
 
 public class AmazonDDBClientMock extends AmazonDynamoDBClient {
     public static final long NOW = 1327709390233L;
@@ -87,7 +88,7 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
                     .withTableStatus(TableStatus.ACTIVE)
                     .withCreationDateTime(new Date(NOW))
                     .withItemCount(100L)
-                    .withKeySchema(new KeySchema(new KeySchemaElement().withAttributeName("name")))
+                    .withKeySchema(new KeySchemaElement().withAttributeName("name"))
                     .withProvisionedThroughput(new ProvisionedThroughputDescription()
                             .withReadCapacityUnits(20L)
                             .withWriteCapacityUnits(10L))
@@ -121,7 +122,7 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
                 .withTableName(deleteTableRequest.getTableName())
                 .withCreationDateTime(new Date(NOW))
                 .withItemCount(10L)
-                .withKeySchema(new KeySchema())
+                .withKeySchema(new ArrayList<KeySchemaElement>())
                 .withTableSizeBytes(20L)
                 .withTableStatus(TableStatus.ACTIVE));
     }
@@ -160,12 +161,15 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
     @Override
     public BatchGetItemResult batchGetItem(BatchGetItemRequest batchGetItemRequest) {
         this.batchGetItemRequest = batchGetItemRequest;
-        Map<String, BatchResponse> responseMap = new HashMap<String, BatchResponse>();
-        responseMap.put("DOMAIN1", new BatchResponse().withItems(getAttributes()));
-
+        Map<String, List<Map<String, AttributeValue>>> responseMap = new HashMap<String, List<Map<String, AttributeValue>>>();
+        List<Map<String, AttributeValue>> p = new ArrayList<Map<String, AttributeValue>>();
+        p.add(getAttributes());
+        responseMap.put("DOMAIN1", p);
+        Map<String,AttributeValue> keysMap = new HashMap<String, AttributeValue>();
+        keysMap.put("1", new AttributeValue("UNPROCESSED_KEY"));
         Map<String, KeysAndAttributes> unprocessedKeys = new HashMap<String, KeysAndAttributes>();
         unprocessedKeys.put("DOMAIN1", new KeysAndAttributes().withKeys(
-                new Key(new AttributeValue("UNPROCESSED_KEY"))));
+        		keysMap));
 
         return new BatchGetItemResult()
                 .withResponses(responseMap)
@@ -176,22 +180,30 @@ public class AmazonDDBClientMock extends AmazonDynamoDBClient {
     @Override
     public ScanResult scan(ScanRequest scanRequest) {
         this.scanRequest = scanRequest;
+        ConsumedCapacity consumed = new ConsumedCapacity();
+        consumed.setCapacityUnits(1.0);
+        Map<String,AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
+        lastEvaluatedKey.put("1", new AttributeValue("LAST_KEY"));
         return new ScanResult()
-                .withConsumedCapacityUnits(1.0)
+                .withConsumedCapacity(consumed)
                 .withCount(1)
                 .withItems(getAttributes())
                 .withScannedCount(10)
-                .withLastEvaluatedKey(new Key(new AttributeValue("LAST_KEY")));
+                .withLastEvaluatedKey(lastEvaluatedKey);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public QueryResult query(QueryRequest queryRequest) {
         this.queryRequest = queryRequest;
+        ConsumedCapacity consumed = new ConsumedCapacity();
+        consumed.setCapacityUnits(1.0);
+        Map<String,AttributeValue> lastEvaluatedKey = new HashMap<String, AttributeValue>();
+        lastEvaluatedKey.put("1", new AttributeValue("LAST_KEY"));
         return new QueryResult()
-                .withConsumedCapacityUnits(1.0)
+                .withConsumedCapacity(consumed)
                 .withCount(1)
                 .withItems(getAttributes())
-                .withLastEvaluatedKey(new Key(new AttributeValue("LAST_KEY")));
+                .withLastEvaluatedKey(lastEvaluatedKey);
     }
 }

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommandTest.java
@@ -16,20 +16,19 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+import static org.junit.Assert.assertEquals;
 
 public class BatchGetItemsCommandTest {
 
@@ -48,10 +47,10 @@ public class BatchGetItemsCommandTest {
 
     @Test
     public void execute() {
-    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
-    	key.put("1", new AttributeValue("Key_1"));
-    	Map<String,AttributeValue> unprocessedKey = new HashMap<String, AttributeValue>();
-    	unprocessedKey.put("1", new AttributeValue("UNPROCESSED_KEY"));
+        Map<String, AttributeValue> key = new HashMap<String, AttributeValue>();
+        key.put("1", new AttributeValue("Key_1"));
+        Map<String, AttributeValue> unprocessedKey = new HashMap<String, AttributeValue>();
+        unprocessedKey.put("1", new AttributeValue("UNPROCESSED_KEY"));
         Map<String, KeysAndAttributes> keysAndAttributesMap = new HashMap<String, KeysAndAttributes>();
         KeysAndAttributes keysAndAttributes = new KeysAndAttributes().withKeys(key);
         keysAndAttributesMap.put("DOMAIN1", keysAndAttributes);
@@ -67,7 +66,7 @@ public class BatchGetItemsCommandTest {
 
         KeysAndAttributes unProcessedAttributes = (KeysAndAttributes)exchange.getIn().getHeader(
                 DdbConstants.UNPROCESSED_KEYS, Map.class).get("DOMAIN1");
-        Map<String,AttributeValue> next = unProcessedAttributes.getKeys().iterator().next();
+        Map<String, AttributeValue> next = unProcessedAttributes.getKeys().iterator().next();
 
         assertEquals(new AttributeValue("attrValue"), value);
         assertEquals(unprocessedKey, next);

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteItemCommandTest.java
@@ -16,12 +16,10 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.ExpectedAttributeValue;
-import com.amazonaws.services.dynamodb.model.Key;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -29,7 +27,8 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 public class DeleteItemCommandTest {
 
@@ -49,7 +48,8 @@ public class DeleteItemCommandTest {
 
     @Test
     public void execute() {
-        Key key = new Key(new AttributeValue("Key_1"));
+    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
+    	key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteItemCommandTest.java
@@ -16,19 +16,18 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import static org.junit.Assert.assertEquals;
 
 public class DeleteItemCommandTest {
 
@@ -48,8 +47,8 @@ public class DeleteItemCommandTest {
 
     @Test
     public void execute() {
-    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
-    	key.put("1", new AttributeValue("Key_1"));
+        Map<String, AttributeValue> key = new HashMap<String, AttributeValue>();
+        key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteTableCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteTableCommandTest.java
@@ -16,20 +16,22 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import java.util.Date;
+import static org.junit.Assert.assertEquals;
 
-import com.amazonaws.services.dynamodb.model.KeySchema;
-import com.amazonaws.services.dynamodb.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodb.model.TableStatus;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
-
 import org.junit.Before;
 import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
+import com.amazonaws.services.dynamodbv2.model.TableStatus;
 
 public class DeleteTableCommandTest {
 
@@ -58,7 +60,7 @@ public class DeleteTableCommandTest {
         assertEquals(new Date(AmazonDDBClientMock.NOW), exchange.getIn().getHeader(DdbConstants.CREATION_DATE,
                 Date.class));
         assertEquals(Long.valueOf(10L), exchange.getIn().getHeader(DdbConstants.ITEM_COUNT, Long.class));
-        assertEquals(new KeySchema(), exchange.getIn().getHeader(DdbConstants.KEY_SCHEMA, KeySchema.class));
+        assertEquals(new ArrayList<KeySchemaElement>(), exchange.getIn().getHeader(DdbConstants.KEY_SCHEMA, ArrayList.class));
         assertEquals(Long.valueOf(20L), exchange.getIn().getHeader(DdbConstants.TABLE_SIZE, Long.class));
         assertEquals(TableStatus.ACTIVE, exchange.getIn().getHeader(DdbConstants.TABLE_STATUS, TableStatus.class));
     }

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteTableCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DeleteTableCommandTest.java
@@ -16,22 +16,19 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
+import com.amazonaws.services.dynamodbv2.model.TableStatus;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertArrayEquals;
-
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodbv2.model.TableStatus;
+import static org.junit.Assert.assertEquals;
 
 public class DeleteTableCommandTest {
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DescribeTableCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DescribeTableCommandTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import java.util.Date;
+import static org.junit.Assert.assertEquals;
 
-import com.amazonaws.services.dynamodb.model.KeySchema;
-import com.amazonaws.services.dynamodb.model.KeySchemaElement;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -27,7 +28,7 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 
 public class DescribeTableCommandTest {
 
@@ -48,12 +49,16 @@ public class DescribeTableCommandTest {
     @Test
     public void testExecute() {
         command.execute();
+        
+    	List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+    	keySchema.add(new KeySchemaElement().withAttributeName("name"));
+    	
         assertEquals("FULL_DESCRIBE_TABLE", ddbClient.describeTableRequest.getTableName());
         assertEquals("FULL_DESCRIBE_TABLE", exchange.getIn().getHeader(DdbConstants.TABLE_NAME));
         assertEquals("ACTIVE", exchange.getIn().getHeader(DdbConstants.TABLE_STATUS));
         assertEquals(new Date(AmazonDDBClientMock.NOW), exchange.getIn().getHeader(DdbConstants.CREATION_DATE));
         assertEquals(100L, exchange.getIn().getHeader(DdbConstants.ITEM_COUNT));
-        assertEquals(new KeySchema(new KeySchemaElement().withAttributeName("name")),
+        assertEquals(keySchema,
                 exchange.getIn().getHeader(DdbConstants.KEY_SCHEMA));
         assertEquals(20L, exchange.getIn().getHeader(DdbConstants.READ_CAPACITY));
         assertEquals(10L, exchange.getIn().getHeader(DdbConstants.WRITE_CAPACITY));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DescribeTableCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/DescribeTableCommandTest.java
@@ -16,19 +16,18 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import static org.junit.Assert.assertEquals;
 
 public class DescribeTableCommandTest {
 
@@ -49,10 +48,8 @@ public class DescribeTableCommandTest {
     @Test
     public void testExecute() {
         command.execute();
-        
-    	List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
-    	keySchema.add(new KeySchemaElement().withAttributeName("name"));
-    	
+        List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+        keySchema.add(new KeySchemaElement().withAttributeName("name"));
         assertEquals("FULL_DESCRIBE_TABLE", ddbClient.describeTableRequest.getTableName());
         assertEquals("FULL_DESCRIBE_TABLE", exchange.getIn().getHeader(DdbConstants.TABLE_NAME));
         assertEquals("ACTIVE", exchange.getIn().getHeader(DdbConstants.TABLE_STATUS));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/GetItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/GetItemCommandTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.Key;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -29,7 +29,7 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 public class GetItemCommandTest {
     private GetItemCommand command;
@@ -48,7 +48,8 @@ public class GetItemCommandTest {
 
     @Test
     public void execute() {
-        Key key = new Key(new AttributeValue("Key_1"));
+    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
+    	key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
         List<String> attrNames = Arrays.asList("attrName");

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/GetItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/GetItemCommandTest.java
@@ -16,20 +16,19 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import static org.junit.Assert.assertEquals;
 
 public class GetItemCommandTest {
     private GetItemCommand command;
@@ -48,8 +47,8 @@ public class GetItemCommandTest {
 
     @Test
     public void execute() {
-    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
-    	key.put("1", new AttributeValue("Key_1"));
+        Map<String, AttributeValue> key = new HashMap<String, AttributeValue>();
+        key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
         List<String> attrNames = Arrays.asList("attrName");

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/PutItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/PutItemCommandTest.java
@@ -16,19 +16,18 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import static org.junit.Assert.assertEquals;
 
 public class PutItemCommandTest {
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/PutItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/PutItemCommandTest.java
@@ -16,11 +16,10 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.ExpectedAttributeValue;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -28,7 +27,8 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 public class PutItemCommandTest {
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/QueryCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/QueryCommandTest.java
@@ -16,24 +16,22 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
-import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import static org.junit.Assert.assertEquals;
 
 public class QueryCommandTest {
 
@@ -54,8 +52,8 @@ public class QueryCommandTest {
     @Test
     public void execute() {
 
-    	Map<String,AttributeValue> startKey = new HashMap<String, AttributeValue>();
-    	startKey.put("1", new AttributeValue("startKey"));
+        Map<String, AttributeValue> startKey = new HashMap<String, AttributeValue>();
+        startKey.put("1", new AttributeValue("startKey"));
 
         List<String> attributeNames = Arrays.asList("attrNameOne", "attrNameTwo");
         exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, attributeNames);
@@ -66,8 +64,8 @@ public class QueryCommandTest {
         
         Map<String, Condition> keyConditions = new HashMap<String, Condition>();
         Condition condition = new Condition()
-	        .withComparisonOperator(ComparisonOperator.GT.toString())
-	        .withAttributeValueList(new AttributeValue().withN("1985"));
+            .withComparisonOperator(ComparisonOperator.GT.toString())
+            .withAttributeValueList(new AttributeValue().withN("1985"));
         
         keyConditions.put("1", condition);
         
@@ -75,9 +73,9 @@ public class QueryCommandTest {
 
         command.execute();
 
-    	Map<String,AttributeValue> mapAssert = new HashMap<String, AttributeValue>();
-    	mapAssert.put("1", new AttributeValue("LAST_KEY"));
-    	ConsumedCapacity consumed = (ConsumedCapacity) exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY);
+        Map<String, AttributeValue> mapAssert = new HashMap<String, AttributeValue>();
+        mapAssert.put("1", new AttributeValue("LAST_KEY"));
+        ConsumedCapacity consumed = (ConsumedCapacity) exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY);
         assertEquals(Integer.valueOf(1), exchange.getIn().getHeader(DdbConstants.COUNT, Integer.class));
         assertEquals(Double.valueOf(1.0), consumed.getCapacityUnits());
         assertEquals(mapAssert, exchange.getIn().getHeader(DdbConstants.LAST_EVALUATED_KEY, Map.class));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/QueryCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/QueryCommandTest.java
@@ -16,23 +16,24 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.ComparisonOperator;
-import com.amazonaws.services.dynamodb.model.Condition;
-import com.amazonaws.services.dynamodb.model.Key;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 
 public class QueryCommandTest {
 
@@ -53,27 +54,34 @@ public class QueryCommandTest {
     @Test
     public void execute() {
 
-        Key startKey = new Key(new AttributeValue("startKey"));
-        AttributeValue attributeValue = new AttributeValue().withN("1985");
-        Condition condition = new Condition()
-                .withComparisonOperator(ComparisonOperator.GT.toString())
-                .withAttributeValueList(new AttributeValue().withN("1985"));
+    	Map<String,AttributeValue> startKey = new HashMap<String, AttributeValue>();
+    	startKey.put("1", new AttributeValue("startKey"));
 
         List<String> attributeNames = Arrays.asList("attrNameOne", "attrNameTwo");
         exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, attributeNames);
-        exchange.getIn().setHeader(DdbConstants.EXACT_COUNT, true);
         exchange.getIn().setHeader(DdbConstants.CONSISTENT_READ, true);
         exchange.getIn().setHeader(DdbConstants.START_KEY, startKey);
-        exchange.getIn().setHeader(DdbConstants.HASH_KEY_VALUE, attributeValue);
         exchange.getIn().setHeader(DdbConstants.LIMIT, 10);
-        exchange.getIn().setHeader(DdbConstants.SCAN_RANGE_KEY_CONDITION, condition);
         exchange.getIn().setHeader(DdbConstants.SCAN_INDEX_FORWARD, true);
+        
+        Map<String, Condition> keyConditions = new HashMap<String, Condition>();
+        Condition condition = new Condition()
+	        .withComparisonOperator(ComparisonOperator.GT.toString())
+	        .withAttributeValueList(new AttributeValue().withN("1985"));
+        
+        keyConditions.put("1", condition);
+        
+        exchange.getIn().setHeader(DdbConstants.KEY_CONDITIONS, keyConditions);
 
         command.execute();
 
+    	Map<String,AttributeValue> mapAssert = new HashMap<String, AttributeValue>();
+    	mapAssert.put("1", new AttributeValue("LAST_KEY"));
+    	ConsumedCapacity consumed = (ConsumedCapacity) exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY);
         assertEquals(Integer.valueOf(1), exchange.getIn().getHeader(DdbConstants.COUNT, Integer.class));
-        assertEquals(Double.valueOf(1.0), exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY, Double.class));
-        assertEquals(new Key(new AttributeValue("LAST_KEY")), exchange.getIn().getHeader(DdbConstants.LAST_EVALUATED_KEY, Key.class));
+        assertEquals(Double.valueOf(1.0), consumed.getCapacityUnits());
+        assertEquals(mapAssert, exchange.getIn().getHeader(DdbConstants.LAST_EVALUATED_KEY, Map.class));
+        assertEquals(keyConditions, exchange.getIn().getHeader(DdbConstants.KEY_CONDITIONS, Map.class));
 
         Map<?, ?> items = (Map<?, ?>) exchange.getIn().getHeader(DdbConstants.ITEMS, List.class).get(0);
         assertEquals(new AttributeValue("attrValue"), items.get("attrName"));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/ScanCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/ScanCommandTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
-import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
+import static org.junit.Assert.assertEquals;
 
 public class ScanCommandTest {
 
@@ -60,10 +59,10 @@ public class ScanCommandTest {
 
         command.execute();
 
-    	Map<String,AttributeValue> mapAssert = new HashMap<String, AttributeValue>();
-    	mapAssert.put("1", new AttributeValue("LAST_KEY"));
-    	
-    	ConsumedCapacity consumed = (ConsumedCapacity) exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY);
+        Map<String, AttributeValue> mapAssert = new HashMap<String, AttributeValue>();
+        mapAssert.put("1", new AttributeValue("LAST_KEY"));
+
+        ConsumedCapacity consumed = (ConsumedCapacity) exchange.getIn().getHeader(DdbConstants.CONSUMED_CAPACITY);
         assertEquals(scanFilter, ddbClient.scanRequest.getScanFilter());
         assertEquals(Integer.valueOf(10), exchange.getIn().getHeader(DdbConstants.SCANNED_COUNT, Integer.class));
         assertEquals(Integer.valueOf(1), exchange.getIn().getHeader(DdbConstants.COUNT, Integer.class));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/UpdateItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/UpdateItemCommandTest.java
@@ -16,14 +16,10 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import com.amazonaws.services.dynamodb.model.AttributeAction;
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodb.model.AttributeValueUpdate;
-import com.amazonaws.services.dynamodb.model.ExpectedAttributeValue;
-import com.amazonaws.services.dynamodb.model.Key;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -31,7 +27,10 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.amazonaws.services.dynamodbv2.model.AttributeAction;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 public class UpdateItemCommandTest {
 
@@ -51,7 +50,8 @@ public class UpdateItemCommandTest {
 
     @Test
     public void execute() {
-        Key key = new Key(new AttributeValue("Key_1"));
+    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
+    	key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
         Map<String, AttributeValueUpdate> attributeMap = new HashMap<String, AttributeValueUpdate>();

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/UpdateItemCommandTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/UpdateItemCommandTest.java
@@ -16,21 +16,20 @@
  */
 package org.apache.camel.component.aws.ddb;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeAction;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeAction;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
-import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import static org.junit.Assert.assertEquals;
 
 public class UpdateItemCommandTest {
 
@@ -50,8 +49,8 @@ public class UpdateItemCommandTest {
 
     @Test
     public void execute() {
-    	Map<String,AttributeValue> key = new HashMap<String, AttributeValue>();
-    	key.put("1", new AttributeValue("Key_1"));
+        Map<String, AttributeValue> key = new HashMap<String, AttributeValue>();
+        key.put("1", new AttributeValue("Key_1"));
         exchange.getIn().setHeader(DdbConstants.KEY, key);
 
         Map<String, AttributeValueUpdate> attributeMap = new HashMap<String, AttributeValueUpdate>();

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -30,8 +32,6 @@ import org.apache.camel.component.aws.ddb.DdbOperations;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 @Ignore("Must be manually tested. Provide your own accessKey and secretKey!")
 public class DdbComponentIntegrationTest extends CamelTestSupport {

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodb.model.AttributeValue;
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -32,6 +30,8 @@ import org.apache.camel.component.aws.ddb.DdbOperations;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 @Ignore("Must be manually tested. Provide your own accessKey and secretKey!")
 public class DdbComponentIntegrationTest extends CamelTestSupport {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -64,8 +64,8 @@
     <avro-bundle-version>1.7.7_1</avro-bundle-version>
     <avro-ipc-bundle-version>1.7.7_1</avro-ipc-bundle-version>
     <awaitility.version>1.6.3</awaitility.version>
-    <aws-java-sdk-bundle-version>1.8.9.1_1</aws-java-sdk-bundle-version>
-    <aws-java-sdk-version>1.8.9.1</aws-java-sdk-version>
+    <aws-java-sdk-bundle-version>1.9.17.1</aws-java-sdk-bundle-version>
+    <aws-java-sdk-version>1.9.17</aws-java-sdk-version>
     <axiom-version>1.2.14</axiom-version>
     <backport-util-concurrent-version>3.1</backport-util-concurrent-version>
     <bcel-bundle-version>5.2_4</bcel-bundle-version>


### PR DESCRIPTION
Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/CAMEL-8572

There are some new feature to consider:
- The package is different: from com.amazonaws.services.dynamodb to com.amazonaws.services.dynamodbv2
- Key class is gone (among other changes) and it's been replaced by Map(String, AttributeValue)

The most important changes:
- from com.amazonaws.services.dynamodb.model.Key to Map(String, AttributeValue)
- from com.amazonaws.services.dynamodb.model.BatchResponse to List of Map(String,AttributeValue)
- from com.amazonaws.services.dynamodb.model.KeySchema to List(KeySchemaElement)

- QueryRequest methods withHashKeyValue(AttributeValue) and withRangeKeyCondition(Condition) now are merged into withKeyConditions(Map(String,Condition))

- QueryRequest method withCount(Boolean) doesn't exist anymore

So we will even need to make some changes on documentation (I've deleted some constant from DdbConstants.java class).

Andrea