### PR TITLE
[CAMEL-9414] update quickfixj to v1.6.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -426,7 +426,7 @@
     <quartz-version>1.8.6</quartz-version>
     <quartz-version-range>[1.8,2)</quartz-version-range>
     <quartz2-version>2.2.2</quartz2-version>
-    <quickfix-bundle-version>1.6.0_1</quickfix-bundle-version>
+    <quickfix-bundle-version>1.6.1_1</quickfix-bundle-version>
     <rabbitmq-amqp-client-version>3.6.0</rabbitmq-amqp-client-version>
     <reflections-bundle-version>0.9.10_3</reflections-bundle-version>
     <regexp-bundle-version>1.4_1</regexp-bundle-version>


### PR DESCRIPTION
quickfix-j dependency updated to 1.6.1 using ServiceMix bundle [SM-2773](https://issues.apache.org/jira/browse/SM-2773)