### PR TITLE
CAMEL-8742 - Reconnect when connections are closed.

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -1,0 +1,293 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.rabbitmq;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RabbitConsumer implements com.rabbitmq.client.Consumer {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final RabbitMQConsumer consumer;
+    private Channel channel;
+    private String tag;
+    /** Consumer tag for this consumer. */
+    private volatile String consumerTag;
+    private volatile boolean stopping;
+
+    /**
+     * Constructs a new instance and records its association to the passed-in
+     * channel.
+     *
+     * @param channel
+     *            the channel to which this consumer is attached
+     */
+    public RabbitConsumer(RabbitMQConsumer consumer) {
+        // super(channel);
+        this.consumer = consumer;
+        try {
+            Connection conn = consumer.getConnection();
+            this.channel = openChannel(conn);
+        } catch (IOException | TimeoutException e) {
+            log.warn("Unable to open channel for RabbitMQConsumer. Continuing and will try again", e);
+        }
+    }
+
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        Exchange exchange = consumer.getEndpoint().createRabbitExchange(envelope, properties, body);
+        consumer.getEndpoint().getMessageConverter().mergeAmqpProperties(exchange, properties);
+
+        boolean sendReply = properties.getReplyTo() != null;
+        if (sendReply && !exchange.getPattern().isOutCapable()) {
+            log.debug("In an inOut capable route");
+            exchange.setPattern(ExchangePattern.InOut);
+        }
+
+        log.trace("Created exchange [exchange={}]", exchange);
+        long deliveryTag = envelope.getDeliveryTag();
+        try {
+            consumer.getProcessor().process(exchange);
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+
+        // obtain the message after processing
+        Message msg;
+        if (exchange.hasOut()) {
+            msg = exchange.getOut();
+        } else {
+            msg = exchange.getIn();
+        }
+
+        if (exchange.getException() != null) {
+            consumer.getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
+        }
+
+        if (!exchange.isFailed()) {
+            // processing success
+            if (sendReply && exchange.getPattern().isOutCapable()) {
+                try {
+                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
+                } catch (RuntimeCamelException e) {
+                    // set the exception on the exchange so it can send the
+                    // exception back to the producer
+                    exchange.setException(e);
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                }
+            }
+            if (!consumer.getEndpoint().isAutoAck()) {
+                log.trace("Acknowledging receipt [delivery_tag={}]", deliveryTag);
+                channel.basicAck(deliveryTag, false);
+            }
+        }
+        // The exchange could have failed when sending the above message
+        if (exchange.isFailed()) {
+            if (consumer.getEndpoint().isTransferException() && exchange.getPattern().isOutCapable()) {
+                // the inOut exchange failed so put the exception in the body
+                // and send back
+                msg.setBody(exchange.getException());
+                exchange.setOut(msg);
+                exchange.getOut().setHeader(RabbitMQConstants.CORRELATIONID, exchange.getIn().getHeader(RabbitMQConstants.CORRELATIONID));
+                try {
+                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
+                } catch (RuntimeCamelException e) {
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                }
+
+                if (!consumer.getEndpoint().isAutoAck()) {
+                    log.trace("Acknowledging receipt when transferring exception [delivery_tag={}]", deliveryTag);
+                    channel.basicAck(deliveryTag, false);
+                }
+            } else {
+                boolean isRequeueHeaderSet = msg.getHeader(RabbitMQConstants.REQUEUE, false, boolean.class);
+                // processing failed, then reject and handle the exception
+                if (deliveryTag != 0 && !consumer.getEndpoint().isAutoAck()) {
+                    log.trace("Rejecting receipt [delivery_tag={}] with requeue={}", deliveryTag, isRequeueHeaderSet);
+                    if (isRequeueHeaderSet) {
+                        channel.basicReject(deliveryTag, true);
+                    } else {
+                        channel.basicReject(deliveryTag, false);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Bind consumer to channel
+     */
+    public void start() throws IOException {
+        if (channel == null) {
+            throw new IOException("The RabbitMQ channel is not open");
+        }
+        tag = channel.basicConsume(consumer.getEndpoint().getQueue(), consumer.getEndpoint().isAutoAck(), this);
+    }
+
+    /**
+     * Unbind consumer from channel
+     */
+    public void stop() throws IOException, TimeoutException {
+        stopping = true;
+        if (channel == null) {
+            return;
+        }
+        if (tag != null) {
+            channel.basicCancel(tag);
+        }
+        try {
+            channel.close();
+        } catch (TimeoutException e) {
+            log.error("Timeout occured");
+            throw e;
+        }
+    }
+
+    /**
+     * Stores the most recently passed-in consumerTag - semantically, there
+     * should be only one.
+     * 
+     * @see Consumer#handleConsumeOk
+     */
+    public void handleConsumeOk(String consumerTag) {
+        this.consumerTag = consumerTag;
+    }
+
+    /**
+     * Retrieve the consumer tag.
+     * 
+     * @return the most recently notified consumer tag.
+     */
+    public String getConsumerTag() {
+        return consumerTag;
+    }
+
+    /**
+     * No-op implementation of {@link Consumer#handleCancelOk}.
+     * 
+     * @param consumerTag
+     *            the defined consumer tag (client- or server-generated)
+     */
+    public void handleCancelOk(String consumerTag) {
+        // no work to do
+        log.debug("Recieved cancelOk signal on the rabbitMQ channel");
+    }
+
+    /**
+     * No-op implementation of {@link Consumer#handleCancel(String)}
+     * 
+     * @param consumerTag
+     *            the defined consumer tag (client- or server-generated)
+     */
+    public void handleCancel(String consumerTag) throws IOException {
+        // no work to do
+        log.debug("Recieved cancel signal on the rabbitMQ channel");
+    }
+
+    /**
+     * No-op implementation of {@link Consumer#handleShutdownSignal}.
+     */
+    public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
+        log.info("Recieved shutdown signal on the rabbitMQ channel");
+
+        // Check if the consumer closed the connection or something else
+        if (!sig.isInitiatedByApplication()) {
+            // Something else closed the connection so reconnect
+            boolean connected = false;
+            while (!connected && !stopping) {
+                try {
+                    reconnect();
+                    connected = true;
+                } catch (IOException | TimeoutException e) {
+                    log.warn("Unable to obtain a RabbitMQ channel. Will try again");
+
+                    Integer networkRecoveryInterval = consumer.getEndpoint().getNetworkRecoveryInterval();
+                    final long connectionRetryInterval = networkRecoveryInterval != null && networkRecoveryInterval > 0
+                            ? networkRecoveryInterval : 100L;
+                    try {
+                        Thread.sleep(connectionRetryInterval);
+                    } catch (InterruptedException e1) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * No-op implementation of {@link Consumer#handleRecoverOk}.
+     */
+    public void handleRecoverOk(String consumerTag) {
+        // no work to do
+        log.debug("Recieved recover ok signal on the rabbitMQ channel");
+    }
+
+    /**
+     * If the RabbitMQ connection is good this returns without changing
+     * anything. If the connection is down it will attempt to reconnect
+     */
+    public void reconnect() throws IOException, TimeoutException {
+        if (isChannelOpen()) {
+            // The connection is good, so nothing to do
+            return;
+        }
+        log.info("Attempting to open a new rabbitMQ channel");
+        Connection conn = consumer.getConnection();
+        channel = openChannel(conn);
+        // Register the channel to the tag
+        start();
+    }
+
+    private boolean isChannelOpen() {
+        return channel != null && channel.isOpen();
+    }
+
+    /**
+     * Open channel
+     */
+    private Channel openChannel(Connection conn) throws IOException {
+        log.trace("Creating channel...");
+        Channel channel = conn.createChannel();
+        log.debug("Created channel: {}", channel);
+        // setup the basicQos
+        if (consumer.getEndpoint().isPrefetchEnabled()) {
+            channel.basicQos(consumer.getEndpoint().getPrefetchSize(), consumer.getEndpoint().getPrefetchCount(),
+                    consumer.getEndpoint().isPrefetchGlobal());
+        }
+
+        // This really only needs to be called on the first consumer or on
+        // reconnections.
+        if (consumer.getEndpoint().isDeclare()) {
+            consumer.getEndpoint().declareExchangeAndQueue(channel);
+        }
+        return channel;
+    }
+
+}

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -24,16 +24,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.Envelope;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.ExchangePattern;
-import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.DefaultConsumer;
 
 public class RabbitMQConsumer extends DefaultConsumer {
@@ -72,42 +65,46 @@ public class RabbitMQConsumer extends DefaultConsumer {
     }
 
     /**
-     * Open channel
+     * Returns the exiting open connection or opens a new one
+     * @throws IOException
+     * @throws TimeoutException
      */
-    private Channel openChannel() throws IOException {
-        log.trace("Creating channel...");
-        Channel channel = conn.createChannel();
-        log.debug("Created channel: {}", channel);
-        // setup the basicQos
-        if (endpoint.isPrefetchEnabled()) {
-            channel.basicQos(endpoint.getPrefetchSize(), endpoint.getPrefetchCount(), endpoint.isPrefetchGlobal());
+    protected synchronized Connection getConnection() throws IOException, TimeoutException {
+        if (this.conn != null && this.conn.isOpen()) {
+            return this.conn;
         }
-        return channel;
+        log.debug("The existing connection is closed");
+        openConnection();
+        return this.conn;
     }
+
 
     /**
      * Add a consumer thread for given channel
      */
     private void startConsumers() throws IOException {
-        // First channel used to declare Exchange and Queue
-        Channel channel = openChannel();
-        if (getEndpoint().isDeclare()) {
-            getEndpoint().declareExchangeAndQueue(channel);
+
+        // Create consumers but don't start yet
+        for (int i = 0; i < endpoint.getConcurrentConsumers(); i++) {
+            createConsumer();
         }
-        startConsumer(channel);
-        // Other channels
-        for (int i = 1; i < endpoint.getConcurrentConsumers(); i++) {
-            channel = openChannel();
-            startConsumer(channel);
+
+        // Try starting consumers (which will fail if RabbitMQ can't connect)
+        try {
+            for (RabbitConsumer consumer : this.consumers) {
+                consumer.start();
+            }
+        } catch (Exception e) {
+            log.info("Connection failed, will start background thread to retry!", e);
+            reconnect();
         }
     }
 
     /**
      * Add a consumer thread for given channel
      */
-    private void startConsumer(Channel channel) throws IOException {
-        RabbitConsumer consumer = new RabbitConsumer(this, channel);
-        consumer.start();
+    private void createConsumer() throws IOException {
+        RabbitConsumer consumer = new RabbitConsumer(this);
         this.consumers.add(consumer);
     }
 
@@ -115,16 +112,13 @@ public class RabbitMQConsumer extends DefaultConsumer {
     protected void doStart() throws Exception {
         executor = endpoint.createExecutor();
         log.debug("Using executor {}", executor);
-        try {
-            openConnection();
-            startConsumers();
-        } catch (Exception e) {
-            log.info("Connection failed, will start background thread to retry!", e);
-            reconnect();
-        }
+        startConsumers();
     }
 
-    private void reconnect() {
+    private synchronized void reconnect() {
+        if (startConsumerCallable != null) {
+            return;
+        }
         // Open connection, and start message listener in background
         Integer networkRecoveryInterval = getEndpoint().getNetworkRecoveryInterval();
         final long connectionRetryInterval = networkRecoveryInterval != null && networkRecoveryInterval > 0 ? networkRecoveryInterval : 100L;
@@ -179,119 +173,7 @@ public class RabbitMQConsumer extends DefaultConsumer {
         }
     }
 
-    class RabbitConsumer extends com.rabbitmq.client.DefaultConsumer {
 
-        private final RabbitMQConsumer consumer;
-        private final Channel channel;
-        private String tag;
-
-        /**
-         * Constructs a new instance and records its association to the
-         * passed-in channel.
-         *
-         * @param channel the channel to which this consumer is attached
-         */
-        public RabbitConsumer(RabbitMQConsumer consumer, Channel channel) {
-            super(channel);
-            this.consumer = consumer;
-            this.channel = channel;
-        }
-
-        @Override
-        public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-            Exchange exchange = consumer.endpoint.createRabbitExchange(envelope, properties, body);
-            endpoint.getMessageConverter().mergeAmqpProperties(exchange, properties);
-
-            boolean sendReply = properties.getReplyTo() != null;
-            if (sendReply && !exchange.getPattern().isOutCapable()) {
-                log.debug("In an inOut capable route");
-                exchange.setPattern(ExchangePattern.InOut);
-            }
-
-            log.trace("Created exchange [exchange={}]", exchange);
-            long deliveryTag = envelope.getDeliveryTag();
-            try {
-                consumer.getProcessor().process(exchange);
-            } catch (Exception e) {
-                exchange.setException(e);
-            }
-
-            // obtain the message after processing
-            Message msg;
-            if (exchange.hasOut()) {
-                msg = exchange.getOut();
-            } else {
-                msg = exchange.getIn();
-            }
-            
-            if (exchange.getException() != null) {
-                getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
-            }
-            
-            if (!exchange.isFailed()) {
-                // processing success
-                if (sendReply && exchange.getPattern().isOutCapable()) {
-                    try {
-                        endpoint.publishExchangeToChannel(exchange, channel, properties.getReplyTo());
-                    } catch (RuntimeCamelException e) {
-                        getExceptionHandler().handleException("Error processing exchange", exchange, e);
-                    }
-                }
-                if (!consumer.endpoint.isAutoAck()) {
-                    log.trace("Acknowledging receipt [delivery_tag={}]", deliveryTag);
-                    channel.basicAck(deliveryTag, false);
-                }
-            } else if (endpoint.isTransferException() && exchange.getPattern().isOutCapable()) {
-                // the inOut exchange failed so put the exception in the body
-                // and send back
-                msg.setBody(exchange.getException());
-                exchange.setOut(msg);
-                try {
-                    endpoint.publishExchangeToChannel(exchange, channel, properties.getReplyTo());
-                } catch (RuntimeCamelException e) {
-                    getExceptionHandler().handleException("Error processing exchange", exchange, e);
-                }
-
-                if (!consumer.endpoint.isAutoAck()) {
-                    log.trace("Acknowledging receipt when transferring exception [delivery_tag={}]", deliveryTag);
-                    channel.basicAck(deliveryTag, false);
-                }
-            } else {
-                boolean isRequeueHeaderSet = msg.getHeader(RabbitMQConstants.REQUEUE, false, boolean.class);
-                // processing failed, then reject and handle the exception
-                if (deliveryTag != 0 && !consumer.endpoint.isAutoAck()) {
-                    log.trace("Rejecting receipt [delivery_tag={}] with requeue={}", deliveryTag, isRequeueHeaderSet);
-                    if (isRequeueHeaderSet) {
-                        channel.basicReject(deliveryTag, true);
-                    } else {
-                        channel.basicReject(deliveryTag, false);
-                    }
-                }
-            }
-        }
-
-        /**
-         * Bind consumer to channel
-         */
-        public void start() throws IOException {
-            tag = channel.basicConsume(endpoint.getQueue(), endpoint.isAutoAck(), this);
-        }
-
-        /**
-         * Unbind consumer from channel
-         */
-        public void stop() throws IOException, TimeoutException {
-            if (tag != null) {
-                channel.basicCancel(tag);
-            }
-            try {
-                channel.close();
-            } catch (TimeoutException e) {
-                log.error("Timeout occured");
-                throw e;
-            }
-        }
-    }
 
     /**
      * Task in charge of opening connection and adding listener when consumer is
@@ -316,10 +198,12 @@ public class RabbitMQConsumer extends DefaultConsumer {
             // Reconnection loop
             while (running.get() && connectionFailed) {
                 try {
-                    openConnection();
+                    for (RabbitConsumer consumer : consumers) {
+                        consumer.reconnect();
+                    }
                     connectionFailed = false;
                 } catch (Exception e) {
-                    log.info("Connection failed, will retry in {}" + connectionRetryInterval + "ms", e);
+                    log.info("Connection failed, will retry in " + connectionRetryInterval + "ms", e);
                     Thread.sleep(connectionRetryInterval);
                 }
             }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
+
 import javax.net.ssl.TrustManager;
 
 import com.rabbitmq.client.AMQP;
@@ -31,6 +32,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Envelope;
+
 import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -41,14 +43,11 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @UriEndpoint(scheme = "rabbitmq", title = "RabbitMQ", syntax = "rabbitmq:hostname:portNumber/exchangeName", consumerClass = RabbitMQConsumer.class, label = "messaging")
 public class RabbitMQEndpoint extends DefaultEndpoint {
     // header to indicate that the message body needs to be de-serialized
     public static final String SERIALIZE_HEADER = "CamelSerialize";
-    private static final Logger LOG = LoggerFactory.getLogger(RabbitMQEndpoint.class);
 
     @UriPath @Metadata(required = "true")
     private String hostname;

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/ReplyManager.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/ReplyManager.java
@@ -87,4 +87,11 @@ public interface ReplyManager {
      * @param holder  containing needed data to process the reply and continue routing
      */
     void processReply(ReplyHolder holder);
+
+    /**
+     * Unregister a correlationId when you no longer need a reply
+     * 
+     * @param correlationId
+     */
+    void cancelCorrelationId(String correlationId);
 }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/ReplyManagerSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/ReplyManagerSupport.java
@@ -110,6 +110,15 @@ public abstract class ReplyManagerSupport extends ServiceSupport implements Repl
 
     protected abstract ReplyHandler createReplyHandler(ReplyManager replyManager, Exchange exchange, AsyncCallback callback,
                                                        String originalCorrelationId, String correlationId, long requestTimeout);
+    
+
+    public void cancelCorrelationId(String correlationId) {
+        ReplyHandler handler = correlation.get(correlationId);
+        if (handler != null) {
+            log.warn("Cancelling correlationID: {}", correlationId);
+            correlation.remove(correlationId);
+        }
+    }
 
     public void onMessage(AMQP.BasicProperties properties, byte[] message) {
         String correlationID = properties.getCorrelationId();

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQConsumerTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQConsumerTest.java
@@ -44,6 +44,7 @@ public class RabbitMQConsumerTest {
 
         ThreadPoolExecutor e = (ThreadPoolExecutor) Executors.newFixedThreadPool(3);
         Mockito.when(endpoint.createExecutor()).thenReturn(e);
+        Mockito.when(endpoint.getConcurrentConsumers()).thenReturn(1);
         Mockito.when(endpoint.connect(Matchers.any(ExecutorService.class))).thenReturn(conn);
         Mockito.when(conn.createChannel()).thenReturn(channel);
 
@@ -59,6 +60,7 @@ public class RabbitMQConsumerTest {
         RabbitMQConsumer consumer = new RabbitMQConsumer(endpoint, processor);
 
         Mockito.when(endpoint.createExecutor()).thenReturn(Executors.newFixedThreadPool(3));
+        Mockito.when(endpoint.getConcurrentConsumers()).thenReturn(1);
         Mockito.when(endpoint.connect(Matchers.any(ExecutorService.class))).thenReturn(conn);
         Mockito.when(conn.createChannel()).thenReturn(channel);
 

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQReConnectionIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQReConnectionIntTest.java
@@ -33,13 +33,14 @@ import org.junit.Test;
 
 /**
  * Integration test to check that RabbitMQ Endpoint is able to reconnect to broker when broker
- * is not avaibable.
+ * is not available.
  * <ul>
  * <li>Stop the broker</li>
  * <li>Run the test: the producer complains it can not send messages, the consumer is silent</li>
  * <li>Start the broker: the producer sends messages, and the consumer receives messages</li>
  * <li>Stop the broker: the producer complains it can not send messages, the consumer is silent</li>
  * <li>Start the broker: the producer sends messages, and the consumer receives messages</li>
+ * <li>Kill all connections from the broker: the producer sends messages, and the consumer receives messages</li>
  * </ul>
  */
 public class RabbitMQReConnectionIntTest extends CamelTestSupport {

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQSupendResumeIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQSupendResumeIntTest.java
@@ -28,12 +28,12 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
 public class RabbitMQSupendResumeIntTest extends CamelTestSupport {
-    private static final String EXCHANGE = "ex4";
+    private static final String EXCHANGE = "ex6";
 
     @EndpointInject(uri = "mock:result")
     private MockEndpoint resultEndpoint;
 
-    @EndpointInject(uri = "rabbitmq:localhost:5672/" + EXCHANGE + "?username=cameltest&password=cameltest&queue=q3&routingKey=rk3&autoDelete=false")
+    @EndpointInject(uri = "rabbitmq:localhost:5672/" + EXCHANGE + "?username=cameltest&password=cameltest&queue=q6&routingKey=rk3&autoDelete=false")
     private Endpoint rabbitMQEndpoint;
 
     @Produce(uri = "direct:start")


### PR DESCRIPTION
* Publishers and subscribers will reconnect if the connection / channel is closed
* Cancel reply manager when sending a message in the producer fails so the reply thread doesn't time out.
* Change the SuspendResume test to use a different queue since it conflicts with other queue settings