### PR TITLE
camel-scr: Removed unnecessary method calls

### DIFF
--- a/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
+++ b/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
@@ -174,12 +174,6 @@ public abstract class AbstractCamelRunner implements Runnable {
 
         cancelDelayedRun();
 
-        doDeactivate();
-
-        stopCamelContext();
-    }
-
-    protected void doDeactivate() {
         stop();
     }
 


### PR DESCRIPTION
No effect in practice, but stopCamelContext() was called twice in a row for no reason.