### PR TITLE
CAMEL-9084: Fixed AdviceWithRouteBuilder's remove with selectLast

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/AdviceWithBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/AdviceWithBuilder.java
@@ -149,7 +149,7 @@ public class AdviceWithBuilder<T extends ProcessorDefinition<?>> {
         } else if (toString != null) {
             builder.getAdviceWithTasks().add(AdviceWithTasks.removeByToString(route, toString, selectLast, selectFirst, selectFrom, selectTo, maxDeep));
         } else if (type != null) {
-            builder.getAdviceWithTasks().add(AdviceWithTasks.removeByType(route, type, selectFirst, selectFirst, selectFrom, selectTo, maxDeep));
+            builder.getAdviceWithTasks().add(AdviceWithTasks.removeByType(route, type, selectFirst, selectLast, selectFrom, selectTo, maxDeep));
         }
     }
 


### PR DESCRIPTION
The remove implementation wrongfully passed the selectFirst value for the selectLast parameter