### PR TITLE
support for adding multiple parameters at once

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -352,6 +352,15 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return new RestOperationResponseMsgDefinition(verb);
     }
 
+    public RestDefinition responseMessages(List<RestOperationResponseMsgDefinition> msgs) {
+        if (getVerbs().isEmpty()) {
+            throw new IllegalArgumentException("Must add verb first, such as get/post/delete");
+        }
+        VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
+        verb.getResponseMsgs().addAll(msgs);
+        return this;
+    }
+
     public RestDefinition produces(String mediaType) {
         if (getVerbs().isEmpty()) {
             this.produces = mediaType;

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -318,6 +318,15 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return this;
     }
 
+    public RestDefinition params(List<RestOperationParamDefinition> params) {
+        if (getVerbs().isEmpty()) {
+            throw new IllegalArgumentException("Must add verb first, such as get/post/delete");
+        }
+        VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
+        verb.getParams().addAll(params);
+        return this;
+    }
+
     public RestOperationParamDefinition param(VerbDefinition verb) {
         return new RestOperationParamDefinition(verb);
     }


### PR DESCRIPTION
We had a lot of APIs that shared a lot of query params and we needed a method to simply add them without duplicating the code. Same goes for the response messages.