### PR TITLE
Feature to load rest dsl from xml file in camel-spring-boot

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/CamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/CamelContext.java
@@ -34,6 +34,7 @@ import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.RoutesDefinition;
 import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestsDefinition;
 import org.apache.camel.spi.AsyncProcessorAwaitManager;
 import org.apache.camel.spi.CamelContextNameStrategy;
 import org.apache.camel.spi.ClassResolver;
@@ -625,6 +626,15 @@ public interface CamelContext extends SuspendableService, RuntimeConfiguration {
      */
     RoutesDefinition loadRoutesDefinition(InputStream is) throws Exception;
 
+    /**
+     * Loads a collection of rest definitions from the given {@link java.io.InputStream}.
+	 *
+	 * @param is input stream with the rest(s) definition to add
+	 * @throws Exception if the rest definitions could not be loaded for whatever reason
+	 * @return the rest definitions
+	 */
+    RestsDefinition loadRestsDefinition(InputStream is) throws Exception;
+    
     /**
      * Adds a collection of route definitions to the context
      *

--- a/camel-core/src/main/java/org/apache/camel/model/ModelCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/model/ModelCamelContext.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestsDefinition;
 
 /**
  * Model level interface for the {@link CamelContext}
@@ -53,6 +54,15 @@ public interface ModelCamelContext extends CamelContext {
      */
     RoutesDefinition loadRoutesDefinition(InputStream is) throws Exception;
 
+    /**
+     * Loads a collection of rest definitions from the given {@link java.io.InputStream}.
+	 *
+	 * @param is input stream with the rest(s) definition to add
+	 * @throws Exception if the rest definitions could not be loaded for whatever reason
+	 * @return the rest definitions
+	 */
+    RestsDefinition loadRestsDefinition(InputStream is) throws Exception;
+    
     /**
      * Adds a collection of route definitions to the context
      * <p/>

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -533,7 +533,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         }
         for (RestConfiguration config : camelContext.getRestConfigurations()) {
             addRouteDefinition(camelContext, answer, config.getComponent());
-            if (config.getApiContextPath() != null) {
+            if (config.getApiContextPath() != null && !config.isApiContextRouteDefined()) {
                 addApiRouteDefinition(camelContext, answer, config);
             }
         }
@@ -576,6 +576,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         route.to(to);
         route.setRestDefinition(this);
         answer.add(route);
+        configuration.setApiContextRouteDefined(true);
     }
 
     private void addRouteDefinition(CamelContext camelContext, List<RouteDefinition> answer, String component) {

--- a/camel-core/src/main/java/org/apache/camel/spi/RestConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/RestConfiguration.java
@@ -58,6 +58,7 @@ public class RestConfiguration {
     private Map<String, Object> dataFormatProperties;
     private Map<String, Object> apiProperties;
     private Map<String, String> corsHeaders;
+    private boolean apiContextRouteDefined = false;
 
     /**
      * Gets the name of the Camel component to use as the REST consumer
@@ -458,4 +459,22 @@ public class RestConfiguration {
     public void setCorsHeaders(Map<String, String> corsHeaders) {
         this.corsHeaders = corsHeaders;
     }
+
+	/**
+	 * @return
+	 */
+	public boolean isApiContextRouteDefined() {
+		return apiContextRouteDefined;
+	}
+
+	/**
+	 * Sets if a route definition for the API has been set or not.
+	 * This is to avoid adding API routes multiple times.
+	 * 
+	 * @param apiContextRouteDefined
+	 */
+	public void setApiContextRouteDefined(boolean apiContextRouteDefined) {
+		this.apiContextRouteDefined = apiContextRouteDefined;
+	}
+    
 }

--- a/camel-core/src/test/java/org/apache/camel/impl/CamelContextAddRestDefinitionsFromXmlTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/CamelContextAddRestDefinitionsFromXmlTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.rest.DummyRestConsumerFactory;
+import org.apache.camel.component.rest.DummyRestProcessorFactory;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.model.rest.RestDefinition;
+
+/**
+ * @version 
+ */
+public class CamelContextAddRestDefinitionsFromXmlTest extends ContextTestSupport {
+
+    protected JAXBContext jaxbContext;
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+        jndi.bind("dummy-rest", new DummyRestConsumerFactory());
+        jndi.bind("dummy-rest-api", new DummyRestProcessorFactory());
+        return jndi;
+    }
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        jaxbContext = context.getModelJAXBContextFactory().newJAXBContext();
+    }
+
+    protected Object parseUri(String uri) throws JAXBException {
+        Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        URL resource = getClass().getResource(uri);
+        assertNotNull("Cannot find resource on the classpath: " + uri, resource);
+        Object value = unmarshaller.unmarshal(resource);
+        return value;
+    }
+
+    protected RestDefinition loadRest(String uri) throws Exception {
+        Object rest = parseUri(uri);
+        return assertIsInstanceOf(RestDefinition.class, rest);
+    }
+
+    public void testAddRouteDefinitionsFromXml() throws Exception {
+    	RestDefinition rest = loadRest("rest1.xml");
+        assertNotNull(rest);
+
+        assertEquals("foo", rest.getId());
+        assertEquals(0, context.getRestDefinitions().size());
+
+        context.getRestDefinitions().add(rest);
+        assertEquals(1, context.getRestDefinitions().size());
+
+        final List<RouteDefinition> routeDefinitions = rest.asRouteDefinition(context);
+        
+        for (final RouteDefinition routeDefinition : routeDefinitions) {
+        	context.addRouteDefinition(routeDefinition);
+		}
+
+        assertEquals(2, context.getRoutes().size());
+        
+        assertTrue("Route should be started", context.getRouteStatus("route1").isStarted());
+
+        getMockEndpoint("mock:bar").expectedBodiesReceived("Hello World");
+        template.sendBody("seda:get-say-hello-bar", "Hello World");
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                restConfiguration().host("localhost").component("dummy-rest").apiContextPath("/api-docs");
+            }
+        };
+    }
+    
+}

--- a/camel-core/src/test/java/org/apache/camel/model/LoadRestFromXmlTest.java
+++ b/camel-core/src/test/java/org/apache/camel/model/LoadRestFromXmlTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.rest.DummyRestConsumerFactory;
+import org.apache.camel.component.rest.DummyRestProcessorFactory;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestsDefinition;
+
+/**
+ * @version 
+ */
+public class LoadRestFromXmlTest extends ContextTestSupport {
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+        jndi.bind("dummy-rest", new DummyRestConsumerFactory());
+        jndi.bind("dummy-rest-api", new DummyRestProcessorFactory());
+        return jndi;
+    }
+	
+    public void testLoadRouteFromXml() throws Exception {
+        assertNotNull("Existing foo route should be there", context.getRoute("foo"));
+        assertEquals(1, context.getRoutes().size());
+
+        // test that existing route works
+        MockEndpoint foo = getMockEndpoint("mock:foo");
+        foo.expectedBodiesReceived("Hello World");
+        template.sendBody("direct:foo", "Hello World");
+        foo.assertIsSatisfied();
+
+        // load rest from XML and add them to the existing camel context
+        InputStream is = getClass().getResourceAsStream("barRest.xml");
+        RestsDefinition rests = context.loadRestsDefinition(is);
+        context.addRestDefinitions(rests.getRests());
+        
+        for (final RestDefinition restDefinition : rests.getRests()) {
+            List<RouteDefinition> routeDefinitions = restDefinition.asRouteDefinition(context);
+            context.addRouteDefinitions(routeDefinitions);
+		}
+
+        assertNotNull("Loaded rest route should be there", context.getRoute("route1"));
+        assertEquals(3, context.getRoutes().size());
+
+        // test that loaded route works
+        MockEndpoint bar = getMockEndpoint("mock:bar");
+        bar.expectedBodiesReceived("Bye World");
+        template.sendBody("seda:get-say-hello-bar", "Bye World");
+        bar.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+            	restConfiguration().host("localhost").component("dummy-rest").apiContextPath("/api-docs");
+            	
+                from("direct:foo").routeId("foo")
+                    .to("mock:foo");
+            }
+        };
+    }
+}

--- a/camel-core/src/test/resources/org/apache/camel/impl/rest1.xml
+++ b/camel-core/src/test/resources/org/apache/camel/impl/rest1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<rest id="foo" path="/say/hello" xmlns="http://camel.apache.org/schema/spring">
+    <get uri="/bar">
+      <to uri="mock:bar"/>
+    </get>
+</rest>

--- a/camel-core/src/test/resources/org/apache/camel/model/barRest.xml
+++ b/camel-core/src/test/resources/org/apache/camel/model/barRest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<rests xmlns="http://camel.apache.org/schema/spring">
+	<rest id="bar" path="/say/hello">
+	    <get uri="/bar">
+	      <to uri="mock:bar"/>
+	    </get>
+    </rest>
+</rests>


### PR DESCRIPTION
This PR ultimately adds a feature to the spring-boot component to load REST DSL configuration from XML files in the "camel-rest" dir on the classpath. Since spring-boot can already load routes from XML files in "camel" classpath dir I thought it would be nice to also load REST DSL that way.

One thing I am not sure about and may need another look is the way I avoid creating the rest-api route definition multiple times. For now I created a variable in spi.RestConfiguration.java to track if the configuration already has the API route defined or not. If there is a better way to do this please let me know and I'll change it. 