### PR TITLE
CAMEL-9187  add eventHost parameter to endpoint to support splunk host override p…

### DIFF
--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConfiguration.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConfiguration.java
@@ -60,6 +60,8 @@ public class SplunkConfiguration {
     @UriParam(label = "producer")
     private String source;
     @UriParam(label = "producer")
+    private String eventHost;
+    @UriParam(label = "producer")
     private int tcpReceiverPort;
     @UriParam(label = "producer", defaultValue = "false")
     private boolean raw;
@@ -184,6 +186,17 @@ public class SplunkConfiguration {
      */
     public void setSource(String source) {
         this.source = source;
+    }
+
+    public String getEventHost() {
+        return eventHost;
+    }
+
+    /**
+     * Override the default Splunk event host field
+     */
+    public void setEventHost(String eventHost) {
+        this.eventHost = eventHost;
     }
 
     /**
@@ -359,4 +372,5 @@ public class SplunkConfiguration {
         splunkConnectionFactory.setSslProtocol(getSslProtocol());
         return splunkConnectionFactory;
     }
+
 }

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkProducer.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkProducer.java
@@ -103,6 +103,9 @@ public class SplunkProducer extends DefaultProducer {
         if (endpoint.getConfiguration().getSource() != null) {
             args.put("source", endpoint.getConfiguration().getSource());
         }
+        if (endpoint.getConfiguration().getEventHost() != null) {
+            args.put("host", endpoint.getConfiguration().getEventHost());
+        }
         return args;
     }
 

--- a/components/camel-splunk/src/test/java/org/apache/camel/component/splunk/SplunkComponentConfigurationTest.java
+++ b/components/camel-splunk/src/test/java/org/apache/camel/component/splunk/SplunkComponentConfigurationTest.java
@@ -52,7 +52,7 @@ public class SplunkComponentConfigurationTest extends CamelTestSupport {
 
         SplunkEndpoint endpoint = (SplunkEndpoint)component
             .createEndpoint("splunk://tcp?username=test&password=pw&host=myhost&port=3333&" + "tcpReceiverPort=4444&index=myindex&sourceType=testSource&"
-                            + "source=test&owner=me&app=fantasticapp&useSunHttpsHandler=true&raw=true&sslProtocol=SSLv3");
+                            + "source=test&eventHost=original-host.com&owner=me&app=fantasticapp&useSunHttpsHandler=true&raw=true&sslProtocol=SSLv3");
         assertEquals("myhost", endpoint.getConfiguration().getHost());
         assertEquals(3333, endpoint.getConfiguration().getPort());
         assertEquals("test", endpoint.getConfiguration().getUsername());
@@ -61,6 +61,7 @@ public class SplunkComponentConfigurationTest extends CamelTestSupport {
         assertEquals("myindex", endpoint.getConfiguration().getIndex());
         assertEquals("testSource", endpoint.getConfiguration().getSourceType());
         assertEquals("test", endpoint.getConfiguration().getSource());
+        assertEquals("original-host.com", endpoint.getConfiguration().getEventHost());
         assertEquals("me", endpoint.getConfiguration().getOwner());
         assertEquals("fantasticapp", endpoint.getConfiguration().getApp());
         assertTrue(endpoint.getConfiguration().isUseSunHttpsHandler());


### PR DESCRIPTION
For your consideration:

CAMEL-9187 add eventHost parameter to endpoint to support splunk host override per: http://docs.splunk.com/Documentation/Splunk/6.2.6/Data/Aboutdefaultfields#Override_host_assignment

https://issues.apache.org/jira/browse/CAMEL-9187