### PR TITLE
camel-test/camel-testng: Add #exchangeProperty(String) to TestSupport…

### DIFF
--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/TestSupport.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/TestSupport.java
@@ -69,11 +69,21 @@ public abstract class TestSupport extends Assert {
 
     /**
      * Returns a value builder for the given property
+     * 
+     * @deprecated use {@link #exchangeProperty(String)}
      */
+    @Deprecated
     public static ValueBuilder property(String name) {
         return Builder.exchangeProperty(name);
-    }    
-    
+    }
+
+    /**
+     * Returns a value builder for the given exchange property
+     */
+    public static ValueBuilder exchangeProperty(String name) {
+        return Builder.exchangeProperty(name);
+    }
+
     /**
      * Returns a predicate and value builder for the inbound body on an exchange
      */
@@ -92,7 +102,10 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the outbound body on an
      * exchange
+     *
+     * @deprecated use {@link #body()}
      */
+    @Deprecated
     public static ValueBuilder outBody() {
         return Builder.outBody();
     }
@@ -100,7 +113,10 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the outbound message body as a
      * specific type
+     *
+     * @deprecated use {@link #bodyAs(Class)}
      */
+    @Deprecated
     public static <T> ValueBuilder outBodyAs(Class<T> type) {
         return Builder.outBodyAs(type);
     }
@@ -116,7 +132,10 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the fault message body as a
      * specific type
+     *
+     * @deprecated use {@link #bodyAs(Class)}
      */
+    @Deprecated
     public static <T> ValueBuilder faultBodyAs(Class<T> type) {
         return Builder.faultBodyAs(type);
     }

--- a/components/camel-testng/src/main/java/org/apache/camel/testng/TestSupport.java
+++ b/components/camel-testng/src/main/java/org/apache/camel/testng/TestSupport.java
@@ -64,8 +64,18 @@ public abstract class TestSupport extends Assert {
 
     /**
      * Returns a value builder for the given property
+     * 
+     * @deprecated use {@link #exchangeProperty(String)}
      */
+    @Deprecated
     public static ValueBuilder property(String name) {
+        return Builder.exchangeProperty(name);
+    }
+
+    /**
+     * Returns a value builder for the given exchange property
+     */
+    public static ValueBuilder exchangeProperty(String name) {
         return Builder.exchangeProperty(name);
     }
 
@@ -87,7 +97,10 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the outbound body on an
      * exchange
+     *
+     * @deprecated use {@link #body()}
      */
+    @Deprecated
     public static ValueBuilder outBody() {
         return Builder.outBody();
     }
@@ -95,6 +108,8 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the outbound message body as a
      * specific type
+     *
+     * @deprecated use {@link #bodyAs(Class)}
      */
     public static <T> ValueBuilder outBodyAs(Class<T> type) {
         return Builder.outBodyAs(type);
@@ -111,7 +126,10 @@ public abstract class TestSupport extends Assert {
     /**
      * Returns a predicate and value builder for the fault message body as a
      * specific type
+     *
+     * @deprecated use {@link #bodyAs(Class)}
      */
+    @Deprecated
     public static <T> ValueBuilder faultBodyAs(Class<T> type) {
         return Builder.faultBodyAs(type);
     }


### PR DESCRIPTION
… and deprecate methods which redirect to deprecated methods of org.apache.camel.builder.Builder