### PR TITLE
add VELOCITY_SUPPLEMENTAL_CONTEXT header

### DIFF
--- a/components/camel-velocity/src/main/java/org/apache/camel/component/velocity/VelocityConstants.java
+++ b/components/camel-velocity/src/main/java/org/apache/camel/component/velocity/VelocityConstants.java
@@ -24,8 +24,10 @@ public final class VelocityConstants {
     public static final String VELOCITY_RESOURCE_URI = "CamelVelocityResourceUri";
 
     public static final String VELOCITY_TEMPLATE = "CamelVelocityTemplate";
-    
+
     public static final String VELOCITY_CONTEXT = "CamelVelocityContext";
+
+    public static final String VELOCITY_SUPPLEMENTAL_CONTEXT = "CamelVelocitySupplementalContext";
 
     private VelocityConstants() {
         // Utility class

--- a/components/camel-velocity/src/main/java/org/apache/camel/component/velocity/VelocityEndpoint.java
+++ b/components/camel-velocity/src/main/java/org/apache/camel/component/velocity/VelocityEndpoint.java
@@ -42,7 +42,7 @@ import org.apache.velocity.runtime.log.CommonsLogLogChute;
 
 @UriEndpoint(scheme = "velocity", title = "Velocity", syntax = "velocity:resourceUri", producerOnly = true, label = "transformation")
 public class VelocityEndpoint extends ResourceEndpoint {
-    
+
     private VelocityEngine velocityEngine;
 
     @UriParam(defaultValue = "true")
@@ -102,7 +102,7 @@ public class VelocityEndpoint extends ResourceEndpoint {
             }
 
             log.debug("Initializing VelocityEngine with properties {}", properties);
-            // help the velocityEngine to load the CamelVelocityClasspathResourceLoader 
+            // help the velocityEngine to load the CamelVelocityClasspathResourceLoader
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             try {
                 ClassLoader delegate = new CamelVelocityDelegateClassLoader(old);
@@ -196,6 +196,13 @@ public class VelocityEndpoint extends ResourceEndpoint {
         Context velocityContext = exchange.getIn().getHeader(VelocityConstants.VELOCITY_CONTEXT, Context.class);
         if (velocityContext == null) {
             Map<String, Object> variableMap = ExchangeHelper.createVariableMap(exchange);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> supplementalMap = exchange.getIn().getHeader(VelocityConstants.VELOCITY_SUPPLEMENTAL_CONTEXT, Map.class);
+            if (supplementalMap != null) {
+                variableMap.putAll(supplementalMap);
+            }
+
             velocityContext = new VelocityContext(variableMap);
         }
 

--- a/components/camel-velocity/src/test/java/org/apache/camel/component/velocity/VelocitySupplementalContextTest.java
+++ b/components/camel-velocity/src/test/java/org/apache/camel/component/velocity/VelocitySupplementalContextTest.java
@@ -1,0 +1,55 @@
+package org.apache.camel.component.velocity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class VelocitySupplementalContextTest extends CamelTestSupport {
+
+    @Produce(uri = "direct:input")
+    protected ProducerTemplate inputEndpoint;
+
+    @EndpointInject(uri = "mock:results")
+    protected MockEndpoint outputEndpoint;
+
+    @Test
+    public void testCamelRoute() throws Exception {
+        outputEndpoint.expectedMessageCount(1);
+        outputEndpoint.expectedHeaderReceived("body", "new_body");
+        outputEndpoint.expectedHeaderReceived("in.body", "old_body");
+        outputEndpoint.expectedBodiesReceived("bar");
+
+        Map<String, Object> headers = new HashMap<String, Object>();
+        headers.put(VelocityConstants.VELOCITY_TEMPLATE,
+                "#set( $headers.body = ${body} )\n" +
+                "#set( $headers['in.body'] = $in.body )\n" + "bar");
+        inputEndpoint.sendBodyAndHeaders("old_body", headers);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+
+        final Map<String, Object> supplementalContext = new HashMap<>();
+        supplementalContext.put("body", "new_body");
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:input")
+                .setHeader(VelocityConstants.VELOCITY_SUPPLEMENTAL_CONTEXT).constant(supplementalContext)
+                .to("velocity:template-in-header")
+                .to("mock:results");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Add a header to specify a Map of supplementary variables to the
default velocity context entries.  Entries in this map will override
the default pre-defined values when using the same key, e.g. "body".

This provides a simpler way to pre-define variables than providing
a custom context that completely replaces the default, while still
allowing values to be "returned" from the template via headers.