### PR TITLE
ADDED unit and integration test for RedisStringIdempotentRepository

### DIFF
--- a/components/camel-spring-redis/src/test/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepositoryIntegrationTest.java
+++ b/components/camel-spring-redis/src/test/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepositoryIntegrationTest.java
@@ -1,0 +1,119 @@
+package org.apache.camel.component.redis.processor.idempotent;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import javax.annotation.Resource;
+
+
+@Ignore
+public class RedisStringIdempotentRepositoryIntegrationTest extends CamelTestSupport {
+
+  @Produce(uri = "direct:start")
+  private ProducerTemplate producer;
+
+  @EndpointInject(uri = "mock:result")
+  private MockEndpoint mockResult;
+
+  @Resource
+  private RedisTemplate redisTemplate;
+
+  protected RedisStringIdempotentRepository idempotentRepository;
+
+  private static final JedisConnectionFactory CONNECTION_FACTORY = new JedisConnectionFactory();
+
+  static {
+    CONNECTION_FACTORY.afterPropertiesSet();
+  }
+
+  @Override
+  protected JndiRegistry createRegistry() throws Exception {
+    JndiRegistry registry = super.createRegistry();
+    redisTemplate = new RedisTemplate();
+    redisTemplate.setConnectionFactory(CONNECTION_FACTORY);
+    redisTemplate.afterPropertiesSet();
+
+    registry.bind("redisTemplate", redisTemplate);
+    return registry;
+  }
+
+  @Override
+  protected RouteBuilder createRouteBuilder() throws Exception {
+    idempotentRepository = new RedisStringIdempotentRepository(redisTemplate,
+                                                               "redis-idempotent-repository");
+    RouteBuilder rb = new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+        from("direct:start").idempotentConsumer(body(), idempotentRepository).to("mock:result");
+      }
+    };
+    return rb;
+  }
+
+  @Override
+  protected CamelContext createCamelContext() throws Exception {
+    CamelContext context = super.createCamelContext();
+    context.setTracing(true);
+    return context;
+  }
+
+  @Test
+  public void blockDoubleSubmission() throws Exception {
+    mockResult.expectedMessageCount(3);
+    mockResult.setResultWaitTime(5000);
+    producer.sendBody("abc");
+    producer.sendBody("bcd");
+    producer.sendBody("abc");
+    producer.sendBody("xyz");
+
+    assertTrue(idempotentRepository.contains("abc"));
+    assertTrue(idempotentRepository.contains("bcd"));
+    assertTrue(idempotentRepository.contains("xyz"));
+    assertFalse(idempotentRepository.contains("mustNotContain"));
+    mockResult.assertIsSatisfied();
+
+  }
+
+  @Test
+  public void clearIdempotentRepository() {
+    for (int i = 0; i < 10000; i++) {
+      redisTemplate.opsForValue().set("key4711", "value4711");
+    }
+    assertEquals("value4711", redisTemplate.opsForValue().get("key4711"));
+    producer.sendBody("abc");
+    producer.sendBody("bcd");
+    redisTemplate.opsForValue().set("redis1", "1");
+    redisTemplate.opsForValue().set("different:xyz", "2");
+    assertTrue(idempotentRepository.contains("abc"));
+    assertTrue(idempotentRepository.contains("bcd"));
+    idempotentRepository.clear();
+    assertFalse(idempotentRepository.contains("abc"));
+    assertFalse(idempotentRepository.contains("bcd"));
+    assertFalse(idempotentRepository.contains("redis1"));
+    assertFalse(idempotentRepository.contains("different:xyz"));
+
+    assertEquals("1", redisTemplate.opsForValue().get("redis1"));
+    assertEquals("2", redisTemplate.opsForValue().get("different:xyz"));
+  }
+
+  @Test
+  public void expireIdempotent() throws Exception {
+    idempotentRepository.setExpiry(5L);
+    producer.sendBody("abc");
+    assertTrue(idempotentRepository.contains("abc"));
+    Thread.sleep(5000);
+    assertFalse(idempotentRepository.contains("abc"));
+  }
+}
+

--- a/components/camel-spring-redis/src/test/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepositoryTest.java
+++ b/components/camel-spring-redis/src/test/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepositoryTest.java
@@ -1,0 +1,68 @@
+package org.apache.camel.component.redis.processor.idempotent;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created with IntelliJ IDEA. User: Marco Zapletal Date: 06.07.2015 Time: 18:47
+ */
+public class RedisStringIdempotentRepositoryTest {
+
+  private static final String REPOSITORY = "testRepository";
+  private static final String KEY = "KEY";
+  private RedisTemplate redisTemplate;
+  private RedisConnectionFactory redisConnectionFactory;
+  private RedisConnection redisConnection;
+  private RedisOperations redisOperations;
+  private ValueOperations valueOperations;
+  private RedisStringIdempotentRepository idempotentRepository;
+
+  @Before
+  public void setUp() throws Exception {
+    redisTemplate = mock(RedisTemplate.class);
+    valueOperations = mock(ValueOperations.class);
+    redisConnection = mock(RedisConnection.class);
+    redisOperations = mock(RedisOperations.class);
+    redisConnectionFactory = mock(RedisConnectionFactory.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(redisTemplate.getConnectionFactory()).thenReturn(redisConnectionFactory);
+    when(valueOperations.getOperations()).thenReturn(redisOperations);
+    when(redisTemplate.getConnectionFactory().getConnection()).thenReturn(redisConnection);
+    idempotentRepository = new RedisStringIdempotentRepository(redisTemplate, REPOSITORY);
+    idempotentRepository.setExpiry(1000L);
+  }
+
+  @Test
+  public void shouldAddKey() {
+    idempotentRepository.add(KEY);
+    verify(valueOperations).setIfAbsent(idempotentRepository.createRedisKey(KEY), KEY);
+    verify(redisOperations)
+        .expire(idempotentRepository.createRedisKey(KEY), 1000L, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void shoulCheckForMembers() {
+    idempotentRepository.contains(KEY);
+    verify(valueOperations).get(idempotentRepository.createRedisKey(KEY));
+  }
+
+
+  @Test
+  public void shouldReturnProcessorName() {
+    String processorName = idempotentRepository.getProcessorName();
+    assertEquals(REPOSITORY, processorName);
+  }
+
+}


### PR DESCRIPTION
The unit test is pretty much copied from `RedisIdempotentRepository` since add/remove logic is almost the same and expiry cannot be tested based on the unit test.

Hence, I've added an integration test as well, which revealed an important issue: the scan/delete keys logic in the `clear`method does not work using ``Jedis`` and having the ``RedisTemplate`` configured with the standard serializer as key serializer. It, however, works with ``lettuce`` and the standard serializer. It works for both clients if the ``RedisTemplate`` is configured with the ``StringRedisSerializer`` as key serializer. In principle, I would recommend to always work with the ``StringRedisSerializer`` when using Strings as keys as for example described in http://stackoverflow.com/questions/13215024/weird-redis-key-with-spring-data-jedis
I am not sure, however, if we can/should enforce the ``StringRedisSerializer`` in the configuration, since the ``RedisTemplate`` could be generally reused across the application (where the usage of ``StringRedisSerializer`` might not be desired).