### PR TITLE
CAMEL-8801 Make spring-boot auto-configuration defer to existing beans

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -43,6 +43,7 @@ public class CamelAutoConfiguration {
      * context.
      */
     @Bean
+    @ConditionalOnMissingBean(CamelContext.class)
     CamelContext camelContext(ApplicationContext applicationContext,
                               CamelConfigurationProperties configurationProperties) {
         CamelContext camelContext = new SpringCamelContext(applicationContext);
@@ -75,6 +76,7 @@ public class CamelAutoConfiguration {
      * Default producer template for the bootstrapped Camel context.
      */
     @Bean
+    @ConditionalOnMissingBean(ProducerTemplate.class)
     ProducerTemplate producerTemplate(CamelContext camelContext,
                                       CamelConfigurationProperties configurationProperties) {
         return camelContext.createProducerTemplate(configurationProperties.getProducerTemplateCacheSize());
@@ -84,6 +86,7 @@ public class CamelAutoConfiguration {
      * Default consumer template for the bootstrapped Camel context.
      */
     @Bean
+    @ConditionalOnMissingBean(ConsumerTemplate.class)
     ConsumerTemplate consumerTemplate(CamelContext camelContext,
                                       CamelConfigurationProperties configurationProperties) {
         return camelContext.createConsumerTemplate(configurationProperties.getConsumerTemplateCacheSize());

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelNonInvasiveCamelContextTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelNonInvasiveCamelContextTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.annotation.Resource;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.spring.boot.CamelNonInvasiveCamelContextTest.TestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@EnableAutoConfiguration
+@SpringApplicationConfiguration(classes = { TestApplication.class, CamelNonInvasiveCamelContextTest.class })
+public class CamelNonInvasiveCamelContextTest {
+
+    // Collaborators fixtures
+
+    @Autowired
+    CamelContext camelContext;
+
+    @Autowired
+    ProducerTemplate producerTemplate;
+
+    @Resource(name = "xmlProducerTemplate")
+    ProducerTemplate xmlProducerTemplate;
+
+    @Autowired
+    ConsumerTemplate consumerTemplate;
+
+    @Resource(name = "xmlConsumerTemplate")
+    ConsumerTemplate xmlConsumerTemplate;
+
+    // Tests
+
+    @Test
+    public void shouldUseCamelContextFromXml() {
+        assertNotNull(camelContext);
+        assertEquals("xmlCamelContext", camelContext.getName());
+    }
+
+    @Test
+    public void shouldUseProducerTemplateFromXml() {
+        assertNotNull(producerTemplate);
+        assertEquals(xmlProducerTemplate, producerTemplate);
+    }
+
+    @Test
+    public void shouldUseConsumerTemplateFromXml() {
+        assertNotNull(consumerTemplate);
+        assertEquals(xmlConsumerTemplate, consumerTemplate);
+    }
+
+    @ImportResource(value = { "classpath:externalCamelContext.xml" })
+    public static class TestApplication {
+
+    }
+
+}

--- a/components/camel-spring-boot/src/test/resources/externalCamelContext.xml
+++ b/components/camel-spring-boot/src/test/resources/externalCamelContext.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+
+  <camelContext id="xmlCamelContext" xmlns="http://camel.apache.org/schema/spring">
+    <template id="xmlProducerTemplate"/>
+    <consumerTemplate id="xmlConsumerTemplate"/>
+
+    <route>
+      <from uri="direct:input"/>
+      <to uri="mock:output"/>
+    </route>
+  </camelContext>
+
+</beans>


### PR DESCRIPTION
Only instantiate a CamelContext bean if one does not already exist.  Same with ConsumerTemplate and ProducerTemplate.