### PR TITLE
CAMEL-8870 Remove version from URL in archetype web project

### DIFF
--- a/tooling/archetypes/camel-archetype-web/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/tooling/archetypes/camel-archetype-web/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -74,7 +74,7 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
-    <fileSet encoding="UTF-8">
+    <fileSet filtered="true" encoding="UTF-8">
       <directory></directory>
       <includes>
         <include>ReadMe.txt</include>

--- a/tooling/archetypes/camel-archetype-web/src/main/resources/archetype-resources/ReadMe.txt
+++ b/tooling/archetypes/camel-archetype-web/src/main/resources/archetype-resources/ReadMe.txt
@@ -21,6 +21,10 @@ Or to redeploy
 
     mvn jboss-as:redeploy
 
+
+The application will be available at:
+   http://localhost:8080/${artifactId}/
+
 For more help see the Apache Camel documentation
 
     http://camel.apache.org/

--- a/tooling/archetypes/camel-archetype-web/src/main/resources/archetype-resources/pom.xml
+++ b/tooling/archetypes/camel-archetype-web/src/main/resources/archetype-resources/pom.xml
@@ -115,7 +115,7 @@
         <version>${jetty-plugin-version}</version>
         <configuration>
           <webAppConfig>
-            <contextPath>/</contextPath>
+            <contextPath>/${project.artifactId}</contextPath>
           </webAppConfig>
           <systemProperties>
             <!-- enable easy JMX connection to JConsole -->


### PR DESCRIPTION
Removed the requirement for specifying the version when accessing the deployed application generated by the archetype