### PR TITLE
Add After Camel Start Hook

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelContextConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelContextConfiguration.java
@@ -22,4 +22,6 @@ public interface CamelContextConfiguration {
 
     void beforeApplicationStart(CamelContext camelContext);
 
+    void afterApplicationStart(CamelContext camelContext);
+
 }

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -83,6 +83,11 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
                     }
 
                     camelContext.start();
+                    
+                    for (CamelContextConfiguration camelContextConfiguration : camelContextConfigurations) {
+                        camelContextConfiguration.afterApplicationStart(camelContext);
+                    }
+                    
                 } catch (Exception e) {
                     throw new CamelSpringBootInitializationException(e);
                 }


### PR DESCRIPTION
This patch was used locally to send to a route by a producer template once the camel context is started and all routes are loaded.