### PR TITLE
Enable multiple consumer support for SQS endpoints.

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
@@ -35,6 +35,7 @@ import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Message;
+import org.apache.camel.MultipleConsumersSupport;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.impl.DefaultExchange;
@@ -52,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * Defines the <a href="http://camel.apache.org/aws.html">AWS SQS Endpoint</a>.  
  */
 @UriEndpoint(scheme = "aws-sqs", title = "AWS Simple Queue Service", syntax = "aws-sqs:queueName", consumerClass = SqsConsumer.class, label = "cloud,messaging")
-public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterStrategyAware {
+public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterStrategyAware, MultipleConsumersSupport {
     
     private static final Logger LOG = LoggerFactory.getLogger(SqsEndpoint.class);
 
@@ -73,6 +74,11 @@ public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterSt
     
     public HeaderFilterStrategy getHeaderFilterStrategy() {
         return headerFilterStrategy;
+    }
+
+    @Override
+    public boolean isMultipleConsumersSupported() {
+        return true;
     }
 
     /**


### PR DESCRIPTION
AWS SQS has a maximum throughput per consuming thread as at most 10 msgs can be fetched per poll.
To consume messages faster than this in the same app requites multiple polling threads.
So far as I can tell to make this work in Camel its just a case of adding `MultipleConsumersSupport` to `SqsEndpoint`.
Please let me know if I have missed something that means this will break things.
Thanks!

p.s. I noticed that some other classes that implement `MultipleConsumersSupport` have  `@ManagedAttribute` on `isMultipleConsumersSupported()`, but I am not sure if this is required in all cases.