### PR TITLE
CAMEL-9201 - Minor fixes to the project structure.

### DIFF
--- a/components/camel-cdi/pom.xml
+++ b/components/camel-cdi/pom.xml
@@ -79,13 +79,6 @@
 
     <!-- DeltaSpike is only used to provide Main support thus optional -->
     <dependency>
-      <groupId>org.apache.deltaspike.core</groupId>
-      <artifactId>deltaspike-core-api</artifactId>
-      <version>${deltaspike-version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.deltaspike.cdictrl</groupId>
       <artifactId>deltaspike-cdictrl-api</artifactId>
       <version>${deltaspike-version}</version>

--- a/components/camel-cdi/src/main/docs/cdi.adoc
+++ b/components/camel-cdi/src/main/docs/cdi.adoc
@@ -55,7 +55,7 @@ route is as simple as declaring a class, e.g.:
 
 [source,java]
 ----
-class MyRouteBean extends RoutesBuilder {
+class MyRouteBean extends RouteBuilder {
  
     @Override
     public void configure() {
@@ -103,7 +103,7 @@ you can used the `@ContextName` qualifier provided by Camel CDI, e.g.:
 [source,java]
 ----
 @ContextName("camel-context")
-class MyRouteBean extends RoutesBuilder {
+class MyRouteBean extends RouteBuilder {
  
     @Override
     public void configure() {
@@ -215,7 +215,7 @@ class BarCamelContext extends DefaultCamelContext {
 }
  
 @ContextName("foo")
-class RouteAddedToFooCamelContext extends RoutesBuilder {
+class RouteAddedToFooCamelContext extends RouteBuilder {
 
     @Override
     public void configure() {
@@ -224,7 +224,7 @@ class RouteAddedToFooCamelContext extends RoutesBuilder {
 }
  
 @BarContextQualifier
-class RouteAddedToBarCamelContext extends RoutesBuilder {
+class RouteAddedToBarCamelContext extends RouteBuilder {
 
     @Override
     public void configure() {
@@ -233,7 +233,7 @@ class RouteAddedToBarCamelContext extends RoutesBuilder {
 }
  
 @ContextName("baz")
-class RouteAddedToBazCamelContext extends RoutesBuilder {
+class RouteAddedToBazCamelContext extends RouteBuilder {
 
     @Override
     public void configure() {
@@ -242,7 +242,7 @@ class RouteAddedToBazCamelContext extends RoutesBuilder {
 }
  
 @MyOtherQualifier
-class RouteNotAddedToAnyCamelContext extends RoutesBuilder {
+class RouteNotAddedToAnyCamelContext extends RouteBuilder {
 
     @Override
     public void configure() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -133,7 +133,7 @@
     <cxf-version-range>[3.0,4.0)</cxf-version-range>
     <cxf-xjc-plugin-version>3.0.5</cxf-xjc-plugin-version>
     <cxf-xjc-utils-version>3.0.5</cxf-xjc-utils-version>
-    <deltaspike-version>1.5.3</deltaspike-version>
+    <deltaspike-version>1.5.4</deltaspike-version>
     <derby-version>10.11.1.1</derby-version>
     <disruptor-version>3.3.4</disruptor-version>
     <dnsjava-version>2.1.7</dnsjava-version>


### PR DESCRIPTION
The changes introduced no longer depend on DeltaSpike Core, so removed that dependency and upgraded to the latest patch version (v1.5.4)
Updated some docs, they were referring to RoutesBuilder and extending it, however its an interface so that doesn't work well.

I used the origin ticket that Antonin worked on, since thats the most relevant piece.