### PR TITLE
[MyBatis] If ExchangePattern is InOut retain headers for all statement types an…

### DIFF
--- a/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisProducer.java
+++ b/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisProducer.java
@@ -227,14 +227,17 @@ public class MyBatisProducer extends DefaultProducer {
 
     private void doProcessResult(Exchange exchange, Object result, SqlSession session) {
         final String outputHeader = getEndpoint().getOutputHeader();
-        if (endpoint.getStatementType() == StatementType.SelectList || endpoint.getStatementType() == StatementType.SelectOne) {
-            Message answer = exchange.getIn();
-            if (ExchangeHelper.isOutCapable(exchange)) {
-                answer = exchange.getOut();
-                // preserve headers
-                answer.getHeaders().putAll(exchange.getIn().getHeaders());
+        Message answer = exchange.getIn();
+        if (ExchangeHelper.isOutCapable(exchange)) {
+            answer = exchange.getOut();
+            // preserve headers
+            answer.getHeaders().putAll(exchange.getIn().getHeaders());
+            if (outputHeader != null) {
+            	//if we put the MyBatis result into a header we should preserve the body as well
+            	answer.setBody(exchange.getIn().getBody());
             }
-
+        }
+        if (endpoint.getStatementType() == StatementType.SelectList || endpoint.getStatementType() == StatementType.SelectOne) {
             // we should not set the body if its a stored procedure as the result is already in its OUT parameter
             MappedStatement ms = session.getConfiguration().getMappedStatement(statement);
             if (ms != null && ms.getStatementType() == org.apache.ibatis.mapping.StatementType.CALLABLE) {
@@ -265,16 +268,11 @@ public class MyBatisProducer extends DefaultProducer {
                 }
             }
 
-            answer.setHeader(MyBatisConstants.MYBATIS_STATEMENT_NAME, statement);
         } else {
-            Message msg = exchange.getIn();
-            if (outputHeader != null) {
-                msg.setHeader(outputHeader, result);
-            } else {
-                msg.setHeader(MyBatisConstants.MYBATIS_RESULT, result);
-            }
-            msg.setHeader(MyBatisConstants.MYBATIS_STATEMENT_NAME, statement);
+        	final String headerName = (outputHeader != null) ? outputHeader : MyBatisConstants.MYBATIS_RESULT;
+           	answer.setHeader(headerName, result);
         }
+        answer.setHeader(MyBatisConstants.MYBATIS_STATEMENT_NAME, statement);
     }
 
     @Override

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneExchangeInOutWithOutputHeaderTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisSelectOneExchangeInOutWithOutputHeaderTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mybatis;
+
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class MyBatisSelectOneExchangeInOutWithOutputHeaderTest extends MyBatisTestSupport {
+
+    private static final String TEST_CASE_HEADER_NAME = "testCaseHeader";
+    private static final int TEST_ACCOUNT_ID = 456;
+
+    @Test
+    public void testSelectOneWithOutputHeader() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.message(0).header(TEST_CASE_HEADER_NAME).isInstanceOf(Account.class);
+        mock.message(0).body().isEqualTo(TEST_ACCOUNT_ID);
+        mock.message(0).header(MyBatisConstants.MYBATIS_RESULT).isNull();
+
+        template.sendBody("direct:start", TEST_ACCOUNT_ID);
+
+        assertMockEndpointsSatisfied();
+
+        Account account = mock.getReceivedExchanges().get(0).getIn().getHeader(TEST_CASE_HEADER_NAME, Account.class);
+        assertEquals("Claus", account.getFirstName());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // START SNIPPET: e1
+                from("direct:start")
+                	.setExchangePattern(ExchangePattern.InOut)
+                    .to("mybatis:selectAccountById?statementType=SelectOne&outputHeader=" + TEST_CASE_HEADER_NAME)
+                    .to("mock:result");
+                // END SNIPPET: e1
+            }
+        };
+    }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -365,7 +365,7 @@
     <mustache-guava-version>16.0</mustache-guava-version>
     <mustache-bundle-version>0.8.16_1</mustache-bundle-version>
     <mvel-version>2.2.4.Final</mvel-version>
-    <mybatis-version>3.2.8</mybatis-version>
+    <mybatis-version>3.3.0</mybatis-version>
     <neethi-bundle-version>3.0.1</neethi-bundle-version>
     <netty3-version>3.10.3.Final</netty3-version>
     <netty-version>4.0.28.Final</netty-version>


### PR DESCRIPTION
…d not only for select queries. Also preserve the body if outputHeader is set.
IMHO makes the component more consistent and intuitive.