### PR TITLE
CAMEL-9305: PropertiesComponent.isDefaultCreated method only check th…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/properties/PropertiesComponent.java
+++ b/camel-core/src/main/java/org/apache/camel/component/properties/PropertiesComponent.java
@@ -92,6 +92,7 @@ public class PropertiesComponent extends DefaultComponent {
     private final Map<String, PropertiesFunction> functions = new HashMap<String, PropertiesFunction>();
     private PropertiesResolver propertiesResolver = new DefaultPropertiesResolver(this);
     private PropertiesParser propertiesParser = new DefaultPropertiesParser(this);
+    private boolean isDefaultCreated;
     private String[] locations;
     private boolean ignoreMissingLocation;
     private String encoding;
@@ -115,7 +116,11 @@ public class PropertiesComponent extends DefaultComponent {
         addFunction(new ServiceHostPropertiesFunction());
         addFunction(new ServicePortPropertiesFunction());
     }
-    
+
+    public PropertiesComponent(boolean isDefaultCreated) {
+        this.isDefaultCreated = isDefaultCreated;
+    }
+
     public PropertiesComponent(String location) {
         this();
         setLocation(location);
@@ -207,7 +212,7 @@ public class PropertiesComponent extends DefaultComponent {
      * Is this component created as a default by {@link org.apache.camel.CamelContext} during starting up Camel.
      */
     public boolean isDefaultCreated() {
-        return locations == null;
+        return isDefaultCreated;
     }
 
     public String[] getLocations() {

--- a/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
@@ -582,7 +582,7 @@ public final class CamelContextHelper {
             // create a default properties component to be used as there may be default values we can use
             LOG.info("No existing PropertiesComponent has been configured, creating a new default PropertiesComponent with name: properties");
             // do not auto create using getComponent as spring auto-wire by constructor causes a side effect
-            answer = new PropertiesComponent();
+            answer = new PropertiesComponent(true);
             camelContext.addComponent("properties", answer);
         }
         return answer;


### PR DESCRIPTION
…e absence of defined locations

The method now returns 'false' except but for the default properties component that gets created
at start time when no component named 'properties' exists. The implementation intentionally doesn't introduce
any member nor setter in order to avoid any unintended usage of the isDefaultCreated semantic. The default
properties component that gets created extends PropertiesComponent and overrides the default implementation.