### PR TITLE
CAMEL-8578 - May double encode uri when using HTTP_URI or HTTP_QUERY …

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/util/UnsafeCharactersEncoderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/UnsafeCharactersEncoderTest.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,13 +18,16 @@ package org.apache.camel.util;
 
 import junit.framework.TestCase;
 
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
 public class UnsafeCharactersEncoderTest extends TestCase {
 
     private void testEncoding(String before, String after) {
         String result = UnsafeUriCharactersEncoder.encode(before);
         assertEquals("Get the wrong encoding result", after, result);
     }
-    
+
     public void testQnameEncoder() {
         String afterEncoding = "%7Bhttp://www.example.com/test%7DServiceName";
         String beforeEncoding = "{http://www.example.com/test}ServiceName";
@@ -35,10 +38,11 @@ public class UnsafeCharactersEncoderTest extends TestCase {
         String noEncoding = "http://www.example.com";
         testEncoding(noEncoding, noEncoding);
     }
-    
+
     public void testUnicodes() {
-        String noEncoding = "http://test.com/\uFD04";
-        testEncoding(noEncoding, noEncoding);
+        String before = "http://test.com/\uFD04";
+        String after = "http://test.com/%EF%B4%84";
+        testEncoding(before, after);
     }
 
     public void testPercentEncode() {
@@ -55,7 +59,7 @@ public class UnsafeCharactersEncoderTest extends TestCase {
 
     public void testPercentEncodeDanishChar() {
         String beforeEncoding = "http://localhost:{{port}}/myapp/mytest?columns=claus,s\u00F8ren&username=apiuser";
-        String afterEncoding = "http://localhost:%7B%7Bport%7D%7D/myapp/mytest?columns=claus,s\u00F8ren&username=apiuser";
+        String afterEncoding = "http://localhost:%7B%7Bport%7D%7D/myapp/mytest?columns=claus,s%C3%B8ren&username=apiuser";
         testEncoding(beforeEncoding, afterEncoding);
     }
 
@@ -77,4 +81,29 @@ public class UnsafeCharactersEncoderTest extends TestCase {
         testEncoding(beforeEncoding, afterEncoding);
     }
 
+    public void testPercentEncodingUtf8() throws UnsupportedEncodingException {
+        /**
+         "When a new URI scheme defines a component that represents textual
+         data consisting of characters from the Universal Character Set [UCS],
+         the data should first be encoded as octets according to the UTF-8
+         character encoding [STD63]; then only those octets that do not
+         correspond to characters in the unreserved set should be percent-
+         encoded.  For example, the character A would be represented as "A",
+         the character LATIN CAPITAL LETTER A WITH GRAVE would be represented
+         as "%C3%80", and the character KATAKANA LETTER A would be represented
+         as "%E3%82%A2"."
+
+         src: https://tools.ietf.org/html/rfc3986
+         */
+        testEncodeHttpUri("q= ", "q=%20");
+        testEncodeHttpUri("q=€", "q=%E2%82%AC");
+        testEncodeHttpUri("q=\u00C0", "q=%C3%80");
+        testEncodeHttpUri("q=\u30C4", "q=%E3%83%84");
+        testEncodeHttpUri("q=\u0080", "q=%C2%80");
+        testEncodeHttpUri("q=\u0081", "q=%C2%81");
+    }
+
+    private void testEncodeHttpUri(String before, String after) {
+        assertEquals("Got wrong encoding result", after, UnsafeUriCharactersEncoder.encodeHttpURI(before));
+    }
 }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
@@ -161,6 +161,13 @@ public class HttpHelperTest {
         assertEquals(HttpMethods.POST, method);
     }
 
+    @Test
+    public void createURIShouldNotDecodeEuroSymbolAway() throws URISyntaxException{
+        final URI result =  HttpHelper.createURI(createExchangeWithOptionalHttpQueryAndHttpMethodHeader(null, null),
+                "http://www.google.com/search?hl=en&q=%E2%82%AC",createHttpEndpoint(true, "http://host"));
+        assertEquals("http://www.google.com/search?hl=en&q=%E2%82%AC",result.toString());
+    }
+
     private Exchange createExchangeWithOptionalHttpQueryAndHttpMethodHeader(String httpQuery, HttpMethods httpMethod) {
         CamelContext context = new DefaultCamelContext();
         Exchange exchange = new DefaultExchange(context);


### PR DESCRIPTION
Fix for issue https://issues.apache.org/jira/browse/CAMEL-8578.
camel-http uses class UnsafeUriCharactersEncoder in HttpHelper#createURI.
UnsafeUriCharactersEncoder explicitly doesn't encode character >= 128.

If url = "http://www.google.com/search?hl=en&q=%E2%82%AC" is
as parameter for HttpHelper#createURI, then:

$URI uri = new URI(url);

Here uri now contains queryString in unencoded form,
which means, that also euro-character is in encoded form.
http://www.fileformat.info/info/unicode/char/20aC/index.htm.

Later in same method
$// need to encode query string
$queryString = UnsafeUriCharactersEncoder.encodeHttpURI(queryString);

Method UnsafeUriCharactersEncoder#encodeHttpURI does not
encode euro character back to encoded form.

Fix was to add UTF-8 encoding support into UnsafeUriCharactersEncoder#encodeHttpURI
according to https://tools.ietf.org/html/rfc3986.
