### PR TITLE
Stomp Component - Add support for virtual hosts in Apache Apollo

### DIFF
--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompComponent.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompComponent.java
@@ -75,4 +75,11 @@ public class StompComponent extends UriEndpointComponent {
     public void setPasscode(String passcode) {
         getConfiguration().setPasscode(passcode);
     }
+    
+    /**
+     * The virtual host
+     */
+    public void setHost(String host) {
+        getConfiguration().setHost(host);
+    }
 }

--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
@@ -30,6 +30,8 @@ public class StompConfiguration implements Cloneable {
     private String login;
     @UriParam
     private String passcode;
+    @UriParam
+    private String host;
 
     /**
      * Returns a copy of this configuration
@@ -45,6 +47,10 @@ public class StompConfiguration implements Cloneable {
 
     public String getBrokerURL() {
         return brokerURL;
+    }
+    
+    public String getHost() {
+        return host;
     }
 
     /**

--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
@@ -52,6 +52,10 @@ public class StompConfiguration implements Cloneable {
     public String getHost() {
         return host;
     }
+    
+    public void setHost(String host) {
+        this.host = host;
+    }
 
     /**
      * The URI of the Stomp broker to connect to

--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
@@ -83,6 +83,9 @@ public class StompEndpoint extends DefaultEndpoint {
         stomp.setLogin(configuration.getLogin());
         stomp.setPasscode(configuration.getPasscode());
         stomp.connectCallback(promise);
+        if (configuration.getHost() != null && !configuration.getHost().isEmpty()){
+        	stomp.setHost(configuration.getHost());
+        }
 
         connection = promise.await();
 


### PR DESCRIPTION
This change allows a Stomp endpoint to specify a virtual host that differs from the remote URI in order to allow this component/endpoint to be used with Apache Apollo (or any) brokers that have more than one virtual host.

Example usage:
```
stomp:queue:Q1?brokerURL=tcp://localhost:61613&login=user&passcode=pass&host=broker1
```