### PR TITLE
Future proofing the LoginToken

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/dto/LoginToken.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/dto/LoginToken.java
@@ -16,11 +16,13 @@
  */
 package org.apache.camel.component.salesforce.internal.dto;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * DTO for Salesforce login
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class LoginToken {
 
     private String accessToken;

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/dto/LoginToken.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/dto/LoginToken.java
@@ -34,6 +34,8 @@ public class LoginToken {
     private String issuedAt;
 
     private String tokenType;
+    
+    private String isReadOnly;
 
     @JsonProperty("access_token")
     public String getAccessToken() {
@@ -90,5 +92,15 @@ public class LoginToken {
     public void setTokenType(String tokenType) {
         this.tokenType = tokenType;
     }
+
+    @JsonProperty("is_readonly")
+	public String getIsReadOnly() {
+		return isReadOnly;
+	}
+
+    @JsonProperty("is_readonly")
+	public void setIsReadOnly(String isReadOnly) {
+		this.isReadOnly = isReadOnly;
+	}
 
 }

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/LoginTokenTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/LoginTokenTest.java
@@ -1,0 +1,45 @@
+package org.apache.camel.component.salesforce.internal;
+
+import org.apache.camel.component.salesforce.internal.dto.LoginToken;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.junit.Assert.*;
+
+public class LoginTokenTest {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(SessionIntegrationTest.class);
+	
+	@Test
+	public void testLoginTokenWithUnknownFields() throws Exception {
+		
+		String salesforceOAuthResponse = "{\n" + 
+				"    \"access_token\": \"00XXXXXXXXXXXX!ARMAQKg_lg_hGaRElvizVFBQHoCpvX8tzwGnROQ0_MDPXSceMeZHtm3JHkPmMhlgK0Km3rpJkwxwHInd_8o022KsDy.p4O.X\",\n" + 
+				"    \"is_readonly\": \"false\",\n" + 
+				"    \"signature\": \"XXXXXXXXXX+MYU+JrOXPSbpHa2ihMpSvUqow1iTPh7Q=\",\n" + 
+				"    \"instance_url\": \"https://xxxxxxxx--xxxxxxx.cs5.my.salesforce.com\",\n" + 
+				"    \"id\": \"https://test.salesforce.com/id/00DO00000054tO8MAI/005O0000001cmmdIAA\",\n" + 
+				"    \"token_type\": \"Bearer\",\n" + 
+				"    \"issued_at\": \"1442798068621\",\n" + 
+				"    \"an_unrecognised_field\": \"foo\"\n" + 
+				"}";
+		ObjectMapper mapper = new ObjectMapper();
+		Exception e = null;
+		LoginToken token = null;
+		try {
+			token = mapper.readValue(salesforceOAuthResponse, LoginToken.class);
+		} catch (Exception ex) {
+			e = ex;
+		}
+		
+		//assert ObjectMapper deserialized the SF OAuth response and returned a valid token back
+		assertNotNull("An invalid token was returned" , token);
+		//assert No exception was thrown during the JSON deserialization process
+		assertNull("Exception was thrown during JSON deserialisation" , e);
+		//assert one of the token fields
+		assertEquals("false", token.getIsReadOnly());
+		
+	}
+
+}


### PR DESCRIPTION
Salesforce can potentially add new fields to their OAuth JSON output which can break the LoginToken.java and we have to keep patching it on a regular basis. Added a new class level annotation which ignores all new unrecognised fields during json deserialisation. So, now we only need to patch the LoginToken.java where we really need to use that new field. Added a test case which demonstrates it. 