### PR TITLE
CAMEL-9433: Upgrade java mail with new maven coord.

### DIFF
--- a/components/camel-atom/pom.xml
+++ b/components/camel-atom/pom.xml
@@ -76,10 +76,6 @@
       <version>${abdera-version}</version>
       <exclusions>
           <exclusion>
-              <groupId>com.sun.mail</groupId>
-              <artifactId>javax.mail</artifactId>
-          </exclusion>
-          <exclusion>
               <groupId>xml-apis</groupId>
               <artifactId>xml-apis</artifactId>
           </exclusion>
@@ -118,8 +114,8 @@
         <artifactId>axiom-api</artifactId>
         <exclusions>
             <exclusion>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
+                <artifactId>geronimo-javamail_1.4_spec</artifactId>
+                <groupId>org.apache.geronimo.specs</groupId>
             </exclusion>
             <exclusion>
                 <groupId>xml-apis</groupId>
@@ -160,8 +156,8 @@
         <artifactId>axiom-impl</artifactId>
         <exclusions>
             <exclusion>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
+                <artifactId>geronimo-javamail_1.4_spec</artifactId>
+                <groupId>org.apache.geronimo.specs</groupId>
             </exclusion>
             <exclusion>
                 <groupId>xml-apis</groupId>

--- a/components/camel-atom/pom.xml
+++ b/components/camel-atom/pom.xml
@@ -76,8 +76,8 @@
       <version>${abdera-version}</version>
       <exclusions>
           <exclusion>
-              <groupId>javax.mail</groupId>
-              <artifactId>mail</artifactId>
+              <groupId>com.sun.mail</groupId>
+              <artifactId>javax.mail</artifactId>
           </exclusion>
           <exclusion>
               <groupId>xml-apis</groupId>
@@ -118,8 +118,8 @@
         <artifactId>axiom-api</artifactId>
         <exclusions>
             <exclusion>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>javax.mail</artifactId>
             </exclusion>
             <exclusion>
                 <groupId>xml-apis</groupId>
@@ -160,8 +160,8 @@
         <artifactId>axiom-impl</artifactId>
         <exclusions>
             <exclusion>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>javax.mail</artifactId>
             </exclusion>
             <exclusion>
                 <groupId>xml-apis</groupId>

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -90,8 +90,8 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -119,8 +119,8 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
             <version>${javax-mail-version}</version>
         </dependency>
 

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -89,10 +89,6 @@
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.sun.mail</groupId>
-                    <artifactId>javax.mail</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/components/camel-google-mail/pom.xml
+++ b/components/camel-google-mail/pom.xml
@@ -69,8 +69,8 @@
     </dependency>
 
     <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>javax.mail</artifactId>
         <version>${javax-mail-version}</version>
         <exclusions>
           <!-- javax activation is part of the JDK now -->

--- a/tests/test-bundles/mock-javamail_1.7/pom.xml
+++ b/tests/test-bundles/mock-javamail_1.7/pom.xml
@@ -60,13 +60,13 @@
             <version>${pkgVersion}</version>
             <exclusions>
                  <exclusion>
-                     <groupId>com.sun.mail</groupId>
-                     <artifactId>javax.mail</artifactId>
+                     <groupId>javax.mail</groupId>
+                     <artifactId>mail</artifactId>
                  </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-	    <groupId>com.sun.mail</groupId>
+            <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
             <version>${javax-mail-version}</version>
         </dependency>


### PR DESCRIPTION
Some things I noticed:

camel-atom
* axiom-api/axiom-impl do not have a (transitive) dependency on javax.mail anymore, but on geronimo-javamail_1.4_spec. Should that be excluded instead?
* abdera-parser does not have a (transitive) dependency on javax.mail anymore. Should the exclusion be removed?

camel-aws
* aws-java-sdk does not have a (transitive) dependency on javax.mail anymore. Should the exclusion be removed?