### PR TITLE
Added support for reference parameters to the Timer component

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/timer/TimerComponent.java
+++ b/camel-core/src/main/java/org/apache/camel/component/timer/TimerComponent.java
@@ -94,9 +94,13 @@ public class TimerComponent extends UriEndpointComponent {
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         TimerEndpoint answer = new TimerEndpoint(uri, this, remaining);
 
+        /**
+         * added support for reference configuration parameters 
+         */
+        
         // convert time from String to a java.util.Date using the supported patterns
-        String time = getAndRemoveParameter(parameters, "time", String.class);
-        String pattern = getAndRemoveParameter(parameters, "pattern", String.class);
+        String time = getAndRemoveOrResolveReferenceParameter(parameters, "time", String.class);
+        String pattern = getAndRemoveOrResolveReferenceParameter(parameters, "pattern", String.class);
         if (time != null) {
             SimpleDateFormat sdf;
             if (pattern != null) {
@@ -109,11 +113,36 @@ public class TimerComponent extends UriEndpointComponent {
             Date date = sdf.parse(time);
             answer.setTime(date);
         }
-
+         
+        Long period = getAndRemoveOrResolveReferenceParameter(parameters, "period", Long.class);
+        if(period != null){
+            answer.setPeriod(period);
+        }
+        
+        Long delay = getAndRemoveOrResolveReferenceParameter(parameters, "delay", Long.class);
+        if(delay != null){
+            answer.setDelay(delay);
+        }
+        
+        Boolean fixedRate = getAndRemoveOrResolveReferenceParameter(parameters, "fixedRate", Boolean.class);
+        if(fixedRate != null){
+            answer.setFixedRate(fixedRate);
+        }
+        
+        Boolean daemon = getAndRemoveOrResolveReferenceParameter(parameters, "daemon", Boolean.class);
+        if(daemon != null){
+            answer.setDaemon(daemon);
+        }
+        
+        Long repeatCount = getAndRemoveOrResolveReferenceParameter(parameters, "repeatCount", Long.class);
+        if(repeatCount != null){
+            answer.setRepeatCount(repeatCount);
+        }
+        
         setProperties(answer, parameters);
         return answer;
     }
-
+    
     @Override
     protected void doStop() throws Exception {
         Collection<Timer> collection = timers.values();

--- a/camel-core/src/test/java/org/apache/camel/component/timer/TimerReferenceConfigurationTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/timer/TimerReferenceConfigurationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.timer;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Endpoint;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.JndiRegistry;
+
+/**
+ *
+ * @author JCostello
+ */
+public class TimerReferenceConfigurationTest extends ContextTestSupport{
+    
+    /**
+     * reference params
+     */
+    final String refExpectedTimeString = "1972-12-11 19:55:00";
+    final String refExpectedPattern = "yyyy-MM-dd HH:mm:ss";
+    final long refExpectedPeriod = 500;
+    final long refExpectedDelay = 100;
+    final boolean refExpectedFixedRate = true;
+    final boolean refExpectedDaemon = false;
+    final long refExpectedRepeatCount = 11;
+    
+    /**
+     * value params
+     */
+    final String valExpectedTimeString = "1970-04-17T18:07:41";
+    final String valExpectedPattern = "yyyy-MM-dd'T'HH:mm:ss";
+    final long valExpectedPeriod = 350;
+    final long valExpectedDelay = 123;
+    final boolean valExpectedFixedRate = false;
+    final boolean valExpectedDaemon = true;
+    final long valExpectedRepeatCount = 13;
+    
+    final String refTimerUri = "timer://passByRefTimer?"
+            + "time=#refExpectedTimeString"
+            + "&pattern=#refExpectedPattern"
+            + "&period=#refExpectedPeriod"
+            + "&delay=#refExpectedDelay"
+            + "&fixedRate=#refExpectedFixedRate"
+            + "&daemon=#refExpectedDaemon"
+            + "&repeatCount=#refExpectedRepeatCount";
+    
+    final String valueTimerUri = "timer://passByValueTimer?"
+            + "time="+valExpectedTimeString
+            + "&pattern="+valExpectedPattern
+            + "&period="+valExpectedPeriod
+            + "&delay="+valExpectedDelay
+            + "&fixedRate="+valExpectedFixedRate
+            + "&daemon="+valExpectedDaemon
+            + "&repeatCount="+valExpectedRepeatCount;
+    
+    final String mockEndpointUri = "mock:result";
+    
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry reg = super.createRegistry();
+        reg.bind("refExpectedTimeString", refExpectedTimeString);
+        reg.bind("refExpectedPattern", refExpectedPattern);
+        reg.bind("refExpectedPeriod", refExpectedPeriod);
+        reg.bind("refExpectedDelay", refExpectedDelay);
+        reg.bind("refExpectedFixedRate", refExpectedFixedRate);
+        reg.bind("refExpectedDaemon", refExpectedDaemon);
+        reg.bind("refExpectedRepeatCount", refExpectedRepeatCount);
+        return reg;
+    } 
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(refTimerUri).to(mockEndpointUri);
+                from(valueTimerUri).to(mockEndpointUri);
+            }
+        };
+    }
+
+    /**
+     * Test that the reference configuration params are correct
+     * @throws Exception 
+     */
+    public void testReferenceConfiguration()throws Exception{
+        
+        Endpoint e = context.getEndpoint(refTimerUri);
+        TimerEndpoint timer = (TimerEndpoint)e;
+        final Date expectedTimeObject = new SimpleDateFormat(refExpectedPattern).parse(refExpectedTimeString);
+        final Date time = timer.getTime();
+        final long period = timer.getPeriod();
+        final long delay = timer.getDelay();
+        final boolean fixedRate = timer.isFixedRate();
+        final boolean daemon = timer.isDaemon();
+        final long repeatCount = timer.getRepeatCount();
+        
+        assertEquals(refExpectedDelay, delay);
+        assertEquals(refExpectedPeriod, period);
+        assertEquals(expectedTimeObject, time);
+        assertEquals(refExpectedFixedRate, fixedRate);
+        assertEquals(refExpectedDaemon, daemon);
+        assertEquals(refExpectedRepeatCount, repeatCount);
+    }
+    
+    /**
+     * Test that the 'value' configuration params are correct
+     * @throws Exception 
+     */
+    public void testValueConfiguration()throws Exception{
+        Endpoint e = context.getEndpoint(valueTimerUri);
+        TimerEndpoint timer = (TimerEndpoint)e;
+        final Date expectedTimeObject = new SimpleDateFormat(valExpectedPattern).parse(valExpectedTimeString);
+        final Date time = timer.getTime();
+        final long period = timer.getPeriod();
+        final long delay = timer.getDelay();
+        final boolean fixedRate = timer.isFixedRate();
+        final boolean daemon = timer.isDaemon();
+        final long repeatCount = timer.getRepeatCount();
+        
+        assertEquals(valExpectedDelay, delay);
+        assertEquals(valExpectedPeriod, period);
+        assertEquals(expectedTimeObject, time);
+        assertEquals(valExpectedFixedRate, fixedRate);
+        assertEquals(valExpectedDaemon, daemon);
+        assertEquals(valExpectedRepeatCount, repeatCount);
+    }
+    
+}


### PR DESCRIPTION
I added support for reference parameters to the Timer component. Users should use the standard '#' notation to specify param values that should be resolved from the registry. 