### PR TITLE
[CAMEL-9279] add parent to Elasticsearch IndexRequest

### DIFF
--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConstants.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConstants.java
@@ -35,6 +35,7 @@ public interface ElasticsearchConstants {
     String PARAM_INDEX_TYPE = "indexType";
     String PARAM_CONSISTENCY_LEVEL = "consistencyLevel";
     String PARAM_REPLICATION_TYPE = "replicationType";
+    String PARENT = "parent";
     String TRANSPORT_ADDRESSES = "transportAddresses";
     String PROTOCOL = "elasticsearch";
     String LOCAL_NAME = "local";

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -51,6 +51,8 @@ public final class ElasticsearchActionRequestConverter {
         } else {
             return null;
         }
+        
+        indexRequest.parent(exchange.getIn().getHeader(ElasticsearchConstants.PARENT, String.class));
 
         return indexRequest
                 .consistencyLevel(exchange.getIn().getHeader(

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -51,14 +51,14 @@ public final class ElasticsearchActionRequestConverter {
         } else {
             return null;
         }
-        
-        indexRequest.parent(exchange.getIn().getHeader(ElasticsearchConstants.PARENT, String.class));
 
         return indexRequest
                 .consistencyLevel(exchange.getIn().getHeader(
                         ElasticsearchConstants.PARAM_CONSISTENCY_LEVEL, WriteConsistencyLevel.class))
                 .replicationType(exchange.getIn().getHeader(
                         ElasticsearchConstants.PARAM_REPLICATION_TYPE, ReplicationType.class))
+                .parent(exchange.getIn().getHeader(
+                        ElasticsearchConstants.PARENT, String.class))
                 .index(exchange.getIn().getHeader(
                         ElasticsearchConstants.PARAM_INDEX_NAME, String.class))
                 .type(exchange.getIn().getHeader(


### PR DESCRIPTION
it is currently not possible to use camel-elasticsearch to send index requests for children in parent-child relationships, since the ?parent=<id> property isn't set. see: https://www.elastic.co/guide/en/elasticsearch/guide/current/indexing-parent-child.html