### PR TITLE
CAMEL-9224 : FIX1 - Command syntax exceptions. Endpoint stats filter.

### DIFF
--- a/platforms/commands/commands-spring-boot/src/main/java/org/apache/camel/springboot/commands/crsh/CamelCommandsFacade.java
+++ b/platforms/commands/commands-spring-boot/src/main/java/org/apache/camel/springboot/commands/crsh/CamelCommandsFacade.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Route;
 import org.apache.camel.commands.AbstractCamelCommand;
+import org.apache.camel.commands.AbstractContextCommand;
 import org.apache.camel.commands.AbstractRouteCommand;
 import org.apache.camel.commands.LocalCamelController;
 import org.apache.camel.commands.StringEscape;
@@ -56,6 +57,13 @@ public class CamelCommandsFacade {
         if (AbstractRouteCommand.class.isAssignableFrom(clazz) && null == commandArgs[1]) {
             commandArgs[1] = getCamelContextForRoute((String) commandArgs[0]);
             ops.println("Automatically inferred context name : " + commandArgs[1]);
+        }
+
+        // The order of the varargs for Context Command
+        // [0] - camel context
+        if (AbstractContextCommand.class.isAssignableFrom(clazz) && null == commandArgs[0]) {
+            commandArgs[0] = getFirstCamelContextName();
+            ops.println("Context name is not provided. Using the first : " + commandArgs[0]);
         }
 
         // Finding the right constructor
@@ -112,5 +120,14 @@ public class CamelCommandsFacade {
         }
 
         return contextNames.get(0);
+    }
+
+    private String getFirstCamelContextName() throws Exception {
+        if (null == camelController.getLocalCamelContexts() ||
+                camelController.getLocalCamelContexts().size() == 0) {
+            throw new org.crsh.cli.impl.SyntaxException("No camel contexts available");
+        }
+
+        return camelController.getLocalCamelContexts().get(0).getName();
     }
 }

--- a/platforms/commands/commands-spring-boot/src/main/resources/crash/commands/camel/camel.groovy
+++ b/platforms/commands/commands-spring-boot/src/main/resources/crash/commands/camel/camel.groovy
@@ -163,7 +163,7 @@ public class camel extends GroovyCommand {
                                  @Usage("Filter the list by in,out,static,dynamic")
                                  @Option(names = ["f", "filter"]) String filter) {
         Boolean _decode = (null != decode && Boolean.valueOf(decode))
-        String[] _filter = null != filter ? filter.split(",") : ["in", "out", "static", "dynamic"];
+        String[] _filter = filter == null ? [] : filter.split(",")
         return getCommandsFacade().runCommand(EndpointStatisticCommand.class, camelContext, _decode, _filter);
     }
 


### PR DESCRIPTION
* Removed @Required CRaSH annotation to minimise unnecessary exceptions on parameter validation.
  Replaced it with a default option (where possible) - the first camel context.
  Otherwise validating required params/options with a custom method isNull()

* Replaced the default option for the endpoint-stats filter - it is working now

I understand the idea behind minimising the exceptions. All for it, but wanted to mention that it seems that CRaSH shell is generating one on logout.