### PR TITLE
Enable the use of contextPath() parameter for netty4-http rest configuration

### DIFF
--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
@@ -271,6 +271,13 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
             port = num;
         }
 
+        String contextPath = config.getContextPath();
+        if(ObjectHelper.isNotEmpty(contextPath)) {
+        	contextPath = FileUtil.stripTrailingSeparator(contextPath);
+        	contextPath = FileUtil.stripLeadingSeparator(contextPath);
+        	path =  contextPath + "/" + path;
+        }
+        
         // if no explicit hostname set then resolve the hostname
         if (ObjectHelper.isEmpty(host)) {
             if (config.getRestHostNameResolver() == RestConfiguration.RestHostNameResolver.localHostName) {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/rest/RestNettyHttpContextPathConfigurationTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/rest/RestNettyHttpContextPathConfigurationTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty.http.rest;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.netty.http.BaseNettyTest;
+import org.junit.Test;
+
+public class RestNettyHttpContextPathConfigurationTest extends BaseNettyTest {
+
+    @Test
+    public void testProducerGet() throws Exception {
+        String out = template.requestBody("netty-http:http://localhost:{{port}}/rest/users/123", null, String.class);
+        assertEquals("123;Donald Duck", out);
+
+        out = template.requestBody("netty-http:http://localhost:{{port}}/rest/users/list", null, String.class);
+        assertEquals("123;Donald Duck\n456;John Doe", out);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use netty-http on localhost with the given port
+                restConfiguration().component("netty-http").host("localhost").contextPath("/rest").port(getPort());
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .get("{id}")
+                        .route()
+                        .to("mock:input")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                String id = exchange.getIn().getHeader("id", String.class);
+                                exchange.getOut().setBody(id + ";Donald Duck");
+                            }
+                        })
+                    .endRest()
+                    .get("list")
+                        .route()
+                        .to("mock:input")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                exchange.getOut().setBody("123;Donald Duck\n456;John Doe");
+                            }
+                        });
+            }
+        };
+    }
+
+}

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpComponent.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpComponent.java
@@ -41,7 +41,6 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.ServiceHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -272,7 +271,7 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
         }
 
         String contextPath = config.getContextPath();
-        if(StringUtils.isNotEmpty(contextPath)) {
+        if(ObjectHelper.isNotEmpty(contextPath)) {
         	contextPath = FileUtil.stripTrailingSeparator(contextPath);
         	contextPath = FileUtil.stripLeadingSeparator(contextPath);
         	path =  contextPath + "/" + path;

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpComponent.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpComponent.java
@@ -41,6 +41,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.ServiceHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,7 +250,7 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
             }
         }
         path = FileUtil.stripLeadingSeparator(path);
-
+        
         String scheme = "http";
         String host = "";
         int port = 0;
@@ -270,6 +271,13 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
             port = num;
         }
 
+        String contextPath = config.getContextPath();
+        if(StringUtils.isNotEmpty(contextPath)) {
+        	contextPath = FileUtil.stripTrailingSeparator(contextPath);
+        	contextPath = FileUtil.stripLeadingSeparator(contextPath);
+        	path =  contextPath + "/" + path;
+        }
+        
         // if no explicit hostname set then resolve the hostname
         if (ObjectHelper.isEmpty(host)) {
             if (config.getRestHostNameResolver() == RestConfiguration.RestHostNameResolver.localHostName) {

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/rest/RestNettyHttpContextPathConfigurationTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/rest/RestNettyHttpContextPathConfigurationTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http.rest;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.netty4.http.BaseNettyTest;
+import org.junit.Test;
+
+public class RestNettyHttpContextPathConfigurationTest extends BaseNettyTest {
+
+    @Test
+    public void testProducerGet() throws Exception {
+        String out = template.requestBody("netty4-http:http://localhost:{{port}}/rest/users/123", null, String.class);
+        assertEquals("123;Donald Duck", out);
+
+        out = template.requestBody("netty4-http:http://localhost:{{port}}/rest/users/list", null, String.class);
+        assertEquals("123;Donald Duck\n456;John Doe", out);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use netty4-http on localhost with the given port
+                restConfiguration().component("netty4-http").contextPath("/rest").host("localhost").port(getPort());
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .get("{id}")
+                        .route()
+                        .to("mock:input")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                String id = exchange.getIn().getHeader("id", String.class);
+                                exchange.getOut().setBody(id + ";Donald Duck");
+                            }
+                        })
+                    .endRest()
+                    .get("list")
+                        .route()
+                        .to("mock:input")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                exchange.getOut().setBody("123;Donald Duck\n456;John Doe");
+                            }
+                        });
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
This will just prepend it to the path really but this should make drop in replacement between different rest components (e.g. servlet) more seamless and intuitive.