### PR TITLE
use System.lineSeparator()

### DIFF
--- a/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
+++ b/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
@@ -143,7 +143,7 @@ public class StreamProducer extends DefaultProducer {
             LOG.debug("Writing as text: {} to {} using encoding: {}", new Object[]{body, outputStream, charset});
         }
         bw.write(s);
-        bw.write("\n");
+        bw.write(System.lineSeparator());
         bw.flush();
     }
 

--- a/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamFileTest.java
+++ b/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamFileTest.java
@@ -90,7 +90,7 @@ public class StreamFileTest extends CamelTestSupport {
                 from("direct:start").routeId("produce")
                     .to("stream:file?fileName=target/stream/StreamFileTest.txt&autoCloseCount=2");
                 from("file://target/stream?fileName=StreamFileTest.txt&noop=true").routeId("consume").autoStartup(false)
-                    .split().tokenize("\n").to("mock:result");
+                    .split().tokenize(System.lineSeparator()).to("mock:result");
             }
         });
         context.start();

--- a/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamGroupLinesStrategyTest.java
+++ b/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamGroupLinesStrategyTest.java
@@ -38,7 +38,7 @@ public class StreamGroupLinesStrategyTest extends StreamGroupLinesTest {
             StringBuilder buffer = new StringBuilder();
             for (String line : lines) {
                 buffer.append(line);
-                buffer.append("\n");
+                buffer.append(System.lineSeparator());
             }
             return buffer.toString();
         }

--- a/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamSystemOutTest.java
+++ b/components/camel-stream/src/test/java/org/apache/camel/component/stream/StreamSystemOutTest.java
@@ -45,7 +45,7 @@ public class StreamSystemOutTest extends CamelTestSupport {
             template.sendBody("direct:in", message);
 
             // Then
-            assertEquals(message + "\n", new String(mockOut.toByteArray()));
+            assertEquals(message + System.lineSeparator(), new String(mockOut.toByteArray()));
         } finally {
             System.setOut(stdOut);
         }


### PR DESCRIPTION
use the system-dependent line separator string.