### PR TITLE
CAMEL-8959

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/HybridSourceDataBinding.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/HybridSourceDataBinding.java
@@ -84,19 +84,6 @@ public class HybridSourceDataBinding extends JAXBDataBinding {
                     if (obj == null) {
                         return;
                     }
-                    // workaround issue in CXF that is causing these to go through 
-                    // sax instead of stax.  Fixed in 2.4.4/2.5.
-                    if (obj instanceof StaxSource
-                        || obj instanceof StAXSource) {
-                        XMLStreamReader reader = StaxUtils.createXMLStreamReader((Source)obj);
-                        try {
-                            StaxUtils.copy(reader, output);
-                            reader.close();
-                        } catch (XMLStreamException e) {
-                            throw new Fault(new Message("COULD_NOT_READ_XML_STREAM", LOG), e);
-                        }
-                        return;
-                    }
                     super.write(obj, part, output);
                 }
                 


### PR DESCRIPTION
Remove old code from camel-cxf no longer needed due the CXF 3.0+ upgrade

Tests pass.

Please point me at any other code that needs removing.

I tried to use WSDLGetInterceptor instead of RawMessageWSDLGetInterceptor, but it breaks as RawMessageWSDLGetOutInterceptor was changed.