### PR TITLE
CAMEL-9375: TarSplitter includes one extra empty entry at the end.

### DIFF
--- a/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
@@ -86,7 +86,7 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
     @Override
     public Object unmarshal(final Exchange exchange, final InputStream stream) throws Exception {
         if (usingIterator) {
-            return new TarIterator(exchange.getIn(), stream);
+            return new TarIterator(exchange, stream);
         } else {
             BufferedInputStream bis = new BufferedInputStream(stream);
             TarArchiveInputStream tis = (TarArchiveInputStream) new ArchiveStreamFactory().createArchiveInputStream(ArchiveStreamFactory.TAR, bis);

--- a/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarSplitter.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarSplitter.java
@@ -33,7 +33,7 @@ public class TarSplitter implements Expression {
 
     public Object evaluate(Exchange exchange) {
         Message inputMessage = exchange.getIn();
-        return new TarIterator(inputMessage, inputMessage.getBody(InputStream.class));
+        return new TarIterator(exchange, inputMessage.getBody(InputStream.class));
     }
 
     @Override


### PR DESCRIPTION
CAMEL-9375: TarSplitter includes one extra empty entry at the end.
Modified iterator. It simply tries to generate next element and returns true if then there exists a next element.

Message body is now StreamCached because tarInputStream.getNextTarEntry() advances stream beyond current entry. Other solution would be use ByteArrayInputStream as body, but with large files that might cause OutOfMemoryError.