### PR TITLE
CAMEL-8961: Upgrade Docker component to docker-java 1.4.0 and reenabled unit tests

### DIFF
--- a/components/camel-docker/README.md
+++ b/components/camel-docker/README.md
@@ -45,6 +45,7 @@ The following are the the primary options for communicating with the Docker serv
 | Operation | Options | Description  | Produces |
 | ------------- | ---------------- | ------------- | ---------------- |
 |events| initialRange | Amount of time in the past to begin receiving events (Long) | Event |
+|statistics| **containerId** | Statistics based on resource usage | Statistics |
 
 ## Producer Operations
 
@@ -80,7 +81,7 @@ The following producer operations are available
 | container/attach | **containerId**, followStream, logs, stdErr, stdOut, timestamps  | Attach to a container | | InputStream |
 | container/commit | **containerId**, author, attachStdErr, attachStdIn, attachStdOut, cmd, disableNetwork, env, exposedPorts, hostname, memory, memorySwap, message, openStdIn, pause, portSpecs, repository, stdInOnce, tag, tty, user, volumes, workingDir | Create a new image from a container's changes | | String |
 | container/copyfile | **containerId**, **resource**, hostPath | Copy files or folders from a container | | InputStream |
-| container/create | **image**, attachStdErr, attachStdIn, attachStdOut, capAdd, capDrop, cmd, cpuShares, disableNetwork, dns, entrypoint, env, exposedPorts, hostConfig, hostname, memoryLimit, memorySwap, name, portSpecs, stdInOnce, stdInOpen, tty, user, volumes, volumesFrom, workingDir | Create a container |  |CreateContainerResponse |
+| container/create | **image**, attachStdErr, attachStdIn, attachStdOut, capAdd, capDrop, cmd, cpuShares, disableNetwork, dns, domanName, entrypoint, env, exposedPorts, hostConfig, hostname, memoryLimit, memorySwap, name, portSpecs, stdInOnce, stdInOpen, tty, user, volumes, volumesFrom, workingDir | Create a container |  |CreateContainerResponse |
 | container/diff | **containerId**, containerIdDiff | Differences on the container filesystem | | List&lt;ChangeLog&gt; |
 | container/inspect | **containerId** | Inspect a container  | | InspectContainerResponse |
 | container/kill | **containerId**, signal | Kill a container | | |
@@ -89,7 +90,7 @@ The following producer operations are available
 | container/pause | **containerId** | Pause a container | | |
 | container/remove | **containerId**, force, removeVolumes | Remove a container | | |
 | container/restart | **containerId**, timeout | Restart a container | |
-| container/start | **containerId**, binds, capAdd, capDrop, devices, dns, dnsSearch, links, lxcConf, networkMode, portBindings, privileged, publishAllPorts, restartPolicy, volumesFrom | Start a container | | |
+| container/start | **containerId** | Start a container | | |
 | container/stop | **containerId**, timeout | Stop a container | |
 | container/top | **containerId**, psArgs | List processes running in a container | |TopContainerResponse |
 | container/unpause | **containerId** | Unpause a container | | |

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConstants.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerConstants.java
@@ -194,6 +194,7 @@ public final class DockerConstants {
     public static final String DOCKER_MEMORY_LIMIT = "CamelDockerMemoryLimit";
     public static final String DOCKER_STD_IN_OPEN = "CamelDockerStdInOpen";
     public static final String DOCKER_VOLUMES_FROM = "CamelDockerVolumesFrom";
+    public static final String DOCKER_DOMAIN_NAME = "CamelDockerDomainName";
 
 
     /**

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerEndpoint.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerEndpoint.java
@@ -20,6 +20,7 @@ import org.apache.camel.Consumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.component.docker.consumer.DockerEventsConsumer;
+import org.apache.camel.component.docker.consumer.DockerStatsConsumer;
 import org.apache.camel.component.docker.exception.DockerException;
 import org.apache.camel.component.docker.producer.DockerProducer;
 import org.apache.camel.impl.DefaultEndpoint;
@@ -64,6 +65,8 @@ public class DockerEndpoint extends DefaultEndpoint {
         switch (operation) {
         case EVENTS:
             return new DockerEventsConsumer(this, processor);
+        case STATS:
+            return new DockerStatsConsumer(this, processor);
         default:
             throw new DockerException(operation + " is not a valid consumer operation");
         }

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerOperation.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/DockerOperation.java
@@ -32,6 +32,12 @@ public enum DockerOperation {
             DockerConstants.DOCKER_INITIAL_RANGE, Long.class),
 
     /**
+     * Stats *
+     */
+    STATS("stats", false, true,
+            DockerConstants.DOCKER_CONTAINER_ID, Long.class),
+
+    /**
      * General *
      */
     AUTH("auth", false, true,
@@ -125,6 +131,7 @@ public enum DockerOperation {
             DockerConstants.DOCKER_CPU_SHARES, Integer.class,
             DockerConstants.DOCKER_DISABLE_NETWORK, Boolean.class,
             DockerConstants.DOCKER_DNS, String.class,
+            DockerConstants.DOCKER_DOMAIN_NAME, String.class,
             DockerConstants.DOCKER_ENTRYPOINT, String.class,
             DockerConstants.DOCKER_ENV, String.class,
             DockerConstants.DOCKER_EXPOSED_PORTS, String.class,
@@ -171,22 +178,7 @@ public enum DockerOperation {
             DockerConstants.DOCKER_FORCE, Boolean.class,
             DockerConstants.DOCKER_REMOVE_VOLUMES, Boolean.class),
     START_CONTAINER("containerstart", false, true,
-            DockerConstants.DOCKER_BINDS, String.class,
-            DockerConstants.DOCKER_CAP_ADD, String.class,
-            DockerConstants.DOCKER_CAP_DROP, String.class,
-            DockerConstants.DOCKER_CONTAINER_ID, String.class,
-            DockerConstants.DOCKER_DEVICES, String.class,
-            DockerConstants.DOCKER_DNS_SEARCH, String.class,
-            DockerConstants.DOCKER_DNS, String.class,
-            DockerConstants.DOCKER_LINKS, String.class,
-            DockerConstants.DOCKER_LXC_CONF, String.class,
-            DockerConstants.DOCKER_NETWORK_MODE, String.class,
-            DockerConstants.DOCKER_PORTS, String.class,
-            DockerConstants.DOCKER_PORT_BINDINGS, String.class,
-            DockerConstants.DOCKER_PRIVILEGED, Boolean.class,
-            DockerConstants.DOCKER_PUBLISH_ALL_PORTS, Boolean.class,
-            DockerConstants.DOCKER_RESTART_POLICY, String.class,
-            DockerConstants.DOCKER_VOLUMES_FROM, String.class),
+            DockerConstants.DOCKER_CONTAINER_ID, String.class),
     STOP_CONTAINER("containerstop", false, true,
             DockerConstants.DOCKER_CONTAINER_ID, String.class,
             DockerConstants.DOCKER_TIMEOUT, Integer.class),

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerStatsConsumer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerStatsConsumer.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.consumer;
+
+import java.util.concurrent.ExecutorService;
+
+import com.github.dockerjava.api.command.StatsCallback;
+import com.github.dockerjava.api.command.StatsCmd;
+import com.github.dockerjava.api.model.Statistics;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.component.docker.DockerClientFactory;
+import org.apache.camel.component.docker.DockerComponent;
+import org.apache.camel.component.docker.DockerConstants;
+import org.apache.camel.component.docker.DockerEndpoint;
+import org.apache.camel.component.docker.DockerHelper;
+import org.apache.camel.impl.DefaultConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Docker Consumer for streaming statistical events
+ */
+public class DockerStatsConsumer extends DefaultConsumer implements StatsCallback {
+
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(DockerStatsConsumer.class);
+
+    private DockerEndpoint endpoint;
+
+    private DockerComponent component;
+
+    private StatsCmd statsCmd;
+
+    private ExecutorService eventsExecutorService;
+
+    public DockerStatsConsumer(DockerEndpoint endpoint, Processor processor) throws Exception {
+        super(endpoint, processor);
+        this.endpoint = endpoint;
+        this.component = (DockerComponent) endpoint.getComponent();
+
+    }
+
+    @Override
+    public DockerEndpoint getEndpoint() {
+        return (DockerEndpoint) super.getEndpoint();
+    }
+
+
+
+    @Override
+    protected void doStart() throws Exception {
+
+        statsCmd = DockerClientFactory.getDockerClient(component, endpoint.getConfiguration(), null).statsCmd(this);
+
+        String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID, endpoint.getConfiguration(), null, String.class);
+
+        statsCmd.withContainerId(containerId);
+        
+        eventsExecutorService = statsCmd.exec();
+
+        super.doStart();
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+
+        if (eventsExecutorService != null && !eventsExecutorService.isTerminated()) {
+            LOGGER.trace("Stopping Docker statistics Executor Service");
+
+            eventsExecutorService.shutdown();
+        }
+
+        super.doStop();
+    }
+
+
+    @Override
+    public void onStats(Statistics statistics) {
+
+        LOGGER.debug("Received Docker Statistics Event: " + statistics);
+
+        final Exchange exchange = getEndpoint().createExchange();
+        Message message = exchange.getIn();
+        message.setBody(statistics);
+
+        try {
+            LOGGER.trace("Processing exchange [{}]...", exchange);
+            getAsyncProcessor().process(exchange, new AsyncCallback() {
+                @Override
+                public void done(boolean doneSync) {
+                    LOGGER.trace("Done processing exchange [{}]...", exchange);
+                }
+            });
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+        if (exchange.getException() != null) {
+            getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
+        }
+
+    }
+
+    @Override
+    public void onException(Throwable throwable) {
+        LOGGER.error("Error Consuming from Docker Statistics: {}", throwable.getMessage());
+    }
+
+    @Override
+    public void onCompletion(int numEvents) {
+
+        LOGGER.debug("Docker statistics connection completed. Events processed : {}", numEvents);
+
+        statsCmd.exec();
+
+    }
+
+    @Override
+    public boolean isReceiving() {
+        return isRunAllowed();
+    }
+}

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
@@ -54,17 +54,10 @@ import com.github.dockerjava.api.command.UnpauseContainerCmd;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Capability;
-import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.api.model.LxcConf;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.Volumes;
 import com.github.dockerjava.api.model.VolumesFrom;
@@ -908,6 +901,12 @@ public class DockerProducer extends DefaultProducer {
         if (dns != null) {
             createContainerCmd.withDns(dns);
         }
+        
+        String domainName = DockerHelper.getProperty(DockerConstants.DOCKER_DOMAIN_NAME, configuration, message, String.class);
+
+        if (domainName != null) {
+            createContainerCmd.withDomainName(domainName);
+        }
 
         String[] env = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_ENV, message);
 
@@ -1285,96 +1284,6 @@ public class DockerProducer extends DefaultProducer {
         ObjectHelper.notNull(containerId, "Container ID must be specified");
 
         StartContainerCmd startContainerCmd = client.startContainerCmd(containerId);
-
-        Bind[] binds = DockerHelper.getArrayProperty(DockerConstants.DOCKER_BINDS, message, Bind.class);
-
-        if (binds != null) {
-            startContainerCmd.withBinds(binds);
-        }
-
-        Capability[] capAdd = DockerHelper.getArrayProperty(DockerConstants.DOCKER_CAP_ADD, message, Capability.class);
-
-        if (capAdd != null) {
-            startContainerCmd.withCapAdd(capAdd);
-        }
-
-        Capability[] capDrop = DockerHelper.getArrayProperty(DockerConstants.DOCKER_CAP_DROP, message, Capability.class);
-
-        if (capDrop != null) {
-            startContainerCmd.withCapDrop(capDrop);
-        }
-
-        Device[] devices = DockerHelper.getArrayProperty(DockerConstants.DOCKER_DEVICES, message, Device.class);
-
-        if (devices != null) {
-            startContainerCmd.withDevices(devices);
-        }
-
-        String[] dns = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_DNS, message);
-
-        if (dns != null) {
-            startContainerCmd.withDns(dns);
-        }
-
-        String[] dnsSearch = DockerHelper.parseDelimitedStringHeader(DockerConstants.DOCKER_DNS_SEARCH, message);
-
-        if (dnsSearch != null) {
-            startContainerCmd.withDnsSearch(dnsSearch);
-        }
-
-        Link[] links = DockerHelper.getArrayProperty(DockerConstants.DOCKER_LINKS, message, Link.class);
-
-        if (links != null) {
-            startContainerCmd.withLinks(links);
-        }
-
-        LxcConf[] lxcConf = DockerHelper.getArrayProperty(DockerConstants.DOCKER_LXC_CONF, message, LxcConf.class);
-
-        if (lxcConf != null) {
-            startContainerCmd.withLxcConf(lxcConf);
-        }
-
-        String networkMode = DockerHelper.getProperty(DockerConstants.DOCKER_NETWORK_MODE, configuration, message, String.class);
-
-        if (networkMode != null) {
-            startContainerCmd.withNetworkMode(networkMode);
-        }
-
-        Ports ports = DockerHelper.getProperty(DockerConstants.DOCKER_PORTS, configuration, message, Ports.class);
-
-        if (ports != null) {
-            startContainerCmd.withPortBindings(ports);
-        }
-
-        PortBinding[] portBinding = DockerHelper.getArrayProperty(DockerConstants.DOCKER_PORT_BINDINGS, message, PortBinding.class);
-
-        if (portBinding != null) {
-            startContainerCmd.withPortBindings(portBinding);
-        }
-
-        Boolean privileged = DockerHelper.getProperty(DockerConstants.DOCKER_PRIVILEGED, configuration, message, Boolean.class);
-
-        if (privileged != null) {
-            startContainerCmd.withPrivileged(privileged);
-        }
-
-        Boolean publishAllPorts = DockerHelper.getProperty(DockerConstants.DOCKER_PUBLISH_ALL_PORTS, configuration, message, Boolean.class);
-
-        if (publishAllPorts != null) {
-            startContainerCmd.withPublishAllPorts(publishAllPorts);
-        }
-
-        RestartPolicy restartPolicy = DockerHelper.getProperty(DockerConstants.DOCKER_RESTART_POLICY, configuration, message, RestartPolicy.class);
-
-        if (restartPolicy != null) {
-            startContainerCmd.withRestartPolicy(restartPolicy);
-        }
-
-        String volumesFrom = DockerHelper.getProperty(DockerConstants.DOCKER_VOLUMES_FROM, configuration, message, String.class);
-
-        if (volumesFrom != null) {
-            startContainerCmd.withVolumesFrom(volumesFrom);
-        }
 
         return startContainerCmd;
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerEventsConsumerTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerEventsConsumerTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.util.concurrent.TimeUnit;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.EventCallback;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.model.Event;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.docker.util.DockerTestUtils;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Consumer test for events on Docker Platform
+ */
+@RunWith(PowerMockRunner.class)
+public class DockerEventsConsumerTest extends CamelTestSupport {
+
+    private String host = "localhost";
+    private Integer port = 2375;
+    private EventCallback callback;
+
+    private DockerConfiguration dockerConfiguration;
+    
+    @Mock
+    private EventsCmd eventsCmd;
+    
+    @Mock
+    private DockerClient dockerClient;
+    
+    public void setupMocks() {
+        Mockito.when(dockerClient.eventsCmd(Mockito.any(EventCallback.class))).thenAnswer(new Answer<EventsCmd>() {
+            public EventsCmd answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                callback = (EventCallback)args[0];
+                return eventsCmd;
+            }
+        });
+        
+      
+    }
+
+    @Test
+    public void testEvent() throws Exception {
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMinimumMessageCount(1);
+
+        callback.onEvent(new Event());
+                
+        assertMockEndpointsSatisfied(10, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("docker://events?host=" + host + "&port=" + port)
+                        .log("${body}")
+                        .to("mock:result");
+            }
+        };
+    }
+    
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        dockerConfiguration = new DockerConfiguration();
+        dockerConfiguration.setParameters(DockerTestUtils.getDefaultParameters(host, port, dockerConfiguration));
+
+        DockerComponent dockerComponent = new DockerComponent(dockerConfiguration);
+        dockerComponent.setClient(DockerTestUtils.getClientProfile(host, port, dockerConfiguration), dockerClient);
+        camelContext.addComponent("docker", dockerComponent);
+
+        setupMocks();
+        
+        return camelContext;
+    }
+ 
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerStatsConsumerTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerStatsConsumerTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker;
+
+import java.util.concurrent.TimeUnit;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.StatsCallback;
+import com.github.dockerjava.api.command.StatsCmd;
+import com.github.dockerjava.api.model.Statistics;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.docker.util.DockerTestUtils;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+/**
+ * Consumer test for statistics on Docker Platform
+ */
+@RunWith(PowerMockRunner.class)
+public class DockerStatsConsumerTest extends CamelTestSupport {
+
+    private String host = "localhost";
+    private Integer port = 2375;
+    private String containerId = "470b9b823e6c";
+    private StatsCallback callback;
+    
+    private DockerConfiguration dockerConfiguration;
+    
+    @Mock
+    private StatsCmd statsCmd;
+    
+    @Mock
+    private DockerClient dockerClient;
+
+    public void setupMocks() {
+        Mockito.when(dockerClient.statsCmd(Mockito.any(StatsCallback.class))).thenAnswer(new Answer<StatsCmd>() {
+            public StatsCmd answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                callback = (StatsCallback)args[0];
+                return statsCmd;
+            }
+        });
+        
+      
+    }
+
+    @Test
+    public void testStats() throws Exception {
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMinimumMessageCount(1);
+
+        callback.onStats(new Statistics());
+                
+        assertMockEndpointsSatisfied(10, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("docker://stats?host=" + host + "&port=" + port + "&containerId=" + containerId)
+                        .log("${body}")
+                        .to("mock:result");
+            }
+        };
+    }
+    
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        dockerConfiguration = new DockerConfiguration();
+        dockerConfiguration.setParameters(DockerTestUtils.getDefaultParameters(host, port, dockerConfiguration));
+
+        DockerComponent dockerComponent = new DockerComponent(dockerConfiguration);
+        dockerComponent.setClient(DockerTestUtils.getClientProfile(host, port, dockerConfiguration), dockerClient);
+        camelContext.addComponent("docker", dockerComponent);
+
+        setupMocks();
+        
+        return camelContext;
+    }
+ 
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.AttachContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class AttachContainerCmdHeaderTest extends BaseDockerHeaderTest<AttachCon
     @Mock
     private AttachContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void attachContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AuthCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AuthCmdHeaderTest.java
@@ -24,7 +24,6 @@ import com.github.dockerjava.api.model.AuthConfig;
 import org.apache.camel.component.docker.DockerClientProfile;
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -42,7 +41,6 @@ public class AuthCmdHeaderTest extends BaseDockerHeaderTest<AuthCmd> {
     private String email = "jdoe@example.com";
     private String serverAddress = "http://docker.io/v1";
 
-    @Ignore
     @Test
     public void authHeaderTest() {
         String userName = "jdoe";

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
@@ -101,6 +101,10 @@ public abstract class BaseDockerHeaderTest<T> extends CamelTestSupport {
         return "https://index.docker.io/v1/";
     }
 
+    public boolean isSecure() {
+        return false;
+    }
+
     public T getMockObject() {
         return mockObject;
     }
@@ -135,9 +139,9 @@ public abstract class BaseDockerHeaderTest<T> extends CamelTestSupport {
         clientProfile.setServerAddress(getServerAddress());
         clientProfile.setMaxPerRouteConnections(getMaxPerRouteConnections());
         clientProfile.setMaxTotalConnections(getMaxTotalConnections());
-        clientProfile.setLoggingFilter(false);
-        clientProfile.setFollowRedirectFilter(false);
-
+        clientProfile.setLoggingFilter(getLoggingFilter());
+        clientProfile.setFollowRedirectFilter(getFollowRedirectFilter());
+        clientProfile.setSecure(isSecure());
         return clientProfile;
 
     }

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BuildImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BuildImageCmdHeaderTest.java
@@ -25,7 +25,6 @@ import com.github.dockerjava.api.command.BuildImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -51,7 +50,6 @@ public class BuildImageCmdHeaderTest extends BaseDockerHeaderTest<BuildImageCmd>
     private boolean remove = true;
     private String tag = "1.0";
 
-    @Ignore
     @Test
     public void buildImageFromInputStreamHeaderTest() {
 
@@ -65,7 +63,6 @@ public class BuildImageCmdHeaderTest extends BaseDockerHeaderTest<BuildImageCmd>
 
     }
 
-    @Ignore
     @Test
     public void buildImageFromFileHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CommitContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CommitContainerCmdHeaderTest.java
@@ -26,7 +26,6 @@ import com.github.dockerjava.api.model.Volumes;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -41,7 +40,6 @@ public class CommitContainerCmdHeaderTest extends BaseDockerHeaderTest<CommitCmd
     @Mock
     private CommitCmd mockObject;
 
-    @Ignore
     @Test
     public void commitContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CopyFileContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CopyFileContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class CopyFileContainerCmdHeaderTest extends BaseDockerHeaderTest<CopyFil
     @Mock
     private CopyFileFromContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void copyFileFromContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateContainerCmdHeaderTest.java
@@ -27,7 +27,6 @@ import com.github.dockerjava.api.model.VolumesFrom;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -42,7 +41,6 @@ public class CreateContainerCmdHeaderTest extends BaseDockerHeaderTest<CreateCon
     @Mock
     private CreateContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void createContainerHeaderTest() {
 
@@ -52,6 +50,7 @@ public class CreateContainerCmdHeaderTest extends BaseDockerHeaderTest<CreateCon
         String name = "cameldocker";
         String workingDir = "/opt";
         boolean disableNetwork = false;
+        String domainName = "apache.org";
         String hostname = "dockerjava";
         String user = "docker";
         boolean stdInOpen = false;
@@ -101,6 +100,7 @@ public class CreateContainerCmdHeaderTest extends BaseDockerHeaderTest<CreateCon
         headers.put(DockerConstants.DOCKER_ENTRYPOINT, entrypoint);
         headers.put(DockerConstants.DOCKER_PORT_SPECS, portSpecs);
         headers.put(DockerConstants.DOCKER_DNS, dns);
+        headers.put(DockerConstants.DOCKER_DOMAIN_NAME, domainName);
 
 
         template.sendBodyAndHeaders("direct:in", "", headers);
@@ -131,6 +131,8 @@ public class CreateContainerCmdHeaderTest extends BaseDockerHeaderTest<CreateCon
         Mockito.verify(mockObject, Mockito.times(1)).withEntrypoint(entrypoint);
         Mockito.verify(mockObject, Mockito.times(1)).withPortSpecs(portSpecs);
         Mockito.verify(mockObject, Mockito.times(1)).withDns(dns);
+        Mockito.verify(mockObject, Mockito.times(1)).withDomainName(domainName);
+
 
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/CreateImageCmdHeaderTest.java
@@ -23,7 +23,6 @@ import com.github.dockerjava.api.command.CreateImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -40,7 +39,6 @@ public class CreateImageCmdHeaderTest extends BaseDockerHeaderTest<CreateImageCm
     @Mock
     private InputStream inputStream;
 
-    @Ignore
     @Test
     public void createImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/DiffContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/DiffContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.ContainerDiffCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class DiffContainerCmdHeaderTest extends BaseDockerHeaderTest<ContainerDi
     @Mock
     private ContainerDiffCmd mockObject;
 
-    @Ignore
     @Test
     public void containerDiffHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecCreateCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecCreateCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.ExecCreateCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class ExecCreateCmdHeaderTest extends BaseDockerHeaderTest<ExecCreateCmd>
     @Mock
     private ExecCreateCmd mockObject;
 
-    @Ignore
     @Test
     public void execCreateHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecStartCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecStartCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.ExecStartCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class ExecStartCmdHeaderTest extends BaseDockerHeaderTest<ExecStartCmd> {
     @Mock
     private ExecStartCmd mockObject;
 
-    @Ignore
     @Test
     public void execCreateHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InfoCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InfoCmdHeaderTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import com.github.dockerjava.api.command.InfoCmd;
 
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -34,7 +33,6 @@ public class InfoCmdHeaderTest extends BaseDockerHeaderTest<InfoCmd> {
     @Mock
     private InfoCmd mockObject;
 
-    @Ignore
     @Test
     public void infoHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.InspectContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class InspectContainerCmdHeaderTest extends BaseDockerHeaderTest<InspectC
     @Mock
     private InspectContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void inspectContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/InspectImageCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.InspectImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class InspectImageCmdHeaderTest extends BaseDockerHeaderTest<InspectImage
     @Mock
     private InspectImageCmd mockObject;
 
-    @Ignore
     @Test
     public void listImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/KillContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/KillContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.KillContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class KillContainerCmdHeaderTest extends BaseDockerHeaderTest<KillContain
     @Mock
     private KillContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void stopContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListContainersCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListContainersCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.ListContainersCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class ListContainersCmdHeaderTest extends BaseDockerHeaderTest<ListContai
     @Mock
     private ListContainersCmd mockObject;
 
-    @Ignore
     @Test
     public void listContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListImagesCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ListImagesCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.ListImagesCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -37,7 +36,6 @@ public class ListImagesCmdHeaderTest extends BaseDockerHeaderTest<ListImagesCmd>
     @Mock
     private ListImagesCmd mockObject;
 
-    @Ignore
     @Test
     public void listImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.LogContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class LogContainerCmdHeaderTest extends BaseDockerHeaderTest<LogContainer
     @Mock
     private LogContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void logContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PauseContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PauseContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.PauseContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class PauseContainerCmdHeaderTest extends BaseDockerHeaderTest<PauseConta
     @Mock
     private PauseContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void pauseHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PingCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PingCmdHeaderTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import com.github.dockerjava.api.command.PingCmd;
 
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -34,7 +33,6 @@ public class PingCmdHeaderTest extends BaseDockerHeaderTest<PingCmd> {
     @Mock
     private PingCmd mockObject;
 
-    @Ignore
     @Test
     public void pingHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.PullImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class PullImageCmdHeaderTest extends BaseDockerHeaderTest<PullImageCmd> {
     @Mock
     private PullImageCmd mockObject;
 
-    @Ignore
     @Test
     public void pullImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
@@ -23,7 +23,6 @@ import com.github.dockerjava.api.command.PushImageCmd;
 import org.apache.camel.component.docker.DockerClientProfile;
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -44,7 +43,6 @@ public class PushImageCmdHeaderTest extends BaseDockerHeaderTest<PushImageCmd> {
     private String name = "imagename";
     private String tag = "1.0";
 
-    @Ignore
     @Test
     public void pushImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.RemoveContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class RemoveContainerCmdHeaderTest extends BaseDockerHeaderTest<RemoveCon
     @Mock
     private RemoveContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void removeContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RemoveImageCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.RemoveImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class RemoveImageCmdHeaderTest extends BaseDockerHeaderTest<RemoveImageCm
     @Mock
     private RemoveImageCmd mockObject;
 
-    @Ignore
     @Test
     public void removeImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RestartContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/RestartContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.RestartContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class RestartContainerCmdHeaderTest extends BaseDockerHeaderTest<RestartC
     @Mock
     private RestartContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void restartContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/SearchImagesCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/SearchImagesCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class SearchImagesCmdHeaderTest extends BaseDockerHeaderTest<SearchImages
     @Mock
     private SearchImagesCmd mockObject;
 
-    @Ignore
     @Test
     public void searchImagesHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StartContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StartContainerCmdHeaderTest.java
@@ -32,7 +32,6 @@ import com.github.dockerjava.api.model.Volume;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -49,64 +48,17 @@ public class StartContainerCmdHeaderTest extends BaseDockerHeaderTest<StartConta
     @Mock
     private StartContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void startContainerHeaderTest() {
 
         String containerId = "be29975e0098";
-        Volume vol = new Volume("/opt/webapp1");
-        Bind[] binds = new Bind[]{new Bind("/opt/webapp1", vol)};
-        boolean publishAllPorts = false;
-        boolean privileged = false;
-        String[] dns = new String[]{"8.8.8.8"};
-        Link[] links = new Link[]{new Link("container1", "container1Link")};
-        String networkMode = "host";
-        LxcConf[] lxcConf = new LxcConf[]{new LxcConf()};
-        String volumesFromContainer = "container2";
-        Capability capAdd = Capability.NET_BROADCAST;
-        Capability capDrop = Capability.BLOCK_SUSPEND;
-        Device[] devices = new Device[]{new Device("rwm", "/dev/nulo", "/dev/zero")};
-        RestartPolicy restartPolicy = RestartPolicy.noRestart();
-        PortBinding[] portBindings = new PortBinding[]{new PortBinding(Ports.Binding(28768), ExposedPort.tcp(22))};
-        Ports ports = new Ports(ExposedPort.tcp(22), Ports.Binding(11022));
 
         Map<String, Object> headers = getDefaultParameters();
         headers.put(DockerConstants.DOCKER_CONTAINER_ID, containerId);
-        headers.put(DockerConstants.DOCKER_BINDS, binds);
-        headers.put(DockerConstants.DOCKER_PUBLISH_ALL_PORTS, publishAllPorts);
-        headers.put(DockerConstants.DOCKER_PRIVILEGED, privileged);
-        headers.put(DockerConstants.DOCKER_DNS, dns);
-        headers.put(DockerConstants.DOCKER_DNS_SEARCH, dns);
-        headers.put(DockerConstants.DOCKER_LINKS, links);
-        headers.put(DockerConstants.DOCKER_NETWORK_MODE, networkMode);
-        headers.put(DockerConstants.DOCKER_LXC_CONF, lxcConf);
-        headers.put(DockerConstants.DOCKER_VOLUMES_FROM, volumesFromContainer);
-        headers.put(DockerConstants.DOCKER_CAP_ADD, capAdd);
-        headers.put(DockerConstants.DOCKER_CAP_DROP, capDrop);
-        headers.put(DockerConstants.DOCKER_DEVICES, devices);
-        headers.put(DockerConstants.DOCKER_RESTART_POLICY, restartPolicy);
-        headers.put(DockerConstants.DOCKER_PORT_BINDINGS, portBindings);
-        headers.put(DockerConstants.DOCKER_PORTS, ports);
-
 
         template.sendBodyAndHeaders("direct:in", "", headers);
 
         Mockito.verify(dockerClient, Mockito.times(1)).startContainerCmd(containerId);
-        Mockito.verify(mockObject, Mockito.times(1)).withBinds(binds);
-        Mockito.verify(mockObject, Mockito.times(1)).withPublishAllPorts(publishAllPorts);
-        Mockito.verify(mockObject, Mockito.times(1)).withPrivileged(privileged);
-        Mockito.verify(mockObject, Mockito.times(1)).withDns(dns);
-        Mockito.verify(mockObject, Mockito.times(1)).withDnsSearch(dns);
-        Mockito.verify(mockObject, Mockito.times(1)).withLinks(links);
-        Mockito.verify(mockObject, Mockito.times(1)).withNetworkMode(networkMode);
-        Mockito.verify(mockObject, Mockito.times(1)).withLxcConf(lxcConf);
-        Mockito.verify(mockObject, Mockito.times(1)).withVolumesFrom(volumesFromContainer);
-        Mockito.verify(mockObject, Mockito.times(1)).withCapAdd(capAdd);
-        Mockito.verify(mockObject, Mockito.times(1)).withCapDrop(capDrop);
-        Mockito.verify(mockObject, Mockito.times(1)).withDevices(devices);
-        Mockito.verify(mockObject, Mockito.times(1)).withRestartPolicy(restartPolicy);
-        Mockito.verify(mockObject, Mockito.times(1)).withPortBindings(portBindings);
-        Mockito.verify(mockObject, Mockito.times(1)).withPortBindings(ports);
 
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StopContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/StopContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.StopContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class StopContainerCmdHeaderTest extends BaseDockerHeaderTest<StopContain
     @Mock
     private StopContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void stopContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TagImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TagImageCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.TagImageCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class TagImageCmdHeaderTest extends BaseDockerHeaderTest<TagImageCmd> {
     @Mock
     private TagImageCmd mockObject;
 
-    @Ignore
     @Test
     public void tagImageHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TopContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/TopContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.TopContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class TopContainerCmdHeaderTest extends BaseDockerHeaderTest<TopContainer
     @Mock
     private TopContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void topContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/UnpauseContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/UnpauseContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.UnpauseContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class UnpauseContainerCmdHeaderTest extends BaseDockerHeaderTest<UnpauseC
     @Mock
     private UnpauseContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void unpauseHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/VersionCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/VersionCmdHeaderTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import com.github.dockerjava.api.command.VersionCmd;
 
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -34,7 +33,6 @@ public class VersionCmdHeaderTest extends BaseDockerHeaderTest<VersionCmd> {
     @Mock
     private VersionCmd mockObject;
 
-    @Ignore
     @Test
     public void pingHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/WaitContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/WaitContainerCmdHeaderTest.java
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.command.WaitContainerCmd;
 
 import org.apache.camel.component.docker.DockerConstants;
 import org.apache.camel.component.docker.DockerOperation;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -36,7 +35,6 @@ public class WaitContainerCmdHeaderTest extends BaseDockerHeaderTest<WaitContain
     @Mock
     private WaitContainerCmd mockObject;
 
-    @Ignore
     @Test
     public void waitContainerHeaderTest() {
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/it/DockerStatsConsumerTestIT.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/it/DockerStatsConsumerTestIT.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.it;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+/**
+ * Integration test consuming statistics on Docker Platform
+ */
+public class DockerStatsConsumerTestIT extends CamelTestSupport {
+
+    private String host = "192.168.59.103";
+    private String port = "2376";
+    private String containerId = "470b9b823e6c";
+
+    @Test
+    public void testDocker() throws Exception {
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMinimumMessageCount(1);
+
+        assertMockEndpointsSatisfied(60, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("docker://stats?host=" + host + "&port=" + port + "&certPath=/Users/cameluser/.docker/boot2docker-vm&secure=true&containerId=" + containerId)
+                        .log("${body}")
+                        .to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/util/DockerTestUtils.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/util/DockerTestUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.docker.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.component.docker.DockerClientProfile;
+import org.apache.camel.component.docker.DockerConfiguration;
+import org.apache.camel.component.docker.DockerConstants;
+
+public final class DockerTestUtils {
+    
+    private DockerTestUtils() {
+        
+    }
+    
+    public static Map<String, Object> getDefaultParameters(String host, Integer port, DockerConfiguration dockerConfiguration) {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put(DockerConstants.DOCKER_HOST, host);
+        parameters.put(DockerConstants.DOCKER_PORT, port);
+        parameters.put(DockerConstants.DOCKER_EMAIL, dockerConfiguration.getEmail());
+        parameters.put(DockerConstants.DOCKER_SERVER_ADDRESS, dockerConfiguration.getServerAddress());
+        parameters.put(DockerConstants.DOCKER_MAX_PER_ROUTE_CONNECTIONS, dockerConfiguration.getMaxPerRouteConnections());
+        parameters.put(DockerConstants.DOCKER_MAX_TOTAL_CONNECTIONS, dockerConfiguration.getMaxTotalConnections());
+        parameters.put(DockerConstants.DOCKER_LOGGING_FILTER, false);
+        parameters.put(DockerConstants.DOCKER_FOLLOW_REDIRECT_FILTER, false);
+
+        return parameters;
+    }
+
+    public static DockerClientProfile getClientProfile(String host, Integer port, DockerConfiguration dockerConfiguration) {
+        DockerClientProfile clientProfile = new DockerClientProfile();
+        clientProfile.setHost(host);
+        clientProfile.setPort(port);
+        clientProfile.setEmail(dockerConfiguration.getEmail());
+        clientProfile.setServerAddress(dockerConfiguration.getServerAddress());
+        clientProfile.setMaxPerRouteConnections(dockerConfiguration.getMaxPerRouteConnections());
+        clientProfile.setMaxTotalConnections(dockerConfiguration.getMaxTotalConnections());
+        clientProfile.setLoggingFilter(false);
+        clientProfile.setFollowRedirectFilter(false);
+        clientProfile.setSecure(false);
+        return clientProfile;
+
+    }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -132,8 +132,8 @@
     <disruptor-version>3.3.2</disruptor-version>
     <dnsjava-version>2.1.7</dnsjava-version>
     <dnsjava-bundle-version>2.1.7_1</dnsjava-bundle-version>
-    <docker-java-version>1.3.0</docker-java-version>
-    <docker-bundle-version>1.3.0_1</docker-bundle-version>
+    <docker-java-version>1.4.0</docker-java-version>
+    <docker-bundle-version>1.4.0_1</docker-bundle-version>
     <dom4j-bundle-version>1.6.1_5</dom4j-bundle-version>
     <dozer-version>5.5.1</dozer-version>
     <drools-version>6.2.0.Final</drools-version>


### PR DESCRIPTION
Upgrades to Camel Docker component to support docker-java 1.4.0

* Removed deprecated start options
* Add Domainname attribute on create command
* Added ReadonlyRootfs option
* Labels are array of Strings
* Add docker stats support

Also reenabled unit tests that were failing on an earlier version of Java 7