### PR TITLE
[CAMEL-9657] Move container management of camel contexts to start method

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -295,9 +295,6 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         // Call all registered trackers with this context
         // Note, this may use a partially constructed object
         CamelContextTrackerRegistry.INSTANCE.contextCreated(this);
-
-        // [TODO] Remove in 3.0
-        Container.Instance.manage(this);
     }
 
     /**
@@ -898,7 +895,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
 
         return answer;
     }
-    
+
     public synchronized void addRouteDefinitions(Collection<RouteDefinition> routeDefinitions) throws Exception {
         if (routeDefinitions == null || routeDefinitions.isEmpty()) {
             return;
@@ -2521,7 +2518,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
     }
 
     public void addRestConfiguration(RestConfiguration restConfiguration) {
-        restConfigurations.put(restConfiguration.getComponent(), restConfiguration);        
+        restConfigurations.put(restConfiguration.getComponent(), restConfiguration);
     }
     public RestConfiguration getRestConfiguration(String component, boolean defaultIfNotExist) {
         if (component == null) {
@@ -2537,7 +2534,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         }
         return config;
     }
-    
+
     public List<InterceptStrategy> getInterceptStrategies() {
         return interceptStrategies;
     }
@@ -2795,6 +2792,11 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         startDate = new Date();
         stopWatch.restart();
         log.info("Apache Camel " + getVersion() + " (CamelContext: " + getName() + ") is starting");
+
+        // Note: This is done on context start as we want to avoid doing it during object construction
+        // where we could be dealing with CDI proxied camel contexts which may never be started (CAMEL-9657)
+        // [TODO] Remove in 3.0
+        Container.Instance.manage(this);
 
         doNotStartRoutesOnFirstStart = !firstStartDone && !isAutoStartup();
 

--- a/camel-core/src/main/java/org/apache/camel/spi/Container.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/Container.java
@@ -82,9 +82,9 @@ public interface Container {
         }
 
         /**
-         * Called by Camel when a <code>CamelContext</code> has been created.
+         * Called by Camel when a <code>CamelContext</code> is being started.
          *
-         * @param camelContext the newly created CamelContext
+         * @param camelContext the CamelContext to manage
          */
         public static void manage(CamelContext camelContext) {
             Container cnt = container;
@@ -105,9 +105,9 @@ public interface Container {
         }
 
         /**
-         * Called by Camel when a <code>CamelContext</code> has been destroyed.
+         * Called by Camel when a <code>CamelContext</code> is being stopped.
          *
-         * @param camelContext the CamelContext which has been destroyed
+         * @param camelContext the CamelContext which is being stopped
          */
         public static void unmanage(CamelContext camelContext) {
             CONTEXTS.remove(camelContext);
@@ -115,20 +115,20 @@ public interface Container {
     }
 
     /**
-     * Called by Camel when a <code>CamelContext</code> has been created by its constructor.
+     * Called by Camel before a <code>CamelContext</code> has been started.
      * <p/>
-     * Notice this method is invoked when the {@link org.apache.camel.CamelContext} has been created by its constructor.
+     * Notice this method is invoked when the {@link org.apache.camel.CamelContext} has been started.
      * The context is <b>not</b> yet finished being configured. For example the id/name of the {@link org.apache.camel.CamelContext}
      * has not been resolved yet, and may return <tt>null</tt>.
      * <p/>
      * The intention is implementations of {@link org.apache.camel.spi.Container} is able to configure the {@link org.apache.camel.CamelContext}
-     * before its being started.
+     * before it has been fully started.
      * <p/>
-     * To receive callbacks when the {@link org.apache.camel.CamelContext} has finished being configured and is being started, then
+     * To receive callbacks when the {@link org.apache.camel.CamelContext} is fully configured and has been started, then
      * use {@link org.apache.camel.spi.EventNotifier} to listen for the {@link org.apache.camel.management.event.CamelContextStartedEvent}
      * event.
      *
-     * @param camelContext the newly created CamelContext by its constructor
+     * @param camelContext the CamelContext to manage
      */
     void manage(CamelContext camelContext);
 

--- a/camel-core/src/test/java/org/apache/camel/spi/ContainerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/spi/ContainerTest.java
@@ -47,12 +47,18 @@ public class ContainerTest extends TestCase {
         CamelContext camel1 = new DefaultCamelContext();
         CamelContext camel2 = new DefaultCamelContext();
 
+        // Must call start to make contexts 'managed'
+        camel1.start();
+        camel2.start();
+
         assertEquals(0, myContainer.names.size());
         Container.Instance.set(myContainer);
         // after we set, then we should manage the 2 pending contexts
         assertEquals(2, myContainer.names.size());
 
         CamelContext camel3 = new DefaultCamelContext();
+        camel3.start();
+
         assertEquals(3, myContainer.names.size());
         assertEquals(camel1.getName(), myContainer.names.get(0));
         assertEquals(camel2.getName(), myContainer.names.get(1));
@@ -68,6 +74,9 @@ public class ContainerTest extends TestCase {
 
         CamelContext camel1 = new DefaultCamelContext();
         CamelContext camel2 = new DefaultCamelContext();
+
+        camel1.start();
+        camel2.start();
 
         assertEquals(0, myContainer.names.size());
 


### PR DESCRIPTION
Also ignore CDI proxied camel contexts when invoking contextCreated()
from CamelContextTrackerRegistry