### PR TITLE
Feature/kafka deferred offset commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dependency-reduced-pom.xml
 id_file
 components/camel-solr/data
 *.epoch
+*.class
+bin/

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -60,6 +60,8 @@ public class KafkaConfiguration {
     @UriParam
     private Integer fetchMessageMaxBytes;
     @UriParam
+    private Boolean deferredCommitEnable=false;
+    @UriParam
     private Boolean autoCommitEnable;
     @UriParam
     private Integer autoCommitIntervalMs;
@@ -309,6 +311,15 @@ public class KafkaConfiguration {
 
     public void setFetchMessageMaxBytes(Integer fetchMessageMaxBytes) {
         this.fetchMessageMaxBytes = fetchMessageMaxBytes;
+    }
+    
+    
+    public Boolean isDeferredCommitEnabled() {
+    	return deferredCommitEnable;
+    }
+    
+    public void setDeferredCommitEnabled(Boolean deferred) {
+    	this.deferredCommitEnable = deferred;
     }
 
     public Boolean isAutoCommitEnable() {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
@@ -27,6 +27,7 @@ public final class KafkaConstants {
     public static final String PARTITION = "kafka.EXCHANGE_NAME";
     public static final String KEY = "kafka.CONTENT_TYPE";
     public static final String TOPIC = "kafka.TOPIC";
+    public static final String CONSUMER = "kafka.CONSUMER";
 
     public static final String KAFKA_DEFAULT_ENCODER = "kafka.serializer.DefaultEncoder";
     public static final String KAFKA_STRING_ENCODER = "kafka.serializer.StringEncoder";

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
@@ -27,6 +27,7 @@ import org.apache.camel.Message;
 import org.apache.camel.MultipleConsumersSupport;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
+import org.apache.camel.component.kafka.KafkaConfiguration;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.impl.DefaultExchange;
 import org.apache.camel.impl.DefaultMessage;
@@ -367,6 +368,10 @@ public class KafkaEndpoint extends DefaultEndpoint implements MultipleConsumersS
 
     public int getRebalanceMaxRetries() {
         return configuration.getRebalanceMaxRetries();
+    }
+    
+    public Boolean isDeferredCommitEnabled() {
+    	return configuration.isAutoCommitEnable();
     }
 
     public Boolean isAutoCommitEnable() {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -64,14 +64,21 @@ public class KafkaProducer<K, V> extends DefaultProducer {
     @Override
     @SuppressWarnings("unchecked")
     public void process(Exchange exchange) throws CamelException {
-        String topic = exchange.getIn().getHeader(KafkaConstants.TOPIC, endpoint.getTopic(), String.class);
-        if (topic == null) {
+    	
+    	// ensures that the factoried KafkaEndpoint topic UriParam is honored
+    	// when routing messages from one topic to another
+    	String topic = null;
+    	if ((topic = endpoint.getTopic()) == null)
+    		topic = exchange.getIn().getHeader(KafkaConstants.TOPIC, null, String.class);
+    	
+    	if (topic == null) {
             throw new CamelExchangeException("No topic key set", exchange);
         }
-        K partitionKey = (K) exchange.getIn().getHeader(KafkaConstants.PARTITION_KEY);
+    	
+        K partitionKey = (K) exchange.getIn().getHeader(KafkaConstants.PARTITION_KEY);        
         boolean hasPartitionKey = partitionKey != null;
 
-        K messageKey = (K) exchange.getIn().getHeader(KafkaConstants.KEY);
+        K messageKey = (K) exchange.getIn().getHeader(KafkaConstants.KEY);        
         boolean hasMessageKey = messageKey != null;
 
         V msg = (V) exchange.getIn().getBody();


### PR DESCRIPTION
Currently the Camel Kafka connect auto-commits or commits in batch based upon the countdown of a CyclicBarrier from the varying partitions as they await.  This pull request introduces the ability to defer the commit instead by barrier but by subsequent Processor invocations (e.g. a message is read, then transformed, routed to a new topic, and if the Producer is successful then a subsequent Processor can issue the commit).

```
from().process(new MyTransformer()).to().process(new Processor() {
    public void process(Exchange exchange) throws Exception {

        ConsumerConnector c = (Consumer)exchange.getProperty(KafkaConstants.CONSUMER);
        if (c != null ) c.commitOffset();
    }
})
```
