### PR TITLE
Fix the logging event to use placeholders correctly.

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsProducer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsProducer.java
@@ -125,7 +125,7 @@ public class SqsProducer extends DefaultProducer {
                     result.put(entry.getKey(), mav);
                 } else {
                     // cannot translate the message header to message attribute value
-                    LOG.warn("Cannot put the message header key={0}, value={1} into Sqs MessageAttribute", entry.getKey(), entry.getValue());
+                    LOG.warn("Cannot put the message header key={}, value={} into Sqs MessageAttribute", entry.getKey(), entry.getValue());
                 }
             }
         }


### PR DESCRIPTION
Logging events like `WARN  org.apache.camel.component.aws.sqs.SqsProducer  - Cannot put the message header key={0}, value={1} into Sqs MessageAttribute` are not particularly helpful, this change fixes the logging event to use the SLF4J placeholders correctly, displaying the key/value that it could not add to the message.