### PR TITLE
Added uripath endpoint mapping for spring-ws route endpoints

### DIFF
--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/bean/CamelEndpointMapping.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/bean/CamelEndpointMapping.java
@@ -16,19 +16,6 @@
  */
 package org.apache.camel.component.spring.ws.bean;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import javax.xml.namespace.QName;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-
-import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
-
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.spring.ws.type.EndpointMappingKey;
 import org.apache.camel.component.spring.ws.type.EndpointMappingType;
@@ -37,9 +24,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.ws.context.MessageContext;
-import org.springframework.ws.server.EndpointInterceptor;
-import org.springframework.ws.server.EndpointInvocationChain;
-import org.springframework.ws.server.EndpointMapping;
+import org.springframework.ws.server.*;
 import org.springframework.ws.server.endpoint.MessageEndpoint;
 import org.springframework.ws.server.endpoint.mapping.AbstractEndpointMapping;
 import org.springframework.ws.server.endpoint.support.PayloadRootUtils;
@@ -50,6 +35,18 @@ import org.springframework.ws.transport.WebServiceConnection;
 import org.springframework.ws.transport.context.TransportContext;
 import org.springframework.ws.transport.context.TransportContextHolder;
 import org.springframework.xml.xpath.XPathExpression;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Spring {@link EndpointMapping} for mapping messages to corresponding Camel
@@ -84,6 +81,7 @@ import org.springframework.xml.xpath.XPathExpression;
 public class CamelEndpointMapping extends AbstractEndpointMapping implements InitializingBean, CamelSpringWSEndpointMapping, SoapEndpointMapping {
 
     private static final String DOUBLE_QUOTE = "\"";
+    private static final String URI_PATH_WILDCARD = "*";
     private Map<EndpointMappingKey, MessageEndpoint> endpoints = new ConcurrentHashMap<EndpointMappingKey, MessageEndpoint>();
     private TransformerFactory transformerFactory;
     private XmlConverter xmlConverter;
@@ -95,7 +93,7 @@ public class CamelEndpointMapping extends AbstractEndpointMapping implements Ini
     @Override
     protected Object getEndpointInternal(MessageContext messageContext) throws Exception {
         for (EndpointMappingKey key : endpoints.keySet()) {
-            Object messageKey = null;
+            String messageKey;
             switch (key.getType()) {
             case ROOT_QNAME:
                 messageKey = getRootQName(messageContext);
@@ -108,6 +106,18 @@ public class CamelEndpointMapping extends AbstractEndpointMapping implements Ini
                 break;
             case URI:
                 messageKey = getUri();
+                break;
+            case URI_PATH:
+                messageKey = getUriPath();
+
+                if (messageKey != null && key.getLookupKey().endsWith(URI_PATH_WILDCARD)) {
+                    String lookupKey = key.getLookupKey().substring(0, key.getLookupKey().length() - 1);
+
+                    if (messageKey.startsWith(lookupKey)) {
+                        return endpoints.get(key);
+                    }
+                }
+
                 break;
             default:
                 throw new RuntimeCamelException("Invalid mapping type specified. Supported types are: root QName, SOAP action, XPath expression and URI");
@@ -145,11 +155,28 @@ public class CamelEndpointMapping extends AbstractEndpointMapping implements Ini
     }
 
     private String getUri() throws URISyntaxException {
+        WebServiceConnection webServiceConnection = getWeServiceConnection();
+        if (webServiceConnection != null) {
+            return webServiceConnection.getUri().toString();
+        }
+        return null;
+    }
+
+    private String getUriPath() throws URISyntaxException {
+        WebServiceConnection webServiceConnection = getWeServiceConnection();
+        if (webServiceConnection != null) {
+            return webServiceConnection.getUri().getPath();
+        }
+
+        return null;
+    }
+
+    private WebServiceConnection getWeServiceConnection() {
         TransportContext transportContext = TransportContextHolder.getTransportContext();
         if (transportContext != null) {
             WebServiceConnection webServiceConnection = transportContext.getConnection();
             if (webServiceConnection != null) {
-                return webServiceConnection.getUri().toString();
+                return webServiceConnection;
             }
         }
         return null;

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/type/EndpointMappingType.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/type/EndpointMappingType.java
@@ -26,6 +26,7 @@ public enum EndpointMappingType {
     SOAP_ACTION("soapaction:"),
     XPATHRESULT("xpathresult:"),
     URI("uri:"),
+    URI_PATH("uripath:"),
     BEANNAME("beanname:");
 
     private String prefix;

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerEndpointMappingResponseHandlingRouteTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerEndpointMappingResponseHandlingRouteTest.java
@@ -16,13 +16,6 @@
  */
 package org.apache.camel.component.spring.ws;
 
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.net.URI;
-
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
-
 import org.apache.camel.component.spring.ws.utils.TestUtil;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Before;
@@ -33,6 +26,13 @@ import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.soap.addressing.client.ActionCallback;
 import org.springframework.ws.soap.addressing.version.Addressing10;
 import org.springframework.ws.soap.client.core.SoapActionCallback;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.URI;
 
 public class ConsumerEndpointMappingResponseHandlingRouteTest extends CamelSpringTestSupport {
 
@@ -62,20 +62,48 @@ public class ConsumerEndpointMappingResponseHandlingRouteTest extends CamelSprin
 
     @Test
     public void testSoapAction() throws Exception {
-        StreamSource source = new StreamSource(new StringReader(xmlRequestForGoogleStockQuoteNoNamespace));
         StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
-        webServiceTemplate.sendSourceAndReceiveToResult(source, new SoapActionCallback("http://www.webserviceX.NET/GetQuote"), result);
+        webServiceTemplate.sendSourceAndReceiveToResult(getDefaultRequestSource(), new SoapActionCallback("http://www.webserviceX.NET/GetQuote"), result);
         assertNotNull(result);
         TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
     }
 
     @Test
     public void testUri() throws Exception {
-        StreamSource source = new StreamSource(new StringReader(xmlRequestForGoogleStockQuoteNoNamespace));
         StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
-        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost/stockquote2", source, result);
+        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost/stockquote2", getDefaultRequestSource(), result);
+        assertNotNull(result);
+        TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
+    }
+
+    @Test
+    public void testUriPath() throws Exception {
+        StringWriter sw = new StringWriter();
+        StreamResult result = new StreamResult(sw);
+        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost/stockquote3/service", getDefaultRequestSource(), result);
+        assertNotNull(result);
+        TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
+
+        sw = new StringWriter();
+        result = new StreamResult(sw);
+        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost:8080/stockquote3/service", getDefaultRequestSource(), result);
+        assertNotNull(result);
+        TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
+    }
+
+    @Test
+    public void testUriPathWildcard() throws Exception {
+        StringWriter sw = new StringWriter();
+        StreamResult result = new StreamResult(sw);
+        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost/stockquote4/service/test", getDefaultRequestSource(), result);
+        assertNotNull(result);
+        TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
+
+        sw = new StringWriter();
+        result = new StreamResult(sw);
+        webServiceTemplate.sendSourceAndReceiveToResult("http://localhost:8080/stockquote4/services/test", getDefaultRequestSource(), result);
         assertNotNull(result);
         TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
     }
@@ -92,20 +120,18 @@ public class ConsumerEndpointMappingResponseHandlingRouteTest extends CamelSprin
 
     @Test
     public void testAction() throws Exception {
-        StreamSource source = new StreamSource(new StringReader(xmlRequestForGoogleStockQuoteNoNamespace));
         StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
-        webServiceTemplate.sendSourceAndReceiveToResult(source, new ActionCallback("http://www.webserviceX.NET/GetQuote"), result);
+        webServiceTemplate.sendSourceAndReceiveToResult(getDefaultRequestSource(), new ActionCallback("http://www.webserviceX.NET/GetQuote"), result);
         assertNotNull(result);
         TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
     }
 
     @Test
     public void testTo() throws Exception {
-        StreamSource source = new StreamSource(new StringReader(xmlRequestForGoogleStockQuoteNoNamespace));
         StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
-        webServiceTemplate.sendSourceAndReceiveToResult(source, new ActionCallback(new URI("http://action-does-not-matter-here"), new Addressing10(), new URI("http://url.to")),
+        webServiceTemplate.sendSourceAndReceiveToResult(getDefaultRequestSource(), new ActionCallback(new URI("http://action-does-not-matter-here"), new Addressing10(), new URI("http://url.to")),
                                                         result);
         assertNotNull(result);
         TestUtil.assertEqualsIgnoreNewLinesSymbol(expectedResponse, sw.toString());
@@ -114,5 +140,9 @@ public class ConsumerEndpointMappingResponseHandlingRouteTest extends CamelSprin
     @Override
     protected AbstractXmlApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/component/spring/ws/ConsumerEndpointMappingResponseHandlingRouteTest-context.xml");
+    }
+
+    private Source getDefaultRequestSource() {
+        return new StreamSource(new StringReader(xmlRequestForGoogleStockQuoteNoNamespace));
     }
 }

--- a/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerEndpointMappingResponseHandlingRouteTest-context.xml
+++ b/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerEndpointMappingResponseHandlingRouteTest-context.xml
@@ -39,6 +39,14 @@
             <to uri="responseProcessor"/>
         </route>
         <route>
+            <from uri="spring-ws:uripath:/stockquote3/service?endpointMapping=#endpointMapping"/>
+            <to uri="responseProcessor"/>
+        </route>
+        <route>
+            <from uri="spring-ws:uripath:/stockquote4/service*?endpointMapping=#endpointMapping"/>
+            <to uri="responseProcessor"/>
+        </route>
+        <route>
             <from uri="spring-ws:xpathresult:GRABME?expression=//GetQuote&amp;endpointMapping=#endpointMapping"/>
             <to uri="responseProcessor"/>
         </route>

--- a/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerEndpointMappingRouteTest-context.xml
+++ b/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerEndpointMappingRouteTest-context.xml
@@ -42,6 +42,14 @@
             <to uri="mock:testUri"/>
         </route>
         <route>
+            <from uri="spring-ws:uripath:/stockquote3/service?endpointMapping=#endpointMapping"/>
+            <to uri="mock:testUriPath"/>
+        </route>
+        <route>
+            <from uri="spring-ws:uripath:/stockquote4/service*?endpointMapping=#endpointMapping"/>
+            <to uri="mock:testUriPath"/>
+        </route>
+        <route>
             <from uri="spring-ws:xpathresult:GRABME?expression=//GetQuote&amp;endpointMapping=#endpointMapping"/>
             <to uri="mock:testXPath"/>
         </route>


### PR DESCRIPTION
Extended Camel endpoint mapping for spring-ws endpoints, so routes can use uri path instead of complete WebService uri. This way route definitions are independent of host and port specifications that may be different in test and production environments.

Uri path is defined as resource path in a WebService URI: 
```
[<scheme>://]<host>:[<port>]<uri-path>[#<fragment>][?<query-params>]
```
Endpoint mapping implementation does supports wildcard character at the uri path end, such as:

spring-ws:uripath:/sample/services*

This mapping would match following request URIs:

http://localhost:8080/sample/services
http://somehost/sample/services
http://localhost:8888/sample/services/test
http://localhost/sample/services/foo?version=1.0

This way route definitions are independent of host, port and query parameters that are likely to change in different environments.