### PR TITLE
CAMEL-9371: camel-swagger-java with camel-restlet

### DIFF
--- a/components/camel-restlet/pom.xml
+++ b/components/camel-restlet/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>camel-jaxb</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-swagger-java</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
@@ -34,6 +34,7 @@ import org.apache.camel.Consumer;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.impl.HeaderFilterStrategyComponent;
+import org.apache.camel.spi.RestApiConsumerFactory;
 import org.apache.camel.spi.RestConfiguration;
 import org.apache.camel.spi.RestConsumerFactory;
 import org.apache.camel.util.FileUtil;
@@ -60,7 +61,7 @@ import org.slf4j.LoggerFactory;
  *
  * @version
  */
-public class RestletComponent extends HeaderFilterStrategyComponent implements RestConsumerFactory {
+public class RestletComponent extends HeaderFilterStrategyComponent implements RestConsumerFactory, RestApiConsumerFactory {
     private static final Logger LOG = LoggerFactory.getLogger(RestletComponent.class);
 
     private final Map<String, Server> servers = new HashMap<String, Server>();
@@ -754,5 +755,12 @@ public class RestletComponent extends HeaderFilterStrategyComponent implements R
         }
 
         return consumer;
+    }
+
+    @Override
+    public Consumer createApiConsumer(CamelContext camelContext, Processor processor, String contextPath,
+                                      RestConfiguration configuration, Map<String, Object> parameters) throws Exception {
+        // reuse the createConsumer method we already have. The api need to use GET and match on uri prefix
+        return createConsumer(camelContext, processor, "GET", contextPath, null, null, null, configuration, parameters);
     }
 }

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletApiTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletApiTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.restlet;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestParamType;
+import org.junit.Test;
+
+import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+public class RestRestletApiTest extends RestletTestSupport {
+
+    @Override
+    protected boolean useJmx() {
+        return true;
+    }
+
+    @Test
+    public void testApi() throws Exception {
+        Exchange exchange = template.request("http://localhost:" + portNum + "/docs", null);
+        assertThat(exchange.getOut().getHeader(HTTP_RESPONSE_CODE, Integer.class), is(200));
+        String body = exchange.getOut().getBody(String.class);
+        log.info("Received body: ", body);
+
+        assertThat(body, containsString("\"version\" : \"1.2.3\""));
+        assertThat(body, containsString("\"title\" : \"The hello rest thing\""));
+        assertThat(body, containsString("\"/bye/{name}\""));
+        assertThat(body, containsString("\"/hello/{name}\""));
+        assertThat(body, containsString("\"summary\" : \"To update the greeting message\""));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use restlet on localhost with the given port
+                restConfiguration()
+                        .component("restlet").port(portNum)
+                        .apiContextPath("/docs")
+                        .apiProperty("cors", "true")
+                        .apiProperty("api.title", "The hello rest thing")
+                        .apiProperty("api.version", "1.2.3");
+
+                rest("/hello").consumes("application/json").produces("application/json")
+                        .get("/{name}").description("Saying hi")
+                        .param().name("name").type(RestParamType.path).dataType("string").description("Who is it").endParam()
+                        .to("log:hi");
+
+                rest("/bye").consumes("application/json").produces("application/json")
+                        .get("/{name}").description("Saying bye")
+                        .param().name("name").type(RestParamType.path).dataType("string").description("Who is it").endParam()
+                        .responseMessage().code(200).message("A reply message").endResponseMessage()
+                        .to("log:bye")
+
+                        .post().description("To update the greeting message")
+                        .consumes("application/xml").produces("application/xml")
+                        .param().name("greeting").type(RestParamType.body).dataType("string").description("Message to use as greeting").endParam()
+                        .to("log:bye");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Tiny fix (+test) to support camel-restlet as the Rest DSL component for camel-swagger-java docs functionality. Inspired by camel-servlet code.