### PR TITLE
Jt400 ssl

### DIFF
--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
@@ -128,6 +128,12 @@ public class Jt400Configuration {
     @UriParam(defaultValue = "EQ")
     private SearchType searchType = SearchType.EQ;
 
+    /**
+     * Whether connections to AS/400 are secured with SSL.
+     */
+    @UriParam
+    private boolean secured;
+
     @UriParam
     private Integer[] outputFieldsIdxArray;
 
@@ -293,6 +299,14 @@ public class Jt400Configuration {
         return outputFieldsIdxArray;
     }
 
+    public boolean isSecured() {
+        return secured;
+    }
+
+    public void setSecured(boolean secured) {
+        this.secured = secured;
+    }
+
     /**
      * Specifies which fields (program parameters) are output parameters.
      */
@@ -349,7 +363,13 @@ public class Jt400Configuration {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Getting an AS400 object for '{}' from {}.", systemName + '/' + userID, connectionPool);
             }
-            system = connectionPool.getConnection(systemName, userID, password);
+
+            if(isSecured()){
+                system = connectionPool.getSecureConnection(systemName, userID, password);
+            }else{
+                system = connectionPool.getConnection(systemName, userID, password);
+            }
+
             if (ccsid != DEFAULT_SYSTEM_CCSID) {
                 system.setCcsid(ccsid);
             }

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueConsumer.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueConsumer.java
@@ -108,6 +108,7 @@ public class Jt400DataQueueConsumer extends PollingConsumerSupport {
         }
 
         Exchange exchange = new DefaultExchange(endpoint.getCamelContext());
+        exchange.setFromEndpoint(endpoint);
         if (entry != null) {
             exchange.getIn().setHeader(Jt400Endpoint.SENDER_INFORMATION, entry.getSenderInformation());
             if (endpoint.getFormat() == Jt400Configuration.Format.binary) {
@@ -134,6 +135,7 @@ public class Jt400DataQueueConsumer extends PollingConsumerSupport {
         }
 
         Exchange exchange = new DefaultExchange(endpoint.getCamelContext());
+        exchange.setFromEndpoint(endpoint);
         if (entry != null) {
             exchange.getIn().setHeader(Jt400Endpoint.SENDER_INFORMATION, entry.getSenderInformation());
             if (endpoint.getFormat() == Jt400Configuration.Format.binary) {

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Endpoint.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Endpoint.java
@@ -246,4 +246,9 @@ public class Jt400Endpoint extends DefaultPollingEndpoint {
     public void setSystemName(String systemName) {
         configuration.setSystemName(systemName);
     }
+
+    public void setSecured(boolean secured) { configuration.setSecured(secured); }
+
+    public boolean isSecured() { return configuration.isSecured(); }
+
 }

--- a/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ComponentDefaultSecureConnectionPoolTest.java
+++ b/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ComponentDefaultSecureConnectionPoolTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jt400;
+
+import com.ibm.as400.access.AS400ConnectionPool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class Jt400ComponentDefaultSecureConnectionPoolTest extends Jt400TestSupport {
+    private Jt400Component component;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        component = new Jt400Component();
+        component.setCamelContext(context);
+        try {
+            // Use an invalid object type so that endpoints are never created
+            // and actual connections are never requested
+            component.createEndpoint("jt400://user:password@host/qsys.lib/library.lib/program.xxx?secured=true");
+            Assert.fail("Should have thrown exception");
+        } catch (Exception e) {
+            /* Expected */
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (component != null) {
+            component.stop();
+        }
+    }
+
+    @Test
+    public void testDefaultConnectionPoolIsCreated() {
+        assertNotNull(component.getConnectionPool());
+    }
+
+    /**
+     * Note: white-box testing.
+     */
+    @Test
+    public void testDefaultConnectionPoolIsOfExpectedType() {
+        assertEquals(AS400ConnectionPool.class, component.getConnectionPool().getClass());
+    }
+}

--- a/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ComponentTest.java
+++ b/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ComponentTest.java
@@ -71,4 +71,28 @@ public class Jt400ComponentTest extends Jt400TestSupport {
         }
     }
 
+    /**
+     * Test creation of a {@link Jt400Endpoint} secured for Datq
+     */
+    @Test
+    public void testCreateDatqSecuredEndpoint() throws Exception {
+        Endpoint endpoint = component
+                .createEndpoint("jt400://user:password@host/qsys.lib/library.lib/queue.dtaq?connectionPool=#mockPool&secured=true");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof Jt400Endpoint);
+        assertTrue( ((Jt400Endpoint)endpoint).isSecured() );
+    }
+
+    /**
+     * Test creation of a {@link Jt400Endpoint} secured for pgm calls
+     */
+    @Test
+    public void testCreatePgmSecuredEndpoint() throws Exception {
+        Endpoint endpoint = component
+                .createEndpoint("jt400://user:password@host/qsys.lib/library.lib/queue.pgm?connectionPool=#mockPool&secured=true");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof Jt400Endpoint);
+        assertTrue( ((Jt400Endpoint)endpoint).isSecured() );
+    }
+
 }

--- a/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ConfigurationSecureConnectionTest.java
+++ b/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400ConfigurationSecureConnectionTest.java
@@ -16,57 +16,52 @@
  */
 package org.apache.camel.component.jt400;
 
+import com.ibm.as400.access.AS400;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class Jt400ConfigurationTest extends Jt400TestSupport {
+public class Jt400ConfigurationSecureConnectionTest extends Jt400SecureTestSupport {
 
     private Jt400Configuration jt400Configuration;
+    private AS400 connection;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
+
         jt400Configuration = new Jt400Configuration("jt400://USER:password@host/QSYS.LIB/LIBRARY.LIB/QUEUE.DTAQ", getConnectionPool());
+        jt400Configuration.setCcsid(37);
+        jt400Configuration.setSecured(true);
+        connection = jt400Configuration.getConnection();
     }
 
-    @Test
-    public void testDefaultSecured() {
-        assertFalse( jt400Configuration.isSecured());
+    @After
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            jt400Configuration.releaseConnection(connection);
+        }
+        super.tearDown();
     }
 
     @Test
     public void testSystemName() {
-        assertEquals("host", jt400Configuration.getSystemName());
+        assertEquals("host", connection.getSystemName());
     }
 
     @Test
-    public void testUserID() {
-        assertEquals("USER", jt400Configuration.getUserID());
+    public void testUserId() {
+        assertEquals("USER", connection.getUserId());
     }
 
     @Test
-    public void testPassword() {
-        assertEquals("password", jt400Configuration.getPassword());
+    public void testCssid() {
+        assertEquals(37, connection.getCcsid());
     }
 
     @Test
-    public void testObjectPath() {
-        assertEquals("/QSYS.LIB/LIBRARY.LIB/QUEUE.DTAQ", jt400Configuration.getObjectPath());
-    }
-
-    @Test
-    public void testDefaultCcsid() {
-        assertEquals(-1, jt400Configuration.getCssid());
-    }
-
-    @Test
-    public void testDefaultFormat() {
-        assertEquals(Jt400Configuration.Format.text, jt400Configuration.getFormat());
-    }
-
-    @Test
-    public void testDefaultGuiAvailable() {
-        assertEquals(false, jt400Configuration.isGuiAvailable());
+    public void testGuiAvailable() {
+        assertFalse(connection.isGuiAvailable());
     }
 
 }

--- a/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400SecureTestSupport.java
+++ b/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/Jt400SecureTestSupport.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jt400;
+
+import com.ibm.as400.access.AS400ConnectionPool;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.util.ObjectHelper;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Useful base class for JT400 secured component unit tests. It creates a mock
+ * secured connection pool, registers it under the ID {@code "mockPool"} and releases it
+ * after the test runs.
+ */
+public abstract class Jt400SecureTestSupport extends CamelTestSupport {
+
+    private AS400ConnectionPool connectionPool;
+
+    protected Jt400SecureTestSupport() {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        connectionPool = new MockAS400SecureConnectionPool();
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (connectionPool != null) {
+            connectionPool.close();
+        }
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        ObjectHelper.notNull(connectionPool, "connectionPool");
+        JndiRegistry registry = super.createRegistry();
+        registry.bind("mockPool", connectionPool);
+        return registry;
+    }
+
+    /**
+     * Returns the mock connection pool.
+     *
+     * @return the mock connection pool
+     */
+    public AS400ConnectionPool getConnectionPool() {
+        return connectionPool;
+    }
+
+}

--- a/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/MockAS400SecureConnectionPool.java
+++ b/components/camel-jt400/src/test/java/org/apache/camel/component/jt400/MockAS400SecureConnectionPool.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jt400;
+
+import com.ibm.as400.access.AS400;
+import com.ibm.as400.access.AS400ConnectionPool;
+import com.ibm.as400.access.ConnectionPoolException;
+import com.ibm.as400.security.auth.ProfileTokenCredential;
+
+import java.util.Locale;
+
+/**
+ * Mock {@code AS400ConnectionPool} implementation, useful in unit testing JT400 endpoints with secure option=true.
+ */
+public class MockAS400SecureConnectionPool extends AS400ConnectionPool {
+
+
+    public MockAS400SecureConnectionPool() {
+        setRunMaintenance(false);
+        setThreadUsed(false);
+    }
+
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID, String password) throws ConnectionPoolException {
+        return new AS400(systemName, userID, password);
+    }
+
+    @Deprecated
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID, String password, int i) throws ConnectionPoolException {
+        return new AS400(systemName, userID, password);
+    }
+
+    @Deprecated
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID, int i) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID, ProfileTokenCredential profileTokenCredential) throws ConnectionPoolException {
+        return new AS400(systemName, userID);
+    }
+
+    @Override
+    public AS400 getSecureConnection(String systemName, String userID, ProfileTokenCredential profileTokenCredential, int i) throws ConnectionPoolException {
+        return new AS400(systemName, userID);
+    }
+
+    @Deprecated
+    @Override
+    public AS400 getConnection(String systemName, String userID) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public AS400 getConnection(String systemName, String userID, int service) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getConnection(String systemName, String userID, String password) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getConnection(String systemName, String userID, String password, int service) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getConnection(String systemName, String userID, String password, int service, Locale locale) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AS400 getConnection(String systemName, String userID, String password, Locale locale) throws ConnectionPoolException {
+        throw new UnsupportedOperationException();
+    }
+
+}


### PR DESCRIPTION
Added support for SSL connection encryption to iSeries systems.
The connection pool of jt400 library provide 2 different methods:
- getConnection()
- getSecureConnection()
using a camel URI option (secured=true or secure=false, default vale: false) one can toggle the use of one or the other connection type. Jt400 library relay on JVM trust cert store to Instantiate the SSL secure connection.