### PR TITLE
camel-undertow: refactor unit tests to use dynamic ports

### DIFF
--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/BaseUndertowTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/BaseUndertowTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.properties.PropertiesComponent;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.BeforeClass;
+
+/**
+ * Base class of tests which allocates ports
+ */
+public class BaseUndertowTest extends CamelTestSupport {
+
+    private static volatile int port;
+    private static volatile int port2;
+    private final AtomicInteger counter = new AtomicInteger(1);
+
+    @BeforeClass
+    public static void initPort() throws Exception {
+        port = AvailablePortFinder.getNextAvailable(8000);
+        port2 = AvailablePortFinder.getNextAvailable(9000);
+    }
+
+    protected static int getPort() {
+        return port;
+    }
+
+    protected static int getPort2() {
+        return port2;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.addComponent("properties", new PropertiesComponent("ref:prop"));
+        return context;
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+
+        Properties prop = new Properties();
+        prop.setProperty("port", "" + getPort());
+        prop.setProperty("port2", "" + getPort2());
+        jndi.bind("prop", prop);
+        return jndi;
+    }
+
+    protected int getNextPort() {
+        return AvailablePortFinder.getNextAvailable(port + counter.getAndIncrement());
+    }
+
+    protected int getNextPort(int startWithPort) {
+        return AvailablePortFinder.getNextAvailable(startWithPort);
+    }
+}

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowComponentTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowComponentTest.java
@@ -19,24 +19,18 @@ package org.apache.camel.component.undertow;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UndertowComponentTest extends CamelTestSupport {
+public class UndertowComponentTest extends BaseUndertowTest {
     private static final Logger LOG = LoggerFactory.getLogger(UndertowComponentTest.class);
 
     @Test
     public void testUndertow() throws Exception {
 
 
-        String response = template.requestBody("undertow://http://localhost:8888/myapp", "Hello Camel!", String.class);
-//        MockEndpoint mockEndpoint = getMockEndpoint("mock:myapp");
-//        assertTrue(mockEndpoint.getExchanges().size() == 1);
-//        for (Exchange exchange : mockEndpoint.getExchanges()) {
-//            assertEquals("Bye Camel", exchange.getIn().getBody(String.class));
-//        }
+        String response = template.requestBody("undertow://http://localhost:{{port}}/myapp", "Hello Camel!", String.class);
 
         assertNotNull(response);
 
@@ -50,14 +44,6 @@ public class UndertowComponentTest extends CamelTestSupport {
             assertEquals("Hello Camel! Bye Camel!", exchange.getIn().getBody(String.class));
         }
 
-//        Exchange out = template.request("undertow:http://localhost:8888/myapp", new Processor() {
-//            @Override
-//            public void process(Exchange exchange) throws Exception {
-//                exchange.getIn().setBody("Hello World!");
-//            }
-//        });
-
-
         mockEndpoint.assertIsSatisfied();
 
     }
@@ -66,15 +52,9 @@ public class UndertowComponentTest extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                from("undertow:http://localhost:8888/myapp")
+                from("undertow:http://localhost:{{port}}/myapp")
                     .transform().constant("Bye Camel!")
                     .to("mock:myapp");
-
-//                from("undertow:http://localhost:8888/bar")
-//                        .transform(bodyAs(String.class).append(" Bar Camel!"))
-//                        .to("mock:bar");
-
-
             }
         };
     }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowError500Test.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowError500Test.java
@@ -19,19 +19,16 @@ package org.apache.camel.component.undertow;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
-public class UndertowError500Test extends CamelTestSupport {
-
-    // TODO: add unit test should use dynamic port number, see camel-jetty9 for example
+public class UndertowError500Test extends BaseUndertowTest {
 
     @Test
     public void testHttp500Error() throws Exception {
         getMockEndpoint("mock:input").expectedBodiesReceived("Hello World");
 
         try {
-            template.requestBody("http://localhost:8888/foo", "Hello World", String.class);
+            template.requestBody("http://localhost:{{port}}/foo", "Hello World", String.class);
             fail("Should have failed");
         } catch (CamelExecutionException e) {
 
@@ -45,7 +42,7 @@ public class UndertowError500Test extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("undertow:http://localhost:8888/foo")
+                from("undertow:http://localhost:{{port}}/foo")
                     .to("mock:input")
                         // trigger failure by setting error code to 500
                     .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(500))

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHeaderTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHeaderTest.java
@@ -18,22 +18,21 @@ package org.apache.camel.component.undertow;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
-public class UndertowHeaderTest extends CamelTestSupport {
+public class UndertowHeaderTest extends BaseUndertowTest {
 
     @Test
     public void testHttpHeaders() throws Exception {
         getMockEndpoint("mock:input").expectedBodiesReceived("Hello World");
         getMockEndpoint("mock:input").expectedHeaderReceived("param", "true");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
-        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URL, "http://localhost:8888/headers");
+        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URL, "http://localhost:" + getPort() + "/headers");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URI, "/headers");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_QUERY, "param=true");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_PATH, "/headers");
 
-        String out = template.requestBody("http://localhost:8888/headers?param=true", "Hello World", String.class);
+        String out = template.requestBody("http://localhost:" + getPort() + "/headers?param=true", "Hello World", String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -44,7 +43,7 @@ public class UndertowHeaderTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("undertow:http://localhost:8888/headers")
+                from("undertow:http://localhost:{{port}}/headers")
                     .to("mock:input")
                     .transform().constant("Bye World");
             }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpProducerTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpProducerTest.java
@@ -18,16 +18,15 @@ package org.apache.camel.component.undertow;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
-public class UndertowHttpProducerTest extends CamelTestSupport {
+public class UndertowHttpProducerTest extends BaseUndertowTest {
 
     @Test
     public void testHttpSimple() throws Exception {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
 
-        String out = template.requestBody("http://localhost:8888/foo", null, String.class);
+        String out = template.requestBody("http://localhost:{{port}}/foo", null, String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -37,7 +36,7 @@ public class UndertowHttpProducerTest extends CamelTestSupport {
     public void testHttpSimpleHeader() throws Exception {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
-        String out = template.requestBodyAndHeader("http://localhost:8888/foo", null, Exchange.HTTP_METHOD, "POST", String.class);
+        String out = template.requestBodyAndHeader("http://localhost:{{port}}/foo", null, Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -49,7 +48,7 @@ public class UndertowHttpProducerTest extends CamelTestSupport {
         getMockEndpoint("mock:input").expectedBodiesReceived("Hello World");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
-        String out = template.requestBodyAndHeader("http://localhost:8888/foo", "Hello World", Exchange.HTTP_METHOD, "POST", String.class);
+        String out = template.requestBodyAndHeader("http://localhost:{{port}}/foo", "Hello World", Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -60,7 +59,7 @@ public class UndertowHttpProducerTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("undertow:http://localhost:8888/foo")
+                from("undertow:http://localhost:{{port}}/foo")
                     .to("mock:input")
                     .transform().constant("Bye World");
             }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpsSpringTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpsSpringTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.undertow;
 
 import java.net.URL;
+import javax.annotation.Resource;
 
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
@@ -34,6 +35,8 @@ import static org.junit.Assert.assertEquals;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"/SpringTest.xml"})
 public class UndertowHttpsSpringTest {
+
+    private Integer port;
 
     @Produce
     private ProducerTemplate template;
@@ -53,13 +56,22 @@ public class UndertowHttpsSpringTest {
     }
 
     @Test
-    public void testSSLInOutWithNettyConsumer() throws Exception {
+    public void testSSLConsumer() throws Exception {
         mockEndpoint.expectedBodiesReceived("Hello World");
 
-        String out = template.requestBody("https://localhost:9000/spring", "Hello World", String.class);
+        String out = template.requestBody("https://localhost:" + port + "/spring", "Hello World", String.class);
         assertEquals("Bye World", out);
 
         mockEndpoint.assertIsSatisfied();
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    @Resource(name = "dynaPort")
+    public void setPort(Integer port) {
+        this.port = port;
     }
 
 }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMethodRestricTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMethodRestricTest.java
@@ -20,16 +20,21 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class UndertowMethodRestricTest extends CamelTestSupport {
+public class UndertowMethodRestricTest extends BaseUndertowTest {
 
-    private String url = "http://localhost:8888/methodRestrict";
+    private static String url;
+
+    @BeforeClass
+    public static void init() {
+        url = "http://localhost:" + getPort() + "/methodRestrict";
+    }
 
     @Test
     public void testProperHttpMethod() throws Exception {
@@ -61,7 +66,7 @@ public class UndertowMethodRestricTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("undertow://http://localhost:8888/methodRestrict?httpMethodRestrict=POST").process(new Processor() {
+                from("undertow://http://localhost:{{port}}/methodRestrict?httpMethodRestrict=POST").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         Message in = exchange.getIn();
                         String request = in.getBody(String.class);

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowPrefixMatchingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowPrefixMatchingTest.java
@@ -20,17 +20,16 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.http.HttpOperationFailedException;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UndertowPrefixMatchingTest extends CamelTestSupport {
+public class UndertowPrefixMatchingTest extends BaseUndertowTest {
     private static final Logger LOG = LoggerFactory.getLogger(UndertowComponentTest.class);
 
     @Test
     public void passOnExactPath() throws Exception {
-        Exchange response = template.requestBody("http://localhost:8888/myapp/suffix", "Hello Camel!", Exchange.class);
+        Exchange response = template.requestBody("http://localhost:{{port}}/myapp/suffix", "Hello Camel!", Exchange.class);
         getMockEndpoint("mock:myapp").expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
     }
 
@@ -38,7 +37,7 @@ public class UndertowPrefixMatchingTest extends CamelTestSupport {
     public void failsOnPrefixPath() throws Exception {
 
         try {
-            String response = template.requestBody("http://localhost:8888/myapp", "Hello Camel!", String.class);
+            String response = template.requestBody("http://localhost:{{port}}/myapp", "Hello Camel!", String.class);
             fail("Should fail, something is wrong");
         } catch (CamelExecutionException ex) {
             HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, ex.getCause());
@@ -48,7 +47,7 @@ public class UndertowPrefixMatchingTest extends CamelTestSupport {
 
     @Test
     public void passOnPrefixPath() throws Exception {
-        Exchange response = template.requestBody("http://localhost:8888/bar/somethingNotImportant", "Hello Camel!", Exchange.class);
+        Exchange response = template.requestBody("http://localhost:{{port}}/bar/somethingNotImportant", "Hello Camel!", Exchange.class);
         getMockEndpoint("mock:myapp").expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
     }
 
@@ -57,11 +56,11 @@ public class UndertowPrefixMatchingTest extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                from("undertow:http://localhost:8888/myapp/suffix?matchOnUriPrefix=false")
+                from("undertow:http://localhost:{{port}}/myapp/suffix?matchOnUriPrefix=false")
                     .transform(bodyAs(String.class).append(" Must match exact path"))
                     .to("mock:myapp");
 
-                from("undertow:http://localhost:8888/bar")
+                from("undertow:http://localhost:{{port}}/bar")
                     .transform(bodyAs(String.class).append(" Matching prefix"))
                     .to("mock:bar");
             }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowProducerTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowProducerTest.java
@@ -18,18 +18,17 @@ package org.apache.camel.component.undertow;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class UndertowProducerTest extends CamelTestSupport {
+public class UndertowProducerTest extends BaseUndertowTest {
 
     @Ignore
     @Test
     public void testHttpSimple() throws Exception {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
 
-        String out = template.requestBody("undertow:http://localhost:8888/foo", null, String.class);
+        String out = template.requestBody("undertow:http://localhost:{{port}}/foo", null, String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -40,7 +39,7 @@ public class UndertowProducerTest extends CamelTestSupport {
     public void testHttpSimpleHeader() throws Exception {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
-        String out = template.requestBodyAndHeader("undertow:http://localhost:8888/foo", null, Exchange.HTTP_METHOD, "POST", String.class);
+        String out = template.requestBodyAndHeader("undertow:http://localhost:{{port}}/foo", null, Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -53,7 +52,7 @@ public class UndertowProducerTest extends CamelTestSupport {
         getMockEndpoint("mock:input").expectedBodiesReceived("Hello World");
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
-        String out = template.requestBodyAndHeader("undertow:http://localhost:8888/foo", "Hello World", Exchange.HTTP_METHOD, "POST", String.class);
+        String out = template.requestBodyAndHeader("undertow:http://localhost:{{port}}/foo", "Hello World", Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);
 
         assertMockEndpointsSatisfied();
@@ -64,7 +63,7 @@ public class UndertowProducerTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("undertow:http://localhost:8888/foo")
+                from("undertow:http://localhost:{{port}}/foo")
                     .to("mock:input")
                     .transform().constant("Bye World");
             }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowSharedPortTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowSharedPortTest.java
@@ -16,5 +16,57 @@
  */
 package org.apache.camel.component.undertow;
 
-public class UndertowSharedPortTest {
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UndertowSharedPortTest extends BaseUndertowTest {
+    private static final Logger LOG = LoggerFactory.getLogger(UndertowSharedPortTest.class);
+
+    @Test
+    public void testFirstPath() throws Exception {
+        testPath("first");
+    }
+
+    @Test
+    public void testSecondPath() throws Exception {
+        testPath("second");
+    }
+
+    private void testPath(String pathSuffix) throws InterruptedException {
+        String response = template.requestBody("undertow://http://localhost:{{port}}/" + pathSuffix, "Hello Camel!", String.class);
+
+        assertNotNull(response);
+
+        assertEquals("Hello Camel!", response);
+
+        MockEndpoint mockEndpoint = getMockEndpoint("mock:" + pathSuffix);
+        mockEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+        LOG.debug("Number of exchanges in mock:" + pathSuffix + mockEndpoint.getExchanges().size());
+
+        for (Exchange exchange : mockEndpoint.getExchanges()) {
+            assertEquals("Hello Camel! Bye Camel! " + pathSuffix, exchange.getIn().getBody(String.class));
+        }
+
+        mockEndpoint.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("undertow:http://localhost:{{port}}/first")
+                    .transform().constant("Bye Camel! first")
+                    .to("mock:first");
+
+                from("undertow:http://localhost:{{port}}/second")
+                    .transform().constant("Bye Camel! second")
+                    .to("mock:second");
+            }
+        };
+    }
+
 }

--- a/components/camel-undertow/src/test/resources/SpringTest.xml
+++ b/components/camel-undertow/src/test/resources/SpringTest.xml
@@ -32,10 +32,25 @@
         </camel:trustManagers>
     </camel:sslContextParameters>
 
+    <bean id="dynaPort" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetClass">
+            <value>org.apache.camel.test.AvailablePortFinder</value>
+        </property>
+        <property name="targetMethod">
+            <value>getNextAvailable</value>
+        </property>
+        <property name="arguments">
+            <list>
+                <value>8800</value>
+            </list>
+        </property>
+    </bean>
+
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <endpoint id="input" uri="undertow:https://localhost:#{dynaPort}/spring?sslContextParametersRef=sslContextParameters"/>
 
         <route>
-            <from uri="undertow:https://localhost:9000/spring?sslContextParametersRef=sslContextParameters"/>
+            <from ref="input"/>
             <to uri="mock:input"/>
             <transform>
                 <simple>Bye World</simple>


### PR DESCRIPTION
Follow-up to https://github.com/apache/camel/pull/562