### PR TITLE
Stop storing the columns in the dynamic CsvMarshaller

### DIFF
--- a/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvMarshaller.java
+++ b/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvMarshaller.java
@@ -22,7 +22,6 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -130,17 +129,14 @@ abstract class CsvMarshaller {
      * This marshaller adapts the columns but always keep them in the same order
      */
     private static final class DynamicColumnsMarshaller extends CsvMarshaller {
-        private final LinkedHashSet<Object> columns = new LinkedHashSet<Object>();
-
         private DynamicColumnsMarshaller(CSVFormat format) {
             super(format);
         }
 
         @Override
         protected Iterable<?> getMapRecordValues(Map<?, ?> map) {
-            columns.addAll(map.keySet());
-            List<Object> result = new ArrayList<Object>(columns.size());
-            for (Object key : columns) {
+            List<Object> result = new ArrayList<Object>(map.size());
+            for (Object key : map.keySet()) {
                 result.add(map.get(key));
             }
             return result;

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalTest.java
@@ -98,6 +98,18 @@ public class CsvMarshalTest extends CamelTestSupport {
         assertArrayEquals(new String[]{"A,C", "1,3", "one,three"}, readOutputLines());
     }
 
+    @Test
+    public void shouldMarshalDifferentDynamicColumns() throws Exception {
+    	output.expectedMessageCount(2);
+    	
+    	template.sendBody("direct:default", TestUtils.asMap("A", "1", "B", "2"));    	
+    	template.sendBody("direct:default", TestUtils.asMap("X", "1", "Y", "2", "Z", "3"));
+    	
+    	output.assertIsSatisfied();
+    	assertArrayEquals(new String[]{"1,2"}, readOutputLines());
+    	assertArrayEquals(new String[]{"1,2,3"}, output.getExchanges().get(1).getIn().getBody(String.class).split("\r\n|\r|\n"));
+    }
+    
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {


### PR DESCRIPTION
When the CsvMarshaller (no fixed columns) is used in a router that dynamically receives different (asymmetric) records from the consumer, the columns was always being added in a `LinkedHashSet`. This generates additional empty columns in the resulting csv entry.

My proposal is always use the map structure, allowing the marshaller to be reused.   
A new test verifies if different maps can be used using the same marshaller without extra columns being generated.