### PR TITLE
updating rest tests for new restParam option

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/RouteBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/RouteBuilder.java
@@ -355,6 +355,7 @@ public abstract class RouteBuilder extends BuilderSupport implements RoutesBuild
             RouteBuilder builder = (RouteBuilder) routes;
             builder.setContext(this.getContext());
             builder.setRouteCollection(this.getRouteCollection());
+            builder.setRestCollection(this.getRestCollection());
             builder.setErrorHandlerBuilder(this.getErrorHandlerBuilder());
             // must invoke configure on the original builder so it adds its configuration to me
             builder.configure();

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -268,27 +268,27 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return this;
     }
 
-    public RestOperationParamDefinition restParam() {
+    public RestOperationParamDefinition param() {
         if (getVerbs().isEmpty()) {
             throw new IllegalArgumentException("Must add verb first, such as get/post/delete");
         }
         VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
-        return restParam(verb);
+        return param(verb);
     }
 
-    public RestOperationParamDefinition restParam(VerbDefinition verb) {
+    public RestOperationParamDefinition param(VerbDefinition verb) {
         return new RestOperationParamDefinition(verb);
     }
 
-    public RestOperationResponseMsgDefinition restResponseMsg() {
+    public RestOperationResponseMsgDefinition responseMessage() {
         if (getVerbs().isEmpty()) {
             throw new IllegalArgumentException("Must add verb first, such as get/post/delete");
         }
         VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
-        return restResponseMsg(verb);
+        return responseMessage(verb);
     }
 
-    public RestOperationResponseMsgDefinition restResponseMsg(VerbDefinition verb) {
+    public RestOperationResponseMsgDefinition responseMessage(VerbDefinition verb) {
         return new RestOperationResponseMsgDefinition(verb);
     }
 
@@ -584,7 +584,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                         }
                     }
                     if (!found) {
-                        restParam(verb).name(key).type(RestParamType.path).endParam();
+                        param(verb).name(key).type(RestParamType.path).endParam();
                     }
                 }
             }
@@ -594,7 +594,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                 if (bodyType.endsWith("[]")) {
                     bodyType = "List[" + bodyType.substring(0, bodyType.length() - 2) + "]";
                 }
-                restParam(verb).name(RestParamType.body.name()).type(RestParamType.body).dataType(bodyType).endParam();
+                param(verb).name(RestParamType.body.name()).type(RestParamType.body).dataType(bodyType).endParam();
             }
 
 

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -575,15 +575,15 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                 if (a.startsWith("{") && a.endsWith("}")) {
                     String key = a.substring(1, a.length() - 1);
                     //  merge if exists
-                    boolean found=false;
-                    for(RestOperationParamDefinition param: verb.getParams()){
-                        if(param.getName().equalsIgnoreCase(key)){
+                    boolean found = false;
+                    for (RestOperationParamDefinition param : verb.getParams()) {
+                        if (param.getName().equalsIgnoreCase(key)) {
                             param.type(RestParamType.path);
-                            found=true;
+                            found = true;
                             break;
                         }
                     }
-                    if(!found) {
+                    if (!found) {
                         restParam(verb).name(key).type(RestParamType.path).endParam();
                     }
                 }

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
@@ -17,6 +17,7 @@
 package org.apache.camel.model.rest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -222,6 +223,12 @@ public class RestOperationParamDefinition {
         setAllowableValues(allowableValues);
         return this;
     }
+
+    public RestOperationParamDefinition allowableValues(String... allowableValues) {
+        setAllowableValues(Arrays.asList(allowableValues));
+        return this;
+    }
+
 
     public RestOperationParamDefinition type(RestParamType type) {
         setParamType(type);

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
@@ -45,22 +45,25 @@ public class RestOperationParamDefinition {
 
     @XmlAttribute(required = true)
     @Metadata(defaultValue = "path")
-    private RestParamType paramType = RestParamType.path;
+    private RestParamType paramType;
 
     @XmlAttribute(required = true)
     private String name;
 
     @XmlAttribute
+    @Metadata(defaultValue = "")
     private String description;
 
     @XmlAttribute
+    @Metadata(defaultValue = "")
     private String defaultValue;
 
     @XmlAttribute
     @Metadata(defaultValue = "true")
-    private Boolean required = true;
+    private Boolean required;
 
     @XmlAttribute
+    @Metadata(defaultValue = "false")
     private Boolean allowMultiple;
 
     @XmlAttribute
@@ -72,6 +75,7 @@ public class RestOperationParamDefinition {
     private List<String> allowableValues;
 
     @XmlAttribute
+    @Metadata(defaultValue = "")
     private String paramAccess;
 
     public RestOperationParamDefinition(VerbDefinition verb) {
@@ -82,7 +86,7 @@ public class RestOperationParamDefinition {
     }
 
     public RestParamType getParamType() {
-        return paramType;
+        return paramType != null ? paramType : RestParamType.path;
     }
 
     /**
@@ -104,7 +108,7 @@ public class RestOperationParamDefinition {
     }
 
     public String getDescription() {
-        return description;
+        return description != null ? description : "";
     }
 
     /**
@@ -118,7 +122,7 @@ public class RestOperationParamDefinition {
      * Sets the Swagger Parameter default value.
      */
     public String getDefaultValue() {
-        return defaultValue;
+        return defaultValue != null ? defaultValue : "";
     }
 
     public void setDefaultValue(String defaultValue) {
@@ -126,7 +130,7 @@ public class RestOperationParamDefinition {
     }
 
     public Boolean getRequired() {
-        return required;
+        return required != null ? required : true;
     }
 
     /**
@@ -137,7 +141,7 @@ public class RestOperationParamDefinition {
     }
 
     public Boolean getAllowMultiple() {
-        return allowMultiple;
+        return allowMultiple != null ? allowMultiple : false;
     }
 
     /**
@@ -174,7 +178,7 @@ public class RestOperationParamDefinition {
     }
 
     public String getParamAccess() {
-        return paramAccess;
+        return paramAccess != null ? paramAccess : "";
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
@@ -32,7 +32,7 @@ import org.apache.camel.spi.Metadata;
  * and https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#525-response-message-object.
  */
 @Metadata(label = "rest")
-@XmlRootElement(name = "respMsg")
+@XmlRootElement(name = "responseMessage")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RestOperationResponseMsgDefinition {
 
@@ -106,7 +106,7 @@ public class RestOperationResponseMsgDefinition {
         return this;
     }
 
-    public RestDefinition endResponseMsg() {
+    public RestDefinition endResponseMessage() {
         verb.getResponseMsgs().add(this);
         return verb.getRest();
     }

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.rest;
+
+import org.apache.camel.spi.Metadata;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * To specify the rest operation parameters using Swagger.
+ * <p/>
+ * This maps to the Swagger Parameter Object.
+ * see com.wordnik.swagger.model.Parameter
+ * and https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#524-parameter-object.
+ */
+@Metadata(label = "rest")
+@XmlRootElement(name = "respMsg")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RestOperationResponseMsgDefinition {
+
+    @XmlTransient
+    private VerbDefinition verb;
+
+    @XmlAttribute(required = true)
+    private int code;
+
+    @XmlAttribute(required = true)
+    private String message;
+
+    @XmlAttribute
+    @Metadata(defaultValue = "")
+    private String responseModel;
+
+
+    public RestOperationResponseMsgDefinition(VerbDefinition verb) {
+        this.verb = verb;
+    }
+
+    public RestOperationResponseMsgDefinition() {
+    }
+
+
+    public int getCode() {
+        return code != 0 ? code : 200;
+    }
+    /**
+     * Sets the Swagger Operation's ResponseMessage code
+     */
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getResponseModel() {
+        return responseModel != null ? responseModel : "";
+    }
+
+    /**
+     * Sets the Swagger Operation's ResponseMessage responseModel
+     */
+    public void setResponseModel(String responseModel) {
+        this.responseModel = responseModel;
+    }
+
+    public String getMessage() {
+        return message != null ? message : "success";
+    }
+
+    /**
+     * Sets the Swagger Operation's ResponseMessage message
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    public RestOperationResponseMsgDefinition code(int code) {
+        setCode(code);
+        return this;
+    }
+
+    public RestOperationResponseMsgDefinition message(String msg) {
+        setMessage(msg);
+        return this;
+    }
+
+    public RestOperationResponseMsgDefinition responseModel(Class<?> type) {
+        setResponseModel(type.getCanonicalName());
+        return this;
+    }
+
+    public RestDefinition endResponseMsg() {
+        verb.getResponseMsgs().add(this);
+        return verb.getRest();
+    }
+
+}

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
@@ -16,11 +16,13 @@
  */
 package org.apache.camel.model.rest;
 
-import org.apache.camel.spi.Metadata;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.camel.spi.Metadata;
 
 /**
  * To specify the rest operation response messages using Swagger.

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationResponseMsgDefinition.java
@@ -23,11 +23,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * To specify the rest operation parameters using Swagger.
+ * To specify the rest operation response messages using Swagger.
  * <p/>
- * This maps to the Swagger Parameter Object.
- * see com.wordnik.swagger.model.Parameter
- * and https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#524-parameter-object.
+ * This maps to the Swagger Response Message Object.
+ * see com.wordnik.swagger.model.ResponseMessage
+ * and https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#525-response-message-object.
  */
 @Metadata(label = "rest")
 @XmlRootElement(name = "respMsg")

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -48,6 +48,9 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlElementRef
     private List<RestOperationParamDefinition> params = new ArrayList<RestOperationParamDefinition>();
 
+    @XmlElementRef
+    private List<RestOperationResponseMsgDefinition> responseMsgs = new ArrayList<RestOperationResponseMsgDefinition>();
+
     @XmlAttribute
     private String uri;
 
@@ -107,6 +110,17 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
      */
     public void setParams(List<RestOperationParamDefinition> params) {
         this.params = params;
+    }
+
+    public List<RestOperationResponseMsgDefinition> getResponseMsgs() {
+        return responseMsgs;
+    }
+
+    /**
+     * Sets swagger operation response messages
+     */
+    public void setResponseMsgs(List<RestOperationResponseMsgDefinition> params) {
+        this.responseMsgs = responseMsgs;
     }
 
     public String getMethod() {

--- a/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
@@ -29,3 +29,4 @@ RestParamType
 RestPropertyDefinition
 RestsDefinition
 VerbDefinition
+RestOperationResponseMsgDefinition

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestConfigurationTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestConfigurationTest.java
@@ -35,6 +35,7 @@ public class FromRestConfigurationTest extends FromRestGetTest {
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
+        final RouteBuilder lowerR=super.createRouteBuilder();
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -44,18 +45,8 @@ public class FromRestConfigurationTest extends FromRestGetTest {
                     .endpointProperty("size", "200")
                     .consumerProperty("pollTimeout", "1000");
 
-                rest("/say/hello")
-                        .get().to("direct:hello");
+                includeRoutes(lowerR);
 
-                rest("/say/bye")
-                        .get().consumes("application/json").to("direct:bye")
-                        .post().to("mock:update");
-
-                from("direct:hello")
-                    .transform().constant("Hello World");
-
-                from("direct:bye")
-                    .transform().constant("Bye World");
             }
         };
     }

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestConfigurationTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestConfigurationTest.java
@@ -35,7 +35,7 @@ public class FromRestConfigurationTest extends FromRestGetTest {
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
-        final RouteBuilder lowerR=super.createRouteBuilder();
+        final RouteBuilder lowerR = super.createRouteBuilder();
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.component.rest;
 
+import java.util.Arrays;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestParamType;
-
-import java.util.Arrays;
 
 public class FromRestExplicitComponentTest extends FromRestGetTest {
 

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
@@ -17,6 +17,9 @@
 package org.apache.camel.component.rest;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestParamType;
+
+import java.util.Arrays;
 
 public class FromRestExplicitComponentTest extends FromRestGetTest {
 
@@ -32,7 +35,15 @@ public class FromRestExplicitComponentTest extends FromRestGetTest {
                         .get().to("direct:hello");
 
                 rest("dummy-rest").path("/say/bye")
-                        .get().consumes("application/json").to("direct:bye")
+                        .get().consumes("application/json")
+                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
+                        .endParam().
+                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
+                        .endParam()
+                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .to("direct:bye")
                         .post().to("mock:update");
 
                 from("direct:hello")
@@ -40,6 +51,7 @@ public class FromRestExplicitComponentTest extends FromRestGetTest {
 
                 from("direct:bye")
                     .transform().constant("Bye World");
+
             }
         };
     }

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestExplicitComponentTest.java
@@ -36,13 +36,13 @@ public class FromRestExplicitComponentTest extends FromRestGetTest {
 
                 rest("dummy-rest").path("/say/bye")
                         .get().consumes("application/json")
-                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .param().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues("1", "2", "3", "4")
                         .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
                         .endParam().
-                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        param().type(RestParamType.query).description("header param description2").dataType("string").allowableValues("a", "b", "c", "d")
                         .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
                         .endParam()
-                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .responseMessage().code(300).message("test msg").responseModel(Integer.class).endResponseMessage()
                         .to("direct:bye")
                         .post().to("mock:update");
 

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetTest.java
@@ -108,13 +108,13 @@ public class FromRestGetTest extends ContextTestSupport {
 
                 rest("/say/bye")
                         .get().consumes("application/json")
-                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .param().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues("1", "2", "3", "4")
                         .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
                         .endParam().
-                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        param().type(RestParamType.query).description("header param description2").dataType("string").allowableValues("a", "b", "c", "d")
                         .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
                         .endParam()
-                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .responseMessage().code(300).message("test msg").responseModel(Integer.class).endResponseMessage()
                         .to("direct:bye")
                         .post().to("mock:update");
 

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.component.rest;
 
+import java.util.Arrays;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.JndiRegistry;
 import org.apache.camel.model.ToDefinition;
 import org.apache.camel.model.rest.RestDefinition;
 import org.apache.camel.model.rest.RestParamType;
-
-import java.util.Arrays;
 
 public class FromRestGetTest extends ContextTestSupport {
 
@@ -64,8 +64,8 @@ public class FromRestGetTest extends ContextTestSupport {
 
         assertEquals("integer", rest.getVerbs().get(0).getParams().get(0).getDataType());
         assertEquals("string", rest.getVerbs().get(0).getParams().get(1).getDataType());
-        assertEquals(Arrays.asList("1","2","3","4"), rest.getVerbs().get(0).getParams().get(0).getAllowableValues());
-        assertEquals(Arrays.asList("a","b","c","d"), rest.getVerbs().get(0).getParams().get(1).getAllowableValues());
+        assertEquals(Arrays.asList("1", "2", "3", "4"), rest.getVerbs().get(0).getParams().get(0).getAllowableValues());
+        assertEquals(Arrays.asList("a", "b", "c", "d"), rest.getVerbs().get(0).getParams().get(1).getAllowableValues());
         assertEquals("1", rest.getVerbs().get(0).getParams().get(0).getDefaultValue());
         assertEquals("b", rest.getVerbs().get(0).getParams().get(1).getDefaultValue());
 
@@ -107,16 +107,16 @@ public class FromRestGetTest extends ContextTestSupport {
                     .get().to("direct:hello");
 
                 rest("/say/bye")
-                    .get().consumes("application/json")
-                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1","2","3","4"))
-                            .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
+                        .get().consumes("application/json")
+                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
                         .endParam().
-                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a","b","c","d"))
-                            .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
+                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
                         .endParam()
                         .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
                         .to("direct:bye")
-                    .post().to("mock:update");
+                        .post().to("mock:update");
 
                 from("direct:hello")
                     .transform().constant("Hello World");

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
@@ -18,6 +18,9 @@ package org.apache.camel.component.rest;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestParamType;
+
+import java.util.Arrays;
 
 public class FromRestIdAndDescriptionTest extends FromRestGetTest {
 
@@ -50,7 +53,15 @@ public class FromRestIdAndDescriptionTest extends FromRestGetTest {
                         .get().id("get-say").description("Says hello to you").to("direct:hello");
 
                 rest("/say/bye").description("bye", "Bye Service", "en")
-                        .get().description("Says bye to you").consumes("application/json").to("direct:bye")
+                        .get().description("Says bye to you").consumes("application/json")
+                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
+                        .endParam().
+                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
+                        .endParam()
+                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .to("direct:bye")
                         .post().description("Updates the bye message").to("mock:update");
 
                 from("direct:hello")

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.rest;
 
+import java.util.Arrays;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestDefinition;
 import org.apache.camel.model.rest.RestParamType;
-
-import java.util.Arrays;
 
 public class FromRestIdAndDescriptionTest extends FromRestGetTest {
 

--- a/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/FromRestIdAndDescriptionTest.java
@@ -54,13 +54,13 @@ public class FromRestIdAndDescriptionTest extends FromRestGetTest {
 
                 rest("/say/bye").description("bye", "Bye Service", "en")
                         .get().description("Says bye to you").consumes("application/json")
-                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .param().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues("1", "2", "3", "4")
                         .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
                         .endParam().
-                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        param().type(RestParamType.query).description("header param description2").dataType("string").allowableValues("a", "b", "c", "d")
                         .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
                         .endParam()
-                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .responseMessage().code(300).message("test msg").responseModel(Integer.class).endResponseMessage()
                         .to("direct:bye")
                         .post().description("Updates the bye message").to("mock:update");
 

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
@@ -68,7 +68,7 @@ public class ManagedFromRestGetTest extends ManagementTestSupport {
         assertTrue(xml.contains("<value>1</value>"));
         assertTrue(xml.contains("<value>a</value>"));
 
-        assertTrue(xml.contains("<respMsg code=\"300\" message=\"test msg\" responseModel=\"java.lang.Integer\"/>"));
+        assertTrue(xml.contains("<responseMessage code=\"300\" message=\"test msg\" responseModel=\"java.lang.Integer\"/>"));
 
 
 
@@ -92,13 +92,13 @@ public class ManagedFromRestGetTest extends ManagementTestSupport {
 
                 rest("/say/bye")
                     .get().consumes("application/json")
-                        .restParam().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
+                        .param().type(RestParamType.header).description("header param description1").dataType("integer").allowableValues(Arrays.asList("1", "2", "3", "4"))
                         .defaultValue("1").allowMultiple(false).name("header_count").required(true).paramAccess("acc1")
                         .endParam().
-                        restParam().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
+                        param().type(RestParamType.query).description("header param description2").dataType("string").allowableValues(Arrays.asList("a", "b", "c", "d"))
                         .defaultValue("b").allowMultiple(true).name("header_letter").required(false).paramAccess("acc2")
                         .endParam()
-                        .restResponseMsg().code(300).message("test msg").responseModel(Integer.class).endResponseMsg()
+                        .responseMessage().code(300).message("test msg").responseModel(Integer.class).endResponseMessage()
                         .to("direct:bye")
                     .post().to("mock:update");
 

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.management;
 
+import java.util.Arrays;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -25,8 +27,6 @@ import org.apache.camel.component.rest.DummyRestConsumerFactory;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 import org.apache.camel.model.rest.RestParamType;
-
-import java.util.Arrays;
 
 public class ManagedFromRestGetTest extends ManagementTestSupport {
 
@@ -61,8 +61,10 @@ public class ManagedFromRestGetTest extends ManagementTestSupport {
         assertTrue(xml.contains("application/json"));
         assertTrue(xml.contains("</rests>"));
 
-        assertTrue(xml.contains("<param paramType=\"query\" name=\"header_letter\" description=\"header param description2\" defaultValue=\"b\" required=\"false\" allowMultiple=\"true\" dataType=\"string\" paramAccess=\"acc2\">"));
-        assertTrue(xml.contains("<param paramType=\"header\" name=\"header_count\" description=\"header param description1\" defaultValue=\"1\" required=\"true\" allowMultiple=\"false\" dataType=\"integer\" paramAccess=\"acc1\">"));
+        assertTrue(xml.contains("<param paramType=\"query\" name=\"header_letter\" description=\"header param description2\""
+                + " defaultValue=\"b\" required=\"false\" allowMultiple=\"true\" dataType=\"string\" paramAccess=\"acc2\">"));
+        assertTrue(xml.contains("<param paramType=\"header\" name=\"header_count\" description=\"header param description1\" "
+                + "defaultValue=\"1\" required=\"true\" allowMultiple=\"false\" dataType=\"integer\" paramAccess=\"acc1\">"));
         assertTrue(xml.contains("<value>1</value>"));
         assertTrue(xml.contains("<value>a</value>"));
 

--- a/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestConfigurationTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestConfigurationTest.xml
@@ -41,6 +41,23 @@
     </rest>
     <rest path="/say/bye">
       <get consumes="application/json">
+          <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+              <allowableValues>
+                  <value>1</value>
+                  <value>2</value>
+                  <value>3</value>
+                  <value>4</value>
+              </allowableValues>
+          </param>
+          <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+              <allowableValues>
+                  <value>a</value>
+                  <value>b</value>
+                  <value>c</value>
+                  <value>d</value>
+              </allowableValues>
+          </param>
+          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestGetTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestGetTest.xml
@@ -34,7 +34,24 @@
     </rest>
     <rest path="/say/bye">
       <get consumes="application/json">
-        <to uri="direct:bye"/>
+          <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+              <allowableValues>
+                  <value>1</value>
+                  <value>2</value>
+                  <value>3</value>
+                  <value>4</value>
+              </allowableValues>
+          </param>
+          <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+              <allowableValues>
+                  <value>a</value>
+                  <value>b</value>
+                  <value>c</value>
+                  <value>d</value>
+              </allowableValues>
+          </param>
+          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
+          <to uri="direct:bye"/>
       </get>
       <post>
         <to uri="mock:update"/>

--- a/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestIdAndDescriptionTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/rest/SpringFromRestIdAndDescriptionTest.xml
@@ -38,6 +38,23 @@
       <description lang="en">Bye Service</description>
       <get consumes="application/json">
         <description>Says bye to you</description>
+          <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+              <allowableValues>
+                  <value>1</value>
+                  <value>2</value>
+                  <value>3</value>
+                  <value>4</value>
+              </allowableValues>
+          </param>
+          <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+              <allowableValues>
+                  <value>a</value>
+                  <value>b</value>
+                  <value>c</value>
+                  <value>d</value>
+              </allowableValues>
+          </param>
+          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
+++ b/components/camel-swagger/src/main/scala/org/apache/camel/component/swagger/RestSwaggerReader.scala
@@ -23,7 +23,7 @@ import com.wordnik.swagger.model._
 import com.wordnik.swagger.core.util.ModelUtil
 import com.wordnik.swagger.core.SwaggerSpec
 
-import org.apache.camel.model.rest.{RestOperationParamDefinition, VerbDefinition, RestDefinition}
+import org.apache.camel.model.rest.{RestOperationResponseMsgDefinition, RestOperationParamDefinition, VerbDefinition, RestDefinition}
 import org.apache.camel.util.FileUtil
 import org.slf4j.LoggerFactory
 
@@ -121,7 +121,7 @@ class RestSwaggerReader {
         List(),
         List(),
         createParameters(verb),
-        List(),
+        createResponseMessages(verb),
         None)
     }
 
@@ -173,6 +173,20 @@ class RestSwaggerReader {
     else None
   }
 
+  def createResponseMessages(verb: VerbDefinition): List[ResponseMessage] = {
+    val responseMsgs = new ListBuffer[ResponseMessage]
+
+    for (param:RestOperationResponseMsgDefinition <- verb.getResponseMsgs.asScala) {
+      responseMsgs += ResponseMessage(
+        param.getCode,
+        param.getMessage,
+        Option( param.getResponseModel )
+      )
+    }
+
+    responseMsgs.toList
+  }
+
   def createParameters(verb: VerbDefinition): List[Parameter] = {
     val parameters = new ListBuffer[Parameter]
 
@@ -182,6 +196,7 @@ class RestSwaggerReader {
       if(!param.getAllowableValues.isEmpty){
         AllowableListValues(param.getAllowableValues.asScala.toList)
       }
+
       parameters += Parameter(
         param.getName,
         Some( param.getDescription ),

--- a/components/camel-test-blueprint/src/test/java/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.java
+++ b/components/camel-test-blueprint/src/test/java/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.java
@@ -18,8 +18,11 @@ package org.apache.camel.test.blueprint.component.rest;
 
 import org.apache.camel.model.ToDefinition;
 import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestParamType;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 public class FromRestGetTest extends CamelBlueprintTestSupport {
 
@@ -49,6 +52,35 @@ public class FromRestGetTest extends CamelBlueprintTestSupport {
         assertEquals("/say/bye", rest.getPath());
         assertEquals(2, rest.getVerbs().size());
         assertEquals("application/json", rest.getVerbs().get(0).getConsumes());
+
+        assertEquals(2, rest.getVerbs().get(0).getParams().size());
+        assertEquals(RestParamType.header, rest.getVerbs().get(0).getParams().get(0).getParamType());
+        assertEquals(RestParamType.query, rest.getVerbs().get(0).getParams().get(1).getParamType());
+
+        assertEquals("header param description1", rest.getVerbs().get(0).getParams().get(0).getDescription());
+        assertEquals("header param description2", rest.getVerbs().get(0).getParams().get(1).getDescription());
+
+        assertEquals("integer", rest.getVerbs().get(0).getParams().get(0).getDataType());
+        assertEquals("string", rest.getVerbs().get(0).getParams().get(1).getDataType());
+        assertEquals(Arrays.asList("1", "2", "3", "4"), rest.getVerbs().get(0).getParams().get(0).getAllowableValues());
+        assertEquals(Arrays.asList("a","b","c","d"), rest.getVerbs().get(0).getParams().get(1).getAllowableValues());
+        assertEquals("1", rest.getVerbs().get(0).getParams().get(0).getDefaultValue());
+        assertEquals("b", rest.getVerbs().get(0).getParams().get(1).getDefaultValue());
+
+        assertEquals(Boolean.FALSE, rest.getVerbs().get(0).getParams().get(0).getAllowMultiple());
+        assertEquals(Boolean.TRUE, rest.getVerbs().get(0).getParams().get(1).getAllowMultiple());
+
+        assertEquals("header_count", rest.getVerbs().get(0).getParams().get(0).getName());
+        assertEquals("header_letter", rest.getVerbs().get(0).getParams().get(1).getName());
+        assertEquals(Boolean.TRUE, rest.getVerbs().get(0).getParams().get(0).getRequired());
+        assertEquals(Boolean.FALSE, rest.getVerbs().get(0).getParams().get(1).getRequired());
+        assertEquals("acc1", rest.getVerbs().get(0).getParams().get(0).getParamAccess());
+        assertEquals("acc2", rest.getVerbs().get(0).getParams().get(1).getParamAccess());
+
+        assertEquals(300, rest.getVerbs().get(0).getResponseMsgs().get(0).getCode());
+        assertEquals("test msg", rest.getVerbs().get(0).getResponseMsgs().get(0).getMessage());
+        assertEquals(Integer.class.getCanonicalName(), rest.getVerbs().get(0).getResponseMsgs().get(0).getResponseModel());
+        
         to = assertIsInstanceOf(ToDefinition.class, rest.getVerbs().get(0).getTo());
         assertEquals("direct:bye", to.getUri());
 

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestConfigurationTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestConfigurationTest.xml
@@ -55,7 +55,7 @@
               <value>d</value>
           </allowableValues>
         </param>
-        <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
+        <responseMessage code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestConfigurationTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestConfigurationTest.xml
@@ -39,6 +39,23 @@
     </rest>
     <rest path="/say/bye">
       <get consumes="application/json">
+        <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+          <allowableValues>
+              <value>1</value>
+              <value>2</value>
+              <value>3</value>
+              <value>4</value>
+          </allowableValues>
+        </param>
+        <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+          <allowableValues>
+              <value>a</value>
+              <value>b</value>
+              <value>c</value>
+              <value>d</value>
+          </allowableValues>
+        </param>
+        <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.xml
@@ -48,7 +48,7 @@
                <value>d</value>
             </allowableValues>
          </param>
-          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
+          <responseMessage code="300" message="test msg" responseModel="java.lang.Integer"/>
          <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestGetTest.xml
@@ -32,7 +32,24 @@
     </rest>
     <rest path="/say/bye">
       <get consumes="application/json">
-        <to uri="direct:bye"/>
+         <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+            <allowableValues>
+               <value>1</value>
+               <value>2</value>
+               <value>3</value>
+               <value>4</value>
+            </allowableValues>
+         </param>
+         <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+            <allowableValues>
+               <value>a</value>
+               <value>b</value>
+               <value>c</value>
+               <value>d</value>
+            </allowableValues>
+         </param>
+          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
+         <to uri="direct:bye"/>
       </get>
       <post>
         <to uri="mock:update"/>

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestIdAndDescriptionTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestIdAndDescriptionTest.xml
@@ -52,7 +52,7 @@
                   <value>d</value>
               </allowableValues>
           </param>
-          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
+          <responseMessage code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>

--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestIdAndDescriptionTest.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/component/rest/FromRestIdAndDescriptionTest.xml
@@ -36,6 +36,23 @@
       <description lang="en">Bye Service</description>
       <get consumes="application/json">
         <description>Says bye to you</description>
+          <param paramType="header" description="header param description1" dataType="integer" defaultValue="1" allowMultiple="false" name="header_count" required="true" paramAccess="acc1">
+              <allowableValues>
+                  <value>1</value>
+                  <value>2</value>
+                  <value>3</value>
+                  <value>4</value>
+              </allowableValues>
+          </param>
+          <param paramType="query" description="header param description2" dataType="string" defaultValue="b" allowMultiple="true" name="header_letter" required="false" paramAccess="acc2">
+              <allowableValues>
+                  <value>a</value>
+                  <value>b</value>
+                  <value>c</value>
+                  <value>d</value>
+              </allowableValues>
+          </param>
+          <respMsg code="300" message="test msg" responseModel="java.lang.Integer"/>
         <to uri="direct:bye"/>
       </get>
       <post>


### PR DESCRIPTION
Hey,
   I'm a bit late on my promise, but here is the PR that updates the rest tests and fixes some issues that appeared after the code cleanup. (also it fixes an issue with includeRoutes method as it did not include the rest routes)
   I still need to have investigate why the blueprint tests fails... probably will do it over the weekend
  Also as a side note ,  I will add support also for https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#525-response-message-object in a separate PR

Seb Calbaza