### PR TITLE
Update CMISSessionFacade.java

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -194,6 +194,17 @@ public class CMISSessionFacade {
         return false;
     }
 
+	public boolean supportsSecondaries() {
+		if (session.getRepositoryInfo().getCmisVersion() == CmisVersion.CMIS_1_0)
+			return false;
+		for (ObjectType type : session.getTypeChildren(null, false)) {
+			if (BaseTypeId.CMIS_SECONDARY.value().equals(type.getId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
     public ContentStream createContentStream(String fileName, byte[] buf, String mimeType) throws Exception {
         return buf != null ? session.getObjectFactory()
                 .createContentStream(fileName, buf.length, mimeType, new ByteArrayInputStream(buf)) : null;


### PR DESCRIPTION
Added method supportsSecondaries() to check if the CMIS repository supports and uses secondary types. Used in CMISProducer update proposal bpeters09:patch-1 to support secondary type properties