### PR TITLE
Fix IronMQ URLs in docs and configuration

### DIFF
--- a/components/camel-ironmq/src/main/docs/ironmq.adoc
+++ b/components/camel-ironmq/src/main/docs/ironmq.adoc
@@ -49,7 +49,7 @@ The ironmq component supports 31 endpoint options which are listed below:
 | Name | Group | Default | Java Type | Description
 | queueName | common |  | String | *Required* The name of the IronMQ queue
 | client | common |  | Client | Reference to a io.iron.ironmq.Client in the Registry.
-| ironMQCloud | common | https://mq-aws-us-east-1.iron.io | String | IronMq Cloud url. See http://dev.iron.io/mq/reference/clouds/ for valid options
+| ironMQCloud | common | https://mq-aws-us-east-1-1.iron.io | String | IronMq Cloud url. Urls for public clusters: mq-aws-us-east-1-1.iron.io (US), mq-aws-eu-west-1-1.iron.io (EU)
 | preserveHeaders | common | false | boolean | Should message headers be preserved when publishing messages. This will add the Camel headers to the Iron MQ message as a json payload with a header list and a message body. Useful when Camel is both consumer and producer.
 | projectId | common |  | String | IronMQ projectId
 | token | common |  | String | IronMQ token
@@ -136,7 +136,7 @@ Consume 50 messages pr. poll from the queue 'testqueue' on aws eu, and save the 
 
 [source,java]
 --------------------------------------------------
-from("ironmq:testqueue?ironMQCloud=mq-aws-eu-west-1.iron.io&projectId=myIronMQProjectid&token=myIronMQToken&maxMessagesPerPoll=50")
+from("ironmq:testqueue?ironMQCloud=mq-aws-eu-west-1-1.iron.io&projectId=myIronMQProjectid&token=myIronMQToken&maxMessagesPerPoll=50")
   .to("file:somefolder);
 --------------------------------------------------
 

--- a/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/IronMQConfiguration.java
+++ b/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/IronMQConfiguration.java
@@ -36,8 +36,8 @@ public class IronMQConfiguration {
     @UriPath @Metadata(required = "true")
     private String queueName;
     
-    @UriParam(defaultValue = "https://mq-aws-us-east-1.iron.io")
-    private String ironMQCloud = "https://mq-aws-us-east-1.iron.io";
+    @UriParam(defaultValue = "https://mq-aws-us-east-1-1.iron.io")
+    private String ironMQCloud = "https://mq-aws-us-east-1-1.iron.io";
     
     @UriParam
     private boolean preserveHeaders;
@@ -121,7 +121,7 @@ public class IronMQConfiguration {
     }
 
     /**
-     * IronMq Cloud url. See http://dev.iron.io/mq/reference/clouds/ for valid options
+     * IronMq Cloud url. Urls for public clusters: mq-aws-us-east-1-1.iron.io (US), mq-aws-eu-west-1-1.iron.io (EU)
      */
     public void setIronMQCloud(String ironMQCloud) {
         this.ironMQCloud = ironMQCloud;


### PR DESCRIPTION
http://dev.iron.io/mq/reference/clouds is deprecated