### PR TITLE
[CAMEL-9113] Upgrade infinispan to 8.0.1.Final

### DIFF
--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -74,4 +74,24 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!-- unit testing requires java 8 -->
+    <profiles>
+        <profile>
+            <id>jdk8-test</id>
+            <activation>
+                <jdk>!1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/components/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/InfinispanProducerTest.java
+++ b/components/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/InfinispanProducerTest.java
@@ -45,7 +45,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
     }
     
     @Test
@@ -60,8 +60,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Integer.class), new Integer(2));
-        assertNotEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Integer.class), new Integer(4));
+        Integer cacheSize = exchange.getIn().getHeader(InfinispanConstants.RESULT, Integer.class);
+        assertEquals(cacheSize, new Integer(2));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
     }
     
     @Test
@@ -94,7 +94,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         assertEquals(Boolean.TRUE, resultPutAsync.isDone());
         
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);      
+        assertEquals(VALUE_ONE, value.toString());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -146,7 +146,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         assertEquals(Boolean.TRUE, resultPutAsync.isDone());
         
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);  
+        assertEquals(VALUE_ONE, value.toString());
         
         Thread.sleep(10000);
         exchange = template.send("direct:get", new Processor() {
@@ -156,7 +156,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -172,11 +172,11 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
         value = currentCache().get(KEY_TWO);
-        assertEquals(value.toString(), VALUE_TWO);
+        assertEquals(VALUE_TWO, value.toString());
     }
     
     @Test
@@ -194,11 +194,11 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
         value = currentCache().get(KEY_TWO);
-        assertEquals(value.toString(), VALUE_TWO);
+        assertEquals(VALUE_TWO, value.toString());
         
         Thread.sleep(LIFESPAN_TIME * 1000);
         
@@ -209,7 +209,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -218,7 +218,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -238,7 +238,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         
         Thread.sleep(10000);
         
@@ -249,7 +249,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -258,7 +258,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(null);
     }
     
     @Test
@@ -274,11 +274,11 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
         
         Thread.sleep(100);
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
         value = currentCache().get(KEY_TWO);
-        assertEquals(value.toString(), VALUE_TWO);
+        assertEquals(VALUE_TWO, value.toString());
     }
     
     @Test
@@ -297,11 +297,11 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Thread.sleep(100);
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
         value = currentCache().get(KEY_TWO);
-        assertEquals(value.toString(), VALUE_TWO);
+        assertEquals(VALUE_TWO, value.toString());
         
         Thread.sleep(LIFESPAN_TIME * 1000);
         
@@ -312,7 +312,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -321,7 +321,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -342,7 +342,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
         
         Thread.sleep(100);
-        assertEquals(currentCache().size(), 2);
+        assertEquals(2, currentCache().size());
         
         Thread.sleep(10000);
         
@@ -353,7 +353,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -362,7 +362,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -379,8 +379,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
-        assertEquals(currentCache().size(), 1);
+        assertEquals(VALUE_ONE, value.toString());
+        assertEquals(1, currentCache().size());
     }
     
     @Test
@@ -397,8 +397,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Object value = currentCache().get(KEY_TWO);
-        assertEquals(value.toString(), VALUE_TWO);
-        assertEquals(currentCache().size(), 2);
+        assertEquals(VALUE_TWO, value.toString());
+        assertEquals(2, currentCache().size());
     }
     
     @Test
@@ -416,7 +416,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         assertEquals(Boolean.TRUE, resultPutAsync.isDone());
         
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);      
+        assertEquals(VALUE_ONE, value.toString());
     }
 
     @Test
@@ -436,7 +436,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         assertEquals(Boolean.TRUE, resultPutAsync.isDone());
         
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);  
+        assertEquals(VALUE_ONE, value.toString());
         
         Thread.sleep(6000);
         exchange = template.send("direct:get", new Processor() {
@@ -446,7 +446,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -468,7 +468,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         assertEquals(Boolean.TRUE, resultPutAsync.isDone());
         
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);  
+        assertEquals(VALUE_ONE, value.toString());
         
         Thread.sleep(10000);
         exchange = template.send("direct:get", new Processor() {
@@ -478,7 +478,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -493,7 +493,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), false);
+        Boolean cacheContainsKey = exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class);
+        assertFalse(cacheContainsKey);
     }
     
     @Test
@@ -508,7 +509,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
+        Boolean cacheContainsKey = exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class);
+        assertTrue(cacheContainsKey);
     }
     
     @Test
@@ -523,7 +525,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), false);
+        Boolean cacheContainsValue = exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class);
+        assertFalse(cacheContainsValue);
     }
     
     @Test
@@ -538,7 +541,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
+        Boolean cacheContainsValue = exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class);
+        assertTrue(cacheContainsValue);
     }
     
     @Test
@@ -555,7 +559,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
         });
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value.toString(), VALUE_ONE);
+        assertEquals(VALUE_ONE, value.toString());
         
         Exchange exchange;
         exchange = template.send("direct:get", new Processor() {
@@ -576,7 +580,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
 
     @Test
@@ -592,7 +596,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), "existing value");
+        String result = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
+        assertEquals("existing value", result);
     }
 
     @Test
@@ -607,7 +612,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
     }
     
     @Test
@@ -623,8 +628,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
     }
     
     @Test
@@ -642,8 +647,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(LIFESPAN_TIME * 1000);
         
@@ -654,7 +659,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -674,8 +679,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(10000);
         
@@ -686,7 +691,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
 
     @Test
@@ -703,8 +708,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
     }
     
     @Test
@@ -723,10 +728,10 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
-        Thread.sleep(LIFESPAN_TIME * 1000);
+        Thread.sleep(LIFESPAN_TIME * 1100);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -735,7 +740,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -756,8 +761,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(10000);
         
@@ -768,7 +773,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }    
     
     
@@ -784,8 +789,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
     }
     
     @Test
@@ -802,8 +807,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(LIFESPAN_TIME * 1000);
         
@@ -814,7 +819,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(null, resultGet);
     }
     
     @Test
@@ -833,8 +838,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(10000);
         
@@ -845,7 +850,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -861,8 +866,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
     }
     
     @Test
@@ -880,10 +885,10 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
-        Thread.sleep(LIFESPAN_TIME * 1000);
+        Thread.sleep(LIFESPAN_TIME * 1100);
         
         exchange = template.send("direct:get", new Processor() {
             @Override
@@ -892,7 +897,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
     
     @Test
@@ -912,8 +917,8 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
-        assertEquals(currentCache().get(KEY_ONE), VALUE_TWO);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
+        assertEquals(VALUE_TWO, currentCache().get(KEY_ONE));
         
         Thread.sleep(10000);
         
@@ -924,7 +929,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
         String resultGet = exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class);
-        assertEquals(null, resultGet);
+        assertNull(resultGet);
     }
 
     @Test
@@ -939,10 +944,10 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class), VALUE_ONE);
+        assertEquals(VALUE_ONE, exchange.getIn().getHeader(InfinispanConstants.RESULT, String.class));
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value, null);
+        assertNull(value);
     }
     
     @Test
@@ -959,10 +964,10 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
 
         Thread.sleep(100);
         NotifyingFuture fut = exchange.getIn().getHeader(InfinispanConstants.RESULT, NotifyingFuture.class);
-        assertEquals(fut.isDone(), Boolean.TRUE);
+        assertTrue(fut.isDone());
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value, null);
+        assertNull(value);
     }
     
     @Test
@@ -978,10 +983,10 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class), true);
+        assertTrue(exchange.getIn().getHeader(InfinispanConstants.RESULT, Boolean.class));
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value, null);
+        assertNull(value);
     }
     
     @Test
@@ -999,16 +1004,16 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
 
         Thread.sleep(100);
         NotifyingFuture fut = exchange.getIn().getHeader(InfinispanConstants.RESULT, NotifyingFuture.class);
-        assertEquals(fut.isDone(), Boolean.TRUE);
+        assertTrue(fut.isDone());
 
         Object value = currentCache().get(KEY_ONE);
-        assertEquals(value, null);
+        assertNull(value);
     }
 
     @Test
     public void clearsAllValues() throws Exception {
         currentCache().put(KEY_ONE, VALUE_ONE);
-        assertEquals(currentCache().isEmpty(), false);
+        assertFalse(currentCache().isEmpty());
 
         template.send("direct:start", new Processor() {
             @Override
@@ -1017,7 +1022,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
             }
         });
 
-        assertEquals(currentCache().isEmpty(), true);
+        assertTrue(currentCache().isEmpty());
     }
 
     @Test
@@ -1079,8 +1084,7 @@ public class InfinispanProducerTest extends InfinispanTestSupport {
 
         Thread.sleep(100);
         NotifyingFuture fut = exchange.getIn().getHeader(InfinispanConstants.RESULT, NotifyingFuture.class);
-        assertEquals(fut.isDone(), Boolean.TRUE);
-
+        assertTrue(fut.isDone());
         assertTrue(currentCache().isEmpty());
     }
 

--- a/components/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/InfinispanSyncConsumerTest.java
+++ b/components/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/InfinispanSyncConsumerTest.java
@@ -29,7 +29,7 @@ public class InfinispanSyncConsumerTest extends InfinispanTestSupport {
     @Test
     public void consumerReceivedPreAndPostEntryCreatedEventNotifications() throws Exception {
         mockResult.expectedMessageCount(2);
-        mockResult.setMinimumResultWaitTime(900);
+        mockResult.setResultMinimumWaitTime(900);
 
         currentCache().put(KEY_ONE, VALUE_ONE);
         mockResult.assertIsSatisfied();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -228,7 +228,7 @@
     <ibatis-bundle-version>2.3.4.726_4</ibatis-bundle-version>
     <ibatis-version>2.3.4.726</ibatis-version>
     <ical4j-version>1.0.6</ical4j-version>
-    <infinispan-version>7.2.5.Final</infinispan-version>
+    <infinispan-version>8.0.1.Final</infinispan-version>
     <irclib-bundle-version>1.10_5</irclib-bundle-version>
     <irclib-version>1.10</irclib-version>
     <isorelax-bundle-version>20050913_4</isorelax-bundle-version>


### PR DESCRIPTION
This results in camel-infinispan requiring JDK 8 at runtime. So the component documentation will need updating to reflect this.  