### PR TITLE
Adding support for defining custom swagger parameters

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,8 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
     @XmlAttribute
     private String produces;
 
-    @XmlAttribute @Metadata(defaultValue = "auto")
+    @XmlAttribute
+    @Metadata(defaultValue = "auto")
     private RestBindingMode bindingMode;
 
     @XmlAttribute
@@ -128,7 +129,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
     public void setVerbs(List<VerbDefinition> verbs) {
         this.verbs = verbs;
     }
-   
+
     public Boolean getSkipBindingOnErrorCode() {
         return skipBindingOnErrorCode;
     }
@@ -265,6 +266,14 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         }
 
         return this;
+    }
+
+    public RestParamDefinition restParam() {
+        if (getVerbs().isEmpty()) {
+            throw new IllegalArgumentException("Must add verb first, such as get/post/delete");
+        }
+        VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
+        return new RestParamDefinition(verb);
     }
 
     public RestDefinition produces(String mediaType) {
@@ -416,10 +425,9 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
             answer = new VerbDefinition();
             answer.setMethod(verb);
         }
-
+        getVerbs().add(answer);
         answer.setRest(this);
         answer.setUri(uri);
-        getVerbs().add(answer);
         return this;
     }
 

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,8 +52,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
     @XmlAttribute
     private String produces;
 
-    @XmlAttribute
-    @Metadata(defaultValue = "auto")
+    @XmlAttribute @Metadata(defaultValue = "auto")
     private RestBindingMode bindingMode;
 
     @XmlAttribute

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,57 +16,63 @@
  */
 package org.apache.camel.model.rest;
 
-import org.apache.camel.spi.Metadata;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Created by seb on 5/13/15.
- */
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.camel.spi.Metadata;
+
+
+
+
 @Metadata(label = "rest")
 @XmlRootElement(name = "param")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RestOperationParam {
     @XmlAttribute
-    String paramType="query";
+    RestParamType paramType = RestParamType.query;
 
     @XmlAttribute
     String name;
 
     @XmlAttribute
-    String description="";
+    String description = "";
 
     @XmlAttribute
-    String defaultValue="";
+    String defaultValue = "";
 
     @XmlAttribute
-    Boolean required=true;
+    Boolean required = true;
 
     @XmlAttribute
-    Boolean allowMultiple=false;
+    Boolean allowMultiple = false;
 
     @XmlAttribute
-    String dataType="string";
+    String dataType = "string";
 
-    @XmlElementWrapper( name="allowableValues" )
-    @XmlElement( name="value" )
-    List<String> allowableValues=new ArrayList<String>();
+    @XmlElementWrapper(name = "allowableValues")
+    @XmlElement(name = "value")
+    List<String> allowableValues = new ArrayList<String>();
 
     @XmlAttribute
-    String paramAccess=null;
+    String paramAccess;
 
 
     public RestOperationParam() {
-    
+
     }
 
-    public String getParamType() {
+    public RestParamType getParamType() {
         return paramType;
     }
 
-    public void setParamType(String paramType) {
+    public void setParamType(RestParamType paramType) {
         this.paramType = paramType;
     }
 

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.model.rest;
 
 import org.apache.camel.spi.Metadata;

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParam.java
@@ -1,0 +1,120 @@
+package org.apache.camel.model.rest;
+
+import org.apache.camel.spi.Metadata;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by seb on 5/13/15.
+ */
+@Metadata(label = "rest")
+@XmlRootElement(name = "param")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RestOperationParam {
+    @XmlAttribute
+    String paramType="query";
+
+    @XmlAttribute
+    String name;
+
+    @XmlAttribute
+    String description="";
+
+    @XmlAttribute
+    String defaultValue="";
+
+    @XmlAttribute
+    Boolean required=true;
+
+    @XmlAttribute
+    Boolean allowMultiple=false;
+
+    @XmlAttribute
+    String dataType="string";
+
+    @XmlElementWrapper( name="allowableValues" )
+    @XmlElement( name="value" )
+    List<String> allowableValues=new ArrayList<String>();
+
+    @XmlAttribute
+    String paramAccess=null;
+
+
+    public RestOperationParam() {
+    
+    }
+
+    public String getParamType() {
+        return paramType;
+    }
+
+    public void setParamType(String paramType) {
+        this.paramType = paramType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+
+    public Boolean getAllowMultiple() {
+        return allowMultiple;
+    }
+
+    public void setAllowMultiple(Boolean allowMultiple) {
+        this.allowMultiple = allowMultiple;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
+    }
+
+    public List<String> getAllowableValues() {
+        return allowableValues;
+    }
+
+    public void setAllowableValues(List<String> allowableValues) {
+        this.allowableValues = allowableValues;
+    }
+
+    public String getParamAccess() {
+        return paramAccess;
+    }
+
+    public void setParamAccess(String paramAccess) {
+        this.paramAccess = paramAccess;
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
@@ -1,0 +1,76 @@
+package org.apache.camel.model.rest;
+
+import org.apache.camel.model.OptionalIdentifiedDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by seb on 5/14/15.
+ */
+public class RestParamDefinition extends OptionalIdentifiedDefinition<RestParamDefinition> {
+
+    private RestOperationParam parameter = new RestOperationParam();
+    private VerbDefinition verb;
+
+    public RestParamDefinition(VerbDefinition verb) {
+        this.verb = verb;
+    }
+
+    @Override
+    public String getLabel() {
+        return "param";
+    }
+
+
+    public RestParamDefinition name(String name) {
+        parameter.setName(name);
+        return this;
+    }
+
+    public RestParamDefinition description(String name) {
+        parameter.setDescription(name);
+        return this;
+    }
+
+    public RestParamDefinition defaultValue(String name) {
+        parameter.setDefaultValue(name);
+        return this;
+    }
+
+    public RestParamDefinition required(Boolean required) {
+        parameter.setRequired(required);
+        return this;
+    }
+
+    public RestParamDefinition allowMultiple(Boolean allowMultiple) {
+        parameter.setAllowMultiple(allowMultiple);
+        return this;
+    }
+
+    public RestParamDefinition dataType(String type) {
+        parameter.setDataType(type);
+        return this;
+    }
+
+    public RestParamDefinition allowableValues(List<String> allowableValues) {
+        parameter.setAllowableValues(allowableValues);
+        return this;
+    }
+
+    public RestParamDefinition type(String type) {
+        parameter.setParamType(type);
+        return this;
+    }
+
+    public RestParamDefinition paramAccess(String paramAccess) {
+        parameter.setParamAccess(paramAccess);
+        return this;
+    }
+
+    public RestDefinition endParam() {
+        verb.getParams().add(parameter);
+        return verb.getRest();
+    }
+
+}

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
@@ -20,8 +20,10 @@ import java.util.List;
 
 import org.apache.camel.model.OptionalIdentifiedDefinition;
 
+import javax.xml.bind.annotation.XmlTransient;
 
 
+@XmlTransient
 public class RestParamDefinition extends OptionalIdentifiedDefinition<RestParamDefinition> {
 
     private RestOperationParam parameter = new RestOperationParam();

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,12 @@
  */
 package org.apache.camel.model.rest;
 
-import org.apache.camel.model.OptionalIdentifiedDefinition;
-
 import java.util.List;
 
-/**
- * Created by seb on 5/14/15.
- */
+import org.apache.camel.model.OptionalIdentifiedDefinition;
+
+
+
 public class RestParamDefinition extends OptionalIdentifiedDefinition<RestParamDefinition> {
 
     private RestOperationParam parameter = new RestOperationParam();
@@ -73,7 +72,7 @@ public class RestParamDefinition extends OptionalIdentifiedDefinition<RestParamD
         return this;
     }
 
-    public RestParamDefinition type(String type) {
+    public RestParamDefinition type(RestParamType type) {
         parameter.setParamType(type);
         return this;
     }

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestParamDefinition.java
@@ -1,8 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.model.rest;
 
 import org.apache.camel.model.OptionalIdentifiedDefinition;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestParamType.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestParamType.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.rest;
+
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.camel.spi.Metadata;
+
+@Metadata(label = "rest")
+@XmlType
+@XmlEnum(String.class)
+public enum RestParamType {
+    header, query, body, path, form
+
+}

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,8 +50,7 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private String produces;
 
-    @XmlAttribute
-    @Metadata(defaultValue = "auto")
+    @XmlAttribute @Metadata(defaultValue = "auto")
     private RestBindingMode bindingMode;
 
     @XmlAttribute

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,18 +16,16 @@
  */
 package org.apache.camel.model.rest;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.*;
 
 import org.apache.camel.model.OptionalIdentifiedDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.apache.camel.spi.Metadata;
+import org.apache.camel.util.FileUtil;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Rest command
@@ -40,6 +38,9 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private String method;
 
+    @XmlElementRef
+    private List<RestOperationParam> params = new ArrayList<RestOperationParam>();
+
     @XmlAttribute
     private String uri;
 
@@ -49,7 +50,8 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private String produces;
 
-    @XmlAttribute @Metadata(defaultValue = "auto")
+    @XmlAttribute
+    @Metadata(defaultValue = "auto")
     private RestBindingMode bindingMode;
 
     @XmlAttribute
@@ -89,6 +91,10 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
         }
     }
 
+    public List<RestOperationParam> getParams() {
+        return params;
+    }
+
     public String getMethod() {
         return method;
     }
@@ -109,6 +115,29 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
      */
     public void setUri(String uri) {
         this.uri = uri;
+        String path = this.rest.getPath();
+
+        String s1 = FileUtil.stripTrailingSeparator(path);
+        String s2 = FileUtil.stripLeadingSeparator(uri);
+        String allPath;
+        if (s1 != null && s2 != null) {
+            allPath = s1 + "/" + s2;
+        } else if (path != null) {
+            allPath = path;
+        } else {
+            allPath = uri;
+        }
+
+        // each {} is a parameter
+        String[] arr = allPath.split("\\/");
+        for (String a: arr) {
+            if (a.startsWith("{") && a.endsWith("}")) {
+                String key = a.substring(1, a.length() - 1);
+                rest.restParam().name(key).type("path").endParam();
+            }
+        }
+
+
     }
 
     public String getConsumes() {
@@ -186,6 +215,11 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
      */
     public void setType(String type) {
         this.type = type;
+        String bodyType = type;
+        if (type.endsWith("[]")) {
+            bodyType = "List[" + bodyType.substring(0, type.length() - 2) + "]";
+        }
+        rest.restParam().name("body").type("body").dataType(bodyType).endParam();
     }
 
     public String getOutType() {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,18 @@
  */
 package org.apache.camel.model.rest;
 
-import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 
 import org.apache.camel.model.OptionalIdentifiedDefinition;
 import org.apache.camel.model.RouteDefinition;
@@ -24,8 +35,7 @@ import org.apache.camel.model.ToDefinition;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.util.FileUtil;
 
-import java.util.ArrayList;
-import java.util.List;
+
 
 /**
  * Rest command
@@ -50,7 +60,8 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private String produces;
 
-    @XmlAttribute @Metadata(defaultValue = "auto")
+    @XmlAttribute
+    @Metadata(defaultValue = "auto")
     private RestBindingMode bindingMode;
 
     @XmlAttribute
@@ -129,10 +140,10 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
 
         // each {} is a parameter
         String[] arr = allPath.split("\\/");
-        for (String a: arr) {
+        for (String a : arr) {
             if (a.startsWith("{") && a.endsWith("}")) {
                 String key = a.substring(1, a.length() - 1);
-                rest.restParam().name(key).type("path").endParam();
+                rest.restParam().name(key).type(RestParamType.path).endParam();
             }
         }
 
@@ -218,7 +229,7 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
         if (type.endsWith("[]")) {
             bodyType = "List[" + bodyType.substring(0, type.length() - 2) + "]";
         }
-        rest.restParam().name("body").type("body").dataType(bodyType).endParam();
+        rest.restParam().name("body").type(RestParamType.body).dataType(bodyType).endParam();
     }
 
     public String getOutType() {

--- a/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
@@ -27,3 +27,5 @@ RestHostNameResolver
 RestPropertyDefinition
 RestsDefinition
 VerbDefinition
+RestOperationParam
+RestParamDefinition

--- a/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
+++ b/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
@@ -23,7 +23,7 @@ import com.wordnik.swagger.model._
 import com.wordnik.swagger.core.util.ModelUtil
 import com.wordnik.swagger.core.SwaggerSpec
 
-import org.apache.camel.model.rest.{VerbDefinition, RestDefinition}
+import org.apache.camel.model.rest.{RestOperationParam, VerbDefinition, RestDefinition}
 import org.apache.camel.util.FileUtil
 import org.slf4j.LoggerFactory
 
@@ -120,7 +120,7 @@ class RestSwaggerReader {
         consumes,
         List(),
         List(),
-        createParameters(verb, buildUrl(resourcePath, path)),
+        createParameters(verb),
         List(),
         None)
     }
@@ -173,46 +173,25 @@ class RestSwaggerReader {
     else None
   }
 
-  def createParameters(verb: VerbDefinition, absPath : String): List[Parameter] = {
+  def createParameters(verb: VerbDefinition): List[Parameter] = {
     val parameters = new ListBuffer[Parameter]
 
-    // each {} is a parameter
-    val arr = absPath.split("\\/")
-    for (a <- arr) {
-      if (a.startsWith("{") && a.endsWith("}")) {
-        var key = a.substring(1, a.length - 1)
+    for (param:RestOperationParam <- verb.getParams.asScala) {
+      var allowValues=AnyAllowableValues
 
-        parameters += Parameter(
-          key,
-          None,
-          None,
-          true,
-          false,
-          "string",
-          AnyAllowableValues,
-          "path",
-          None
-        )
+      if(!param.getAllowableValues.isEmpty){
+        AllowableListValues(param.getAllowableValues.asScala.toList)
       }
-    }
-
-    // if we have input type then its a body parameter
-    if (verb.getType != null) {
-      var bodyType = verb.getType
-      if (bodyType.endsWith("[]")) {
-        bodyType = "List[" + bodyType.substring(0, bodyType.length - 2) + "]"
-      }
-
       parameters += Parameter(
-        "body",
-        None,
-        None,
-        true,
-        false,
-        bodyType,
-        AnyAllowableValues,
-        "body",
-        None
+        param.getName,
+        Some( param.getDescription ),
+        Some( param.getDefaultValue),
+        param.getRequired.booleanValue(),
+        param.getAllowMultiple.booleanValue(),
+        param.getDataType,
+        allowValues,
+        param.getParamType,
+        Some(param.getParamAccess)
       )
     }
 

--- a/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
+++ b/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
@@ -190,7 +190,7 @@ class RestSwaggerReader {
         param.getAllowMultiple.booleanValue(),
         param.getDataType,
         allowValues,
-        param.getParamType,
+        param.getParamType.toString,
         Some(param.getParamAccess)
       )
     }


### PR DESCRIPTION
Hey,
   This PR adds support for defining swagger custom operation parameters in rest routes. 
    It has the options for specifying every swagger parameter option.

   An example route:
  rest("products")
                        .get("{url}").description("queries products by url")
                        .produces("application/json").outTypeList(Product.class)
                       .restParam().name("startDate").required(true).description("first verified date").type("query").endParam()
                        .restParam().name("headerName").required(false).description("some header desc").type("header").endParam()
                        .route().processRef("validator").process(proc)
                        .marshal().json(JsonLibrary.Jackson).endRest();

 This will add 1 query param  and one header param  in the swagger json.

Thanks

