### PR TITLE
Allow to use different registries in tests.

### DIFF
--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTestSupport.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTestSupport.java
@@ -56,6 +56,7 @@ import org.apache.camel.management.JmxSystemPropertyKeys;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.spi.Language;
+import org.apache.camel.spi.Registry;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
@@ -556,8 +557,15 @@ public abstract class CamelTestSupport extends TestSupport {
         return context;
     }
 
-    protected JndiRegistry createRegistry() throws Exception {
-        return new JndiRegistry(createJndiContext());
+   /**
+    * Return {@link Registry} to be used in tests - defaults to {@link JndiRegistry}.
+    */
+    protected Registry createRegistry() {
+        try {
+            return new JndiRegistry(createJndiContext());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected Context createJndiContext() throws Exception {

--- a/components/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
@@ -62,10 +62,10 @@ public class CamelTestSupportTest extends CamelTestSupport {
     }
 
     @Override
-    protected JndiRegistry createRegistry() throws Exception {
+    protected JndiRegistry createRegistry() {
         called = true;
 
-        JndiRegistry jndi = super.createRegistry();
+        JndiRegistry jndi = (JndiRegistry) super.createRegistry();
         jndi.bind("beer", "yes");
         return jndi;
     }


### PR DESCRIPTION
It allows to use for example SimpleRegistry without overriding "createContext()" method.

I've replaced checked exception with unchecked, because other registries may not need to throw it.