### PR TITLE
CAMEL-9049: Modifying timing that Jetty connector added and removed

### DIFF
--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketConsumer.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketConsumer.java
@@ -31,15 +31,15 @@ public class WebsocketConsumer extends DefaultConsumer implements WebsocketProdu
     }
 
     @Override
-    public void start() throws Exception {
-        super.start();
+    public void doStart() throws Exception {
+        super.doStart();
         endpoint.connect(this);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         endpoint.disconnect(this);
-        super.stop();
+        super.doStop();
     }
 
     public WebsocketEndpoint getEndpoint() {

--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketProducer.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketProducer.java
@@ -65,15 +65,15 @@ public class WebsocketProducer extends DefaultProducer implements WebsocketProdu
 
 
     @Override
-    public void start() throws Exception {
-        super.start();
+    public void doStart() throws Exception {
+        super.doStart();
         endpoint.connect(this);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         endpoint.disconnect(this);
-        super.stop();
+        super.doStop();
     }
 
     boolean isSendToAllSet(Message in) {


### PR DESCRIPTION
Modified the timing the Jetty connector is added and removed.

Existing functionality of calling connect/disconnect methods on component from endpoint is involved multiple times. This causes the number of references to a single connector to be incorrectly calculated. This resulted in the connector from being removed too early causing the endpoint from being available or not being removed at all. This resulted in the embedded jetty server to not shut down if the context was destroyed. If the context was started once again, the embedded jetty server would still be active and a bind error would occur.