### PR TITLE
CAMEL-9640 - Query string gets decoded when bridging from netty*-http to netty*-http

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
@@ -320,7 +320,7 @@ public final class HttpHelper {
         if (queryString == null) {
             queryString = endpoint.getHttpUri().getRawQuery();
         }
-        // We should user the query string from the HTTP_URI header
+        // We should use the query string from the HTTP_URI header
         if (queryString == null) {
             queryString = uri.getRawQuery();
         }

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
@@ -236,8 +236,12 @@ public final class NettyHttpHelper {
      */
     public static URI createURI(Exchange exchange, String url, NettyHttpEndpoint endpoint) throws URISyntaxException {
         URI uri = new URI(url);
-        // is a query string provided in the endpoint URI or in a header (header overrules endpoint)
-        String queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
+        // is a query string provided in the endpoint URI or in a header
+        // (header overrules endpoint, raw query header overrules query header)
+        String queryString = exchange.getIn().getHeader(Exchange.HTTP_RAW_QUERY, String.class);
+        if (queryString == null) {
+            queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
+        }
         if (queryString == null) {
             // use raw as we encode just below
             queryString = uri.getRawQuery();

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerBridgeTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerBridgeTest.java
@@ -16,18 +16,55 @@
  */
 package org.apache.camel.component.netty.http;
 
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
 
 public class NettyHttpProducerBridgeTest extends BaseNettyTest {
 
     private int port1;
     private int port2;
+    private int port3;
 
     @Test
     public void testProxy() throws Exception {
         String reply = template.requestBody("netty-http:http://localhost:" + port1 + "/foo", "World", String.class);
         assertEquals("Bye World", reply);
+    }
+
+    @Test
+    public void testBridgeWithQuery() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:query");
+        mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
+        mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
+
+        template.request("netty-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
+                exchange.getIn().setHeader(Exchange.HTTP_QUERY, "x=%3B");
+            }
+        });
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testBridgeWithRawQueryAndQuery() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:query");
+        mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
+        mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
+
+        template.request("netty-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
+                exchange.getIn().setHeader(Exchange.HTTP_RAW_QUERY, "x=%3B");
+                exchange.getIn().setHeader(Exchange.HTTP_QUERY, "x=;");
+            }
+        });
+        assertMockEndpointsSatisfied();
     }
 
     @Override
@@ -37,12 +74,16 @@ public class NettyHttpProducerBridgeTest extends BaseNettyTest {
             public void configure() throws Exception {
                 port1 = getPort();
                 port2 = getNextPort();
+                port3 = getNextPort();
 
                 from("netty-http:http://0.0.0.0:" + port1 + "/foo")
                         .to("netty-http:http://localhost:" + port2 + "/bar?bridgeEndpoint=true&throwExceptionOnFailure=false");
 
                 from("netty-http:http://0.0.0.0:" + port2 + "/bar")
                         .transform().simple("Bye ${body}");
+
+                from("netty-http:http://0.0.0.0:" + port3 + "/query")
+                        .to("mock:query");
             }
         };
     }

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpHelper.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpHelper.java
@@ -236,8 +236,12 @@ public final class NettyHttpHelper {
      */
     public static URI createURI(Exchange exchange, String url, NettyHttpEndpoint endpoint) throws URISyntaxException {
         URI uri = new URI(url);
-        // is a query string provided in the endpoint URI or in a header (header overrules endpoint)
-        String queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
+        // is a query string provided in the endpoint URI or in a header
+        // (header overrules endpoint, raw query header overrules query header)
+        String queryString = exchange.getIn().getHeader(Exchange.HTTP_RAW_QUERY, String.class);
+        if (queryString == null) {
+            queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
+        }
         if (queryString == null) {
             // use raw as we encode just below
             queryString = uri.getRawQuery();

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpProducerBridgeTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpProducerBridgeTest.java
@@ -16,18 +16,55 @@
  */
 package org.apache.camel.component.netty4.http;
 
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
 
 public class NettyHttpProducerBridgeTest extends BaseNettyTest {
 
     private int port1;
     private int port2;
+    private int port3;
 
     @Test
     public void testProxy() throws Exception {
         String reply = template.requestBody("netty4-http:http://localhost:" + port1 + "/foo", "World", String.class);
         assertEquals("Bye World", reply);
+    }
+
+    @Test
+    public void testBridgeWithQuery() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:query");
+        mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
+        mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
+
+        template.request("netty4-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
+                exchange.getIn().setHeader(Exchange.HTTP_QUERY, "x=%3B");
+            }
+        });
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testBridgeWithRawQueryAndQuery() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:query");
+        mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
+        mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
+
+        template.request("netty4-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
+                exchange.getIn().setHeader(Exchange.HTTP_RAW_QUERY, "x=%3B");
+                exchange.getIn().setHeader(Exchange.HTTP_QUERY, "x=;");
+            }
+        });
+        assertMockEndpointsSatisfied();
     }
 
     @Override
@@ -37,12 +74,16 @@ public class NettyHttpProducerBridgeTest extends BaseNettyTest {
             public void configure() throws Exception {
                 port1 = getPort();
                 port2 = getNextPort();
+                port3 = getNextPort();
 
                 from("netty4-http:http://0.0.0.0:" + port1 + "/foo")
                         .to("netty4-http:http://localhost:" + port2 + "/bar?bridgeEndpoint=true&throwExceptionOnFailure=false");
 
                 from("netty4-http:http://0.0.0.0:" + port2 + "/bar")
                         .transform().simple("Bye ${body}");
+
+                from("netty4-http:http://0.0.0.0:" + port3 + "/query")
+                        .to("mock:query");
             }
         };
     }


### PR DESCRIPTION
Please review and merge this PR. Thanks!

https://issues.jboss.org/browse/ENTESB-4737