### PR TITLE
Fix erroneous logging when mapTemplate.size()==1

### DIFF
--- a/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerBuilder.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerBuilder.java
@@ -76,12 +76,11 @@ public class TransactionErrorHandlerBuilder extends DefaultErrorHandlerBuilder {
 
             if (transactionTemplate == null) {
                 Map<String, TransactionTemplate> mapTemplate = routeContext.lookupByType(TransactionTemplate.class);
-                if (mapTemplate != null && mapTemplate.size() == 1) {
-                    transactionTemplate = mapTemplate.values().iterator().next();
-                }
                 if (mapTemplate == null || mapTemplate.isEmpty()) {
                     LOG.trace("No TransactionTemplate found in registry.");
-                } else {
+                } else if (mapTemplate.size() == 1) {
+                    transactionTemplate = mapTemplate.values().iterator().next();
+                }else {
                     LOG.debug("Found {} TransactionTemplate in registry. Cannot determine which one to use. "
                               + "Please configure a TransactionTemplate on the TransactionErrorHandlerBuilder", mapTemplate.size());
                 }
@@ -89,12 +88,11 @@ public class TransactionErrorHandlerBuilder extends DefaultErrorHandlerBuilder {
 
             if (transactionTemplate == null) {
                 Map<String, PlatformTransactionManager> mapManager = routeContext.lookupByType(PlatformTransactionManager.class);
-                if (mapManager != null && mapManager.size() == 1) {
-                    transactionTemplate = new TransactionTemplate(mapManager.values().iterator().next());
-                }
                 if (mapManager == null || mapManager.isEmpty()) {
                     LOG.trace("No PlatformTransactionManager found in registry.");
-                } else {
+                } else if (mapManager.size() == 1) {
+                    transactionTemplate = new TransactionTemplate(mapManager.values().iterator().next());
+                }else {
                     LOG.debug("Found {} PlatformTransactionManager in registry. Cannot determine which one to use for TransactionTemplate. "
                               + "Please configure a TransactionTemplate on the TransactionErrorHandlerBuilder", mapManager.size());
                 }


### PR DESCRIPTION
If mapTemplate.size()==1, the previous logic would still output the "Cannot determine which one to use" message.  Minor issue, but the structure of the internal if statements would leave room for silly logic errors if other code were inserted without thinking hard about all the logical combinations.