### PR TITLE
CAMEL-9605 update default unmarshall type to java.lang.Object instead…

### DIFF
--- a/components/camel-gson/src/main/java/org/apache/camel/component/gson/GsonDataFormat.java
+++ b/components/camel-gson/src/main/java/org/apache/camel/component/gson/GsonDataFormat.java
@@ -57,7 +57,7 @@ public class GsonDataFormat extends ServiceSupport implements DataFormat, DataFo
     private String dateFormatPattern;
 
     public GsonDataFormat() {
-        this(Map.class);
+        this(Object.class);
     }
 
     /**

--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonDataFormatTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonDataFormatTest.java
@@ -1,0 +1,35 @@
+package org.apache.camel.component.gson;
+
+import java.io.*;
+import java.util.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GsonDataFormatTest {
+    @Test
+    public void testString() throws Exception {
+        testJson("\"A string\"", "A string");
+    }
+
+    @Test
+    public void testMap() throws Exception {
+        testJson("{value=123}", Collections.singletonMap("value", 123.0));
+    }
+
+    @Test
+    public void testList() throws Exception {
+        testJson("[{value=123}]", Collections.singletonList(Collections.singletonMap("value", 123.0)));
+    }
+
+    private void testJson(String json, Object expected) throws Exception {
+        Object unmarshalled;
+        GsonDataFormat gsonDataFormat = new GsonDataFormat();
+        gsonDataFormat.doStart();
+        try (InputStream in = new ByteArrayInputStream(json.getBytes())) {
+            unmarshalled = gsonDataFormat.unmarshal(null, in);
+        }
+
+        assertEquals(expected, unmarshalled);
+    }
+}


### PR DESCRIPTION
… of java.util.Map to be able to unmarshall any valid Json document with the default configuration of Gson umarshaller