### PR TITLE
Producer no CQL Uri Param handling on doStart()

### DIFF
--- a/components/camel-cassandraql/src/main/java/org/apache/camel/component/cassandra/CassandraProducer.java
+++ b/components/camel-cassandraql/src/main/java/org/apache/camel/component/cassandra/CassandraProducer.java
@@ -51,7 +51,7 @@ public class CassandraProducer extends DefaultProducer {
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-        if (isPrepareStatements()) {
+        if (isPrepareStatements() && getEndpoint().getCql() != null) {
             this.preparedStatement = getEndpoint().prepareStatement();
         }
     }

--- a/components/camel-cassandraql/src/test/java/org/apache/camel/component/cassandra/CassandraComponentProducerTest.java
+++ b/components/camel-cassandraql/src/test/java/org/apache/camel/component/cassandra/CassandraComponentProducerTest.java
@@ -61,6 +61,9 @@ public class CassandraComponentProducerTest extends CamelTestSupport {
     
     @Produce(uri = "direct:loadBalancingPolicy")
     ProducerTemplate loadBalancingPolicyTemplate;
+    
+    @Produce(uri = "direct:inputNoEndpointCql")
+    ProducerTemplate producerTemplateNoEndpointCql;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -85,6 +88,8 @@ public class CassandraComponentProducerTest extends CamelTestSupport {
                         .to("cql://localhost/camel_ks?cql=" + NO_PARAMETER_CQL + "&loadBalancingPolicy=RoundRobinPolicy");
                 from("direct:inputNotConsistent")
                         .to(NOT_CONSISTENT_URI);
+                from("direct:inputNoEndpointCql")
+                	.to("cql://localhost/camel_ks");
             }
         };
     }
@@ -173,6 +178,43 @@ public class CassandraComponentProducerTest extends CamelTestSupport {
         assertNotNull(row);
         assertEquals("Claus 2", row.getString("first_name"));
         assertEquals("Ibsen 2", row.getString("last_name"));
+        session.close();
+        cluster.close();
+    }
+    
+    /**
+     * Simulate different CQL statements in the incoming message containing a header with RegularStatement, justifying the cassandracql endpoint not containing a "cql" Uri parameter
+     */
+    @Test
+    public void testEndpointNoCqlParameter() throws Exception {
+        Update.Where updateFirstName = update("camel_user")
+                .with(set("first_name", bindMarker()))
+                .where(eq("login", bindMarker()));
+        @SuppressWarnings("unused")
+		Object response1 = producerTemplateNoEndpointCql.requestBodyAndHeader(new Object[]{"Claus 2", "c_ibsen"},
+                CassandraConstants.CQL_QUERY, updateFirstName);
+        
+        Cluster cluster = CassandraUnitUtils.cassandraCluster();
+        Session session = cluster.connect(CassandraUnitUtils.KEYSPACE);
+        ResultSet resultSet1 = session.execute("select login, first_name, last_name from camel_user where login = ?", "c_ibsen");
+        Row row1 = resultSet1.one();
+        assertNotNull(row1);
+        assertEquals("Claus 2", row1.getString("first_name"));
+        assertEquals("Ibsen", row1.getString("last_name"));
+        
+        Update.Where updateLastName = update("camel_user")
+                .with(set("last_name", bindMarker()))
+                .where(eq("login", bindMarker()));
+        @SuppressWarnings("unused")
+		Object response2 = producerTemplateNoEndpointCql.requestBodyAndHeader(new Object[]{"Ibsen 2", "c_ibsen"},
+                CassandraConstants.CQL_QUERY, updateLastName);
+        
+        ResultSet resultSet2 = session.execute("select login, first_name, last_name from camel_user where login = ?", "c_ibsen");
+        Row row2 = resultSet2.one();
+        assertNotNull(row2);
+        assertEquals("Claus 2", row2.getString("first_name"));
+        assertEquals("Ibsen 2", row2.getString("last_name"));
+
         session.close();
         cluster.close();
     }


### PR DESCRIPTION
Problem:
- cql Uri param is not mandatory (default null)
- prepareStatements Uri param default true

Therefore creating a Producer like "cql://localhost/camel_ks" fails;
also, the error returned is misleading.

Details:
With the above premises, the top of the stacktrace is
"org.apache.camel.FailedToCreateProducerException: Failed to create
Producer for endpoint: Endpoint[cql://localhost/camel_ks]. Reason:
com.datastax.driver.core.exceptions.NoHostAvailableException: All
host(s) tried for query failed (tried: localhost/127.0.0.1:9042
(com.datastax.driver.core.TransportException: [localhost/127.0.0.1:9042]
Error writing))"
However this actually:
- is caused by the Producer doStart() trying to prepare a null cql
statement
- error looks like server/host is unreachable, but is actually the
failure of trying to prepare a null statement

Proposed solution:
Modify the the Producer's doStart() to invoke the Endpoint's
prepareStatement() method with additional condition that cql is not
null.
An additional unit test is provided to illustrate the scenario, for
instance a component earlier in the route would provide the actual cql
statement as part of the header, for example an EIP Translator.
Therefore in this scenario the cql is not unique and cannot be
configured in the Producer endpoint uri.

Aditional Notes:
On my machine maven test do fail on the master branch earlier than this
modification, and this modification does not solve those problems.