### PR TITLE
CAMEL-9340: Using user.dir as default dir for fileStore file when fil…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/idempotent/FileIdempotentRepository.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/idempotent/FileIdempotentRepository.java
@@ -290,6 +290,9 @@ public class FileIdempotentRepository extends ServiceSupport implements Idempote
         if (!fileStore.exists()) {
             LOG.debug("Creating filestore: {}", fileStore);
             File parent = fileStore.getParentFile();
+            if(parent == null) {
+                parent = new File(System.getProperty("user.dir"));
+            }
             parent.mkdirs();
             boolean created = FileUtil.createNewFile(fileStore);
             if (!created) {

--- a/camel-core/src/test/java/org/apache/camel/processor/FileIdempotentConsumerCreateRepoTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/FileIdempotentConsumerCreateRepoTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import static java.util.UUID.randomUUID;
 
 import org.apache.camel.spi.IdempotentRepository;
+import org.apache.camel.util.FileUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,6 +46,29 @@ public class FileIdempotentConsumerCreateRepoTest extends Assert {
         assertTrue(store.exists());
 
         repo.stop();
+    }
+
+    @Test
+    public void shouldUseUserDirIfStoreFileHasNoParentFile() throws Exception {
+        // Given
+        File store = new File("ids_" + randomUUID());
+
+        try {
+            IdempotentRepository<String> repo = fileIdempotentRepository(store);
+
+            // must start repo
+            repo.start();
+
+            // When
+            repo.add("anyKey");
+
+            // Then
+            assertTrue(store.exists());
+
+            repo.stop();
+        } finally {
+            FileUtil.deleteFile(store);
+        }
     }
 
 }


### PR DESCRIPTION
CAMEL-9340: Using user.dir as default dir for fileStore file when fileStore when file has no parent dir.