### PR TITLE
DynamoDB Stream Consumer

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamComponent.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamComponent.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.ddbstream;
+
+import java.util.Map;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.UriEndpointComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DdbStreamComponent extends UriEndpointComponent {
+    private static final Logger LOG = LoggerFactory.getLogger(DdbStreamComponent.class);
+
+    public DdbStreamComponent() {
+        super(DdbStreamEndpoint.class);
+    }
+
+    public DdbStreamComponent(CamelContext context) {
+        super(context, DdbStreamEndpoint.class);
+    }
+
+    @Override
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        DdbStreamEndpoint endpoint = new DdbStreamEndpoint(uri, remaining, this);
+
+        LOG.debug("Created endpoint: {}", endpoint.toString());
+        return endpoint;
+    }
+}

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumer.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.ddbstream;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams;
+import com.amazonaws.services.dynamodbv2.model.DescribeStreamRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeStreamResult;
+import com.amazonaws.services.dynamodbv2.model.GetRecordsRequest;
+import com.amazonaws.services.dynamodbv2.model.GetRecordsResult;
+import com.amazonaws.services.dynamodbv2.model.GetShardIteratorRequest;
+import com.amazonaws.services.dynamodbv2.model.GetShardIteratorResult;
+import com.amazonaws.services.dynamodbv2.model.ListStreamsRequest;
+import com.amazonaws.services.dynamodbv2.model.ListStreamsResult;
+import com.amazonaws.services.dynamodbv2.model.Record;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.impl.ScheduledBatchPollingConsumer;
+import org.apache.camel.util.CastUtils;
+import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DdbStreamConsumer extends ScheduledBatchPollingConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(DdbStreamConsumer.class);
+
+    private String currentShardIterator = null;
+
+    public DdbStreamConsumer(DdbStreamEndpoint endpoint, Processor processor) {
+        super(endpoint, processor);
+    }
+
+    /*
+     * Returns the number of messages polled.
+     */
+    @Override
+    protected int poll() throws Exception {
+        GetRecordsRequest req = new GetRecordsRequest()
+                .withShardIterator(getShardItertor())
+                .withLimit(getEndpoint().getMaxResultsPerRequest())
+                ;
+        GetRecordsResult result = getClient().getRecords(req);
+
+        Queue<Exchange> exchanges = createExchanges(result.getRecords());
+        int processedExchangeCount = processBatch(CastUtils.cast(exchanges));
+
+        currentShardIterator = result.getNextShardIterator();
+
+        return processedExchangeCount;
+    }
+
+    @Override
+    public int processBatch(Queue<Object> exchanges) throws Exception {
+        int processedExchanges = 0;
+        while (!exchanges.isEmpty()) {
+            final Exchange exchange = ObjectHelper.cast(Exchange.class, exchanges.poll());
+
+            LOG.trace("Processing exchange [{}] started.", exchange);
+            getAsyncProcessor().process(exchange, new AsyncCallback() {
+                @Override
+                public void done(boolean doneSync) {
+                    LOG.trace("Processing exchange [{}] done.", exchange);
+                }
+            });
+            processedExchanges++;
+        }
+        return processedExchanges;
+    }
+
+    private AmazonDynamoDBStreams getClient() {
+        return getEndpoint().getClient();
+    }
+
+    @Override
+    public DdbStreamEndpoint getEndpoint() {
+        return (DdbStreamEndpoint) super.getEndpoint();
+    }
+
+    private String getShardItertor() {
+        // either return a cached one or get a new one via a GetShardIterator request.
+        if (currentShardIterator == null) {
+            ListStreamsRequest req0 = new ListStreamsRequest()
+                    .withTableName(getEndpoint().getTableName())
+                    ;
+            ListStreamsResult res0 = getClient().listStreams(req0);
+            final String streamArn = res0.getStreams().get(0).getStreamArn(); // XXX assumes there is only one stream
+            DescribeStreamRequest req1 = new DescribeStreamRequest()
+                    .withStreamArn(streamArn)
+                    ;
+            DescribeStreamResult res1 = getClient().describeStream(req1);
+
+            GetShardIteratorRequest req = new GetShardIteratorRequest()
+                    .withStreamArn(streamArn)
+                    .withShardId(res1.getStreamDescription().getShards().get(0).getShardId()) // XXX only uses the first shard
+                    .withShardIteratorType(getEndpoint().getIteratorType())
+                    ;
+            GetShardIteratorResult result = getClient().getShardIterator(req);
+            currentShardIterator = result.getShardIterator();
+        }
+        LOG.trace("Shard Iterator is: {}", currentShardIterator);
+        return currentShardIterator;
+    }
+
+    private Queue<Exchange> createExchanges(List<Record> records) {
+        Queue<Exchange> exchanges = new ArrayDeque<>();
+        for (Record record : records) {
+            exchanges.add(getEndpoint().createExchange(record));
+        }
+        return exchanges;
+    }
+}

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumer.java
@@ -107,7 +107,15 @@ public class DdbStreamConsumer extends ScheduledBatchPollingConsumer {
 
             LOG.trace("Current shard is: {} (in {})", currentShard, shardList);
             if (currentShard == null) {
-                currentShard = shardList.first();
+                switch(getEndpoint().getIteratorType()) {
+                case TRIM_HORIZON:
+                    currentShard = shardList.first();
+                    break;
+                default:
+                case LATEST:
+                    currentShard = shardList.last();
+                    break;
+                }
             } else {
                 currentShard = shardList.nextAfter(currentShard);
             }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
@@ -42,10 +42,10 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
     private AmazonDynamoDBStreams amazonDynamoDbStreamsClient;
 
     @UriParam(label = "consumer", description = "Maximum number of records that will be fetched in each poll")
-    private int maxResultsPerRequest = 1;
+    private int maxResultsPerRequest = 100;
 
-    @UriParam(label = "consumer", description = "Defines where in the DynaboDB stream to start getting records")
-    private ShardIteratorType iteratorType = ShardIteratorType.TRIM_HORIZON;
+    @UriParam(label = "consumer", description = "Defines where in the DynaboDB stream to start getting records", defaultValue = "LATEST")
+    private ShardIteratorType iteratorType = ShardIteratorType.LATEST;
 
     public DdbStreamEndpoint(String uri, String tableName, DdbStreamComponent component) {
         super(uri, component);

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
@@ -29,10 +29,10 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 
-@UriEndpoint(scheme = "aws-ddbstream", title = "AWS Kinesis", syntax = "aws-ddbstream:tableName", consumerClass = DdbStreamConsumer.class, label = "cloud,messaging,streams")
+@UriEndpoint(scheme = "aws-ddbstream", title = "AWS DynamoDB Streams", consumerOnly = true, syntax = "aws-ddbstream:tableName", consumerClass = DdbStreamConsumer.class, label = "cloud,messaging,streams")
 public class DdbStreamEndpoint extends ScheduledPollEndpoint {
 
-    @UriPath(label = "consumer,producer", description = "Name of the dynamodb table")
+    @UriPath(label = "consumer", description = "Name of the dynamodb table")
     @Metadata(required = "true")
     private String tableName;
 
@@ -44,8 +44,18 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
     @UriParam(label = "consumer", description = "Maximum number of records that will be fetched in each poll")
     private int maxResultsPerRequest = 100;
 
-    @UriParam(label = "consumer", description = "Defines where in the DynaboDB stream to start getting records", defaultValue = "LATEST")
+    @UriParam(label = "consumer", description = "Defines where in the DynaboDB stream"
+            + " to start getting records. Note that using TRIM_HORIZON can cause a"
+            + " significant delay before the stream has caught up to real-time."
+            + " Currently only LATEST and TRIM_HORIZON are supported.",
+            defaultValue = "LATEST")
     private ShardIteratorType iteratorType = ShardIteratorType.LATEST;
+    // TODO add the ability to use ShardIteratorType.{AT,AFTER}_SEQUENCE_NUMBER
+    // by specifying either a sequence number itself or a bean to fetch the
+    // sequence number from persistant storage or somewhere else.
+    // This can be done by having the type of the parameter an interface
+    // and supplying a default implementation and a converter from a long/String
+    // to an instance of this interface.
 
     public DdbStreamEndpoint(String uri, String tableName, DdbStreamComponent component) {
         super(uri, component);

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
@@ -29,7 +29,9 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 
-@UriEndpoint(scheme = "aws-ddbstream", title = "AWS DynamoDB Streams", consumerOnly = true, syntax = "aws-ddbstream:tableName", consumerClass = DdbStreamConsumer.class, label = "cloud,messaging,streams")
+@UriEndpoint(scheme = "aws-ddbstream", title = "AWS DynamoDB Streams",
+        consumerOnly = true, syntax = "aws-ddbstream:tableName",
+        consumerClass = DdbStreamConsumer.class, label = "cloud,messaging,streams")
 public class DdbStreamEndpoint extends ScheduledPollEndpoint {
 
     @UriPath(label = "consumer", description = "Name of the dynamodb table")
@@ -56,6 +58,8 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
     // This can be done by having the type of the parameter an interface
     // and supplying a default implementation and a converter from a long/String
     // to an instance of this interface.
+    // Note that the shard list needs to have the ability to start at the shard
+    // that includes the supplied sequence number
 
     public DdbStreamEndpoint(String uri, String tableName, DdbStreamComponent component) {
         super(uri, component);
@@ -84,6 +88,16 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
     @Override
     public boolean isSingleton() {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        return "DdbStreamEndpoint{"
+                + "tableName=" + tableName
+                + ", amazonDynamoDbStreamsClient=[redacted], maxResultsPerRequest=" + maxResultsPerRequest
+                + ", iteratorType="
+                + iteratorType + ", uri=" + getEndpointUri()
+                + '}';
     }
 
     AmazonDynamoDBStreams getClient() {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
@@ -73,7 +73,6 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
 
     @Override
     public boolean isSingleton() {
-        // probably right.
         return true;
     }
 
@@ -81,7 +80,6 @@ public class DdbStreamEndpoint extends ScheduledPollEndpoint {
         return amazonDynamoDbStreamsClient;
     }
 
-    // required for injection.
     public AmazonDynamoDBStreams getAmazonDynamoDBStreamsClient() {
         return amazonDynamoDbStreamsClient;
     }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/DdbStreamEndpoint.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.ddbstream;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams;
+import com.amazonaws.services.dynamodbv2.model.Record;
+import com.amazonaws.services.dynamodbv2.model.ShardIteratorType;
+import org.apache.camel.Consumer;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.impl.ScheduledPollEndpoint;
+import org.apache.camel.spi.Metadata;
+import org.apache.camel.spi.UriEndpoint;
+import org.apache.camel.spi.UriParam;
+import org.apache.camel.spi.UriPath;
+
+@UriEndpoint(scheme = "aws-ddbstream", title = "AWS Kinesis", syntax = "aws-ddbstream:tableName", consumerClass = DdbStreamConsumer.class, label = "cloud,messaging,streams")
+public class DdbStreamEndpoint extends ScheduledPollEndpoint {
+
+    @UriPath(label = "consumer,producer", description = "Name of the dynamodb table")
+    @Metadata(required = "true")
+    private String tableName;
+
+    // For now, always assume that we've been supplied a client in the Camel registry.
+    @UriParam(label = "consumer", description = "Amazon DynamoDB client to use for all requests for this endpoint")
+    @Metadata(required = "true")
+    private AmazonDynamoDBStreams amazonDynamoDbStreamsClient;
+
+    @UriParam(label = "consumer", description = "Maximum number of records that will be fetched in each poll")
+    private int maxResultsPerRequest = 1;
+
+    @UriParam(label = "consumer", description = "Defines where in the DynaboDB stream to start getting records")
+    private ShardIteratorType iteratorType = ShardIteratorType.TRIM_HORIZON;
+
+    public DdbStreamEndpoint(String uri, String tableName, DdbStreamComponent component) {
+        super(uri, component);
+        this.tableName = tableName;
+    }
+
+    @Override
+    public Producer createProducer() throws Exception {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Consumer createConsumer(Processor processor) throws Exception {
+        DdbStreamConsumer consumer = new DdbStreamConsumer(this, processor);
+        consumer.setSchedulerProperties(consumer.getEndpoint().getSchedulerProperties());
+        return consumer;
+    }
+
+    Exchange createExchange(Record record) {
+        Exchange ex = super.createExchange();
+        ex.getIn().setBody(record, Record.class);
+
+        return ex;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        // probably right.
+        return true;
+    }
+
+    AmazonDynamoDBStreams getClient() {
+        return amazonDynamoDbStreamsClient;
+    }
+
+    // required for injection.
+    public AmazonDynamoDBStreams getAmazonDynamoDBStreamsClient() {
+        return amazonDynamoDbStreamsClient;
+    }
+
+    public void setAmazonDynamoDbStreamsClient(AmazonDynamoDBStreams amazonDynamoDbStreamsClient) {
+        this.amazonDynamoDbStreamsClient = amazonDynamoDbStreamsClient;
+    }
+
+    public int getMaxResultsPerRequest() {
+        return maxResultsPerRequest;
+    }
+
+    public void setMaxResultsPerRequest(int maxResultsPerRequest) {
+        this.maxResultsPerRequest = maxResultsPerRequest;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public ShardIteratorType getIteratorType() {
+        return iteratorType;
+    }
+
+    public void setIteratorType(ShardIteratorType iteratorType) {
+        this.iteratorType = iteratorType;
+    }
+    
+}

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
@@ -1,0 +1,57 @@
+package org.apache.camel.component.aws.ddbstream;
+
+import com.amazonaws.services.dynamodbv2.model.Shard;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+class ShardList {
+
+    private final Map<String, Shard> shards = new HashMap<>();
+
+    void addAll(Collection<Shard> shards) {
+        for (Shard shard : shards) {
+            add(shard);
+        }
+    }
+
+    void add(Shard shard) {
+        shards.put(shard.getShardId(), shard);
+    }
+
+    Shard nextAfter(Shard previous) {
+        for (Shard shard : shards.values()) {
+            if (previous.getShardId().equals(shard.getParentShardId())) {
+                return shard;
+            }
+        }
+        throw new IllegalStateException("Unable to find the next shard for " + previous + " in " + shards);
+    }
+
+    Shard first() {
+        for (Shard shard : shards.values()) {
+            if (!shards.containsKey(shard.getParentShardId())) {
+                return shard;
+            }
+        }
+        throw new IllegalStateException("Unable to find an unparented shard in " + shards);
+    }
+
+    /**
+     * Removes shards that are older than the provided shard.
+     * Does not remove the provided shard.
+     * @param removeBefore
+     */
+    void removeOlderThan(Shard removeBefore) {
+        String current = removeBefore.getParentShardId();
+
+        while (current != null) {
+            Shard s = shards.remove(current);
+            if (s == null) {
+                current = null;
+            } else {
+                current = s.getParentShardId();
+            }
+        }
+    }
+}

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
@@ -4,8 +4,11 @@ import com.amazonaws.services.dynamodbv2.model.Shard;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ShardList {
+    private final Logger LOG = LoggerFactory.getLogger(ShardList.class);
 
     private final Map<String, Shard> shards = new HashMap<>();
 
@@ -45,13 +48,21 @@ class ShardList {
     void removeOlderThan(Shard removeBefore) {
         String current = removeBefore.getParentShardId();
 
+        int removedShards = 0;
         while (current != null) {
             Shard s = shards.remove(current);
             if (s == null) {
                 current = null;
             } else {
+                removedShards++;
                 current = s.getParentShardId();
             }
         }
+        LOG.trace("removed {} shards from the store, new size is {}", removedShards, shards.size());
+    }
+
+    @Override
+    public String toString() {
+        return "ShardList{" + "shards=" + shards + '}';
     }
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
@@ -1,14 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.aws.ddbstream;
 
-import com.amazonaws.services.dynamodbv2.model.Shard;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.model.Shard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ShardList {
-    private final Logger LOG = LoggerFactory.getLogger(ShardList.class);
+    private final Logger log = LoggerFactory.getLogger(ShardList.class);
 
     private final Map<String, Shard> shards = new HashMap<>();
 
@@ -58,7 +75,7 @@ class ShardList {
                 current = s.getParentShardId();
             }
         }
-        LOG.trace("removed {} shards from the store, new size is {}", removedShards, shards.size());
+        log.trace("removed {} shards from the store, new size is {}", removedShards, shards.size());
     }
 
     @Override

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddbstream/ShardList.java
@@ -57,6 +57,19 @@ class ShardList {
         throw new IllegalStateException("Unable to find an unparented shard in " + shards);
     }
 
+    Shard last() {
+        Map<String, Shard> shardsByParent = new HashMap<>();
+        for (Shard shard : shards.values()) {
+            shardsByParent.put(shard.getParentShardId(), shard);
+        }
+        for (Shard shard : shards.values()) {
+            if (!shardsByParent.containsKey(shard.getShardId())) {
+                return shard;
+            }
+        }
+        throw new IllegalStateException("Unable to find a shard with no children " + shards);
+    }
+
     /**
      * Removes shards that are older than the provided shard.
      * Does not remove the provided shard.

--- a/components/camel-aws/src/main/resources/META-INF/services/org/apache/camel/component/aws-ddbstream
+++ b/components/camel-aws/src/main/resources/META-INF/services/org/apache/camel/component/aws-ddbstream
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+class=org.apache.camel.component.aws.ddbstream.DdbStreamComponent

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
@@ -102,6 +102,14 @@ public class ShardListTest {
     }
 
     @Test
+    public void lastShardGetsTheShardWithNoChildren() throws Exception {
+        ShardList shards = new ShardList();
+        shards.addAll(createShards("a", "b", "c", "d"));
+
+        assertThat(shards.last().getShardId(), is("d"));
+    }
+
+    @Test
     public void removingShards() throws Exception {
         ShardList shards = new ShardList();
         shards.addAll(createShards(null, "a", "b", "c", "d"));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
@@ -1,11 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.aws.ddbstream;
 
-import com.amazonaws.services.dynamodbv2.model.Shard;
+
 import java.util.ArrayList;
 import java.util.List;
+import com.amazonaws.services.dynamodbv2.model.Shard;
+
+import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import org.junit.Test;
 
 public class ShardListTest {
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/ShardListTest.java
@@ -1,0 +1,104 @@
+package org.apache.camel.component.aws.ddbstream;
+
+import com.amazonaws.services.dynamodbv2.model.Shard;
+import java.util.ArrayList;
+import java.util.List;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class ShardListTest {
+
+    @Test
+    public void nextReturnsShardWithParent() throws Exception {
+        Shard first = new Shard()
+                .withShardId("first_shard")
+                .withParentShardId("other_shard_id");
+        Shard second = new Shard()
+                .withParentShardId("first_shard")
+                .withShardId("second_shard");
+
+        ShardList shards = new ShardList();
+        shards.add(first);
+        shards.add(second);
+
+        assertThat(shards.nextAfter(first), is(second));
+    }
+
+    @Test
+    public void nextWithNullReturnsFirstKnownShard() throws Exception {
+        Shard first = new Shard()
+                .withShardId("first_shard");
+        Shard second = new Shard()
+                .withParentShardId("first_shard")
+                .withShardId("second_shard");
+
+        ShardList shards = new ShardList();
+        shards.add(first);
+        shards.add(second);
+
+        assertThat(shards.nextAfter(first), is(second));
+    }
+
+    @Test
+    public void reAddingEntriesMaintainsOrder() throws Exception {
+        Shard first = new Shard()
+                .withShardId("first_shard");
+        Shard second = new Shard()
+                .withParentShardId("first_shard")
+                .withShardId("second_shard");
+
+        ShardList shards = new ShardList();
+        shards.add(first);
+        shards.add(second);
+
+        assertThat(shards.nextAfter(first), is(second));
+
+        Shard second2 = new Shard()
+                .withParentShardId("first_shard")
+                .withShardId("second_shard");
+        Shard third = new Shard()
+                .withParentShardId("second_shard")
+                .withShardId("third_shard");
+        shards.add(second2);
+        shards.add(third);
+
+        assertThat(shards.nextAfter(first), is(second));
+        assertThat(shards.nextAfter(second), is(third));
+    }
+
+    @Test
+    public void firstShardGetsTheFirstWithoutAParent() throws Exception {
+        ShardList shards = new ShardList();
+        shards.addAll(createShards(null, "a", "b", "c", "d"));
+
+        assertThat(shards.first().getShardId(), is("a"));
+    }
+
+    @Test
+    public void firstShardGetsTheFirstWithAnUnknownParent() throws Exception {
+        ShardList shards = new ShardList();
+        shards.addAll(createShards("a", "b", "c", "d"));
+
+        assertThat(shards.first().getShardId(), is("b"));
+    }
+
+    @Test
+    public void removingShards() throws Exception {
+        ShardList shards = new ShardList();
+        shards.addAll(createShards(null, "a", "b", "c", "d"));
+        Shard removeBefore = new Shard().withShardId("c").withParentShardId("b");
+        shards.removeOlderThan(removeBefore);
+        assertThat(shards.first().getShardId(), is("c"));
+    }
+
+    List<Shard> createShards(String initialParent, String... shardIds) {
+        String previous = initialParent;
+        List<Shard> result = new ArrayList<>();
+        for (String s : shardIds) {
+            result.add(new Shard().withShardId(s).withParentShardId(previous));
+            previous = s;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
DynamoDB Streams offer a change feed from your dynamoDB.

While the API calls are very similar to the Kinesis API calls, the use of shards is quite different; in Kinesis they are intended to be parallel, to increase throughput. In DynamoDB Streams, shards are sequential, intended to be walked one at a time to get all the changes available.