### PR TITLE
CAMEL-8578 - May double encode uri when using HTTP_URI or HTTP_QUERY

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/helper/HttpHelper.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/helper/HttpHelper.java
@@ -282,7 +282,7 @@ public final class HttpHelper {
         }
         // We should user the query string from the HTTP_URI header
         if (queryString == null) {
-            queryString = uri.getQuery();
+            queryString = uri.getRawQuery();
         }
         if (queryString != null) {
             // need to encode query string

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
@@ -161,6 +161,50 @@ public class HttpHelperTest {
         assertEquals(HttpMethods.POST, method);
     }
 
+    @Test
+    public void createURIShouldKeepQueryParametersGivenInUrlParameter() throws URISyntaxException {
+
+        URI uri = HttpHelper.createURI(
+                createExchangeWithOptionalCamelHttpUriHeader(null,
+                        null),
+                "http://apache.org/?q=%E2%82%AC"
+                , createHttpEndpoint(false, "http://apache.org"));
+        assertEquals("http://apache.org/?q=%E2%82%AC",uri.toString());
+    }
+
+    @Test
+    public void createURIShouldEncodeExchangeHttpQuery() throws URISyntaxException {
+
+        URI uri = HttpHelper.createURI(
+                createExchangeWithOptionalHttpQueryAndHttpMethodHeader("q= ",
+                        null),
+                "http://apache.org/?q=%E2%82%AC"
+                , createHttpEndpoint(false, "http://apache.org"));
+        assertEquals("http://apache.org/?q=%20",uri.toString());
+    }
+
+    @Test
+    public void createURIShouldNotDoubleEncodeExchangeHttpQuery() throws URISyntaxException {
+
+        URI uri = HttpHelper.createURI(
+                createExchangeWithOptionalHttpQueryAndHttpMethodHeader("q=%E2%82%AC",
+                        null),
+                "http://apache.org/?q=%E2%82%AC"
+                , createHttpEndpoint(false, "http://apache.org"));
+        assertEquals("http://apache.org/?q=%E2%82%AC",uri.toString());
+    }
+
+    @Test
+    public void createURIShouldKeepQueryParametersGivenInEndPointUri() throws URISyntaxException {
+
+        URI uri = HttpHelper.createURI(
+                createExchangeWithOptionalHttpQueryAndHttpMethodHeader(null,
+                        null),
+                "http://apache.org/"
+                , createHttpEndpoint(false, "http://apache.org/?q=%E2%82%AC"));
+        assertEquals("http://apache.org/?q=%E2%82%AC",uri.toString());
+    }
+
     private Exchange createExchangeWithOptionalHttpQueryAndHttpMethodHeader(String httpQuery, HttpMethods httpMethod) {
         CamelContext context = new DefaultCamelContext();
         Exchange exchange = new DefaultExchange(context);


### PR DESCRIPTION
HTTPHelper#createURI now uses raw queries instead of encoding them with UnsafeCharacterEncoder.
Queries should already be in encoded form so no encoding is needed.