### PR TITLE
Hazelcast :: Aggregation Repository

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
@@ -408,10 +408,7 @@ public class HazelcastAggregationRepository extends ServiceSupport
 
     @Override
     protected void doStop() throws Exception {
-        if (useRecovery) {
-            persistedCache.clear();
-        }
-        cache.clear();
+        //noop
         if (useLocalHzInstance) {
             hzInstance.getLifecycleService().shutdown();
         }


### PR DESCRIPTION
Removes clear cache operation at stop.
As Hazelcast is used in a clustered environment, clearing the cache when the bundle
stops prevents other instances running somewhere else to take over the pending
aggregations.