### PR TITLE
Fix if allowable values are not set

### DIFF
--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -219,7 +219,7 @@ public class RestSwaggerReader {
                         if (param.getDataType() != null) {
                             sp.setType(param.getDataType());
                         }
-                        if (param.getAllowableValues() != null) {
+                        if (param.getAllowableValues() != null && !param.getAllowableValues().isEmpty()) {
                             sp.setEnum(param.getAllowableValues());
                         }
                     }

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelTest.java
@@ -88,7 +88,7 @@ public class RestSwaggerReaderModelTest extends CamelTestSupport {
         assertTrue(json.contains("\"$ref\" : \"#/definitions/User\""));
         assertTrue(json.contains("\"x-className\""));
         assertTrue(json.contains("\"format\" : \"org.apache.camel.swagger.User\""));
-
+        assertFalse(json.contains("\"enum\""));
         context.stop();
     }
 


### PR DESCRIPTION
We should not set 'enum' field in parameter if allowable values are empty as it makes swagger ui unusable by not allowing parameter inputs. (for all parameters that do not have allowable values there is a just a select with no options )