### PR TITLE
Added support for secondary types (CMIS 1.1)

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -35,7 +35,9 @@ import org.apache.chemistry.opencmis.client.api.Session;
 import org.apache.chemistry.opencmis.commons.PropertyIds;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.data.ContentStream;
+import org.apache.chemistry.opencmis.commons.enums.BaseTypeId;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
+import org.apache.chemistry.opencmis.commons.enums.CmisVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,6 +195,17 @@ public class CMISSessionFacade {
         }
         return false;
     }
+
+	public boolean supportsSecondaries() {
+		if (session.getRepositoryInfo().getCmisVersion() == CmisVersion.CMIS_1_0)
+			return false;
+		for (ObjectType type : session.getTypeChildren(null, false)) {
+			if (BaseTypeId.CMIS_SECONDARY.value().equals(type.getId())) {
+				return true;
+			}
+		}
+		return false;
+	}
 
     public ContentStream createContentStream(String fileName, byte[] buf, String mimeType) throws Exception {
         return buf != null ? session.getObjectFactory()

--- a/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISProducerTest.java
+++ b/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISProducerTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.cmis;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.NoSuchHeaderException;
@@ -123,6 +126,25 @@ public class CMISProducerTest extends CMISTestSupport {
         assertEquals("text/plain; charset=UTF-8",
                 newNode.getPropertyValue(PropertyIds.CONTENT_STREAM_MIME_TYPE));
     }
+
+	@Test
+	public void cmisSecondaryTypePropertiesAreStored() throws Exception {
+
+		List<String> secondaryTypes = Arrays.asList("MySecondaryType");
+
+		Exchange exchange = createExchangeWithInBody("Some content to be store");
+		exchange.getIn().getHeaders().put(PropertyIds.CONTENT_STREAM_MIME_TYPE, "text/plain; charset=UTF-8");
+		exchange.getIn().getHeaders().put(PropertyIds.NAME, "test.txt");
+		exchange.getIn().getHeaders().put(PropertyIds.SECONDARY_OBJECT_TYPE_IDS, secondaryTypes);
+		exchange.getIn().getHeaders().put("SecondaryStringProp", "secondaryTypePropValue");
+
+		template.send(exchange);
+		String newNodeId = exchange.getOut().getBody(String.class);
+		CmisObject newNode = retrieveCMISObjectByIdFromServer(newNodeId);
+
+		assertEquals(1, newNode.getSecondaryTypes().size());
+		assertEquals("secondaryTypePropValue", newNode.getPropertyValue("SecondaryStringProp"));
+	}
 
     @Test(expected = ResolveEndpointFailedException.class)
     public void failConnectingToNonExistingRepository() throws Exception {

--- a/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISTestSupport.java
+++ b/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISTestSupport.java
@@ -51,9 +51,9 @@ import org.junit.BeforeClass;
 
 public class CMISTestSupport extends CamelTestSupport {
     protected static final String CMIS_ENDPOINT_TEST_SERVER
-        = "http://localhost:%s/chemistry-opencmis-server-inmemory/atom";
+        = "http://localhost:%s/chemistry-opencmis-server-inmemory/atom11";
     protected static final String OPEN_CMIS_SERVER_WAR_PATH
-        = "target/dependency/chemistry-opencmis-server-inmemory-0.8.0.war";
+        = "target/dependency/chemistry-opencmis-server-inmemory-0.13.0.war";
 
     protected static Server cmisServer;
     protected static int port;


### PR DESCRIPTION
Added the ability to add secondary types and secondary type properties to a Camel exchange. Depends on OpenCMIS version 0.13.0 and CMIS 1.1.