### PR TITLE
CAMEL-9182 : Kafka Endpoint - threadpool created based on ConsumerCount

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
@@ -112,7 +112,7 @@ public class KafkaEndpoint extends DefaultEndpoint implements MultipleConsumersS
     }
 
     public ExecutorService createExecutor() {
-        return getCamelContext().getExecutorServiceManager().newFixedThreadPool(this, "KafkaTopic[" + configuration.getTopic() + "]", configuration.getConsumerStreams());
+        return getCamelContext().getExecutorServiceManager().newFixedThreadPool(this, "KafkaTopic[" + configuration.getTopic() + "]", configuration.getConsumersCount());
     }
 
     public Exchange createKafkaExchange(MessageAndMetadata<byte[], byte[]> mm) {


### PR DESCRIPTION
camel-kafka : Kafka Endpoint executor threadpool is not initialized based on consumercount

https://issues.apache.org/jira/browse/CAMEL-9182
