### PR TITLE
Modify camel-paho

### DIFF
--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/MqttProperties.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/MqttProperties.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.paho;
+
+/**
+ * MQTT message properties.
+ */
+public class MqttProperties {
+
+    private String  topic;
+
+    private int     qos;
+
+    private boolean retain;
+
+    private boolean duplicate;
+
+    public MqttProperties() {}
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public int getQos() {
+        return qos;
+    }
+
+    public void setQos(int qos) {
+        this.qos = qos;
+    }
+
+    public boolean isRetain() {
+        return retain;
+    }
+
+    public void setRetain(boolean retain) {
+        this.retain = retain;
+    }
+
+    public boolean isDuplicate() {
+        return duplicate;
+    }
+
+    public void setDuplicate(boolean duplicate) {
+        this.duplicate = duplicate;
+    }
+    
+    @Override
+    public String toString() {
+        return "PahoMqttProperties [topic=" + topic + ", qos=" + qos + "]";
+    }
+
+}

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoComponent.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoComponent.java
@@ -27,6 +27,7 @@ public class PahoComponent extends UriEndpointComponent {
     private String brokerUrl;
     private String clientId;
     private MqttConnectOptions connectOptions;
+    private String headerType;
 
     public PahoComponent() {
         super(PahoEndpoint.class);
@@ -44,6 +45,9 @@ public class PahoComponent extends UriEndpointComponent {
         }
         if (connectOptions != null) {
             answer.setConnectOptions(connectOptions);
+        }
+        if (headerType != null) {
+            answer.setHeaderType(headerType);
         }
 
         setProperties(answer, parameters);
@@ -81,5 +85,16 @@ public class PahoComponent extends UriEndpointComponent {
      */
     public void setConnectOptions(MqttConnectOptions connectOptions) {
         this.connectOptions = connectOptions;
+    }
+    
+    public String getHeaderType() {
+        return headerType;
+    }
+
+    /**
+     * Exchange header type.
+     */
+    public void setHeaderType(String headerType) {
+        this.headerType = headerType;
     }
 }

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConstants.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConstants.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.paho;
 
 public final class PahoConstants {
 
+    public static final String HEASER_MQTT_PROPERTIES = "MqttProperties";
+
     public static final String HEADER_ORIGINAL_MESSAGE = "PahoOriginalMessage";
 
     private PahoConstants() {

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoEndpoint.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoEndpoint.java
@@ -64,6 +64,8 @@ public class PahoEndpoint extends DefaultEndpoint {
     private int qos = DEFAULT_QOS;
     @UriParam(defaultValue = "MEMORY")
     private PahoPersistence persistence = MEMORY;
+    @UriParam(defaultValue = PahoConstants.HEASER_MQTT_PROPERTIES)
+    private String headerType = PahoConstants.HEASER_MQTT_PROPERTIES;
 
     // Collaboration members
     @UriParam
@@ -76,7 +78,12 @@ public class PahoEndpoint extends DefaultEndpoint {
     public PahoEndpoint(String uri, Component component) {
         super(uri, component);
         if (topic == null) {
-            topic = uri.substring(7);
+            int optionIndex = uri.indexOf("?");
+            if (optionIndex > 0) {
+                topic = uri.substring(7, optionIndex);
+            } else {
+                topic = uri.substring(7);
+            }
         }
     }
 
@@ -217,4 +224,16 @@ public class PahoEndpoint extends DefaultEndpoint {
     public void setConnectOptions(MqttConnectOptions connOpts) {
         this.connectOptions = connOpts;
     }
+
+    public String getHeaderType() {
+        return headerType;
+    }
+
+    /**
+     * Exchange header type.
+     */
+    public void setHeaderType(String headerType) {
+        this.headerType = headerType;
+    }
+    
 }


### PR DESCRIPTION
I modified camel-paho,

* Parsing subscribe topic correctly.
I modified parsing logic because previous implementation can not parse the topic with the uri options.

* Changing exchange header value to the mqtt properties which is original bean.
MqttMessage class has not topic. But topic is very important value.
So, I changed the exchange header which has topic, and privious header value can be specified by "headerType" option.


And, in original source,  the following errors occur.

```
java.lang.NullPointerException: null
	at org.apache.camel.impl.DefaultRuntimeEndpointRegistry.notify(DefaultRuntimeEndpointRegistry.java:245)
	at org.apache.camel.util.EventHelper.doNotifyEvent(EventHelper.java:805)
	at org.apache.camel.util.EventHelper.notifyExchangeCreated(EventHelper.java:411)
	at org.apache.camel.impl.DefaultUnitOfWork.<init>(DefaultUnitOfWork.java:123)
	at org.apache.camel.impl.DefaultUnitOfWork.<init>(DefaultUnitOfWork.java:72)
	at org.apache.camel.impl.DefaultUnitOfWorkFactory.createUnitOfWork(DefaultUnitOfWorkFactory.java:34)
	at org.apache.camel.processor.CamelInternalProcessor$UnitOfWorkProcessorAdvice.createUnitOfWork(CamelInternalProcessor.java:663)
	at org.apache.camel.processor.CamelInternalProcessor$UnitOfWorkProcessorAdvice.before(CamelInternalProcessor.java:631)
	at org.apache.camel.processor.CamelInternalProcessor$UnitOfWorkProcessorAdvice.before(CamelInternalProcessor.java:608)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:138)
	at org.apache.camel.component.paho.PahoConsumer$1.messageArrived(PahoConsumer.java:73)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.handleMessage(CommsCallback.java:354)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.run(CommsCallback.java:162)
	at java.lang.Thread.run(Thread.java:745)
```

I do not know why the error occurred.
Could you check it?
