### PR TITLE
camel-optaplanner should not eat exceptions

### DIFF
--- a/components/camel-optaplanner/src/main/java/org/apache/camel/component/optaplanner/OptaPlannerProducer.java
+++ b/components/camel-optaplanner/src/main/java/org/apache/camel/component/optaplanner/OptaPlannerProducer.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OptaPlannerProducer extends DefaultProducer {
+
     private static final transient Logger LOGGER = LoggerFactory.getLogger(OptaPlannerProducer.class);
+
     private ExecutorService executor;
     private final OptaPlannerEndpoint endpoint;
     private final OptaPlannerConfiguration configuration;
@@ -68,7 +70,11 @@ public class OptaPlannerProducer extends DefaultProducer {
                 executor.submit(new Runnable() {
                     @Override
                     public void run() {
-                        solver.solve((Solution)body);
+                        try {
+                            solver.solve((Solution) body);
+                        } catch (Throwable e) {
+                            LOGGER.error("Asynchronously solving failed for solverId ({})", solverId, e);
+                        }
                     }
                 });
             } else {

--- a/components/camel-optaplanner/src/test/java/org/apache/camel/component/optaplanner/OptaPlannerDaemonSolverTest.java
+++ b/components/camel-optaplanner/src/test/java/org/apache/camel/component/optaplanner/OptaPlannerDaemonSolverTest.java
@@ -37,7 +37,7 @@ import org.optaplanner.examples.cloudbalancing.persistence.CloudBalancingGenerat
  */
 public class OptaPlannerDaemonSolverTest extends CamelTestSupport {
 
-    @Test @Ignore("https://issues.jboss.org/browse/PLANNER-468") // TODO Unignore when upgraded to optaplanner 6.3.1+
+    @Test
     public void testAsynchronousProblemSolving() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:result");
         mockEndpoint.setExpectedCount(1);
@@ -98,6 +98,7 @@ public class OptaPlannerDaemonSolverTest extends CamelTestSupport {
                     scoreDirector.beforeProblemFactRemoved(workingComputer);
                     it.remove(); // remove from list
                     scoreDirector.beforeProblemFactRemoved(workingComputer);
+                    scoreDirector.triggerVariableListeners();
                     break;
                 }
             }


### PR DESCRIPTION
Also fix async solving deamon test that broke after upgrade to 6.3

PS: It's a PITA (which cost me some time) that the log4j.properties of the components don't log ERRORs to the console by default. (I can understand they don't do INFO to reduce build verbosity, but they should show errors by default in the console (and intentional errors that are being tested can be filtered out). Anyway, that's a different issue. :)