### PR TITLE
Support `String.format()` strings as input to simple expression

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/BuilderSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/BuilderSupport.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * Base class for implementation inheritance for different clauses in the <a
  * href="http://camel.apache.org/dsl.html">Java DSL</a>
  *
- * @version 
+ * @version
  */
 public abstract class BuilderSupport {
     private ModelCamelContext context;
@@ -71,7 +71,7 @@ public abstract class BuilderSupport {
         Expression exp = new ExchangePropertyExpression(name);
         return new ValueBuilder(exp);
     }
-    
+
     /**
      * Returns a value builder for the given exchange property
      */
@@ -146,7 +146,7 @@ public abstract class BuilderSupport {
     public <T> ValueBuilder faultBodyAs(Class<T> type) {
         return Builder.faultBodyAs(type);
     }
-                             
+
     /**
      * Returns a value builder for the given system property
      */
@@ -181,12 +181,26 @@ public abstract class BuilderSupport {
     public SimpleBuilder simple(String value) {
         return SimpleBuilder.simple(value);
     }
-    
+
     /**
      * Returns a simple expression value builder
      */
     public SimpleBuilder simple(String value, Class<?> resultType) {
         return SimpleBuilder.simple(value, resultType);
+    }
+
+    /**
+     * Returns a simple expression value builder, using String.format style
+     */
+    public SimpleBuilder simpleF(String format, Object...values) {
+        return SimpleBuilder.simpleF(format, values);
+    }
+
+    /**
+     * Returns a simple expression value builder, using String.format style
+     */
+    public SimpleBuilder simpleF(String format, Class<?> resultType, Object...values) {
+        return SimpleBuilder.simpleF(format, resultType, values);
     }
 
     /**
@@ -197,7 +211,7 @@ public abstract class BuilderSupport {
     public XPathBuilder xpath(String value) {
         return XPathBuilder.xpath(value);
     }
-    
+
     /**
      * Returns a xpath expression value builder
      * @param value The XPath expression
@@ -222,7 +236,7 @@ public abstract class BuilderSupport {
     public ValueBuilder bean(Object beanOrBeanRef) {
         return bean(beanOrBeanRef, null);
     }
-    
+
     /**
      * Returns a <a href="http://camel.apache.org/bean-language.html">method call expression</a>
      * value builder
@@ -251,7 +265,7 @@ public abstract class BuilderSupport {
     public ValueBuilder bean(Class<?> beanType) {
         return Builder.bean(beanType);
     }
-    
+
     /**
      * Returns a <a href="http://camel.apache.org/bean-language.html">method call expression</a>
      * value builder
@@ -329,7 +343,7 @@ public abstract class BuilderSupport {
     }
 
     /**
-     * Returns an expression value builder that replaces all occurrences of the 
+     * Returns an expression value builder that replaces all occurrences of the
      * regular expression with the given replacement
      */
     public ValueBuilder regexReplaceAll(Expression content, String regex, String replacement) {
@@ -337,13 +351,13 @@ public abstract class BuilderSupport {
     }
 
     /**
-     * Returns an expression value builder that replaces all occurrences of the 
+     * Returns an expression value builder that replaces all occurrences of the
      * regular expression with the given replacement
      */
     public ValueBuilder regexReplaceAll(Expression content, String regex, Expression replacement) {
         return Builder.regexReplaceAll(content, regex, replacement);
-    }    
-    
+    }
+
     /**
      * Returns a exception expression value builder
      */
@@ -498,7 +512,7 @@ public abstract class BuilderSupport {
     public ModelCamelContext getContext() {
         return context;
     }
-    
+
     public void setContext(CamelContext context) {
         ObjectHelper.notNull(context, "CamelContext", this);
         this.context = context.adapt(ModelCamelContext.class);

--- a/camel-core/src/main/java/org/apache/camel/builder/SimpleBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/SimpleBuilder.java
@@ -29,7 +29,7 @@ import org.apache.camel.util.ResourceHelper;
  * This builder is available in the Java DSL from the {@link RouteBuilder} which means that using
  * simple language for {@link Expression}s or {@link Predicate}s is very easy with the help of this builder.
  *
- * @version 
+ * @version
  */
 public class SimpleBuilder implements Predicate, Expression {
 
@@ -51,6 +51,14 @@ public class SimpleBuilder implements Predicate, Expression {
         SimpleBuilder answer = simple(text);
         answer.setResultType(resultType);
         return answer;
+    }
+
+    public static SimpleBuilder simpleF(String formatText, Object...values) {
+        return simple(String.format(formatText, values));
+    }
+
+    public static SimpleBuilder simpleF(String formatText, Class<?> resultType, Object...values) {
+        return simple(String.format(formatText, values), resultType);
     }
 
     public String getText() {

--- a/camel-core/src/test/java/org/apache/camel/builder/SimpleBuilderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/SimpleBuilderTest.java
@@ -23,7 +23,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 
 /**
- * @version 
+ * @version
  */
 public class SimpleBuilderTest extends TestSupport {
 
@@ -41,6 +41,19 @@ public class SimpleBuilderTest extends TestSupport {
 
         assertEquals("foo", SimpleBuilder.simple("${body}").evaluate(exchange, String.class));
         assertNull(SimpleBuilder.simple("${header.cheese}").evaluate(exchange, String.class));
+    }
+
+    public void testFormatExpression() throws Exception {
+        exchange.getIn().setHeader("head", "foo");
+
+        assertEquals("foo", SimpleBuilder.simpleF("${header.%s}", "head").evaluate(exchange, String.class));
+        assertNull(SimpleBuilder.simple("${header.cheese}").evaluate(exchange, String.class));
+    }
+
+    public void testFormatExpressionWithResultType() throws Exception {
+        exchange.getIn().setHeader("head", "200");
+
+        assertEquals(200, SimpleBuilder.simpleF("${header.%s}", Integer.class, "head").evaluate(exchange, Object.class));
     }
 
     public void testResultType() throws Exception {


### PR DESCRIPTION
Support creating expressions on the form:

    from("direct:foo")
        .filter(simpleF("${header.%s} == 'test'", MyConstants.HEADER_NAME))
        .log("Filtered");

Sorry about the deleted whitespaces in `BuilderSupport.java`. 
`atom` made me do it.