### PR TITLE
CAMEL-8799: Make json-path suppress PathNotFoundExceptions by default

### DIFF
--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
@@ -23,7 +23,10 @@ import java.net.URL;
 import java.nio.charset.Charset;
 
 import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Configuration.Defaults;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.internal.DefaultsImpl;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
@@ -38,7 +41,8 @@ public class JsonPathEngine {
     private final Configuration configuration;
 
     public JsonPathEngine(String expression) {
-        this.configuration = Configuration.defaultConfiguration();
+        Defaults defaults = DefaultsImpl.INSTANCE;
+        this.configuration = Configuration.builder().jsonProvider(defaults.jsonProvider()).options(Option.SUPPRESS_EXCEPTIONS).build();
         this.path = JsonPath.compile(expression);
     }
 
@@ -52,22 +56,22 @@ public class JsonPathEngine {
                 json = ((WrappedFile<?>)json).getFile();
             }
         } else if (json instanceof WrappedFile) {
-            json = ((WrappedFile<?>) json).getFile();
+            json = ((WrappedFile<?>)json).getFile();
         }
 
         // the message body type should use the suitable read method
         if (json instanceof String) {
-            String str = (String) json;
-            return path.read(str);
+            String str = (String)json;
+            return path.read(str, configuration);
         } else if (json instanceof InputStream) {
-            InputStream is = (InputStream) json;
+            InputStream is = (InputStream)json;
             return path.read(is, Charset.defaultCharset().displayName(), configuration);
         } else if (json instanceof File) {
-            File file = (File) json;
-            return path.read(file);
+            File file = (File)json;
+            return path.read(file, configuration);
         } else if (json instanceof URL) {
-            URL url = (URL) json;
-            return path.read(url);
+            URL url = (URL)json;
+            return path.read(url, configuration);
         }
 
         // fallback as input stream

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathBeanTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathBeanTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.jsonpath;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class JsonPathBeanTest extends CamelTestSupport {
+
+    @Test
+    public void testFullName() throws Exception {
+        String json = "{\"person\" : {\"firstname\" : \"foo\", \"middlename\" : \"foo2\", \"lastname\" : \"bar\"}}";
+        getMockEndpoint("mock:result").expectedBodiesReceived("foo foo2 bar");
+        template.sendBody("direct:start", json);
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testFirstAndLastName() throws Exception {
+        String json = "{\"person\" : {\"firstname\" : \"foo\", \"lastname\" : \"bar\"}}";
+        getMockEndpoint("mock:result").expectedBodiesReceived("foo bar");
+        template.sendBody("direct:start", json);
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").bean(FullnameBean.class).to("mock:result");
+            }
+        };
+    }
+
+    protected static class FullnameBean {
+        public static String getName(@JsonPath("person.firstname") String first, @JsonPath("person.middlename") String middle, @JsonPath("person.lastname") String last) {
+            if (middle != null) {
+                return first + " " + middle + " " + last;
+            }
+            return first + " " + last;
+        }
+    }
+}

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathLanguageTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathLanguageTest.java
@@ -48,7 +48,7 @@ public class JsonPathLanguageTest extends CamelTestSupport {
         assertEquals(2, authors.size());
         assertEquals("Nigel Rees", authors.get(0));
         assertEquals("Evelyn Waugh", authors.get(1));
-        
+
         exp = lan.createExpression("$.store.bicycle.price");
         String price = exp.evaluate(exchange, String.class);
         assertEquals("Got a wrong result", "19.95", price);
@@ -87,4 +87,17 @@ public class JsonPathLanguageTest extends CamelTestSupport {
         boolean expensive = pre.matches(exchange);
         assertFalse("Should not have expensive books", expensive);
     }
+
+    @Test
+    public void testSuppressException() throws Exception {
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(new File("src/test/resources/type.json"));
+
+        Language lan = context.resolveLanguage("jsonpath");
+        Expression exp = lan.createExpression("$.foo");
+        String nofoo = exp.evaluate(exchange, String.class);
+
+        assertNull(nofoo);
+    }
+
 }


### PR DESCRIPTION
This PR is a solution for option 1 described in the issue, and the tests can be reused in the implementation of option 2.