### PR TITLE
readding defaulting logic for parameter data type

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestOperationParamDefinition.java
@@ -154,7 +154,7 @@ public class RestOperationParamDefinition {
     }
 
     public String getDataType() {
-        return dataType;
+        return dataType != null ? dataType : "string";
     }
 
     /**


### PR DESCRIPTION
Hey,
  It seems that this was removed somehow... 
  Without a default value an exception is thrown when generating the swagger models:
```
15-08-07 15:50:45 WARN  ServletHandler:563 - /api-docs
java.lang.IllegalArgumentException: Flat hash tables cannot contain null elements.
	at scala.collection.mutable.FlatHashTable$HashUtils$class.elemHashCode(FlatHashTable.scala:390)
	at scala.collection.mutable.HashSet.elemHashCode(HashSet.scala:41)
	at scala.collection.mutable.FlatHashTable$class.addEntry(FlatHashTable.scala:136)
	at scala.collection.mutable.HashSet.addEntry(HashSet.scala:41)
	at scala.collection.mutable.HashSet.$plus$eq(HashSet.scala:60)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1$$anonfun$apply$1$$anonfun$apply$4.apply(ModelUtil.scala:93)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1$$anonfun$apply$1$$anonfun$apply$4.apply(ModelUtil.scala:91)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1$$anonfun$apply$1.apply(ModelUtil.scala:91)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1$$anonfun$apply$1.apply(ModelUtil.scala:88)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1.apply(ModelUtil.scala:88)
	at com.wordnik.swagger.core.util.ModelUtil$$anonfun$modelsFromApis$1.apply(ModelUtil.scala:88)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at com.wordnik.swagger.core.util.ModelUtil$.modelsFromApis(ModelUtil.scala:88)
....
```