### PR TITLE
Update CMISProducer.java

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
@@ -63,7 +63,17 @@ public class CMISProducer extends DefaultProducer {
             objectTypeName = (String) properties.get(PropertyIds.OBJECT_TYPE_ID);
         }
 
-        Set<String> types = cmisSessionFacade.getPropertiesFor(objectTypeName);
+		Set<String> types = new HashSet<String>();
+		types.addAll(cmisSessionFacade.getPropertiesFor(objectTypeName));
+
+		if (cmisSessionFacade.supportsSecondaries() && properties.containsKey(PropertyIds.SECONDARY_OBJECT_TYPE_IDS)) {
+			@SuppressWarnings("unchecked")
+			Collection<String> secondaryTypes = (Collection<String>) properties.get(PropertyIds.SECONDARY_OBJECT_TYPE_IDS);
+			for (String secondaryType : secondaryTypes) {
+				types.addAll(cmisSessionFacade.getPropertiesFor(secondaryType));
+			}
+		}
+
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
             if (types.contains(entry.getKey())) {
                 result.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Propose to add support for secondary type properties in the Camel CMIS implementation. I have added a check in the CMISSessionFacade. Now adding a secondary type works, but any properties are ignored by the filter.