### PR TITLE
CAMEL-9430 - upgrade camel-braintree

### DIFF
--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -50,9 +50,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.braintree-java</artifactId>
-      <version>${braintree-gateway-bundle-version}</version>
+      <groupId>com.braintreepayments.gateway</groupId>
+      <artifactId>braintree-java</artifactId>
+      <version>${braintree-gateway-version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,8 +76,7 @@
     <boon-version>0.33</boon-version>
     <bouncycastle-version>1.54</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
-    <braintree-gateway-version>2.53.0</braintree-gateway-version>
-    <braintree-gateway-bundle-version>2.53.0_1</braintree-gateway-bundle-version>
+    <braintree-gateway-version>2.55.0</braintree-gateway-version>
     <build-helper-maven-plugin-version>1.8</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>
     <californium-version>1.0.0-M3</californium-version>

--- a/platforms/karaf/features/src/main/resources/bundles.properties
+++ b/platforms/karaf/features/src/main/resources/bundles.properties
@@ -33,7 +33,6 @@ org.apache.servicemix.bundles/org.apache.servicemix.bundles.abdera/${abdera-bund
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.ant/${ant-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${antlr-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.asm/${asm-bundle-version}/jar
-org.apache.servicemix.bundles/org.apache.servicemix.bundles.braintree-java/${braintree-gateway-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-beanutils/${commons-beanutils-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-csv/${commons-csv-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-dbcp/${commons-dbcp-bundle-version}/jar

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -227,7 +227,7 @@
   <feature name='camel-braintree' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
      <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
-     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.braintree-java/${braintree-gateway-bundle-version}</bundle>
+     <bundle dependency='true'>mvn:com.braintreepayments.gateway/braintree-java/${braintree-gateway-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-braintree/${project.version}</bundle>
   </feature>
   <feature name='camel-cache' version='${project.version}' resolver='(obr)' start-level='50'>


### PR DESCRIPTION
- upgrade braintree-java SDK to 2.55.0
- remove ServiceMix bundle has 2.55.0 has [OSGi support](https://github.com/braintree/braintree_java/pull/30)