### PR TITLE
Make Kafka KEY and PARTITION values more intuitive.

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
@@ -24,8 +24,8 @@ public final class KafkaConstants {
     public static final String DEFAULT_GROUP = "group1";
 
     public static final String PARTITION_KEY = "kafka.PARTITION_KEY";
-    public static final String PARTITION = "kafka.EXCHANGE_NAME";
-    public static final String KEY = "kafka.CONTENT_TYPE";
+    public static final String PARTITION = "kafka.PARTITION";
+    public static final String KEY = "kafka.KEY";
     public static final String TOPIC = "kafka.TOPIC";
     public static final String OFFSET = "kafka.OFFSET";
 


### PR DESCRIPTION
See discussion: http://camel.465427.n5.nabble.com/Camel-Kafka-Value-of-KafkaConstants-KEY-constant-td5771115.html

I don't think there is any reason to use EXCHANGE_NAME or CONTENT_TYPE here.  This makes use of headers difficult in XML.