### PR TITLE
Fix Endpoint URI for KafkProducer 

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -64,17 +64,21 @@ public class KafkaProducer<K, V> extends DefaultProducer {
     @Override
     @SuppressWarnings("unchecked")
     public void process(Exchange exchange) throws CamelException {
-        String topic = endpoint.getTopic();
-        if (!endpoint.isBridgeEndpoint()) {
-            topic = exchange.getIn().getHeader(KafkaConstants.TOPIC, endpoint.getTopic(), String.class);
-        }
-        if (topic == null) {
+    	
+    	// ensures that the factoried KafkaEndpoint topic UriParam is honored
+    	// when routing messages from one topic to another
+    	String topic = null;
+    	if ((topic = endpoint.getTopic()) == null)
+    		topic = exchange.getIn().getHeader(KafkaConstants.TOPIC, null, String.class);
+    	
+    	if (topic == null) {
             throw new CamelExchangeException("No topic key set", exchange);
         }
-        K partitionKey = (K) exchange.getIn().getHeader(KafkaConstants.PARTITION_KEY);
+    	
+        K partitionKey = (K) exchange.getIn().getHeader(KafkaConstants.PARTITION_KEY);        
         boolean hasPartitionKey = partitionKey != null;
 
-        K messageKey = (K) exchange.getIn().getHeader(KafkaConstants.KEY);
+        K messageKey = (K) exchange.getIn().getHeader(KafkaConstants.KEY);        
         boolean hasMessageKey = messageKey != null;
 
         V msg = (V) exchange.getIn().getBody();


### PR DESCRIPTION
When doing a route from Kafka topic to Kafka topic I noticed that functionality like:

```
from("kafka:localhost:9092?topic=from&zookeeperHost=localhost&groupId=mytest&zookeeperPort=2181&autoOffsetReset=smallest).to("kafka:localhost:9092?topic=to&zookeeperHost=localhost&groupId=mytest&zookeeperPort=2181);
```

did not work as the Exchange header of kafka.TOPIC was being used instead of the UriParam in the KafkaEndpoint for the producer.  