### PR TITLE
CAMEL-9161 Change for dealing with parent contexts

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -82,7 +82,7 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
                 throw new CamelSpringBootInitializationException(e);
             }
         } else {
-            LOG.debug("Not at root context - defer adding routes");
+            LOG.debug("Camel already started, not adding routes.");
         }
     }
 

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
+import org.apache.camel.ServiceStatus;
 import org.apache.camel.model.RoutesDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +56,8 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
         ApplicationContext applicationContext = contextRefreshedEvent.getApplicationContext();
-        if (applicationContext.getParent() == null) {
-            CamelContext camelContext = contextRefreshedEvent.getApplicationContext().getBean(CamelContext.class);
+		CamelContext camelContext = contextRefreshedEvent.getApplicationContext().getBean(CamelContext.class);
+        if (camelContext.getStatus() == ServiceStatus.Stopped) {
             LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
             for (RoutesBuilder routesBuilder : applicationContext.getBeansOfType(RoutesBuilder.class).values()) {
                 try {

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/parent/SpringBootRefreshContextTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/parent/SpringBootRefreshContextTest.java
@@ -18,19 +18,25 @@ package org.apache.camel.spring.boot.parent;
 
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.RoutesCollector;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.support.GenericApplicationContext;
 
-public class SpringBootWithParentContextTest {
+public class SpringBootRefreshContextTest {
 
     @Test
-    public void shouldCollectRoutesOnlyInRootContext() {
+    public void shouldOnlyCollectRoutesOnce() {
         GenericApplicationContext parent = new GenericApplicationContext();
         parent.refresh();
-        new SpringApplicationBuilder(Configuration.class).web(false).parent(parent).run();
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(Configuration.class).web(false).parent(parent).run();
+		ContextRefreshedEvent refreshEvent = new ContextRefreshedEvent(context);
+		RoutesCollector collector = context.getBean(RoutesCollector.class);
+		collector.onApplicationEvent(refreshEvent); //no changes should happen here
     }
 
 }


### PR DESCRIPTION
Changes to look at current status instead of just checking for parent context. Using spring cloud automatically adds a parent context which completely disables camel-spring-boot stuff from 2.15.3 onwards.