### PR TITLE
CAMEL-9338: Upgrade Spring Integration to version 4.2.2

### DIFF
--- a/components/camel-spring-integration/pom.xml
+++ b/components/camel-spring-integration/pom.xml
@@ -31,7 +31,8 @@
 
     <properties>
         <camel.osgi.export.pkg>org.apache.camel.component.spring.integration.*</camel.osgi.export.pkg>
-        <camel.osgi.import.before.defaults>org.springframework.integration.*;version="[2,3)"</camel.osgi.import.before.defaults>
+        <camel.osgi.import.before.defaults>org.springframework.integration.*;version="[4"
+        org.springframework.messaging.*;version="[4"</camel.osgi.import.before.defaults>
         <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=spring-integration</camel.osgi.export.service>
 
         <!-- must use older spring version -->

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationBinding.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationBinding.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.spring.integration;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
-import org.springframework.integration.message.GenericMessage;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * The helper class for Mapping between the Spring Integration message and the Camel Message.
@@ -32,20 +32,20 @@ public final class SpringIntegrationBinding {
         // Helper class
     }
 
-    public static org.springframework.integration.Message<?> createSpringIntegrationMessage(Exchange exchange) {
+    public static org.springframework.messaging.Message<?> createSpringIntegrationMessage(Exchange exchange) {
         return createSpringIntegrationMessage(exchange, exchange.getIn().getHeaders());
     }
 
-    public static org.springframework.integration.Message<?> createSpringIntegrationMessage(Exchange exchange, Map<String, Object> headers) {
+    public static org.springframework.messaging.Message<?> createSpringIntegrationMessage(Exchange exchange, Map<String, Object> headers) {
         org.apache.camel.Message message = exchange.getIn();
         return new GenericMessage<Object>(message.getBody(), headers);
     }
 
-    public static org.springframework.integration.Message<?> storeToSpringIntegrationMessage(org.apache.camel.Message message) {
+    public static org.springframework.messaging.Message<?> storeToSpringIntegrationMessage(org.apache.camel.Message message) {
         return new GenericMessage<Object>(message.getBody(), message.getHeaders());
     }
 
-    public static void storeToCamelMessage(org.springframework.integration.Message<?> siMessage, org.apache.camel.Message cMessage) {
+    public static void storeToCamelMessage(org.springframework.messaging.Message<?> siMessage, org.apache.camel.Message cMessage) {
         cMessage.setBody(siMessage.getPayload());
         cMessage.setHeaders(siMessage.getHeaders());
     }

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationConsumer.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationConsumer.java
@@ -22,11 +22,11 @@ import org.apache.camel.Processor;
 import org.apache.camel.impl.DefaultConsumer;
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.util.ObjectHelper;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.core.SubscribableChannel;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.SubscribableChannel;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
-import org.springframework.integration.support.channel.ChannelResolver;
+import org.springframework.messaging.core.DestinationResolver;
 
 /**
  * A consumer of exchanges for the Spring Integration
@@ -38,14 +38,14 @@ import org.springframework.integration.support.channel.ChannelResolver;
  */
 public class SpringIntegrationConsumer  extends DefaultConsumer implements MessageHandler {
     private final SpringCamelContext context;
-    private final ChannelResolver channelResolver;
+    private final DestinationResolver<MessageChannel> destinationResolver;
     private SubscribableChannel inputChannel;
     private MessageChannel outputChannel;
 
     public SpringIntegrationConsumer(SpringIntegrationEndpoint endpoint, Processor processor) {
         super(endpoint, processor);
         this.context = (SpringCamelContext) endpoint.getCamelContext();
-        this.channelResolver = new BeanFactoryChannelResolver(context.getApplicationContext());
+        this.destinationResolver = new BeanFactoryChannelResolver(context.getApplicationContext());
     }
 
     @Override
@@ -68,7 +68,7 @@ public class SpringIntegrationConsumer  extends DefaultConsumer implements Messa
             }
 
             ObjectHelper.notEmpty(inputChannelName, "inputChannelName", getEndpoint());
-            inputChannel = (SubscribableChannel) channelResolver.resolveChannelName(inputChannelName);
+            inputChannel = (SubscribableChannel) destinationResolver.resolveDestination(inputChannelName);
         } else {
             inputChannel = (SubscribableChannel) getEndpoint().getMessageChannel();
         }
@@ -81,7 +81,7 @@ public class SpringIntegrationConsumer  extends DefaultConsumer implements Messa
         if (getEndpoint().isInOut()) {
             // we need to setup right outputChannel for further processing
             ObjectHelper.notEmpty(getEndpoint().getOutputChannel(), "OutputChannel", getEndpoint());
-            outputChannel = channelResolver.resolveChannelName(getEndpoint().getOutputChannel());
+            outputChannel = destinationResolver.resolveDestination(getEndpoint().getOutputChannel());
 
             if (outputChannel == null) {
                 throw new IllegalArgumentException("Cannot resolve OutputChannel on " + getEndpoint());
@@ -91,7 +91,7 @@ public class SpringIntegrationConsumer  extends DefaultConsumer implements Messa
         inputChannel.subscribe(this);
     }
 
-    public void handleMessage(org.springframework.integration.Message<?> siInMessage) {
+    public void handleMessage(org.springframework.messaging.Message<?> siInMessage) {
         // we received a message from spring integration
         // wrap that in a Camel Exchange and process it
         Exchange exchange = getEndpoint().createExchange(getEndpoint().isInOut() ? ExchangePattern.InOut : ExchangePattern.InOnly);
@@ -131,7 +131,7 @@ public class SpringIntegrationConsumer  extends DefaultConsumer implements Messa
             }
 
             // put the message back the outputChannel if we need
-            org.springframework.integration.Message<?> siOutMessage =
+            org.springframework.messaging.Message<?> siOutMessage =
                 SpringIntegrationBinding.storeToSpringIntegrationMessage(exchange.getOut());
 
             // send the message to spring integration

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationEndpoint.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationEndpoint.java
@@ -26,7 +26,7 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 import org.apache.camel.spring.SpringCamelContext;
-import org.springframework.integration.MessageChannel;
+import org.springframework.messaging.MessageChannel;
 
 /**
  * Defines the <a href="http://camel.apache.org/springIntergration.html">Spring Integration Endpoint</a>

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationMessage.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationMessage.java
@@ -27,20 +27,20 @@ import org.apache.camel.impl.DefaultMessage;
  * @version 
  */
 public class SpringIntegrationMessage extends DefaultMessage {
-    private org.springframework.integration.Message<?> siMessage;
+    private org.springframework.messaging.Message<?> siMessage;
 
     public SpringIntegrationMessage() {
     }
 
-    public SpringIntegrationMessage(org.springframework.integration.Message<?> message) {
+    public SpringIntegrationMessage(org.springframework.messaging.Message<?> message) {
         this.siMessage = message;
     }
 
-    public void setMessage(org.springframework.integration.Message<?> message) {
+    public void setMessage(org.springframework.messaging.Message<?> message) {
         this.siMessage = message;
     }
 
-    public org.springframework.integration.Message<?> getMessage() {
+    public org.springframework.messaging.Message<?> getMessage() {
         return siMessage;
     }
 

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationProducer.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationProducer.java
@@ -21,13 +21,13 @@ import org.apache.camel.Processor;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.util.ObjectHelper;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.core.MessageHandler;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
-import org.springframework.integration.support.channel.ChannelResolver;
+import org.springframework.messaging.core.DestinationResolver;
 
 /**
  * A producer of exchanges for the Spring Integration
@@ -37,13 +37,13 @@ import org.springframework.integration.support.channel.ChannelResolver;
  * @version 
  */
 public class SpringIntegrationProducer extends DefaultProducer implements Processor {    
-    private final ChannelResolver channelResolver;
+    private final DestinationResolver<MessageChannel> destinationResolver;
     private DirectChannel inputChannel;
     private MessageChannel outputChannel;
 
     public SpringIntegrationProducer(SpringCamelContext context, SpringIntegrationEndpoint endpoint) {
         super(endpoint);
-        this.channelResolver = new BeanFactoryChannelResolver(context.getApplicationContext());
+        this.destinationResolver = new BeanFactoryChannelResolver(context.getApplicationContext());
     }
 
     @Override
@@ -62,7 +62,7 @@ public class SpringIntegrationProducer extends DefaultProducer implements Proces
             }
 
             ObjectHelper.notEmpty(outputChannelName, "OutputChannelName", getEndpoint());
-            outputChannel = channelResolver.resolveChannelName(outputChannelName);
+            outputChannel = destinationResolver.resolveDestination(outputChannelName);
         } else {
             outputChannel = getEndpoint().getMessageChannel();
         }
@@ -75,7 +75,7 @@ public class SpringIntegrationProducer extends DefaultProducer implements Proces
         if (getEndpoint().isInOut()) {
             // we need to setup right inputChannel for further processing
             ObjectHelper.notEmpty(getEndpoint().getInputChannel(), "InputChannel", getEndpoint());
-            inputChannel = (DirectChannel)channelResolver.resolveChannelName(getEndpoint().getInputChannel());
+            inputChannel = (DirectChannel)destinationResolver.resolveDestination(getEndpoint().getInputChannel());
 
             if (inputChannel == null) {
                 throw new IllegalArgumentException("Cannot resolve InputChannel on " + getEndpoint());
@@ -100,7 +100,7 @@ public class SpringIntegrationProducer extends DefaultProducer implements Proces
                 }
             });
         }
-        org.springframework.integration.Message<?> siOutmessage = SpringIntegrationBinding.createSpringIntegrationMessage(exchange);
+        org.springframework.messaging.Message<?> siOutmessage = SpringIntegrationBinding.createSpringIntegrationMessage(exchange);
 
         // send the message to spring integration
         log.debug("Sending {} to OutputChannel: {}", siOutmessage, outputChannel);

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/adapter/CamelSourceAdapter.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/adapter/CamelSourceAdapter.java
@@ -27,11 +27,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.core.MessageHandler;
+import org.springframework.messaging.MessageHandler;
 
 /**
  * A CamelContext will be injected into CameSourceAdapter which will
@@ -62,7 +62,7 @@ public class CamelSourceAdapter extends AbstractCamelAdapter implements Initiali
 
     protected class ConsumerProcessor implements Processor {
         public void process(final Exchange exchange) throws Exception {
-            org.springframework.integration.Message<?> request = SpringIntegrationBinding.createSpringIntegrationMessage(exchange);
+            org.springframework.messaging.Message<?> request = SpringIntegrationBinding.createSpringIntegrationMessage(exchange);
 
             if (exchange.getPattern().isOutCapable()) {
                 exchange.getIn().getHeaders().put(MessageHeaders.REPLY_CHANNEL , replyChannel);

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/adapter/CamelTargetAdapter.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/adapter/CamelTargetAdapter.java
@@ -23,11 +23,11 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.spring.integration.SpringIntegrationBinding;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageDeliveryException;
-import org.springframework.integration.MessageHeaders;
-import org.springframework.integration.core.MessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessageHandler;
 
 /**
  * CamelTargetAdapter will redirect the Spring Integration message to the Camel context.

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/converter/SpringIntegrationConverter.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/converter/SpringIntegrationConverter.java
@@ -20,9 +20,9 @@ import org.apache.camel.Converter;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.spring.integration.SpringIntegrationEndpoint;
 import org.apache.camel.component.spring.integration.SpringIntegrationMessage;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageHeaders;
-import org.springframework.integration.message.GenericMessage;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * The <a href="http://camel.apache.org/type-converter.html">Type Converters</a>
@@ -45,10 +45,10 @@ public final class SpringIntegrationConverter {
     }
 
     @Converter
-    public static org.springframework.integration.Message<?> toSpringMessage(final org.apache.camel.Message camelMessage) throws Exception {
+    public static org.springframework.messaging.Message<?> toSpringMessage(final org.apache.camel.Message camelMessage) throws Exception {
         if (camelMessage instanceof SpringIntegrationMessage) {
             SpringIntegrationMessage siMessage = (SpringIntegrationMessage)camelMessage;
-            org.springframework.integration.Message<?> message =  siMessage.getMessage();
+            org.springframework.messaging.Message<?> message =  siMessage.getMessage();
             if (message != null) {
                 return message;
             }
@@ -60,7 +60,7 @@ public final class SpringIntegrationConverter {
     }
 
     @Converter
-    public static org.apache.camel.Message toCamelMessage(final org.springframework.integration.Message<?> springMessage) throws Exception {
+    public static org.apache.camel.Message toCamelMessage(final org.springframework.messaging.Message<?> springMessage) throws Exception {
         return new SpringIntegrationMessage(springMessage);
     }
 

--- a/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/SpringIntegrationOneWayConsumerTest.java
+++ b/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/SpringIntegrationOneWayConsumerTest.java
@@ -20,8 +20,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.message.GenericMessage;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
 
 public class SpringIntegrationOneWayConsumerTest extends CamelSpringTestSupport {
 

--- a/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/SpringIntegrationTwoWayConsumerTest.java
+++ b/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/SpringIntegrationTwoWayConsumerTest.java
@@ -24,12 +24,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.message.GenericMessage;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.GenericMessage;
 
 public class SpringIntegrationTwoWayConsumerTest extends CamelSpringTestSupport {
 

--- a/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/adapter/CamelSourceAdapterTest.java
+++ b/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/adapter/CamelSourceAdapterTest.java
@@ -22,9 +22,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.core.MessageHandler;
+import org.springframework.messaging.MessageHandler;
 
 public class CamelSourceAdapterTest extends CamelSpringTestSupport {
 

--- a/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/adapter/CamelTargetAdapterTest.java
+++ b/components/camel-spring-integration/src/test/java/org/apache/camel/component/spring/integration/adapter/CamelTargetAdapterTest.java
@@ -25,12 +25,12 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageChannel;
-import org.springframework.integration.MessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.message.GenericMessage;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.GenericMessage;
 
 public class CamelTargetAdapterTest extends CamelSpringTestSupport {
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -466,7 +466,7 @@
     <spring-castor-bundle-version>1.2.0</spring-castor-bundle-version>
     <spring-data-commons-version>1.6.5.RELEASE</spring-data-commons-version>
     <spring-data-redis-version>1.6.0.RELEASE</spring-data-redis-version>
-    <spring-integration-version>2.2.6.RELEASE</spring-integration-version>
+    <spring-integration-version>4.2.2.RELEASE</spring-integration-version>
     <spring-javaconfig-version>1.0.0-20090215</spring-javaconfig-version>
     <spring-ldap-version>2.0.4.RELEASE</spring-ldap-version>
     <spring-ldap-bundle-version>2.0.3.RELEASE_1</spring-ldap-bundle-version>


### PR DESCRIPTION
`<camel.osgi.import.before.defaults>` is most probably incorrect, because lacking the required knowledge, I just took a guess at what value it should have.