### PR TITLE
adapted the changes of CAMEL-8460 to only refresh routes on ContextRe…

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -69,7 +69,7 @@ public class CamelAutoConfiguration {
     @ConditionalOnMissingBean(RoutesCollector.class)
     RoutesCollector routesCollector(ApplicationContext applicationContext) {
         Collection<CamelContextConfiguration> configurations = applicationContext.getBeansOfType(CamelContextConfiguration.class).values();
-        return new RoutesCollector(new ArrayList<CamelContextConfiguration>(configurations));
+        return new RoutesCollector(applicationContext, new ArrayList<CamelContextConfiguration>(configurations));
     }
 
     /**

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -41,12 +41,15 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
     private static final Logger LOG = LoggerFactory.getLogger(RoutesCollector.class);
 
     // Collaborators
+    
+    private final ApplicationContext applicationContext;
 
     private final List<CamelContextConfiguration> camelContextConfigurations;
 
     // Constructors
 
-    public RoutesCollector(List<CamelContextConfiguration> camelContextConfigurations) {
+    public RoutesCollector(ApplicationContext applicationContext, List<CamelContextConfiguration> camelContextConfigurations) {
+    	this.applicationContext = applicationContext;
         this.camelContextConfigurations = new ArrayList<CamelContextConfiguration>(camelContextConfigurations);
     }
 
@@ -55,7 +58,9 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
         ApplicationContext applicationContext = contextRefreshedEvent.getApplicationContext();
-        if (applicationContext.getParent() == null) {
+        
+        // only listen to context refreshs of "my" applicationContext
+        if (this.applicationContext.equals(applicationContext)) {
             CamelContext camelContext = contextRefreshedEvent.getApplicationContext().getBean(CamelContext.class);
             LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
             for (RoutesBuilder routesBuilder : applicationContext.getBeansOfType(RoutesBuilder.class).values()) {


### PR DESCRIPTION
…freshEvents from "own" applicationContext. Previously route refreshs were initiated only if the parent applicationContext of the event's context was null. This doesn't work when Spring instantiates the Camel's application context as child of another applicationContext. This e.g. happens as soon as you're using spring-cloud-config.

This proposed change brings back RouteCollector's constructor from camel version 2.15.2 and aims to fix both [the initial reason for the change](https://github.com/spring-cloud/spring-cloud-netflix/issues/438) and the [bug introduced with the change](https://issues.apache.org/jira/browse/CAMEL-8460).

Furthermore it should replace [PR#666](https://github.com/apache/camel/pull/666)