### PR TITLE
CAMEL-8608 Update async-http-client version from 1.9.8 to 1.9.17

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,7 +36,7 @@
     <abdera-version>1.1.3</abdera-version>
     <!-- Note that activemq dependency is only used for testing! -->
     <activemq-version>5.11.1</activemq-version>
-    <ahc-version>1.9.8</ahc-version>
+    <ahc-version>1.9.17</ahc-version>
     <ant-bundle-version>1.7.0_6</ant-bundle-version>
     <antlr-bundle-version>3.4_1</antlr-bundle-version>
     <antlr-runtime-bundle-version>3.4_2</antlr-runtime-bundle-version>


### PR DESCRIPTION
Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/CAMEL-8608

Tests are ok for all the components affected by this change.

Thanks.
Bye,
Andrea