### PR TITLE
CAMEL-8460: Revert simplistic workaround

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -55,33 +55,29 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
         ApplicationContext applicationContext = contextRefreshedEvent.getApplicationContext();
-        if (applicationContext.getParent() == null) {
-            CamelContext camelContext = contextRefreshedEvent.getApplicationContext().getBean(CamelContext.class);
-            LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
-            for (RoutesBuilder routesBuilder : applicationContext.getBeansOfType(RoutesBuilder.class).values()) {
-                try {
-                    LOG.debug("Injecting following route into the CamelContext: {}", routesBuilder);
-                    camelContext.addRoutes(routesBuilder);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            loadXmlRoutes(applicationContext, camelContext);
-
-            if (camelContextConfigurations != null) {
-                for (CamelContextConfiguration camelContextConfiguration : camelContextConfigurations) {
-                    LOG.debug("CamelContextConfiguration found. Invoking: {}", camelContextConfiguration);
-                    camelContextConfiguration.beforeApplicationStart(camelContext);
-                }
-            }
+        CamelContext camelContext = contextRefreshedEvent.getApplicationContext().getBean(CamelContext.class);
+        LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
+        for (RoutesBuilder routesBuilder : applicationContext.getBeansOfType(RoutesBuilder.class).values()) {
             try {
-                camelContext.start();
+                LOG.debug("Injecting following route into the CamelContext: {}", routesBuilder);
+                camelContext.addRoutes(routesBuilder);
             } catch (Exception e) {
-                throw new CamelSpringBootInitializationException(e);
+                throw new RuntimeException(e);
             }
-        } else {
-            LOG.debug("Not at root context - defer adding routes");
+        }
+
+        loadXmlRoutes(applicationContext, camelContext);
+
+        if (camelContextConfigurations != null) {
+            for (CamelContextConfiguration camelContextConfiguration : camelContextConfigurations) {
+                LOG.debug("CamelContextConfiguration found. Invoking: {}", camelContextConfiguration);
+                camelContextConfiguration.beforeApplicationStart(camelContext);
+            }
+        }
+        try {
+            camelContext.start();
+        } catch (Exception e) {
+            throw new CamelSpringBootInitializationException(e);
         }
     }
 

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/parent/SpringBootWithParentContextTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/parent/SpringBootWithParentContextTest.java
@@ -16,21 +16,40 @@
  */
 package org.apache.camel.spring.boot.parent;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.GenericApplicationContext;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/* Don't use
+ * @RunWith(SpringJUnit4ClassRunner.class)
+ * @SpringApplicationConfiguration(classes = Configuration.class)
+ *
+ * The point of the test is to manually setup a parent/child context
+ * relationship and check if routes are initialized exactly once
+ */
 public class SpringBootWithParentContextTest {
 
     @Test
     public void shouldCollectRoutesOnlyInRootContext() {
         GenericApplicationContext parent = new GenericApplicationContext();
         parent.refresh();
-        new SpringApplicationBuilder(Configuration.class).web(false).parent(parent).run();
+
+        ConfigurableApplicationContext applicationContext =
+                new SpringApplicationBuilder(Configuration.class).web(false).parent(parent).run();
+
+        CamelContext camelContext = applicationContext.getBean(CamelContext.class);
+
+        assertTrue("Camel context should be started", camelContext.getStatus().isStarted());
+        assertNotNull("A 'test' route should be created", camelContext.getRoute("test"));
     }
 
 }
@@ -43,7 +62,9 @@ class Configuration {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("seda:test").to("mock:test");
+                from("seda:test")
+                        .id("test")
+                        .to("mock:test");
             }
         };
     }


### PR DESCRIPTION
Workaround failed to initialize routes in case of multiple contexts
with parent/child relationship. Reverted check for `null` parent
application context in `onApplicationEvent()` and added assertions in
unit test to verify correct initialization.