### PR TITLE
Fixes errors in MEP URIs

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/ExchangePattern.java
+++ b/camel-core/src/main/java/org/apache/camel/ExchangePattern.java
@@ -42,7 +42,7 @@ public enum ExchangePattern {
         case InOnly:
             return "http://www.w3.org/ns/wsdl/in-only";
         case InOptionalOut:
-            return "http://www.w3.org/ns/wsdl/in-optional-out";
+            return "http://www.w3.org/ns/wsdl/in-opt-out";
         case InOut:
             return "http://www.w3.org/ns/wsdl/in-out";
         case OutIn:
@@ -50,7 +50,7 @@ public enum ExchangePattern {
         case OutOnly:
             return "http://www.w3.org/ns/wsdl/out-only";
         case OutOptionalIn:
-            return "http://www.w3.org/ns/wsdl/out-optional_in";
+            return "http://www.w3.org/ns/wsdl/out-opt-in";
         case RobustInOnly:
             return "http://www.w3.org/ns/wsdl/robust-in-only";
         case RobustOutOnly:


### PR DESCRIPTION
Hi,

Apparently the URIs used for the Exchange Patterns were wrong in two different ways:
- First opt was wrongly worded optional (see http://www.w3.org/TR/wsdl20-additional-meps/).
- Second there was an underscore instead of a dash in out-opt-in.

I don't think it will have much impact, except maybe with components such as servicemix's nmr that uses the method fromWsdlUri() to set the pattern of exchanges when converting from their classes to camel's.

Thanks!