### PR TITLE
Fix test corruption by6 3 upgrade + ignore test due to upstream issue

### DIFF
--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -50,15 +50,22 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-examples</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- TODO Upgrade from log4j to logback -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-spring</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-optaplanner/src/test/java/org/apache/camel/component/optaplanner/OptaPlannerDaemonSolverTest.java
+++ b/components/camel-optaplanner/src/test/java/org/apache/camel/component/optaplanner/OptaPlannerDaemonSolverTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.commons.lang3.ObjectUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.solver.ProblemFactChange;
@@ -36,7 +37,7 @@ import org.optaplanner.examples.cloudbalancing.persistence.CloudBalancingGenerat
  */
 public class OptaPlannerDaemonSolverTest extends CamelTestSupport {
 
-    @Test
+    @Test @Ignore("https://issues.jboss.org/browse/PLANNER-468") // TODO Unignore when upgraded to optaplanner 6.3.1+
     public void testAsynchronousProblemSolving() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:result");
         mockEndpoint.setExpectedCount(1);


### PR DESCRIPTION
The master code currently suffers from PLANNER-468 and a corrupted test case.
This PR fixes the test case. It also ignores the test case temporary, because PLANNER-468 makes it fail. It clearly comments when it can and should be unignored.

This PR is better than the current master state. An additional improvement(?) could be to revert optaplanner from 6.3 to 6.2 to fix the deamon mode until optaplanner 6.3.1+ is out, but I am not sure if that's desired as it would impact the drools & jbpm version too. I'd rather see this merged and deal with it as a known issue until it's fixed upstream.