### PR TITLE
CAMEL-9498: Universal local registry for CamelContext

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/CamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/CamelContext.java
@@ -29,6 +29,7 @@ import org.apache.camel.api.management.mbean.ManagedCamelContextMBean;
 import org.apache.camel.api.management.mbean.ManagedProcessorMBean;
 import org.apache.camel.api.management.mbean.ManagedRouteMBean;
 import org.apache.camel.builder.ErrorHandlerBuilder;
+import org.apache.camel.impl.SimpleRegistry;
 import org.apache.camel.model.DataFormatDefinition;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.RouteDefinition;
@@ -875,6 +876,13 @@ public interface CamelContext extends SuspendableService, RuntimeConfiguration {
      * @return the type converter registry
      */
     TypeConverterRegistry getTypeConverterRegistry();
+
+    /**
+     * Returns the local registry used for bean lookups
+     *
+     * @return the local registry
+     */
+    SimpleRegistry getLocalRegistry();
 
     /**
      * Returns the registry used to lookup components by name and type such as the Spring ApplicationContext,

--- a/camel-core/src/test/java/org/apache/camel/component/log/LogCustomFormatterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/log/LogCustomFormatterTest.java
@@ -146,13 +146,9 @@ public class LogCustomFormatterTest extends ContextTestSupport {
     }
     
     private JndiRegistry getRegistryAsJndi() {
-        JndiRegistry registry = null;
-        if (context.getRegistry() instanceof PropertyPlaceholderDelegateRegistry) {
-            registry = (JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry();
-        } else if (context.getRegistry() instanceof JndiRegistry) {
-            registry = (JndiRegistry) context.getRegistry();
-        } else {
-            fail("Could not determine Registry type");
+        JndiRegistry registry = context.getRegistry(JndiRegistry.class);
+        if (registry == null) {
+            fail("Could not get JndiRegistry");
         }
         return registry;
     }

--- a/camel-core/src/test/java/org/apache/camel/component/log/LogCustomLoggerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/log/LogCustomLoggerTest.java
@@ -98,15 +98,15 @@ public class LogCustomLoggerTest extends ContextTestSupport {
 
     @Test
     public void testEndpointURIParametrizedLogger() throws Exception {
-        getRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
-        getRegistry().put("logger2", LoggerFactory.getLogger("provided.logger2.name"));
+        context.getLocalRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
+        context.getLocalRegistry().put("logger2", LoggerFactory.getLogger("provided.logger2.name"));
         template.requestBody("log:irrelevant.logger.name?logger=#logger2", "hello");
         assertThat(sw1.toString(), equalTo("provided.logger2.name"));
     }
 
     @Test
     public void testEndpointURIParametrizedNotResolvableLogger() {
-        getRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
+        context.getLocalRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
         try {
             template.requestBody("log:irrelevant.logger.name?logger=#logger2", "hello");
         } catch (ResolveEndpointFailedException e) {
@@ -116,15 +116,15 @@ public class LogCustomLoggerTest extends ContextTestSupport {
 
     @Test
     public void testDefaultRegistryLogger() throws Exception {
-        getRegistry().put("logger", LoggerFactory.getLogger("provided.logger1.name"));
+        context.getLocalRegistry().put("logger", LoggerFactory.getLogger("provided.logger1.name"));
         template.requestBody("log:irrelevant.logger.name", "hello");
         assertThat(sw1.toString(), equalTo("provided.logger1.name"));
     }
 
     @Test
     public void testTwoRegistryLoggers() throws Exception {
-        getRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
-        getRegistry().put("logger2", LoggerFactory.getLogger("provided.logger2.name"));
+        context.getLocalRegistry().put("logger1", LoggerFactory.getLogger("provided.logger1.name"));
+        context.getLocalRegistry().put("logger2", LoggerFactory.getLogger("provided.logger2.name"));
         template.requestBody("log:irrelevant.logger.name", "hello");
         assertThat(sw1.toString(), equalTo("irrelevant.logger.name"));
         assertThat(sw2.toString(), equalTo(LogComponent.class.getName()));
@@ -132,17 +132,6 @@ public class LogCustomLoggerTest extends ContextTestSupport {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        return new DefaultCamelContext(new SimpleRegistry());
+        return new DefaultCamelContext();
     }
-
-    private SimpleRegistry getRegistry() {
-        SimpleRegistry registry = null;
-        if (context.getRegistry() instanceof PropertyPlaceholderDelegateRegistry) {
-            registry = (SimpleRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry();
-        } else {
-            fail("Could not determine Registry type");
-        }
-        return registry;
-    }
-
 }

--- a/camel-core/src/test/java/org/apache/camel/component/ref/RefComponentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/ref/RefComponentTest.java
@@ -49,8 +49,7 @@ public class RefComponentTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
 
-        PropertyPlaceholderDelegateRegistry delegate = (PropertyPlaceholderDelegateRegistry) context.getRegistry();
-        JndiRegistry jndi = (JndiRegistry) delegate.getRegistry();
+        JndiRegistry jndi = context.getRegistry(JndiRegistry.class);
         bindToRegistry(jndi);
 
         template.sendBody("ref:foo", "Hello World");

--- a/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorWithResourceResolverRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorWithResourceResolverRouteTest.java
@@ -78,7 +78,7 @@ public class ValidatorWithResourceResolverRouteTest extends ContextTestSupport {
         URL catalogUrl = ResourceHelper.resolveMandatoryResourceAsUrl(context.getClassResolver(), "org/apache/camel/component/validator/catalog.cat");
         catalogResolver.getCatalog().parseCatalog(catalogUrl);
         LSResourceResolver resourceResolver = new CatalogLSResourceResolver(catalogResolver);
-        JndiRegistry registry = (JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry();
+        JndiRegistry registry = context.getRegistry(JndiRegistry.class);
         registry.bind("resourceResolver", resourceResolver);
 
         return new RouteBuilder() {

--- a/camel-core/src/test/java/org/apache/camel/impl/GetRegistryAsTypeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/GetRegistryAsTypeTest.java
@@ -30,8 +30,9 @@ public class GetRegistryAsTypeTest extends TestCase {
         JndiRegistry jndi = context.getRegistry(JndiRegistry.class);
         assertNotNull(jndi);
 
-        assertNull(context.getRegistry(Map.class));
-        assertNull(context.getRegistry(SimpleRegistry.class));
+        // These should match the local registry
+        assertNotNull(context.getRegistry(Map.class));
+        assertNotNull(context.getRegistry(SimpleRegistry.class));
 
         context.stop();
     }

--- a/components/camel-amqp/src/test/java/org/apache/camel/component/amqp/AMQPRouteTest.java
+++ b/components/camel-amqp/src/test/java/org/apache/camel/component/amqp/AMQPRouteTest.java
@@ -107,7 +107,7 @@ public class AMQPRouteTest extends CamelTestSupport {
 
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        JndiRegistry registry = (JndiRegistry)((PropertyPlaceholderDelegateRegistry)camelContext.getRegistry()).getRegistry();
+        JndiRegistry registry = camelContext.getRegistry(JndiRegistry.class);
         registry.bind("amqpConnection", discoverAMQP(camelContext));
         camelContext.addComponent("amqp-customized", amqpComponent("amqp://localhost:" + amqpPort));
         return camelContext;

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/s3/S3ComponentConfigurationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/s3/S3ComponentConfigurationTest.java
@@ -44,7 +44,7 @@ public class S3ComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithMinimalConfigurationAndProvidedClient() throws Exception {
         AmazonS3ClientMock mock = new AmazonS3ClientMock();
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("amazonS3Client", mock);
+        context.getRegistry(JndiRegistry.class).bind("amazonS3Client", mock);
         
         S3Component component = new S3Component(context);
         S3Endpoint endpoint = (S3Endpoint) component.createEndpoint("aws-s3://MyBucket?amazonS3Client=#amazonS3Client");

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/sdb/SdbComponentConfigurationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/sdb/SdbComponentConfigurationTest.java
@@ -43,8 +43,7 @@ public class SdbComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithMinimalConfigurationAndProvidedClient() throws Exception {
         AmazonSDBClientMock mock = new AmazonSDBClientMock();
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry())
-            .bind("amazonSDBClient", mock);
+        context.getRegistry(JndiRegistry.class).bind("amazonSDBClient", mock);
         
         SdbComponent component = new SdbComponent(context);
         SdbEndpoint endpoint = (SdbEndpoint) component.createEndpoint("aws-sdb://TestDomain?"

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ses/SesComponentConfigurationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ses/SesComponentConfigurationTest.java
@@ -43,8 +43,7 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithMinimalConfigurationAndProvidedClient() throws Exception {
         AmazonSESClientMock mock = new AmazonSESClientMock();
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry())
-            .bind("amazonSESClient", mock);
+        context.getRegistry(JndiRegistry.class).bind("amazonSESClient", mock);
         
         SesComponent component = new SesComponent(context);
         SesEndpoint endpoint = (SesEndpoint) component.createEndpoint("aws-ses://from@example.com?"

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/sns/SnsComponentConfigurationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/sns/SnsComponentConfigurationTest.java
@@ -42,7 +42,7 @@ public class SnsComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithMinimalConfigurationAndProvidedClient() throws Exception {
         AmazonSNSClientMock mock = new AmazonSNSClientMock();
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("amazonSNSClient", mock);
+        context.getRegistry(JndiRegistry.class).bind("amazonSNSClient", mock);
         
         SnsComponent component = new SnsComponent(context);
         SnsEndpoint endpoint = (SnsEndpoint) component.createEndpoint("aws-sns://MyTopic?amazonSNSClient=#amazonSNSClient&amazonSNSEndpoint=sns.ap-southeast-2.amazonaws.com");

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/sqs/SqsComponentConfigurationTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/sqs/SqsComponentConfigurationTest.java
@@ -51,7 +51,7 @@ public class SqsComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithMinimalConfigurationAndProvidedClient() throws Exception {
         AmazonSQSClientMock mock = new AmazonSQSClientMock();
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("amazonSQSClient", mock);
+        context.getRegistry(JndiRegistry.class).bind("amazonSQSClient", mock);
         
         SqsComponent component = new SqsComponent(context);
         SqsEndpoint endpoint = (SqsEndpoint) component.createEndpoint("aws-sqs://MyQueue?amazonSQSClient=#amazonSQSClient");
@@ -81,8 +81,8 @@ public class SqsComponentConfigurationTest extends CamelTestSupport {
         messageAttributeNames.add("msgColor");
         messageAttributeNames.add("msgSize");
         
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("attributeNames", attributeNames);
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("messageAttributeNames", messageAttributeNames);
+        context.getRegistry(JndiRegistry.class).bind("attributeNames", attributeNames);
+        context.getRegistry(JndiRegistry.class).bind("messageAttributeNames", messageAttributeNames);
 
         SqsComponent component = new SqsComponent(context);
         SqsEndpoint endpoint = (SqsEndpoint) component.createEndpoint("aws-sqs://MyQueue?amazonSQSEndpoint=sns.eu-west-1.amazonaws.com&accessKey=xxx&secretKey=yyy&attributeNames=#attributeNames"

--- a/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiCamelContextHelper.java
+++ b/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiCamelContextHelper.java
@@ -52,18 +52,23 @@ public final class OsgiCamelContextHelper {
         LOG.debug("Using OsgiDataFormatResolver");
         camelContext.setDataFormatResolver(new OsgiDataFormatResolver(bundleContext));
     }
-    
-    public static Registry wrapRegistry(CamelContext camelContext, Registry registry, BundleContext bundleContext) {
+
+    public static Registry createRegistry(CamelContext camelContext, BundleContext bundleContext) {
         ObjectHelper.notNull(bundleContext, "BundleContext");
 
         LOG.debug("Setting up OSGi ServiceRegistry");
         OsgiServiceRegistry osgiServiceRegistry = new OsgiServiceRegistry(bundleContext);
         // Need to clean up the OSGi service when camel context is closed.
         camelContext.addLifecycleStrategy(osgiServiceRegistry);
-        CompositeRegistry compositeRegistry = new CompositeRegistry();
-        compositeRegistry.addRegistry(osgiServiceRegistry);
-        compositeRegistry.addRegistry(registry);
-        return compositeRegistry;
+        return osgiServiceRegistry;
     }
 
+    public static Registry wrapRegistry(CamelContext camelContext, Registry registry, BundleContext bundleContext) {
+        CompositeRegistry compositeRegistry = new CompositeRegistry();
+        compositeRegistry.addRegistry(createRegistry(camelContext, bundleContext));
+        if (registry != null) {
+            compositeRegistry.addRegistry(registry);
+        }
+        return compositeRegistry;
+    }
 }

--- a/components/camel-hdfs/src/test/java/org/apache/camel/component/hdfs/HdfsConsumerTest.java
+++ b/components/camel-hdfs/src/test/java/org/apache/camel/component/hdfs/HdfsConsumerTest.java
@@ -268,7 +268,7 @@ public class HdfsConsumerTest extends HdfsTestSupport {
         });
         ScheduledExecutorService pool = context.getExecutorServiceManager().newScheduledThreadPool(null, "unitTestPool", 1);
         DefaultScheduledPollConsumerScheduler scheduler = new DefaultScheduledPollConsumerScheduler(pool);
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("myScheduler", scheduler);
+        context.getRegistry(JndiRegistry.class).bind("myScheduler", scheduler);
         context.start();
 
         MockEndpoint resultEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);

--- a/components/camel-hdfs2/src/test/java/org/apache/camel/component/hdfs2/HdfsConsumerTest.java
+++ b/components/camel-hdfs2/src/test/java/org/apache/camel/component/hdfs2/HdfsConsumerTest.java
@@ -267,7 +267,7 @@ public class HdfsConsumerTest extends HdfsTestSupport {
         });
         ScheduledExecutorService pool = context.getExecutorServiceManager().newScheduledThreadPool(null, "unitTestPool", 1);
         DefaultScheduledPollConsumerScheduler scheduler = new DefaultScheduledPollConsumerScheduler(pool);
-        ((JndiRegistry) ((PropertyPlaceholderDelegateRegistry) context.getRegistry()).getRegistry()).bind("myScheduler", scheduler);
+        context.getRegistry(JndiRegistry.class).bind("myScheduler", scheduler);
         context.start();
 
         MockEndpoint resultEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);

--- a/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
+++ b/components/camel-scr/src/main/java/org/apache/camel/scr/AbstractCamelRunner.java
@@ -56,13 +56,12 @@ public abstract class AbstractCamelRunner implements Runnable {
     public static final String PROPERTY_PREFIX = "camel.scr.properties.prefix";
     
     protected Logger log = LoggerFactory.getLogger(getClass());
-    protected CamelContext context;
-    protected Registry registry;
 
     // Configured fields
     private String camelContextId;
     private boolean active;
 
+    private CamelContext context;
     private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture starter;
     private volatile boolean activated;
@@ -92,15 +91,13 @@ public abstract class AbstractCamelRunner implements Runnable {
 
     protected void createCamelContext(final BundleContext bundleContext, final Map<String, String> props) {
         if (bundleContext != null) {
-            registry = new OsgiServiceRegistry(bundleContext);
-            context = new OsgiDefaultCamelContext(bundleContext, registry);
+            context = new OsgiDefaultCamelContext(bundleContext, new OsgiServiceRegistry(bundleContext));
             // Setup the application context classloader with the bundle classloader
             context.setApplicationContextClassLoader(new BundleDelegatingClassLoader(bundleContext.getBundle()));
             // and make sure the TCCL is our classloader
             Thread.currentThread().setContextClassLoader(context.getApplicationContextClassLoader());
         } else {
-            registry = new SimpleRegistry();
-            context = new DefaultCamelContext(registry);
+            context = new DefaultCamelContext();
         }
         setupPropertiesComponent(context, props, log);
     }

--- a/components/camel-scr/src/test/java/org/apache/camel/scr/ConcreteCamelRunner.java
+++ b/components/camel-scr/src/test/java/org/apache/camel/scr/ConcreteCamelRunner.java
@@ -63,8 +63,8 @@ public class ConcreteCamelRunner extends AbstractCamelRunner implements Lifecycl
     @Override
     protected void createCamelContext(BundleContext bundleContext, Map<String, String> props) {
         super.createCamelContext(bundleContext, props);
-        context.disableJMX();
-        context.addLifecycleStrategy(this);
+        getContext().disableJMX();
+        getContext().addLifecycleStrategy(this);
     }
 
     @Override

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/RegistryInjectionTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/RegistryInjectionTest.java
@@ -37,9 +37,7 @@ public class RegistryInjectionTest extends SpringTestSupport {
 
     public void testInjectedStrategy() throws Exception {
         CamelContext context = createCamelContext();
-
-        PropertyPlaceholderDelegateRegistry delegate = (PropertyPlaceholderDelegateRegistry) context.getRegistry();
-        assertTrue(delegate.getRegistry() instanceof JndiRegistry);
+        assertNotNull(context.getRegistry(JndiRegistry.class));
     }
 
 }

--- a/tooling/archetypes/camel-archetype-scr/src/main/resources/archetype-resources/src/main/java/__className__.java
+++ b/tooling/archetypes/camel-archetype-scr/src/main/resources/archetype-resources/src/main/java/__className__.java
@@ -48,7 +48,7 @@ public class ${className} extends AbstractCamelRunner {
 
     @Override
     protected List<RoutesBuilder>getRouteBuilders() {
-        List<RoutesBuilder>routesBuilders = new ArrayList<>();
+        List<RoutesBuilder> routesBuilders = new ArrayList<>();
         routesBuilders.add(new ${className}Route());
         return routesBuilders;
     }


### PR DESCRIPTION
This change adds an always available local SimpleRegistry to CamelContext. Local registry makes sure that you can always add beans to a CamelContext regardless of how and where you setup and run your CamelContext.

Notes:
1. CompositeRegistry can now handle nested registries.
2. Local registry is directly accessible with CamelContext.getLocalRegistry().
3. DefaultCamelContext.getRegistry() now returns a CompositeRegistry with local SimpleRegistry as its first member. As before, one should not make assumptions on the registry hierarchy getRegistry() will give you. If you want to access a particular subregistry use getRegistry(Class<T> type).

https://issues.apache.org/jira/browse/CAMEL-9498
