### PR TITLE
CAMEL-9660 - HTTP producers crash when Exchange.HTTP_URI header contains unencoded unsafe characters

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
@@ -497,6 +497,8 @@ public final class HttpHelper {
             throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uriString, exchange, e);
         }
         if (uriString != null) {
+            // in case the URI string contains unsafe characters
+            uriString = UnsafeUriCharactersEncoder.encodeHttpURI(uriString);
             URI uri = new URI(uriString);
             queryString = uri.getQuery();
         }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpBridgeEndpointTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpBridgeEndpointTest.java
@@ -106,4 +106,17 @@ public class HttpBridgeEndpointTest extends BaseHttpTest {
         assertExchange(exchange);
     }
 
+    @Test
+    public void unsafeCharsInHttpURIHeader() throws Exception {
+        Exchange exchange = template.request("http://localhost:" + PORT + "/?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "/<>{}");
+            }
+        });
+
+        assertNull(exchange.getException());
+        assertExchange(exchange);
+    }
+
 }

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/helper/HttpMethodHelper.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/helper/HttpMethodHelper.java
@@ -23,12 +23,9 @@ import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.component.http4.HttpEndpoint;
 import org.apache.camel.component.http4.HttpMethods;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
 public final class HttpMethodHelper {
-
-    private static final Logger LOG = LoggerFactory.getLogger(HttpMethodHelper.class);
 
     private HttpMethodHelper() {
         // Helper class
@@ -54,6 +51,8 @@ public final class HttpMethodHelper {
             throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uriString, exchange, e);
         }
         if (uriString != null) {
+            // in case the URI string contains unsafe characters
+            uriString = UnsafeUriCharactersEncoder.encodeHttpURI(uriString);
             URI uri = new URI(uriString);
             queryString = uri.getQuery();
         }

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpBridgeEndpointTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpBridgeEndpointTest.java
@@ -106,4 +106,18 @@ public class HttpBridgeEndpointTest extends BaseHttpTest {
 
         assertExchange(exchange);
     }
+
+    @Test
+    public void unsafeCharsInHttpURIHeader() throws Exception {
+        Exchange exchange = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/?bridgeEndpoint=true", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_URI, "/<>{}");
+            }
+        });
+
+        assertNull(exchange.getException());
+        assertExchange(exchange);
+    }
+
 }

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/HttpProducerUnsafeCharsTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/HttpProducerUnsafeCharsTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+public class HttpProducerUnsafeCharsTest extends BaseJettyTest {
+
+    @Test
+    public void unsafeCharsInHttpURIHeader() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        template.sendBodyAndHeader("jetty:http://localhost:{{port}}/test?bridgeEndpoint=true", "Hello World",
+                Exchange.HTTP_URI, "/<>{}");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("jetty:http://localhost:{{port}}/test").to("mock:result");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Please review and merge it. Thanks!

https://issues.jboss.org/browse/ENTESB-4737