### PR TITLE
CAMEL-8758: Fix to Camel Cache producer to avoid NPE in race condition

### DIFF
--- a/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheProducer.java
+++ b/components/camel-cache/src/main/java/org/apache/camel/component/cache/CacheProducer.java
@@ -93,9 +93,10 @@ public class CacheProducer extends DefaultProducer {
             cache.remove(key);
         } else if (checkIsEqual(operation, CacheConstants.CACHE_OPERATION_URL_GET)) {
             LOG.debug("Quering an element with key {} from the Cache", key);
-            if (cache.get(key) != null) {
+            Element element = cache.get(key);
+            if (element != null) {
                 exchange.getIn().setHeader(CacheConstants.CACHE_ELEMENT_WAS_FOUND, true);
-                exchange.getIn().setBody(cache.get(key).getObjectValue());
+                exchange.getIn().setBody(element.getObjectValue());
             } else {
                 exchange.getIn().removeHeader(CacheConstants.CACHE_ELEMENT_WAS_FOUND);
             }


### PR DESCRIPTION
Fix to avoid potential race condition which can cause NPE. An element is retrieved from the cache to perform a null check and if not null, retrieved once again to perform object retrieval. If the object is either removed from the cache or TTL expires, can result in NPE.