### PR TITLE
CAMEL-8941 improved restlet binary data handling

### DIFF
--- a/components/camel-restlet/pom.xml
+++ b/components/camel-restlet/pom.xml
@@ -122,20 +122,4 @@
       </plugin>
     </plugins>
   </build>
-
-    <!-- skip tests on windows -->
-    <profiles>
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-            </properties>
-        </profile>
-    </profiles>
-
 </project>

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
@@ -54,6 +54,7 @@ import org.restlet.data.Preference;
 import org.restlet.data.Status;
 import org.restlet.engine.application.DecodeRepresentation;
 import org.restlet.engine.header.HeaderConstants;
+import org.restlet.representation.ByteArrayRepresentation;
 import org.restlet.representation.FileRepresentation;
 import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
@@ -272,6 +273,9 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
             response.setEntity(new InputRepresentation(out.getBody(InputStream.class), mediaType));
         } else if (body instanceof File) {
             response.setEntity(new FileRepresentation(out.getBody(File.class), mediaType));
+        } else if (body instanceof byte[]) {
+            byte[] bytes = out.getBody(byte[].class);
+            response.setEntity(new ByteArrayRepresentation(bytes, mediaType, bytes.length));
         } else {
             // fallback and use string
             String text = out.getBody(String.class);

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
@@ -57,6 +57,7 @@ import org.restlet.engine.header.HeaderConstants;
 import org.restlet.representation.FileRepresentation;
 import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
+import org.restlet.representation.StreamRepresentation;
 import org.restlet.util.Series;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -334,8 +335,9 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
                 LOG.debug("Setting the Content-Type to be {}",  mediaType.toString());
                 exchange.getOut().setHeader(Exchange.CONTENT_TYPE, mediaType.toString());
             }
-            if (mediaType != null && mediaType.equals(MediaType.APPLICATION_OCTET_STREAM)) {
-                exchange.getOut().setBody(response.getEntity().getStream());
+            if (response.getEntity() instanceof StreamRepresentation) {
+                Representation representationDecoded = new DecodeRepresentation(response.getEntity());
+                exchange.getOut().setBody(representationDecoded.getStream());
             } else if (response.getEntity() instanceof Representation) {
                 Representation representationDecoded = new DecodeRepresentation(response.getEntity());
                 exchange.getOut().setBody(representationDecoded.getText());

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletProducerBinaryStreamTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletProducerBinaryStreamTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.restlet;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+
+import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.restlet.data.MediaType.APPLICATION_OCTET_STREAM;
+import static org.restlet.data.MediaType.AUDIO_MPEG;
+
+/**
+ * @version
+ */
+public class RestletProducerBinaryStreamTest extends RestletTestSupport {
+
+    @Test
+    public void shouldHandleBinaryOctetStream() throws Exception {
+        Exchange response = template.request("restlet:http://localhost:" + portNum + "/application/octet-stream", null);
+
+        assertThat(response.getOut().getHeader(CONTENT_TYPE, String.class), equalTo("application/octet-stream"));
+        assertThat(response.getOut().getBody(byte[].class), equalTo(getAllBytes()));
+    }
+
+    @Test
+    public void shouldHandleBinaryAudioMpeg() throws Exception {
+        Exchange response = template.request("restlet:http://localhost:" + portNum + "/audio/mpeg", null);
+
+        assertThat(response.getOut().getHeader(CONTENT_TYPE, String.class), equalTo("audio/mpeg"));
+        assertThat(response.getOut().getBody(byte[].class), equalTo(getAllBytes()));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("restlet:http://localhost:" + portNum + "/application/octet-stream")
+                        .setHeader(CONTENT_TYPE, constant(APPLICATION_OCTET_STREAM))
+                        .setBody(constant(new ByteArrayInputStream(getAllBytes())));
+
+                from("restlet:http://localhost:" + portNum + "/audio/mpeg")
+                        .setHeader(CONTENT_TYPE, constant(AUDIO_MPEG))
+                        .setBody(constant(new ByteArrayInputStream(getAllBytes())));
+            }
+        };
+    }
+
+    private static byte[] getAllBytes() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            data[i] = (byte) (Byte.MIN_VALUE + i);
+        }
+        return data;
+    }
+}

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRequestAndResponseAPITest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRequestAndResponseAPITest.java
@@ -42,7 +42,7 @@ public class RestletRequestAndResponseAPITest extends RestletTestSupport {
         headers.put("id", 123);
         headers.put("beverage.beer", "Carlsberg");
 
-        Object out = template.requestBodyAndHeaders("direct:start", null, headers);
+        String out = template.requestBodyAndHeaders("direct:start", null, headers, String.class);
         assertEquals("<response>Beer is Good</response>", out);
     }
 
@@ -61,9 +61,9 @@ public class RestletRequestAndResponseAPITest extends RestletTestSupport {
         assertNotNull(out);
         assertEquals("text/xml", out.getOut().getHeader(Exchange.CONTENT_TYPE));
         assertEquals(200, out.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("<response>Beer is Good</response>", out.getOut().getBody());
+        assertEquals("<response>Beer is Good</response>", out.getOut().getBody(String.class));
 
-        // the restlet response should be accessible if neeeded
+        // the restlet response should be accessible if needed
         Response response = out.getOut().getHeader(RestletConstants.RESTLET_RESPONSE, Response.class);
         assertNotNull(response);
         assertEquals(200, response.getStatus().getCode());
@@ -80,7 +80,7 @@ public class RestletRequestAndResponseAPITest extends RestletTestSupport {
                 from("restlet:http://localhost:" + portNum + "/users/{id}/like/{beer}")
                     .process(new Processor() {
                         public void process(Exchange exchange) throws Exception {
-                            // the Restlet request should be available if neeeded
+                            // the Restlet request should be available if needed
                             Request request = exchange.getIn().getHeader(RestletConstants.RESTLET_REQUEST, Request.class);
                             assertNotNull("Restlet Request", request);
 

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderAuthTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderAuthTest.java
@@ -38,8 +38,8 @@ public class RestletRouteBuilderAuthTest extends CamelSpringTestSupport {
         headers.put(RestletConstants.RESTLET_PASSWORD, "foo");
         headers.put("id", id);
         
-        String response = (String)template.requestBodyAndHeaders(
-            "direct:start-auth", "<order foo='1'/>", headers);
+        String response = template.requestBodyAndHeaders(
+            "direct:start-auth", "<order foo='1'/>", headers, String.class);
         // END SNIPPET: auth_request
 
         assertEquals("received [<order foo='1'/>] as an order id = " + id, response);

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.restlet;
 import java.io.IOException;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -82,36 +81,34 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
 
     @Test
     public void testProducer() throws IOException {
-        String response = (String)template.requestBody("direct:start", "<order foo='1'/>");
+        String response = template.requestBody("direct:start", "<order foo='1'/>", String.class);
         assertEquals("received [<order foo='1'/>] as an order id = " + ID, response);
         
-        response = (String)template.sendBodyAndHeader(
+        response = template.requestBodyAndHeader(
             "restlet:http://localhost:" + portNum + "/orders?restletMethod=post&foo=bar", 
-            ExchangePattern.InOut,
-            "<order foo='1'/>", "id", "89531");
+            "<order foo='1'/>", "id", "89531", String.class);
         assertEquals("received [<order foo='1'/>] as an order id = " + ID, response);
     }
 
     @Test
     public void testProducerJSON() throws IOException {
-        String response = (String)template.sendBodyAndHeader(
+        String response = template.requestBodyAndHeader(
             "restlet:http://localhost:" + portNum + "/ordersJSON?restletMethod=post&foo=bar", 
-            ExchangePattern.InOut,
             JSON,
             Exchange.CONTENT_TYPE,
-            MediaType.APPLICATION_JSON);
+            MediaType.APPLICATION_JSON,
+            String.class);
            
         assertEquals(JSON, response);
     }
 
     @Test
     public void testProducerJSONFailure() throws IOException {
-        String response = (String)template.sendBodyAndHeader(
+        String response = template.requestBodyAndHeader(
             "restlet:http://localhost:" + portNum + "/ordersJSON?restletMethod=post&foo=bar", 
-            ExchangePattern.InOut,
             "{'JSON'}",
             Exchange.CONTENT_TYPE,
-            MediaType.APPLICATION_JSON);
+            MediaType.APPLICATION_JSON, String.class);
            
         assertEquals("{'JSON'}", response);
     }

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
@@ -40,14 +40,14 @@ public class RestletSetBodyTest extends RestletTestSupport {
 
     @Test
     public void testSetBody() throws Exception {
-        String response = template.requestBody("restlet:http://0.0.0.0:" + portNum + "/stock/ORCL?restletMethod=get", null, String.class);
+        String response = template.requestBody("restlet:http://localhost:" + portNum + "/stock/ORCL?restletMethod=get", null, String.class);
         assertEquals("110", response);
        
     }
     
     @Test
     public void testSetBodyRepresentation() throws Exception {
-        HttpGet get = new HttpGet("http://0.0.0.0:" + portNum + "/images/123");
+        HttpGet get = new HttpGet("http://localhost:" + portNum + "/images/123");
         CloseableHttpClient httpclient = HttpClientBuilder.create().build();
         InputStream is = null;
         try {
@@ -71,7 +71,7 @@ public class RestletSetBodyTest extends RestletTestSupport {
     
     @Test
     public void testGzipEntity() {
-        String response = template.requestBody("restlet:http://0.0.0.0:" + portNum + "/gzip/data?restletMethod=get", null, String.class);
+        String response = template.requestBody("restlet:http://localhost:" + portNum + "/gzip/data?restletMethod=get", null, String.class);
         assertEquals("Hello World!", response);
     }
     
@@ -81,12 +81,12 @@ public class RestletSetBodyTest extends RestletTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("restlet:http://0.0.0.0:" + portNum + "/stock/{symbol}?restletMethods=get")
-                    .to("http://127.0.0.1:" + portNum2 + "/test?bridgeEndpoint=true")
+                from("restlet:http://localhost:" + portNum + "/stock/{symbol}?restletMethods=get")
+                    .to("http://localhost:" + portNum2 + "/test?bridgeEndpoint=true")
                     //.removeHeader("Transfer-Encoding")
                     .setBody().constant("110");
                 
-                from("jetty:http://0.0.0.0:" + portNum2 + "/test").setBody().constant("response is back");
+                from("jetty:http://localhost:" + portNum2 + "/test").setBody().constant("response is back");
 
                 // create ByteArrayRepresentation for response
                 byte[] image = new byte[10];
@@ -95,10 +95,10 @@ public class RestletSetBodyTest extends RestletTestSupport {
                 }
                 ByteArrayInputStream inputStream = new ByteArrayInputStream(image);
 
-                from("restlet:http://0.0.0.0:" + portNum + "/images/{symbol}?restletMethods=get")
+                from("restlet:http://localhost:" + portNum + "/images/{symbol}?restletMethods=get")
                     .setBody().constant(new InputRepresentation(inputStream, MediaType.IMAGE_PNG, 10));
                 
-                from("restlet:http://0.0.0.0:" + portNum + "/gzip/data?restletMethods=get")
+                from("restlet:http://localhost:" + portNum + "/gzip/data?restletMethods=get")
                     .setBody().constant(new EncodeRepresentation(Encoding.GZIP, new StringRepresentation("Hello World!", MediaType.TEXT_XML)));
             }
         };

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assume.assumeThat;
 
 /**
- * @version 
+ * @version
  */
 public class RestletSetBodyTest extends RestletTestSupport {
     protected static int portNum2 =  AvailablePortFinder.getNextAvailable(4000);
@@ -47,25 +47,19 @@ public class RestletSetBodyTest extends RestletTestSupport {
         String response = template.requestBody("restlet:http://localhost:" + portNum + "/stock/ORCL?restletMethod=get", null, String.class);
         assertEquals("110", response);
     }
-    
+
     @Test
     public void testSetBodyRepresentation() throws Exception {
         HttpGet get = new HttpGet("http://localhost:" + portNum + "/images/123");
-        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
-        InputStream is = null;
-        try {
+        try (CloseableHttpClient httpclient = HttpClientBuilder.create().build()) {
             HttpResponse response = httpclient.execute(get);
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals("image/png", response.getEntity().getContentType().getValue());
-            is = response.getEntity().getContent();
             assertEquals("Get wrong available size", 256, response.getEntity().getContentLength());
-            byte[] buffer = new byte[256];
-            assumeThat("Should read all data", is.read(buffer), equalTo(256));
-            assertThat("Data should match", buffer, equalTo(getAllBytes()));
-        } finally {
-            httpclient.close();
-            if (is != null) {
-                is.close();
+            try (InputStream is = response.getEntity().getContent()) {
+                byte[] buffer = new byte[256];
+                assumeThat("Should read all data", is.read(buffer), equalTo(256));
+                assertThat("Data should match", buffer, equalTo(getAllBytes()));
             }
         }
     }
@@ -73,21 +67,15 @@ public class RestletSetBodyTest extends RestletTestSupport {
     @Test
     public void consumerShouldReturnByteArray() throws Exception {
         HttpGet get = new HttpGet("http://localhost:" + portNum + "/music/123");
-        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
-        InputStream is = null;
-        try {
+        try (CloseableHttpClient httpclient = HttpClientBuilder.create().build()) {
             HttpResponse response = httpclient.execute(get);
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals("audio/mpeg", response.getEntity().getContentType().getValue());
-            is = response.getEntity().getContent();
             assertEquals("Content length should match returned data", 256, response.getEntity().getContentLength());
-            byte[] buffer = new byte[256];
-            assumeThat("Should read all data", is.read(buffer), equalTo(256));
-            assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
-        } finally {
-            httpclient.close();
-            if (is != null) {
-                is.close();
+            try (InputStream is = response.getEntity().getContent()) {
+                byte[] buffer = new byte[256];
+                assumeThat("Should read all data", is.read(buffer), equalTo(256));
+                assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
             }
         }
     }
@@ -95,32 +83,26 @@ public class RestletSetBodyTest extends RestletTestSupport {
     @Test
     public void consumerShouldReturnInputStream() throws Exception {
         HttpGet get = new HttpGet("http://localhost:" + portNum + "/video/123");
-        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
-        InputStream is = null;
-        try {
+        try (CloseableHttpClient httpclient = HttpClientBuilder.create().build()) {
             HttpResponse response = httpclient.execute(get);
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals("video/mp4", response.getEntity().getContentType().getValue());
             assertTrue("Content should be streamed", response.getEntity().isChunked());
             assertEquals("Content length should be unknown", -1, response.getEntity().getContentLength());
-            is = response.getEntity().getContent();
-            byte[] buffer = new byte[256];
-            assumeThat("Should read all data", is.read(buffer), equalTo(256));
-            assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
-        } finally {
-            httpclient.close();
-            if (is != null) {
-                is.close();
+            try (InputStream is = response.getEntity().getContent()) {
+                byte[] buffer = new byte[256];
+                assumeThat("Should read all data", is.read(buffer), equalTo(256));
+                assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
             }
         }
     }
-    
+
     @Test
     public void testGzipEntity() {
         String response = template.requestBody("restlet:http://localhost:" + portNum + "/gzip/data?restletMethod=get", null, String.class);
         assertEquals("Hello World!", response);
     }
-    
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -130,14 +112,14 @@ public class RestletSetBodyTest extends RestletTestSupport {
                     .to("http://localhost:" + portNum2 + "/test?bridgeEndpoint=true")
                     //.removeHeader("Transfer-Encoding")
                     .setBody().constant("110");
-                
+
                 from("jetty:http://localhost:" + portNum2 + "/test").setBody().constant("response is back");
 
                 // create ByteArrayRepresentation for response
                 from("restlet:http://localhost:" + portNum + "/images/{symbol}?restletMethods=get")
                     .setBody().constant(new InputRepresentation(
                         new ByteArrayInputStream(getAllBytes()), MediaType.IMAGE_PNG, 256));
-                
+
                 from("restlet:http://localhost:" + portNum + "/music/{symbol}?restletMethods=get")
                     .setHeader(Exchange.CONTENT_TYPE).constant("audio/mpeg")
                     .setBody().constant(getAllBytes());

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletSetBodyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.restlet;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.http.HttpResponse;
@@ -32,6 +33,9 @@ import org.restlet.engine.application.EncodeRepresentation;
 import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.StringRepresentation;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assume.assumeThat;
+
 /**
  * @version 
  */
@@ -42,7 +46,6 @@ public class RestletSetBodyTest extends RestletTestSupport {
     public void testSetBody() throws Exception {
         String response = template.requestBody("restlet:http://localhost:" + portNum + "/stock/ORCL?restletMethod=get", null, String.class);
         assertEquals("110", response);
-       
     }
     
     @Test
@@ -55,12 +58,55 @@ public class RestletSetBodyTest extends RestletTestSupport {
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals("image/png", response.getEntity().getContentType().getValue());
             is = response.getEntity().getContent();
-            assertEquals("Get wrong available size", 10, response.getEntity().getContentLength());
-            byte[] buffer = new byte[10];
-            is.read(buffer);
-            for (int i = 0; i < 10; i++) {
-                assertEquals(i + 1, buffer[i]);
+            assertEquals("Get wrong available size", 256, response.getEntity().getContentLength());
+            byte[] buffer = new byte[256];
+            assumeThat("Should read all data", is.read(buffer), equalTo(256));
+            assertThat("Data should match", buffer, equalTo(getAllBytes()));
+        } finally {
+            httpclient.close();
+            if (is != null) {
+                is.close();
             }
+        }
+    }
+
+    @Test
+    public void consumerShouldReturnByteArray() throws Exception {
+        HttpGet get = new HttpGet("http://localhost:" + portNum + "/music/123");
+        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+        InputStream is = null;
+        try {
+            HttpResponse response = httpclient.execute(get);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertEquals("audio/mpeg", response.getEntity().getContentType().getValue());
+            is = response.getEntity().getContent();
+            assertEquals("Content length should match returned data", 256, response.getEntity().getContentLength());
+            byte[] buffer = new byte[256];
+            assumeThat("Should read all data", is.read(buffer), equalTo(256));
+            assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
+        } finally {
+            httpclient.close();
+            if (is != null) {
+                is.close();
+            }
+        }
+    }
+
+    @Test
+    public void consumerShouldReturnInputStream() throws Exception {
+        HttpGet get = new HttpGet("http://localhost:" + portNum + "/video/123");
+        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+        InputStream is = null;
+        try {
+            HttpResponse response = httpclient.execute(get);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertEquals("video/mp4", response.getEntity().getContentType().getValue());
+            assertTrue("Content should be streamed", response.getEntity().isChunked());
+            assertEquals("Content length should be unknown", -1, response.getEntity().getContentLength());
+            is = response.getEntity().getContent();
+            byte[] buffer = new byte[256];
+            assumeThat("Should read all data", is.read(buffer), equalTo(256));
+            assertThat("Binary content should match", buffer, equalTo(getAllBytes()));
         } finally {
             httpclient.close();
             if (is != null) {
@@ -75,7 +121,6 @@ public class RestletSetBodyTest extends RestletTestSupport {
         assertEquals("Hello World!", response);
     }
     
-
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -89,18 +134,29 @@ public class RestletSetBodyTest extends RestletTestSupport {
                 from("jetty:http://localhost:" + portNum2 + "/test").setBody().constant("response is back");
 
                 // create ByteArrayRepresentation for response
-                byte[] image = new byte[10];
-                for (int i = 0; i < 10; i++) {
-                    image[i] = (byte)(i + 1);
-                }
-                ByteArrayInputStream inputStream = new ByteArrayInputStream(image);
-
                 from("restlet:http://localhost:" + portNum + "/images/{symbol}?restletMethods=get")
-                    .setBody().constant(new InputRepresentation(inputStream, MediaType.IMAGE_PNG, 10));
+                    .setBody().constant(new InputRepresentation(
+                        new ByteArrayInputStream(getAllBytes()), MediaType.IMAGE_PNG, 256));
                 
+                from("restlet:http://localhost:" + portNum + "/music/{symbol}?restletMethods=get")
+                    .setHeader(Exchange.CONTENT_TYPE).constant("audio/mpeg")
+                    .setBody().constant(getAllBytes());
+
+                from("restlet:http://localhost:" + portNum + "/video/{symbol}?restletMethods=get")
+                    .setHeader(Exchange.CONTENT_TYPE).constant("video/mp4")
+                    .setBody().constant(new ByteArrayInputStream(getAllBytes()));
+
                 from("restlet:http://localhost:" + portNum + "/gzip/data?restletMethods=get")
                     .setBody().constant(new EncodeRepresentation(Encoding.GZIP, new StringRepresentation("Hello World!", MediaType.TEXT_XML)));
             }
         };
+    }
+
+    private static byte[] getAllBytes() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            data[i] = (byte)(Byte.MIN_VALUE + i);
+        }
+        return data;
     }
 }


### PR DESCRIPTION
Additional support for camel-restlet to properly handle binary data:
* consumer can return binary data as InputStream (test only)
* consumer can return binary data as byte\[\] (test + fix)
* producer can receive "application/octet-stream" content as InputStream (test only)
* producer can receive other content as InputStream (test + fix)