### PR TITLE
Java doc: Users of the deprecated TestSupport#property(String name) s…

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/TestSupport.java
+++ b/camel-core/src/test/java/org/apache/camel/TestSupport.java
@@ -74,6 +74,8 @@ public abstract class TestSupport extends TestCase {
 
     /**
      * Returns a value builder for the given exchange property
+     * 
+     * @deprecated use {@link #exchangeProperty(String)}
      */
     @Deprecated
     public static ValueBuilder property(String name) {


### PR DESCRIPTION
…hould use TestSupport#exchangeProperty(String) instead.

btw: Thanks for providing Camel!