### PR TITLE
CAMEL-8647: Fix duplicated import-package statement for org.osgi.fram…

### DIFF
--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -58,7 +58,6 @@
       org.apache.aries.blueprint.reflect;version="[1.0,2.0)";resolution:=optional,
       org.apache.aries.blueprint.mutable;version="[1.0,2.0)";resolution:=optional,
       org.apache.camel.blueprint;resolution:=optional,
-      org.osgi.framework;resolution:=optional,
       *
     </camel.osgi.import>
 


### PR DESCRIPTION
It seems that in change SHA: f058e02b00c27bec81ee813aee026e727cd1d33d the wildcard expression org.osgi.framework*;version="[1.5,2)", was removed and replaced by org.osgi.framework;version="[1.5,2)". 

In camel-cxf the bundle plugin will create two import-package statements since it defines a org.osgi.framework;resolution:=optional in the camel.osgi.import property. Without the wildcard this leads to two import-package statements which prevents installing the camel-cxf bundle in an osgi container. 

It seems that in SHA: ced83fe5b86a1861821ddefcc740c0ed3698a303we resolved the same issue in camel-spring by removing the import statement in the camel.osgi.import property. We could do the same for camel-cxf.