### PR TITLE
Rest elasticsearch client support

### DIFF
--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -1,86 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache.camel</groupId>
-    <artifactId>components</artifactId>
-    <version>2.17-SNAPSHOT</version>
-  </parent>
+	<parent>
+		<groupId>org.apache.camel</groupId>
+		<artifactId>components</artifactId>
+		<version>2.17-SNAPSHOT</version>
+	</parent>
 
-  <artifactId>camel-elasticsearch</artifactId>
-  <packaging>bundle</packaging>
-  <name>Camel :: ElasticSearch</name>
-  <description>Camel Elasticsearch support</description>
+	<artifactId>camel-elasticsearch</artifactId>
+	<packaging>bundle</packaging>
+	<name>Camel :: ElasticSearch</name>
+	<description>Camel Elasticsearch support</description>
 
-  <properties>
-    <camel.osgi.export.pkg>org.apache.camel.component.elasticsearch.*;${camel.osgi.version}</camel.osgi.export.pkg>
-    <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=elasticsearch</camel.osgi.export.service>
-  </properties>
+	<properties>
+		<camel.osgi.export.pkg>org.apache.camel.component.elasticsearch.*;${camel.osgi.version}</camel.osgi.export.pkg>
+		<camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=elasticsearch</camel.osgi.export.service>
+	</properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-      <version>${elasticsearch-version}</version>
-    </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${elasticsearch-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>2.22.1</version>
+		</dependency>
 
-    <!-- for testing -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codelibs</groupId>
-      <artifactId>elasticsearch-cluster-runner</artifactId>
-      <version>${elasticsearch-cluster-runner-version}</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-json-provider</artifactId>
+			<version>2.5.4</version>
+		</dependency>
 
-    <!-- logging -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+		<!-- for testing -->
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codelibs</groupId>
+			<artifactId>elasticsearch-cluster-runner</artifactId>
+			<version>${elasticsearch-cluster-runner-version}</version>
+			<scope>test</scope>
+		</dependency>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <es.path.data>target/data</es.path.data>
-          </systemPropertyVariables>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+		<!-- logging -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<es.path.data>target/data</es.path.data>
+					</systemPropertyVariables>
+					<forkCount>1</forkCount>
+					<reuseForks>false</reuseForks>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ESDocumentResponse.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ESDocumentResponse.java
@@ -1,0 +1,54 @@
+package org.apache.camel.component.elasticsearch;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ESDocumentResponse {
+
+	@JsonProperty("_id")
+	private String id;
+	
+	@JsonProperty("_type")
+	private String type;
+	
+	@JsonProperty("_version")
+	private String version;
+	
+	@JsonProperty("_index")
+	private String index;
+	
+	@JsonProperty("created")
+	private boolean isCreated;
+
+	@JsonProperty("_source")
+	private JsonNode source;
+	
+	
+	public JsonNode getSource() {
+		return source;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public String getIndex() {
+		return index;
+	}
+
+	public boolean isCreated() {
+		return isCreated;
+	}
+	
+	
+}

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConfiguration.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConfiguration.java
@@ -51,8 +51,23 @@ public class ElasticsearchConfiguration {
     private int port = ElasticsearchConstants.DEFAULT_PORT;
     @UriParam(defaultValue = "true")
     private Boolean clientTransportSniff = true;
+    @UriParam(defaultValue = "false")
+    private Boolean useHttpClient = false; 
 
     /**
+     * Whether or not to use the Http Client instead of NodeClient or TransportClient
+     * 
+     * @return
+     */
+	public Boolean getUseHttpClient() {
+		return useHttpClient;
+	}
+
+	public void setUseHttpClient(Boolean useHttpClient) {
+		this.useHttpClient = useHttpClient;
+	}
+
+	/**
      * Name of cluster or use local for local mode
      */
     public String getClusterName() {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.elasticsearch;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.Message;
@@ -218,9 +219,15 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 		return null;
 	}
 
-	public void update(Message message) {
-		UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
-		message.setBody(client.update(updateRequest).actionGet().getId());
+	public Object update(Message message) {
+		if(useHttpClient) {
+			String id = message.getExchange().getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_ID, String.class);
+			return esHttpClient.update(getIndexName(message), getIndexType(message), id, message.getBody(Map.class));
+		} else {
+			UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
+			return client.update(updateRequest).actionGet().getId();
+		}
+
 	}
 
 	public void get(Message message) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -260,9 +260,13 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 		return indexedIds;
 	}
 
-	public void delete(Message message) {
-		DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
-		message.setBody(client.delete(deleteRequest).actionGet());
+	public Object delete(Message message) {
+		if(useHttpClient) {
+			return esHttpClient.delete(getIndexName(message), getIndexType(message), message.getBody(String.class));
+		} else {
+			DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
+			return client.delete(deleteRequest).actionGet();
+		}
 	}
 
 	public void exists(Message message) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -235,10 +235,17 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 		message.setBody(client.get(getRequest));
 	}
 
-	public void multiget(Message message) {
-		MultiGetRequest multiGetRequest = message
-				.getBody(MultiGetRequest.class);
-		message.setBody(client.multiGet(multiGetRequest));
+	public Object multiget(Message message) {
+		if(useHttpClient) {
+			String indexName = getIndexName(message);
+			String indexType = getIndexType(message);
+			return esHttpClient.multiget(indexName, indexType, message.getBody(List.class));
+		} else {
+			MultiGetRequest multiGetRequest = message
+					.getBody(MultiGetRequest.class);
+			return client.multiGet(multiGetRequest);
+		}
+
 	}
 
 	public void bulk(Message message) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -220,9 +220,14 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 	}
 
 	public Object update(Message message) {
-		if(useHttpClient) {
-			String id = message.getExchange().getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_ID, String.class);
-			return esHttpClient.update(getIndexName(message), getIndexType(message), id, message.getBody(Map.class));
+		if (useHttpClient) {
+			String id = message
+					.getExchange()
+					.getIn()
+					.getHeader(ElasticsearchConstants.PARAM_INDEX_ID,
+							String.class);
+			return esHttpClient.update(getIndexName(message),
+					getIndexType(message), id, message.getBody(Map.class));
 		} else {
 			UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
 			return client.update(updateRequest).actionGet().getId();
@@ -236,10 +241,11 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 	}
 
 	public Object multiget(Message message) {
-		if(useHttpClient) {
+		if (useHttpClient) {
 			String indexName = getIndexName(message);
 			String indexType = getIndexType(message);
-			return esHttpClient.multiget(indexName, indexType, message.getBody(List.class));
+			return esHttpClient.multiget(indexName, indexType,
+					message.getBody(List.class));
 		} else {
 			MultiGetRequest multiGetRequest = message
 					.getBody(MultiGetRequest.class);
@@ -275,18 +281,25 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 	}
 
 	public Object delete(Message message) {
-		if(useHttpClient) {
-			return esHttpClient.delete(getIndexName(message), getIndexType(message), message.getBody(String.class));
+		if (useHttpClient) {
+			return esHttpClient.delete(getIndexName(message),
+					getIndexType(message), message.getBody(String.class));
 		} else {
 			DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
 			return client.delete(deleteRequest).actionGet();
 		}
 	}
 
-	public void exists(Message message) {
-		ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
-		message.setBody(client.admin().indices()
-				.prepareExists(existsRequest.indices()).get().isExists());
+	public boolean indexExists(Message message) {
+		if (useHttpClient) {
+			return esHttpClient.indexExists(getIndexName(message));
+			
+		} else {
+			ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
+			return client.admin().indices()
+					.prepareExists(existsRequest.indices()).get().isExists();
+		}
+
 	}
 
 	public void search(Message message) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -21,11 +21,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.camel.Consumer;
+import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.exists.ExistsRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
@@ -39,111 +49,228 @@ import org.slf4j.LoggerFactory;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
 /**
- * The elasticsearch component is used for interfacing with ElasticSearch server.
+ * The elasticsearch component is used for interfacing with ElasticSearch
+ * server.
  */
 @UriEndpoint(scheme = "elasticsearch", title = "Elasticsearch", syntax = "elasticsearch:clusterName", producerOnly = true, label = "monitoring,search")
 public class ElasticsearchEndpoint extends DefaultEndpoint {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchEndpoint.class);
+	private static final Logger LOG = LoggerFactory
+			.getLogger(ElasticsearchEndpoint.class);
 
-    private Node node;
-    private Client client;
-    private volatile boolean closeClient;
-    @UriParam
-    private ElasticsearchConfiguration configuration;
+	private Node node;
+	private Client client;
+	private ElasticsearchHttpClient esHttpClient;
+	private volatile boolean closeClient;
+	@UriParam
+	private ElasticsearchConfiguration configuration;
+	private Boolean useHttpClient = false;
 
-    public ElasticsearchEndpoint(String uri, ElasticsearchComponent component, ElasticsearchConfiguration config, Client client) throws Exception {
-        super(uri, component);
-        this.configuration = config;
-        this.client = client;
-        this.closeClient = client == null;
-    }
+	public ElasticsearchEndpoint(String uri, ElasticsearchComponent component,
+			ElasticsearchConfiguration config, Client client) throws Exception {
+		super(uri, component);
+		this.configuration = config;
+		this.client = client;
+		this.closeClient = client == null;
+		this.useHttpClient = configuration.getUseHttpClient();
+	}
 
-    public Producer createProducer() throws Exception {
-        return new ElasticsearchProducer(this);
-    }
+	public Producer createProducer() throws Exception {
+		return new ElasticsearchProducer(this);
+	}
 
-    public Consumer createConsumer(Processor processor) throws Exception {
-        throw new UnsupportedOperationException("Cannot consume from an ElasticsearchEndpoint: " + getEndpointUri());
-    }
+	public Consumer createConsumer(Processor processor) throws Exception {
+		throw new UnsupportedOperationException(
+				"Cannot consume from an ElasticsearchEndpoint: "
+						+ getEndpointUri());
+	}
 
-    public boolean isSingleton() {
-        return true;
-    }
+	public boolean isSingleton() {
+		return true;
+	}
 
-    @Override
-    @SuppressWarnings("unchecked")
-    protected void doStart() throws Exception {
-        super.doStart();
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void doStart() throws Exception {
+		super.doStart();
 
-        if (client == null) {
-            if (configuration.isLocal()) {
-                LOG.info("Starting local ElasticSearch server");
-            } else {
-                LOG.info("Joining ElasticSearch cluster " + configuration.getClusterName());
-            }
-            if (configuration.getIp() != null) {
-                this.client = TransportClient.builder().settings(getSettings()).build()
-                    .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(configuration.getIp()), configuration.getPort()));
-            } else if (configuration.getTransportAddressesList() != null
-                    && !configuration.getTransportAddressesList().isEmpty()) {
-                List<TransportAddress> addresses = new ArrayList(configuration.getTransportAddressesList().size());
-                for (TransportAddress address : configuration.getTransportAddressesList()) {
-                    addresses.add(address);
-                }
-                this.client = TransportClient.builder().settings(getSettings()).build().addTransportAddresses(addresses.toArray(new TransportAddress[addresses.size()]));
-            } else {
-                NodeBuilder builder = nodeBuilder().local(configuration.isLocal()).data(configuration.getData());
-                if (configuration.isLocal()) {
-                    builder.getSettings().put("http.enabled", false);
-                }
-                if (!configuration.isLocal() && configuration.getClusterName() != null) {
-                    builder.clusterName(configuration.getClusterName());
-                }
-                node = builder.node();
-                client = node.client();
-            }
-        }
-    }
+		if (client == null) {
+			if (configuration.isLocal()) {
+				LOG.info("Starting local ElasticSearch server");
+			} else {
+				LOG.info("Joining ElasticSearch cluster "
+						+ configuration.getClusterName());
+			}
+			if (configuration.getUseHttpClient()) {
+				LOG.info("Using HTTP Client ");
+				esHttpClient = new ElasticsearchHttpClient();
+				esHttpClient.setHost(configuration.getIp());
+				esHttpClient.setPort(String.valueOf(configuration.getPort()));
+				return;
+			}
+			if (configuration.getIp() != null) {
+				this.client = TransportClient
+						.builder()
+						.settings(getSettings())
+						.build()
+						.addTransportAddress(
+								new InetSocketTransportAddress(InetAddress
+										.getByName(configuration.getIp()),
+										configuration.getPort()));
+			} else if (configuration.getTransportAddressesList() != null
+					&& !configuration.getTransportAddressesList().isEmpty()) {
+				List<TransportAddress> addresses = new ArrayList(configuration
+						.getTransportAddressesList().size());
+				for (TransportAddress address : configuration
+						.getTransportAddressesList()) {
+					addresses.add(address);
+				}
+				this.client = TransportClient
+						.builder()
+						.settings(getSettings())
+						.build()
+						.addTransportAddresses(
+								addresses
+										.toArray(new TransportAddress[addresses
+												.size()]));
+			} else {
+				NodeBuilder builder = nodeBuilder().local(
+						configuration.isLocal()).data(configuration.getData());
+				if (configuration.isLocal()) {
+					builder.getSettings().put("http.enabled", false);
+				}
+				if (!configuration.isLocal()
+						&& configuration.getClusterName() != null) {
+					builder.clusterName(configuration.getClusterName());
+				}
+				node = builder.node();
+				client = node.client();
+			}
+		}
+	}
 
-    private Settings getSettings() {
-        return Settings.settingsBuilder()
-                .put("cluster.name", configuration.getClusterName())
-                .put("client.transport.ignore_cluster_name", false)
-                .put("node.client", true)
-                .put("client.transport.sniff", configuration.getClientTransportSniff())
-                .put("http.enabled", false)
-                .build();
-    }
+	private Settings getSettings() {
+		return Settings
+				.settingsBuilder()
+				.put("cluster.name", configuration.getClusterName())
+				.put("client.transport.ignore_cluster_name", false)
+				.put("node.client", true)
+				.put("client.transport.sniff",
+						configuration.getClientTransportSniff())
+				.put("http.enabled", false).build();
+	}
 
-    @Override
-    protected void doStop() throws Exception {
-        if (closeClient) {
-            if (configuration.isLocal()) {
-                LOG.info("Stopping local ElasticSearch server");
-            } else {
-                LOG.info("Leaving ElasticSearch cluster " + configuration.getClusterName());
-            }
-            client.close();
-            if (node != null) {
-                node.close();
-            }
-            client = null;
-            node = null;
-        }
-        super.doStop();
-    }
+	@Override
+	protected void doStop() throws Exception {
+		if (closeClient) {
+			if (configuration.isLocal()) {
+				LOG.info("Stopping local ElasticSearch server");
+			} else {
+				LOG.info("Leaving ElasticSearch cluster "
+						+ configuration.getClusterName());
+			}
+			if (client != null)
+				client.close();
+			if (node != null) {
+				node.close();
+			}
+			client = null;
+			node = null;
+		}
+		super.doStop();
+	}
 
-    public Client getClient() {
-        return client;
-    }
+	public Client getClient() {
+		return client;
+	}
 
-    public ElasticsearchConfiguration getConfig() {
-        return configuration;
-    }
+	public ElasticsearchConfiguration getConfig() {
+		return configuration;
+	}
 
-    public void setOperation(String operation) {
-        configuration.setOperation(operation);
-    }
+	public void setOperation(String operation) {
+		configuration.setOperation(operation);
+	}
+
+	private String getIndexName(Message message) {
+		return message.getHeader(ElasticsearchConstants.PARAM_INDEX_NAME,
+				String.class);
+	}
+
+	private String getIndexType(Message message) {
+		return message.getHeader(ElasticsearchConstants.PARAM_INDEX_TYPE,
+				String.class);
+	}
+
+	public String index(Message message) {
+		if (useHttpClient) {
+			LOG.info("Indexing into Elasticsearch using HTTP Client ");
+			esHttpClient.index(getIndexName(message), getIndexType(message),
+					message.getBody(String.class));
+		} else {
+			IndexRequest indexRequest = message.getBody(IndexRequest.class);
+			return client.index(indexRequest).actionGet().getId();
+		}
+		return null;
+	}
+
+	public void update(Message message) {
+		UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
+		message.setBody(client.update(updateRequest).actionGet().getId());
+	}
+
+	public void get(Message message) {
+		GetRequest getRequest = message.getBody(GetRequest.class);
+		message.setBody(client.get(getRequest));
+	}
+
+	public void multiget(Message message) {
+		MultiGetRequest multiGetRequest = message
+				.getBody(MultiGetRequest.class);
+		message.setBody(client.multiGet(multiGetRequest));
+	}
+
+	public void bulk(Message message) {
+		BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+		message.setBody(client.bulk(bulkRequest).actionGet());
+	}
+
+	public List<String> bulkIndex(Message message) {
+		List<String> indexedIds = new ArrayList<String>();
+
+		if (useHttpClient) {
+			List<Object> objects = message.getBody(List.class);
+			List<String> documents = new ArrayList<String>(objects.size());
+			for (Object obj : objects) {
+				documents.add((String) obj);
+			}
+			return esHttpClient.bulkIndex(getIndexName(message),
+					getIndexType(message), documents);
+		}
+		else {
+			BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+			for (BulkItemResponse response : client.bulk(bulkRequest).actionGet()
+					.getItems()) {
+				indexedIds.add(response.getId());
+			}
+		}
+		return indexedIds;
+	}
+
+	public void delete(Message message) {
+		DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
+		message.setBody(client.delete(deleteRequest).actionGet());
+	}
+
+	public void exists(Message message) {
+		ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
+		message.setBody(client.admin().indices()
+				.prepareExists(existsRequest.indices()).get().isExists());
+	}
+
+	public void search(Message message) {
+		SearchRequest searchRequest = message.getBody(SearchRequest.class);
+		message.setBody(client.search(searchRequest).actionGet());
+	}
 
 }

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -35,6 +35,7 @@ import org.elasticsearch.action.exists.ExistsRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
@@ -254,9 +255,13 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 
 	}
 
-	public void bulk(Message message) {
-		BulkRequest bulkRequest = message.getBody(BulkRequest.class);
-		message.setBody(client.bulk(bulkRequest).actionGet());
+	public Object bulk(Message message) {
+		if(useHttpClient)
+			throw new UnsupportedOperationException();
+		else {
+			BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+			return client.bulk(bulkRequest).actionGet();
+		}
 	}
 
 	public List<String> bulkIndex(Message message) {
@@ -320,6 +325,17 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 		} else {
 			GetRequest getRequest = message.getBody(GetRequest.class);
 			return client.get(getRequest);
+		}
+	}
+
+	public Object multisearch(Message message) {
+		if(useHttpClient) {
+			List queryObjects = message.getBody(List.class);
+			return esHttpClient.multisearch(getIndexName(message), getIndexType(message), queryObjects);			
+		} else {
+			MultiSearchRequest multiSearchRequest = message
+					.getBody(MultiSearchRequest.class);
+			return client.multiSearch(multiSearchRequest);
 		}
 	}
 

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchEndpoint.java
@@ -293,7 +293,7 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 	public boolean indexExists(Message message) {
 		if (useHttpClient) {
 			return esHttpClient.indexExists(getIndexName(message));
-			
+
 		} else {
 			ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
 			return client.admin().indices()
@@ -302,9 +302,15 @@ public class ElasticsearchEndpoint extends DefaultEndpoint {
 
 	}
 
-	public void search(Message message) {
-		SearchRequest searchRequest = message.getBody(SearchRequest.class);
-		message.setBody(client.search(searchRequest).actionGet());
+	public Object search(Message message) {
+		if (useHttpClient) {
+			Map queryObject = message.getBody(Map.class);
+			return esHttpClient.search(getIndexName(message), getIndexType(message), queryObject);
+		} else {
+			SearchRequest searchRequest = message.getBody(SearchRequest.class);
+			return client.search(searchRequest).actionGet();
+		}
+
 	}
 
 	public Object getById(Message message) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
@@ -144,6 +144,17 @@ public class ElasticsearchHttpClient {
 		// TODO need to rethink this approach of responding with just the ID
 		return response.getId();
 	}
+	
+	
+	/**
+	 * Exists API given an indexName, type, id
+	 * 
+	 */
+	public boolean indexExists(String indexName) {
+		WebTarget target = getRootTarget().path(indexName);
+		Response response = target.request().head();
+		return (response.getStatus() == 200);
+	}
 
 	/**
 	 * Bulk index API using the bulk api format

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
@@ -144,8 +144,7 @@ public class ElasticsearchHttpClient {
 		// TODO need to rethink this approach of responding with just the ID
 		return response.getId();
 	}
-	
-	
+
 	/**
 	 * Exists API given an indexName, type, id
 	 * 
@@ -308,6 +307,35 @@ public class ElasticsearchHttpClient {
 		}
 
 		return new ArrayList<String>();
+	}
+
+	/**
+	 * Executes an elasticsearch query represented by the queryObject and
+	 * optionally sets the index and index type in the URL
+	 * 
+	 * @param indexName
+	 * @param indexType
+	 * @param queryObject
+	 * @return query results as a map representation
+	 */
+	public Object search(String indexName, String indexType, Map queryObject) {
+		WebTarget target = getRootTarget();
+		if (indexName != null) {
+			target = target.path(indexName);
+			if (indexType != null) {
+				target = target.path(indexType);
+			}
+		}
+		target = target.path("_search");
+		try {
+			String searchBody = new ObjectMapper()
+					.writeValueAsString(queryObject);
+			Response response = target.request().post(Entity.json(searchBody));
+			return response.readEntity(Map.class);
+
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Could not process query body map", e);
+		}
 	}
 
 }

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.elasticsearch;
 
 import java.util.List;
@@ -104,9 +120,20 @@ public class ElasticsearchHttpClient {
 		JsonNode responseNode = response.readEntity(JsonNode.class);
 		JsonNode itemsNode = responseNode.get("items");
 		List<String> ids = itemsNode.findValuesAsText("_id");
+
 		// TODO this returning of List<String> doesn't actually tell you which ones failed
 		
 		return ids;
+	}
+
+	public String getById(String indexName, String indexType, String docId) {
+		WebTarget target = getRootTarget()
+				.path(indexName).path(indexType).path(docId);
+		
+		Response response = target.request()
+				.get();
+		//TODO need to rethink this approach of responding with just the ID
+		return response.readEntity(String.class);
 	}
 
 }

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
@@ -132,7 +132,15 @@ public class ElasticsearchHttpClient {
 		
 		Response response = target.request()
 				.get();
-		//TODO need to rethink this approach of responding with just the ID
+		return response.readEntity(String.class);
+	}
+
+	public String delete(String indexName, String indexType, String docId) {
+		WebTarget target = getRootTarget()
+				.path(indexName).path(indexType).path(docId);
+		
+		Response response = target.request()
+				.delete();
 		return response.readEntity(String.class);
 	}
 

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchHttpClient.java
@@ -1,0 +1,112 @@
+package org.apache.camel.component.elasticsearch;
+
+import java.util.List;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+public class ElasticsearchHttpClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchHttpClient.class);
+
+	private Client client = null;
+	private String host = "localhost";
+	private String port = "9200";
+	private Boolean secure = false;
+	private WebTarget rootTarget = null;
+
+	public ElasticsearchHttpClient() {
+		this.client = ClientBuilder.newClient().register(
+				JacksonJsonProvider.class);
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public String getPort() {
+		return port;
+	}
+
+	public void setPort(String port) {
+		this.port = port;
+	}
+
+	public Boolean isSecure() {
+		return secure;
+	}
+
+	public void setSecure(Boolean secure) {
+		this.secure = secure;
+	}
+
+	private WebTarget getRootTarget() {
+		if (rootTarget == null) {
+			String protocol = "http";
+			if (isSecure())
+				protocol = "https";
+
+			rootTarget = client.target(protocol + "://" + host + ":" + port);
+		}
+		return rootTarget;
+	}
+	
+	public String index(String indexName, String type, String body) {		
+		return index(indexName, type, body, null, null);
+	}
+
+	/**
+	 * Call index API with String as body
+	 * 
+	 * @param body
+	 */
+	public String index(String indexName, String type, String body, String parent, String consistency) {		
+		WebTarget target = getRootTarget()
+				.path(indexName).path(type);
+		if(parent!=null)
+			target = target.queryParam("parent", parent);
+		if(consistency!=null)
+			target = target.queryParam("consistency", consistency);
+		
+		ESDocumentResponse response = target.request()
+				.post(Entity.json(body), ESDocumentResponse.class);
+		//TODO need to rethink this approach of responding with just the ID
+		return response.getId();
+	}
+
+	public List<String> bulkIndex(String indexName, String indexType,
+			List<String> documents) {
+		StringBuilder bodyBuilder = new StringBuilder();
+		for(String doc: documents) {
+			bodyBuilder.append("{\"index\":{\"_index\":\"")
+					   .append(indexName).append("\",")
+					   .append("\"_type\":\"")
+					   .append(indexType).append("\"}}\n");
+			String strippedDoc = doc.trim().replaceAll("\r", "").replaceAll("\n", "").replaceAll("\t", "");
+			bodyBuilder.append(strippedDoc).append("\n");
+		}
+		WebTarget target = getRootTarget().path(indexName).path(indexType).path("_bulk");
+		LOG.info("Bulk Indexing \n"+bodyBuilder.toString());
+		Response response = target.request().post(Entity.text(bodyBuilder.toString()));
+		JsonNode responseNode = response.readEntity(JsonNode.class);
+		JsonNode itemsNode = responseNode.get("items");
+		List<String> ids = itemsNode.findValuesAsText("_id");
+		// TODO this returning of List<String> doesn't actually tell you which ones failed
+		
+		return ids;
+	}
+
+}

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -130,44 +130,71 @@ public class ElasticsearchProducer extends DefaultProducer {
             message.setHeader(ElasticsearchConstants.PARAM_CONSISTENCY_LEVEL, getEndpoint().getConfig().getConsistencyLevel());
             configConsistencyLevel = true;
         }
-
-        Client client = getEndpoint().getClient();
-        if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
-            IndexRequest indexRequest = message.getBody(IndexRequest.class);
-            message.setBody(client.index(indexRequest).actionGet().getId());
-        } else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
-            UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
-            message.setBody(client.update(updateRequest).actionGet().getId());
-        } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
-            GetRequest getRequest = message.getBody(GetRequest.class);
-            message.setBody(client.get(getRequest));
-        } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
-            MultiGetRequest multiGetRequest = message.getBody(MultiGetRequest.class);
-            message.setBody(client.multiGet(multiGetRequest));
-        } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
-            BulkRequest bulkRequest = message.getBody(BulkRequest.class);
-            message.setBody(client.bulk(bulkRequest).actionGet());
-        } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
-            BulkRequest bulkRequest = message.getBody(BulkRequest.class);
-            List<String> indexedIds = new ArrayList<String>();
-            for (BulkItemResponse response : client.bulk(bulkRequest).actionGet().getItems()) {
-                indexedIds.add(response.getId());
-            }
-            message.setBody(indexedIds);
-        } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
-            DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
-            message.setBody(client.delete(deleteRequest).actionGet());
-        } else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
-            ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
-            message.setBody(client.admin().indices().prepareExists(existsRequest.indices()).get().isExists());
-        } else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {
-            SearchRequest searchRequest = message.getBody(SearchRequest.class);
-            message.setBody(client.search(searchRequest).actionGet());
-        } else if (ElasticsearchConstants.OPERATION_MULTISEARCH.equals(operation)) {
-            MultiSearchRequest multiSearchRequest = message.getBody(MultiSearchRequest.class);
-            message.setBody(client.multiSearch(multiSearchRequest));
+        
+        ElasticsearchEndpoint endpoint = getEndpoint();
+        if(endpoint.getConfig().getUseHttpClient()) {
+        	 if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
+        		 message.setBody(endpoint.index(message));
+             } else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
+                 // TODO
+             } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
+            	// TODO
+             } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
+            	// TODO
+             } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
+            	 // TODO
+            	 
+             } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
+             	message.setBody(endpoint.bulkIndex(message));
+             } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
+            	// TODO
+             } else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
+            	// TODO
+             } else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {
+            	// TODO
+             } else if (ElasticsearchConstants.OPERATION_MULTISEARCH.equals(operation)) {
+            	// TODO
+             } else {
+                 throw new IllegalArgumentException(ElasticsearchConstants.PARAM_OPERATION + " value '" + operation + "' is not supported");
+             }
         } else {
-            throw new IllegalArgumentException(ElasticsearchConstants.PARAM_OPERATION + " value '" + operation + "' is not supported");
+            Client client = getEndpoint().getClient();
+            if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
+                message.setBody(endpoint.index(message));
+            } else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
+                UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
+                message.setBody(client.update(updateRequest).actionGet().getId());
+            } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
+                GetRequest getRequest = message.getBody(GetRequest.class);
+                message.setBody(client.get(getRequest));
+            } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
+                MultiGetRequest multiGetRequest = message.getBody(MultiGetRequest.class);
+                message.setBody(client.multiGet(multiGetRequest));
+            } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
+                BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+                message.setBody(client.bulk(bulkRequest).actionGet());
+            } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
+                BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+                List<String> indexedIds = new ArrayList<String>();
+                for (BulkItemResponse response : client.bulk(bulkRequest).actionGet().getItems()) {
+                    indexedIds.add(response.getId());
+                }
+                message.setBody(indexedIds);
+            } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
+                DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
+                message.setBody(client.delete(deleteRequest).actionGet());
+            } else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
+                ExistsRequest existsRequest = message.getBody(ExistsRequest.class);
+                message.setBody(client.admin().indices().prepareExists(existsRequest.indices()).get().isExists());
+            } else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {
+                SearchRequest searchRequest = message.getBody(SearchRequest.class);
+                message.setBody(client.search(searchRequest).actionGet());
+            } else if (ElasticsearchConstants.OPERATION_MULTISEARCH.equals(operation)) {
+                MultiSearchRequest multiSearchRequest = message.getBody(MultiSearchRequest.class);
+                message.setBody(client.multiSearch(multiSearchRequest));
+            } else {
+                throw new IllegalArgumentException(ElasticsearchConstants.PARAM_OPERATION + " value '" + operation + "' is not supported");
+            }
         }
 
         // If we set params via the configuration on this exchange, remove them

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -138,12 +138,11 @@ public class ElasticsearchProducer extends DefaultProducer {
              } else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
                  // TODO
              } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
-            	// TODO
+            	message.setBody(endpoint.getById(message));
              } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
             	// TODO
              } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
             	 // TODO
-            	 
              } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
              	message.setBody(endpoint.bulkIndex(message));
              } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -142,13 +142,13 @@ public class ElasticsearchProducer extends DefaultProducer {
              } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
             	message.setBody(endpoint.multiget(message));
              } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
-            	 // TODO
+            	throw new UnsupportedOperationException();
              } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
              	message.setBody(endpoint.bulkIndex(message));
              } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
             	message.setBody(endpoint.delete(message));
              } else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
-            	// TODO
+            	message.setBody(endpoint.indexExists(message));
              } else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {
             	// TODO
              } else if (ElasticsearchConstants.OPERATION_MULTISEARCH.equals(operation)) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -136,7 +136,7 @@ public class ElasticsearchProducer extends DefaultProducer {
         	 if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
         		 message.setBody(endpoint.index(message));
              } else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
-                 // TODO
+                 message.setBody(endpoint.update(message));
              } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
             	message.setBody(endpoint.getById(message));
              } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -140,7 +140,7 @@ public class ElasticsearchProducer extends DefaultProducer {
              } else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
             	message.setBody(endpoint.getById(message));
              } else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
-            	// TODO
+            	message.setBody(endpoint.multiget(message));
              } else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
             	 // TODO
              } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -141,98 +141,32 @@ public class ElasticsearchProducer extends DefaultProducer {
 		}
 
 		ElasticsearchEndpoint endpoint = getEndpoint();
-		if (endpoint.getConfig().getUseHttpClient()) {
-			if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
-				message.setBody(endpoint.index(message));
-			} else if (ElasticsearchConstants.OPERATION_UPDATE
-					.equals(operation)) {
-				message.setBody(endpoint.update(message));
-			} else if (ElasticsearchConstants.OPERATION_GET_BY_ID
-					.equals(operation)) {
-				message.setBody(endpoint.getById(message));
-			} else if (ElasticsearchConstants.OPERATION_MULTIGET
-					.equals(operation)) {
-				message.setBody(endpoint.multiget(message));
-			} else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
-				throw new UnsupportedOperationException();
-			} else if (ElasticsearchConstants.OPERATION_BULK_INDEX
-					.equals(operation)) {
-				message.setBody(endpoint.bulkIndex(message));
-			} else if (ElasticsearchConstants.OPERATION_DELETE
-					.equals(operation)) {
-				message.setBody(endpoint.delete(message));
-			} else if (ElasticsearchConstants.OPERATION_EXISTS
-					.equals(operation)) {
-				message.setBody(endpoint.indexExists(message));
-			} else if (ElasticsearchConstants.OPERATION_SEARCH
-					.equals(operation)) {
-				message.setBody(endpoint.search(message));
-			} else if (ElasticsearchConstants.OPERATION_MULTISEARCH
-					.equals(operation)) {
-				//
-			} else {
-				throw new IllegalArgumentException(
-						ElasticsearchConstants.PARAM_OPERATION + " value '"
-								+ operation + "' is not supported");
-			}
+		if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
+			message.setBody(endpoint.index(message));
+		} else if (ElasticsearchConstants.OPERATION_UPDATE.equals(operation)) {
+			message.setBody(endpoint.update(message));
+		} else if (ElasticsearchConstants.OPERATION_GET_BY_ID.equals(operation)) {
+			message.setBody(endpoint.getById(message));
+		} else if (ElasticsearchConstants.OPERATION_MULTIGET.equals(operation)) {
+			message.setBody(endpoint.multiget(message));
+		} else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
+			message.setBody(endpoint.bulk(message));
+		} else if (ElasticsearchConstants.OPERATION_BULK_INDEX
+				.equals(operation)) {
+			message.setBody(endpoint.bulkIndex(message));
+		} else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
+			message.setBody(endpoint.delete(message));
+		} else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
+			message.setBody(endpoint.indexExists(message));
+		} else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {
+			message.setBody(endpoint.search(message));
+		} else if (ElasticsearchConstants.OPERATION_MULTISEARCH
+				.equals(operation)) {
+			message.setBody(endpoint.multisearch(message));
 		} else {
-			Client client = getEndpoint().getClient();
-			if (ElasticsearchConstants.OPERATION_INDEX.equals(operation)) {
-				message.setBody(endpoint.index(message));
-			} else if (ElasticsearchConstants.OPERATION_UPDATE
-					.equals(operation)) {
-				UpdateRequest updateRequest = message
-						.getBody(UpdateRequest.class);
-				message.setBody(client.update(updateRequest).actionGet()
-						.getId());
-			} else if (ElasticsearchConstants.OPERATION_GET_BY_ID
-					.equals(operation)) {
-				GetRequest getRequest = message.getBody(GetRequest.class);
-				message.setBody(client.get(getRequest));
-			} else if (ElasticsearchConstants.OPERATION_MULTIGET
-					.equals(operation)) {
-				MultiGetRequest multiGetRequest = message
-						.getBody(MultiGetRequest.class);
-				message.setBody(client.multiGet(multiGetRequest));
-			} else if (ElasticsearchConstants.OPERATION_BULK.equals(operation)) {
-				BulkRequest bulkRequest = message.getBody(BulkRequest.class);
-				message.setBody(client.bulk(bulkRequest).actionGet());
-			} else if (ElasticsearchConstants.OPERATION_BULK_INDEX
-					.equals(operation)) {
-				BulkRequest bulkRequest = message.getBody(BulkRequest.class);
-				List<String> indexedIds = new ArrayList<String>();
-				for (BulkItemResponse response : client.bulk(bulkRequest)
-						.actionGet().getItems()) {
-					indexedIds.add(response.getId());
-				}
-				message.setBody(indexedIds);
-			} else if (ElasticsearchConstants.OPERATION_DELETE
-					.equals(operation)) {
-				DeleteRequest deleteRequest = message
-						.getBody(DeleteRequest.class);
-				message.setBody(client.delete(deleteRequest).actionGet());
-			} else if (ElasticsearchConstants.OPERATION_EXISTS
-					.equals(operation)) {
-				ExistsRequest existsRequest = message
-						.getBody(ExistsRequest.class);
-				message.setBody(client.admin().indices()
-						.prepareExists(existsRequest.indices()).get()
-						.isExists());
-			} else if (ElasticsearchConstants.OPERATION_SEARCH
-					.equals(operation)) {
-				SearchRequest searchRequest = message
-						.getBody(SearchRequest.class);
-				message.setBody(client.search(searchRequest).actionGet());
-			} else if (ElasticsearchConstants.OPERATION_MULTISEARCH
-					.equals(operation)) {
-				MultiSearchRequest multiSearchRequest = message
-						.getBody(MultiSearchRequest.class);
-				message.setBody(client.multiSearch(multiSearchRequest));
-			} else {
-				throw new IllegalArgumentException(
-						ElasticsearchConstants.PARAM_OPERATION + " value '"
-								+ operation + "' is not supported");
-			}
+			throw new IllegalArgumentException(
+					ElasticsearchConstants.PARAM_OPERATION + " value '"
+							+ operation + "' is not supported");
 		}
 
 		// If we set params via the configuration on this exchange, remove them

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -146,7 +146,7 @@ public class ElasticsearchProducer extends DefaultProducer {
              } else if (ElasticsearchConstants.OPERATION_BULK_INDEX.equals(operation)) {
              	message.setBody(endpoint.bulkIndex(message));
              } else if (ElasticsearchConstants.OPERATION_DELETE.equals(operation)) {
-            	// TODO
+            	message.setBody(endpoint.delete(message));
              } else if (ElasticsearchConstants.OPERATION_EXISTS.equals(operation)) {
             	// TODO
              } else if (ElasticsearchConstants.OPERATION_SEARCH.equals(operation)) {

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchBaseTest.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchBaseTest.java
@@ -40,7 +40,7 @@ public class ElasticsearchBaseTest extends CamelTestSupport {
 
         // create an embedded node to resue
         node = nodeBuilder().local(true)
-                .settings(Settings.settingsBuilder().put("http.enabled", false).put("path.data", "target/data").put("path.home", "target/home"))
+                .settings(Settings.settingsBuilder().put("http.enabled", true).put("http.port", "9201").put("path.data", "target/data").put("path.home", "target/home"))
                 .node();
 
         client = node.client();

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
@@ -188,8 +188,14 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_EXISTS);
         headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
         Boolean exists = template.requestBodyAndHeaders("direct:exists", "", headers, Boolean.class);
+        
         assertNotNull("response should not be null", exists);
         assertTrue("Index should exists", exists);
+        
+        Boolean exists2 = template.requestBodyAndHeaders("direct:exists2", "", headers, Boolean.class);
+        assertNotNull("response should not be null", exists2);
+        assertTrue("Index should exists", exists2);
+        
     }
     
     @Test
@@ -404,6 +410,8 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
                 from("direct:update2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=UPDATE&indexName=twitter&indexType=tweet&useHttpClient=true");
                 
                 from("direct:exists").to("elasticsearch://local?operation=EXISTS");
+                from("direct:exists2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&useHttpClient=true&operation=EXISTS");
+                
                 from("direct:multisearch").to("elasticsearch://local?operation=MULTISEARCH&indexName=test");
             }
         };

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
@@ -145,6 +145,13 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, indexId);
         indexId = template.requestBodyAndHeaders("direct:update", newMap, headers, String.class);
         assertNotNull("indexId should be set", indexId);
+        
+
+        Map<String, String> newMap2 = new HashMap<>();
+        newMap2.put(createPrefix() + "key2", createPrefix() + "value3");
+        
+        indexId = template.requestBodyAndHeaders("direct:update2", newMap2, headers, String.class);
+        assertNotNull("indexId should be set", indexId);
     }
 
     @Test
@@ -351,10 +358,12 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
                 
                 from("direct:multiget").to("elasticsearch://local?operation=MULTIGET&indexName=twitter&indexType=tweet");
                 from("direct:delete").to("elasticsearch://local?operation=DELETE&indexName=twitter&indexType=tweet");
-                from("direct:delete2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=DELETE&indexName=twitter&indexType=tweet");
+                from("direct:delete2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=DELETE&indexName=twitter&indexType=tweet&useHttpClient=true");
                 
                 from("direct:search").to("elasticsearch://local?operation=SEARCH&indexName=twitter&indexType=tweet");
                 from("direct:update").to("elasticsearch://local?operation=UPDATE&indexName=twitter&indexType=tweet");
+                from("direct:update2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=UPDATE&indexName=twitter&indexType=tweet&useHttpClient=true");
+                
                 from("direct:exists").to("elasticsearch://local?operation=EXISTS");
                 from("direct:multisearch").to("elasticsearch://local?operation=MULTISEARCH&indexName=test");
             }

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.elasticsearch;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,380 +43,493 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
+public class ElasticsearchGetSearchDeleteExistsUpdateTest extends
+		ElasticsearchBaseTest {
 
-public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchBaseTest {
+	@Test
+	public void testGet() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		sendBody("direct:index", map);
+		String indexId = template
+				.requestBody("direct:index", map, String.class);
+		assertNotNull("indexId should be set", indexId);
 
-    @Test
-    public void testGet() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        sendBody("direct:index", map);
-        String indexId = template.requestBody("direct:index", map, String.class);
-        assertNotNull("indexId should be set", indexId);
+		// now, verify GET succeeded
+		GetResponse response = template.requestBody("direct:get", indexId,
+				GetResponse.class);
 
-        //now, verify GET succeeded
-        GetResponse response = template.requestBody("direct:get", indexId, GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response source should not be null",
+				response.getSource());
 
-        assertNotNull("response should not be null", response);
-        assertNotNull("response source should not be null", response.getSource());
+		// http client GET
+		String response2 = template.requestBody("direct:get2", indexId,
+				String.class);
+		assertNotNull("response should not be null", response2);
+		assertNotNull("response source should not be null", response2);
+		assertNotEquals("response should not equal id", indexId, response2);
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode response2JsonNode = objectMapper.readValue(response2,
+				JsonNode.class);
+		assertEquals("response source should equal created source",
+				response.getSourceAsString(),
+				response2JsonNode.findValue("_source").toString());
+	}
 
-        //http client GET
-        String response2 = template.requestBody("direct:get2", indexId, String.class);
-        assertNotNull("response should not be null", response2);
-        assertNotNull("response source should not be null", response2);
-        assertNotEquals("response should not equal id", indexId, response2);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode response2JsonNode = objectMapper.readValue(response2, JsonNode.class);
-        assertEquals("response source should equal created source", response.getSourceAsString(), response2JsonNode.findValue("_source").toString());
-    }
+	@Test
+	public void testDelete() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		sendBody("direct:index", map);
+		String indexId = template
+				.requestBody("direct:index", map, String.class);
+		assertNotNull("indexId should be set", indexId);
 
-    @Test
-    public void testDelete() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        sendBody("direct:index", map);
-        String indexId = template.requestBody("direct:index", map, String.class);
-        assertNotNull("indexId should be set", indexId);
+		// now, verify GET succeeded
+		GetResponse response = template.requestBody("direct:get", indexId,
+				GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response source should not be null",
+				response.getSource());
 
-        //now, verify GET succeeded
-        GetResponse response = template.requestBody("direct:get", indexId, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNotNull("response source should not be null", response.getSource());
+		// now, perform DELETE
+		DeleteResponse deleteResponse = template.requestBody("direct:delete",
+				indexId, DeleteResponse.class);
+		assertNotNull("response should not be null", deleteResponse);
 
-        //now, perform DELETE
-        DeleteResponse deleteResponse = template.requestBody("direct:delete", indexId, DeleteResponse.class);
-        assertNotNull("response should not be null", deleteResponse);
+		// now, verify GET fails to find the indexed value
+		response = template.requestBody("direct:get", indexId,
+				GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNull("response source should be null", response.getSource());
+	}
 
-        //now, verify GET fails to find the indexed value
-        response = template.requestBody("direct:get", indexId, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNull("response source should be null", response.getSource());
-    }
-    
-    @Test
-    public void testHttpDelete() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        sendBody("direct:index", map);
-        String indexId = template.requestBody("direct:index", map, String.class);
-        assertNotNull("indexId should be set", indexId);
+	@Test
+	public void testHttpDelete() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		sendBody("direct:index", map);
+		String indexId = template
+				.requestBody("direct:index", map, String.class);
+		assertNotNull("indexId should be set", indexId);
 
-        //now, verify GET succeeded
-        GetResponse response = template.requestBody("direct:get", indexId, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNotNull("response source should not be null", response.getSource());
+		// now, verify GET succeeded
+		GetResponse response = template.requestBody("direct:get", indexId,
+				GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response source should not be null",
+				response.getSource());
 
-        //now, perform DELETE
-        String deleteResponse = template.requestBody("direct:delete2", indexId, String.class);
-        assertNotNull("response should not be null", deleteResponse);
+		// now, perform DELETE
+		String deleteResponse = template.requestBody("direct:delete2", indexId,
+				String.class);
+		assertNotNull("response should not be null", deleteResponse);
 
-        //now, verify GET fails to find the indexed value
-        response = template.requestBody("direct:get", indexId, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNull("response source should be null", response.getSource());
-    }
+		// now, verify GET fails to find the indexed value
+		response = template.requestBody("direct:get", indexId,
+				GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNull("response source should be null", response.getSource());
+	}
 
-    @Test
-    public void testSearch() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        sendBody("direct:index", map);
+	@Test
+	public void testSearch() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		sendBody("direct:index", map);
 
-        //now, verify GET succeeded
-        Map<String, Object> actualQuery = new HashMap<String, Object>();
-        actualQuery.put("content", "searchtest");
-        Map<String, Object> match = new HashMap<String, Object>();
-        match.put("match", actualQuery);
-        Map<String, Object> query = new HashMap<String, Object>();
-        query.put("query", match);
-        
-        SearchResponse response = template.requestBody("direct:search", query, SearchResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNotNull("response hits should be == 1", response.getHits().totalHits());
-    }
+		// now, verify GET succeeded
+		Map<String, Object> actualQuery = new HashMap<String, Object>();
+		actualQuery.put("testsearch-key", "testsearch-value"); // the field is
+																// actually
+																// called
+																// testsearch-key,
+																// not content
+		Map<String, Object> match = new HashMap<String, Object>();
+		match.put("match", actualQuery);
+		Map<String, Object> query = new HashMap<String, Object>();
+		query.put("query", match);
+		Thread.sleep(1000); // need to wait for the data to be refreshed for
+							// searching
+		SearchResponse response = template.requestBody("direct:search", query,
+				SearchResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response hits should not be null", response.getHits()
+				.totalHits());
+		assertTrue("response hits should be == 1", response.getHits()
+				.getTotalHits() == 1);
 
-    @Test
-    public void testUpdate() throws Exception {
-        Map<String, String> map = createIndexedData();
-        String indexId = template.requestBody("direct:index", map, String.class);
-        assertNotNull("indexId should be set", indexId);
+		Map responseMap = template.requestBody("direct:search2", query,
+				Map.class);
+		assertNotNull("response should not be null", responseMap);
+		assertNotNull("response hits should not be null",
+				responseMap.get("hits"));
+		assertTrue("response hits should be == 1",
+				((Map) responseMap.get("hits")).get("total").equals(1));
+	}
 
-        Map<String, String> newMap = new HashMap<>();
-        newMap.put(createPrefix() + "key2", createPrefix() + "value2");
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(ElasticsearchConstants.PARAM_INDEX_ID, indexId);
-        indexId = template.requestBodyAndHeaders("direct:update", newMap, headers, String.class);
-        assertNotNull("indexId should be set", indexId);
-        
+	@Test
+	public void testUpdate() throws Exception {
+		Map<String, String> map = createIndexedData();
+		String indexId = template
+				.requestBody("direct:index", map, String.class);
+		assertNotNull("indexId should be set", indexId);
 
-        Map<String, String> newMap2 = new HashMap<>();
-        newMap2.put(createPrefix() + "key2", createPrefix() + "value3");
-        
-        indexId = template.requestBodyAndHeaders("direct:update2", newMap2, headers, String.class);
-        assertNotNull("indexId should be set", indexId);
-    }
+		Map<String, String> newMap = new HashMap<>();
+		newMap.put(createPrefix() + "key2", createPrefix() + "value2");
+		Map<String, Object> headers = new HashMap<>();
+		headers.put(ElasticsearchConstants.PARAM_INDEX_ID, indexId);
+		indexId = template.requestBodyAndHeaders("direct:update", newMap,
+				headers, String.class);
+		assertNotNull("indexId should be set", indexId);
 
-    @Test
-    public void testGetWithHeaders() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+		Map<String, String> newMap2 = new HashMap<>();
+		newMap2.put(createPrefix() + "key2", createPrefix() + "value3");
 
-        String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
+		indexId = template.requestBodyAndHeaders("direct:update2", newMap2,
+				headers, String.class);
+		assertNotNull("indexId should be set", indexId);
+	}
 
-        //now, verify GET
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_GET_BY_ID);
-        GetResponse response = template.requestBodyAndHeaders("direct:start", indexId, headers, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNotNull("response source should not be null", response.getSource());
-    }
-    
-    @Test
-    public void testExistsWithHeaders() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+	@Test
+	public void testGetWithHeaders() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
 
-        String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
+		String indexId = template.requestBodyAndHeaders("direct:start", map,
+				headers, String.class);
 
-        //now, verify GET
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_EXISTS);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        Boolean exists = template.requestBodyAndHeaders("direct:exists", "", headers, Boolean.class);
-        
-        assertNotNull("response should not be null", exists);
-        assertTrue("Index should exists", exists);
-        
-        Boolean exists2 = template.requestBodyAndHeaders("direct:exists2", "", headers, Boolean.class);
-        assertNotNull("response should not be null", exists2);
-        assertTrue("Index should exists", exists2);
-        
-    }
-    
-    @Test
-    public void testMultiGet() throws Exception {
-        //first, INDEX two values
-        Map<String, String> map = createIndexedData();
-        Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "1");
+		// now, verify GET
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_GET_BY_ID);
+		GetResponse response = template.requestBodyAndHeaders("direct:start",
+				indexId, headers, GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response source should not be null",
+				response.getSource());
+	}
 
-        template.requestBodyAndHeaders("direct:start", map, headers, String.class);
-        
-        headers.clear();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "facebook");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "status");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "2");
-        
-        template.requestBodyAndHeaders("direct:start", map, headers, String.class);
-        headers.clear();
+	@Test
+	public void testExistsWithHeaders() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
 
-        //now, verify MULTIGET
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_MULTIGET);
-        Item item1 = new Item("twitter", "tweet", "1");
-        Item item2 = new Item("facebook", "status", "2");
-        Item item3 = new Item("instagram", "latest", "3");
-        List<Item> list = new ArrayList<Item>();
-        list.add(item1);
-        list.add(item2);
-        list.add(item3);
-        MultiGetResponse response = template.requestBodyAndHeaders("direct:multiget", list, headers, MultiGetResponse.class);
-        MultiGetItemResponse[] responses = response.getResponses();
-        
-        assertNotNull("response should not be null", response);
-        assertEquals("response should contains three multiGetResponse object", 3, response.getResponses().length);
-        assertEquals("response 1 should contains tweet as type", "tweet", responses[0].getResponse().getType().toString());
-        assertEquals("response 2 should contains status as type", "status", responses[1].getResponse().getType().toString());
-        assertFalse("response 1 should be ok", responses[0].isFailed());
-        assertFalse("response 2 should be ok", responses[1].isFailed());
-        assertTrue("response 3 should be failed", responses[2].isFailed());
-        
-        //Now for the http version of multiget
-        Map<String, String> item1Map = new HashMap<String,String>();
-        item1Map.put("_index", "twitter");
-        item1Map.put("_type", "tweet");
-        item1Map.put("_id", "1");
-        
-        Map<String, String> item2Map = new HashMap<String,String>();
-        item2Map.put("_index", "facebook");
-        item2Map.put("_type", "status");
-        item2Map.put("_id", "2");
-        
-        Map<String, String> item3Map = new HashMap<String,String>();
-        item3Map.put("_index", "instagram");
-        item3Map.put("_type", "latest");
-        item3Map.put("_id", "3");
-        
-        List<Map> list2 = new ArrayList<Map>();
-        list2.add(item1Map);
-        list2.add(item2Map);
-        list2.add(item3Map);
-        List<String> multiGetRequestResults = (List<String>)template.requestBodyAndHeaders("direct:multiget2", list2, headers);
-        assertNotNull("response should not be null", multiGetRequestResults);
-        assertTrue("response size greater than 0", multiGetRequestResults.size()>0);
-        assertTrue("response size equal to 3", multiGetRequestResults.size() == 3);
-        String result1 = multiGetRequestResults.get(0);
-        ObjectMapper objectMapper = new ObjectMapper();
-        assertTrue("response 1 should be ok", objectMapper.readTree(result1).get("_source")!=null);
-        
-        String result2 = multiGetRequestResults.get(1);
-        assertTrue("response 2 should be ok", objectMapper.readTree(result2).get("_source")!=null);
-        
-        String result3 = multiGetRequestResults.get(2);
-        assertTrue("response 3 should fail", objectMapper.readTree(result3).get("_source")==null);
-        
-    }
-    
-    @Test
-    public void testMultiSearch() throws Exception {
-        //first, INDEX two values
-        Map<String, Object> headers = new HashMap<String, Object>();
-        
-        node.client().prepareIndex("test", "type", "1").setSource("field", "xxx").execute().actionGet();
-        node.client().prepareIndex("test", "type", "2").setSource("field", "yyy").execute().actionGet();
+		String indexId = template.requestBodyAndHeaders("direct:start", map,
+				headers, String.class);
 
-        //now, verify MULTISEARCH
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_MULTISEARCH);
-        SearchRequestBuilder srb1 = node.client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.termQuery("field", "xxx"));
-        SearchRequestBuilder srb2 = node.client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.termQuery("field", "yyy"));
-        SearchRequestBuilder srb3 = node.client().prepareSearch("instagram")
-            .setTypes("type").setQuery(QueryBuilders.termQuery("test-multisearchkey", "test-multisearchvalue"));
-        List<SearchRequest> list = new ArrayList<>();
-        list.add(srb1.request());
-        list.add(srb2.request());
-        list.add(srb3.request());
-        MultiSearchResponse response = template.requestBodyAndHeaders("direct:multisearch", list, headers, MultiSearchResponse.class);
-        MultiSearchResponse.Item[] responses = response.getResponses();
-        assertNotNull("response should not be null", response);
-        assertEquals("response should contains three multiSearchResponse object", 3, response.getResponses().length);
-        assertFalse("response 1 should be ok", responses[0].isFailure());
-        assertFalse("response 2 should be ok", responses[1].isFailure());
-        assertTrue("response 3 should be failed", responses[2].isFailure());
-    }
+		// now, verify GET
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_EXISTS);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		Boolean exists = template.requestBodyAndHeaders("direct:exists", "",
+				headers, Boolean.class);
 
-    @Test
-    public void testDeleteWithHeaders() throws Exception {
-        //first, INDEX a value
-        Map<String, String> map = createIndexedData();
-        Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+		assertNotNull("response should not be null", exists);
+		assertTrue("Index should exists", exists);
 
-        String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
+		Boolean exists2 = template.requestBodyAndHeaders("direct:exists2", "",
+				headers, Boolean.class);
+		assertNotNull("response should not be null", exists2);
+		assertTrue("Index should exists", exists2);
 
-        //now, verify GET
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_GET_BY_ID);
-        GetResponse response = template.requestBodyAndHeaders("direct:start", indexId, headers, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNotNull("response source should not be null", response.getSource());
+	}
 
-        //now, perform DELETE
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_DELETE);
-        DeleteResponse deleteResponse = template.requestBodyAndHeaders("direct:start", indexId, headers, DeleteResponse.class);
-        assertNotNull("response should not be null", deleteResponse);
+	@Test
+	public void testMultiGet() throws Exception {
+		// first, INDEX two values
+		Map<String, String> map = createIndexedData();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "1");
 
-        //now, verify GET fails to find the indexed value
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_GET_BY_ID);
-        response = template.requestBodyAndHeaders("direct:start", indexId, headers, GetResponse.class);
-        assertNotNull("response should not be null", response);
-        assertNull("response source should be null", response.getSource());
-    }
+		template.requestBodyAndHeaders("direct:start", map, headers,
+				String.class);
 
-    @Test
-    public void testUpdateWithIDInHeader() throws Exception {
-        Map<String, String> map = createIndexedData();
-        Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_INDEX);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
-        headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "123");
+		headers.clear();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "facebook");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "status");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "2");
 
-        String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
-        assertNotNull("indexId should be set", indexId);
-        assertEquals("indexId should be equals to the provided id", "123", indexId);
+		template.requestBodyAndHeaders("direct:start", map, headers,
+				String.class);
+		headers.clear();
 
-        headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchConstants.OPERATION_UPDATE);
+		// now, verify MULTIGET
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_MULTIGET);
+		Item item1 = new Item("twitter", "tweet", "1");
+		Item item2 = new Item("facebook", "status", "2");
+		Item item3 = new Item("instagram", "latest", "3");
+		List<Item> list = new ArrayList<Item>();
+		list.add(item1);
+		list.add(item2);
+		list.add(item3);
+		MultiGetResponse response = template.requestBodyAndHeaders(
+				"direct:multiget", list, headers, MultiGetResponse.class);
+		MultiGetItemResponse[] responses = response.getResponses();
 
-        indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
-        assertNotNull("indexId should be set", indexId);
-        assertEquals("indexId should be equals to the provided id", "123", indexId);
-    }
+		assertNotNull("response should not be null", response);
+		assertEquals("response should contains three multiGetResponse object",
+				3, response.getResponses().length);
+		assertEquals("response 1 should contains tweet as type", "tweet",
+				responses[0].getResponse().getType().toString());
+		assertEquals("response 2 should contains status as type", "status",
+				responses[1].getResponse().getType().toString());
+		assertFalse("response 1 should be ok", responses[0].isFailed());
+		assertFalse("response 2 should be ok", responses[1].isFailed());
+		assertTrue("response 3 should be failed", responses[2].isFailed());
 
-    @Test
-    public void getRequestBody() throws Exception {
-        String prefix = createPrefix();
+		// Now for the http version of multiget
+		Map<String, String> item1Map = new HashMap<String, String>();
+		item1Map.put("_index", "twitter");
+		item1Map.put("_type", "tweet");
+		item1Map.put("_id", "1");
 
-        // given
-        GetRequest request = new GetRequest(prefix + "foo").type(prefix + "bar");
+		Map<String, String> item2Map = new HashMap<String, String>();
+		item2Map.put("_index", "facebook");
+		item2Map.put("_type", "status");
+		item2Map.put("_id", "2");
 
-        // when
-        String documentId = template.requestBody("direct:index",
-                new IndexRequest(prefix + "foo", prefix + "bar", prefix + "testId")
-                        .source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"), String.class);
-        GetResponse response = template.requestBody("direct:get",
-                request.id(documentId), GetResponse.class);
+		Map<String, String> item3Map = new HashMap<String, String>();
+		item3Map.put("_index", "instagram");
+		item3Map.put("_type", "latest");
+		item3Map.put("_id", "3");
 
-        // then
-        assertThat(response, notNullValue());
-        assertThat(prefix + "hello", equalTo(response.getSourceAsMap().get(prefix + "content")));
-    }
+		List<Map> list2 = new ArrayList<Map>();
+		list2.add(item1Map);
+		list2.add(item2Map);
+		list2.add(item3Map);
+		List<String> multiGetRequestResults = (List<String>) template
+				.requestBodyAndHeaders("direct:multiget2", list2, headers);
+		assertNotNull("response should not be null", multiGetRequestResults);
+		assertTrue("response size greater than 0",
+				multiGetRequestResults.size() > 0);
+		assertTrue("response size equal to 3",
+				multiGetRequestResults.size() == 3);
+		String result1 = multiGetRequestResults.get(0);
+		ObjectMapper objectMapper = new ObjectMapper();
+		assertTrue("response 1 should be ok", objectMapper.readTree(result1)
+				.get("_source") != null);
 
-    @Test
-    public void deleteRequestBody() throws Exception {
-        String prefix = createPrefix();
+		String result2 = multiGetRequestResults.get(1);
+		assertTrue("response 2 should be ok", objectMapper.readTree(result2)
+				.get("_source") != null);
 
-        // given
-        DeleteRequest request = new DeleteRequest(prefix + "foo").type(prefix + "bar");
+		String result3 = multiGetRequestResults.get(2);
+		assertTrue("response 3 should fail", objectMapper.readTree(result3)
+				.get("_source") == null);
 
-        // when
-        String documentId = template.requestBody("direct:index",
-                new IndexRequest("" + prefix + "foo", "" + prefix + "bar", "" + prefix + "testId")
-                        .source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"), String.class);
-        DeleteResponse response = template.requestBody("direct:delete",
-                request.id(documentId), DeleteResponse.class);
+	}
 
-        // then
-        assertThat(response, notNullValue());
-        assertThat(documentId, equalTo(response.getId()));
-    }
+	@Test
+	public void testMultiSearch() throws Exception {
+		// first, INDEX two values
+		Map<String, Object> headers = new HashMap<String, Object>();
 
-    @Override
-    protected RouteBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() {
-                from("direct:start").to("elasticsearch://local?operation=INDEX");
-                from("direct:index").to("elasticsearch://local?operation=INDEX&indexName=twitter&indexType=tweet");
-                from("direct:get").to("elasticsearch://local?operation=GET_BY_ID&indexName=twitter&indexType=tweet");
-                from("direct:get2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=GET_BY_ID&indexName=twitter&indexType=tweet&useHttpClient=true");
-                
-                from("direct:multiget").to("elasticsearch://local?operation=MULTIGET&indexName=twitter&indexType=tweet");
-                from("direct:multiget2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=MULTIGET&indexName=twitter&indexType=tweet&useHttpClient=true");
-                
-                from("direct:delete").to("elasticsearch://local?operation=DELETE&indexName=twitter&indexType=tweet");
-                from("direct:delete2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=DELETE&indexName=twitter&indexType=tweet&useHttpClient=true");
-                
-                from("direct:search").to("elasticsearch://local?operation=SEARCH&indexName=twitter&indexType=tweet");
-                from("direct:update").to("elasticsearch://local?operation=UPDATE&indexName=twitter&indexType=tweet");
-                from("direct:update2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=UPDATE&indexName=twitter&indexType=tweet&useHttpClient=true");
-                
-                from("direct:exists").to("elasticsearch://local?operation=EXISTS");
-                from("direct:exists2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&useHttpClient=true&operation=EXISTS");
-                
-                from("direct:multisearch").to("elasticsearch://local?operation=MULTISEARCH&indexName=test");
-            }
-        };
-    }
+		node.client().prepareIndex("test", "type", "1")
+				.setSource("field", "xxx").execute().actionGet();
+		node.client().prepareIndex("test", "type", "2")
+				.setSource("field", "yyy").execute().actionGet();
+
+		// now, verify MULTISEARCH
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_MULTISEARCH);
+		SearchRequestBuilder srb1 = node.client().prepareSearch("test")
+				.setTypes("type")
+				.setQuery(QueryBuilders.termQuery("field", "xxx"));
+		SearchRequestBuilder srb2 = node.client().prepareSearch("test")
+				.setTypes("type")
+				.setQuery(QueryBuilders.termQuery("field", "yyy"));
+		SearchRequestBuilder srb3 = node
+				.client()
+				.prepareSearch("instagram")
+				.setTypes("type")
+				.setQuery(
+						QueryBuilders.termQuery("test-multisearchkey",
+								"test-multisearchvalue"));
+		List<SearchRequest> list = new ArrayList<>();
+		list.add(srb1.request());
+		list.add(srb2.request());
+		list.add(srb3.request());
+		MultiSearchResponse response = template.requestBodyAndHeaders(
+				"direct:multisearch", list, headers, MultiSearchResponse.class);
+		MultiSearchResponse.Item[] responses = response.getResponses();
+		assertNotNull("response should not be null", response);
+		assertEquals(
+				"response should contains three multiSearchResponse object", 3,
+				response.getResponses().length);
+		assertFalse("response 1 should be ok", responses[0].isFailure());
+		assertFalse("response 2 should be ok", responses[1].isFailure());
+		assertTrue("response 3 should be failed", responses[2].isFailure());
+	}
+
+	@Test
+	public void testDeleteWithHeaders() throws Exception {
+		// first, INDEX a value
+		Map<String, String> map = createIndexedData();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+
+		String indexId = template.requestBodyAndHeaders("direct:start", map,
+				headers, String.class);
+
+		// now, verify GET
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_GET_BY_ID);
+		GetResponse response = template.requestBodyAndHeaders("direct:start",
+				indexId, headers, GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNotNull("response source should not be null",
+				response.getSource());
+
+		// now, perform DELETE
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_DELETE);
+		DeleteResponse deleteResponse = template.requestBodyAndHeaders(
+				"direct:start", indexId, headers, DeleteResponse.class);
+		assertNotNull("response should not be null", deleteResponse);
+
+		// now, verify GET fails to find the indexed value
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_GET_BY_ID);
+		response = template.requestBodyAndHeaders("direct:start", indexId,
+				headers, GetResponse.class);
+		assertNotNull("response should not be null", response);
+		assertNull("response source should be null", response.getSource());
+	}
+
+	@Test
+	public void testUpdateWithIDInHeader() throws Exception {
+		Map<String, String> map = createIndexedData();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_INDEX);
+		headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "tweet");
+		headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "123");
+
+		String indexId = template.requestBodyAndHeaders("direct:start", map,
+				headers, String.class);
+		assertNotNull("indexId should be set", indexId);
+		assertEquals("indexId should be equals to the provided id", "123",
+				indexId);
+
+		headers.put(ElasticsearchConstants.PARAM_OPERATION,
+				ElasticsearchConstants.OPERATION_UPDATE);
+
+		indexId = template.requestBodyAndHeaders("direct:start", map, headers,
+				String.class);
+		assertNotNull("indexId should be set", indexId);
+		assertEquals("indexId should be equals to the provided id", "123",
+				indexId);
+	}
+
+	@Test
+	public void getRequestBody() throws Exception {
+		String prefix = createPrefix();
+
+		// given
+		GetRequest request = new GetRequest(prefix + "foo")
+				.type(prefix + "bar");
+
+		// when
+		String documentId = template.requestBody(
+				"direct:index",
+				new IndexRequest(prefix + "foo", prefix + "bar", prefix
+						+ "testId").source("{\"" + prefix + "content\": \""
+						+ prefix + "hello\"}"), String.class);
+		GetResponse response = template.requestBody("direct:get",
+				request.id(documentId), GetResponse.class);
+
+		// then
+		assertThat(response, notNullValue());
+		assertThat(prefix + "hello",
+				equalTo(response.getSourceAsMap().get(prefix + "content")));
+	}
+
+	@Test
+	public void deleteRequestBody() throws Exception {
+		String prefix = createPrefix();
+
+		// given
+		DeleteRequest request = new DeleteRequest(prefix + "foo").type(prefix
+				+ "bar");
+
+		// when
+		String documentId = template.requestBody(
+				"direct:index",
+				new IndexRequest("" + prefix + "foo", "" + prefix + "bar", ""
+						+ prefix + "testId").source("{\"" + prefix
+						+ "content\": \"" + prefix + "hello\"}"), String.class);
+		DeleteResponse response = template.requestBody("direct:delete",
+				request.id(documentId), DeleteResponse.class);
+
+		// then
+		assertThat(response, notNullValue());
+		assertThat(documentId, equalTo(response.getId()));
+	}
+
+	@Override
+	protected RouteBuilder createRouteBuilder() throws Exception {
+		return new RouteBuilder() {
+			@Override
+			public void configure() {
+				from("direct:start")
+						.to("elasticsearch://local?operation=INDEX");
+				from("direct:index")
+						.to("elasticsearch://local?operation=INDEX&indexName=twitter&indexType=tweet");
+				from("direct:get")
+						.to("elasticsearch://local?operation=GET_BY_ID&indexName=twitter&indexType=tweet");
+				from("direct:get2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=GET_BY_ID&indexName=twitter&indexType=tweet&useHttpClient=true");
+
+				from("direct:multiget")
+						.to("elasticsearch://local?operation=MULTIGET&indexName=twitter&indexType=tweet");
+				from("direct:multiget2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=MULTIGET&indexName=twitter&indexType=tweet&useHttpClient=true");
+
+				from("direct:delete")
+						.to("elasticsearch://local?operation=DELETE&indexName=twitter&indexType=tweet");
+				from("direct:delete2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=DELETE&indexName=twitter&indexType=tweet&useHttpClient=true");
+
+				from("direct:search")
+						.to("elasticsearch://local?operation=SEARCH&indexName=twitter&indexType=tweet");
+				from("direct:search2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&useHttpClient=true&operation=SEARCH&indexName=twitter&indexType=tweet");
+
+				from("direct:update")
+						.to("elasticsearch://local?operation=UPDATE&indexName=twitter&indexType=tweet");
+				from("direct:update2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=UPDATE&indexName=twitter&indexType=tweet&useHttpClient=true");
+
+				from("direct:exists").to(
+						"elasticsearch://local?operation=EXISTS");
+				from("direct:exists2")
+						.to("elasticsearch://elasticsearch?ip=localhost&port=9201&useHttpClient=true&operation=EXISTS");
+
+				from("direct:multisearch")
+						.to("elasticsearch://local?operation=MULTISEARCH&indexName=test");
+			}
+		};
+	}
 }

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchGetSearchDeleteExistsUpdateTest.java
@@ -91,6 +91,29 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
         assertNotNull("response should not be null", response);
         assertNull("response source should be null", response.getSource());
     }
+    
+    @Test
+    public void testHttpDelete() throws Exception {
+        //first, INDEX a value
+        Map<String, String> map = createIndexedData();
+        sendBody("direct:index", map);
+        String indexId = template.requestBody("direct:index", map, String.class);
+        assertNotNull("indexId should be set", indexId);
+
+        //now, verify GET succeeded
+        GetResponse response = template.requestBody("direct:get", indexId, GetResponse.class);
+        assertNotNull("response should not be null", response);
+        assertNotNull("response source should not be null", response.getSource());
+
+        //now, perform DELETE
+        String deleteResponse = template.requestBody("direct:delete2", indexId, String.class);
+        assertNotNull("response should not be null", deleteResponse);
+
+        //now, verify GET fails to find the indexed value
+        response = template.requestBody("direct:get", indexId, GetResponse.class);
+        assertNotNull("response should not be null", response);
+        assertNull("response source should be null", response.getSource());
+    }
 
     @Test
     public void testSearch() throws Exception {
@@ -328,6 +351,8 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
                 
                 from("direct:multiget").to("elasticsearch://local?operation=MULTIGET&indexName=twitter&indexType=tweet");
                 from("direct:delete").to("elasticsearch://local?operation=DELETE&indexName=twitter&indexType=tweet");
+                from("direct:delete2").to("elasticsearch://elasticsearch?ip=localhost&port=9201&operation=DELETE&indexName=twitter&indexType=tweet");
+                
                 from("direct:search").to("elasticsearch://local?operation=SEARCH&indexName=twitter&indexType=tweet");
                 from("direct:update").to("elasticsearch://local?operation=UPDATE&indexName=twitter&indexType=tweet");
                 from("direct:exists").to("elasticsearch://local?operation=EXISTS");


### PR DESCRIPTION
Added support for Elasticsearch Camel operations via HTTP (using Jersey). 
Tried to keep as close to the operation specs based on the web documentation but had to change slightly where using Elasticsearch java classes as return objects was not appropriate. 
Used Maps and Lists as much as possible which can then either be used via Jackson's ObjectMapper to read determine responses.