### PR TITLE
CAMEL-9679: Support for Hessian serialization

### DIFF
--- a/apache-camel/pom.xml
+++ b/apache-camel/pom.xml
@@ -325,6 +325,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-hessian</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-http</artifactId>
     </dependency>
     <dependency>

--- a/camel-core/src/main/java/org/apache/camel/builder/DataFormatClause.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/DataFormatClause.java
@@ -34,6 +34,7 @@ import org.apache.camel.model.dataformat.CastorDataFormat;
 import org.apache.camel.model.dataformat.CsvDataFormat;
 import org.apache.camel.model.dataformat.CustomDataFormat;
 import org.apache.camel.model.dataformat.GzipDataFormat;
+import org.apache.camel.model.dataformat.HessianDataFormat;
 import org.apache.camel.model.dataformat.HL7DataFormat;
 import org.apache.camel.model.dataformat.IcalDataFormat;
 import org.apache.camel.model.dataformat.JacksonXMLDataFormat;
@@ -239,6 +240,13 @@ public class DataFormatClause<T extends ProcessorDefinition<?>> {
     public T gzip() {
         GzipDataFormat gzdf = new GzipDataFormat();
         return dataFormat(gzdf);
+    }
+
+    /**
+     * Uses the Hessian data format
+     */
+    public T hessian() {
+        return dataFormat(new HessianDataFormat());
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/DataFormatsDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/DataFormatsDefinition.java
@@ -51,6 +51,7 @@ public class DataFormatsDefinition {
         @XmlElement(required = false, name = "custom", type = CustomDataFormat.class),
         @XmlElement(required = false, name = "flatpack", type = FlatpackDataFormat.class),
         @XmlElement(required = false, name = "gzip", type = GzipDataFormat.class),
+        @XmlElement(required = false, name = "hessian", type = HessianDataFormat.class),
         @XmlElement(required = false, name = "hl7", type = HL7DataFormat.class),
         @XmlElement(required = false, name = "ical", type = IcalDataFormat.class),
         @XmlElement(required = false, name = "jacksonxml", type = JacksonXMLDataFormat.class),

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/HessianDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/HessianDataFormat.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.dataformat;
+
+import org.apache.camel.model.DataFormatDefinition;
+import org.apache.camel.spi.Metadata;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Hessian data format
+ */
+@Metadata(label = "dataformat,transformation", title = "Hessian")
+@XmlRootElement(name = "hessian")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class HessianDataFormat extends DataFormatDefinition {
+
+    public HessianDataFormat() {
+        super("hessian");
+    }
+
+}

--- a/camel-core/src/main/resources/org/apache/camel/model/dataformat/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/dataformat/jaxb.index
@@ -26,6 +26,7 @@ CustomDataFormat
 DataFormatsDefinition
 FlatpackDataFormat
 GzipDataFormat
+HessianDataFormat
 HL7DataFormat
 IcalDataFormat
 JaxbDataFormat

--- a/components/camel-hessian/pom.xml
+++ b/components/camel-hessian/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>components</artifactId>
+        <version>2.17-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-hessian</artifactId>
+    <packaging>bundle</packaging>
+    <name>Camel :: Hessian</name>
+    <description>Hessian serialization support</description>
+
+    <properties>
+        <camel.osgi.export.pkg>org.apache.camel.dataformat.hessian.*</camel.osgi.export.pkg>
+        <camel.osgi.export.service>org.apache.camel.spi.DataFormatResolver;dataformat=hessian</camel.osgi.export.service>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.caucho</groupId>
+            <artifactId>hessian</artifactId>
+            <version>${hessian-version}</version>
+        </dependency>
+
+        <!-- testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/camel-hessian/src/main/java/org/apache/camel/dataformat/hessian/HessianDataFormat.java
+++ b/components/camel-hessian/src/main/java/org/apache/camel/dataformat/hessian/HessianDataFormat.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.hessian;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.Hessian2Output;
+import org.apache.camel.Exchange;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatName;
+import org.apache.camel.support.ServiceSupport;
+
+/**
+ * The <a href="http://camel.apache.org/data-format.html">data format</a>
+ * using <a href="http://hessian.caucho.com/doc/hessian-serialization.html">Hessian Serialization</a>.
+ * @since 2.17
+ */
+public class HessianDataFormat extends ServiceSupport implements DataFormat, DataFormatName {
+
+    private static final String FORMAT_NAME = "hessian";
+
+    @Override
+    public String getDataFormatName() {
+        return FORMAT_NAME;
+    }
+
+    @Override
+    public void marshal(final Exchange exchange, final Object graph, final OutputStream outputStream) throws Exception {
+        final Hessian2Output out = new Hessian2Output(outputStream);
+        try {
+            out.startMessage();
+            out.writeObject(graph);
+            out.completeMessage();
+        } finally {
+            out.flush();
+            try {
+                out.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    @Override
+    public Object unmarshal(final Exchange exchange, final InputStream inputStream) throws Exception {
+        final Hessian2Input in = new Hessian2Input(inputStream);
+        try {
+            in.startMessage();
+            final Object obj = in.readObject();
+            in.completeMessage();
+            return obj;
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        // noop
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        // noop
+    }
+}

--- a/components/camel-hessian/src/main/resources/META-INF/LICENSE.txt
+++ b/components/camel-hessian/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/components/camel-hessian/src/main/resources/META-INF/NOTICE.txt
+++ b/components/camel-hessian/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/components/camel-hessian/src/main/resources/META-INF/services/org/apache/camel/dataformat/hessian
+++ b/components/camel-hessian/src/main/resources/META-INF/services/org/apache/camel/dataformat/hessian
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class=org.apache.camel.dataformat.hessian.HessianDataFormat

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatConfigDslTest.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatConfigDslTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.hessian;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+/**
+ * Test for {@link HessianDataFormat}.
+ */
+public class HessianDataFormatConfigDslTest extends CamelTestSupport {
+
+    @Test
+    public void testMarshalAndUnmarshalString() throws Exception {
+        final String object = "This is a string";
+
+        final MockEndpoint mock = context().getEndpoint("mock:reverse", MockEndpoint.class);
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isInstanceOf(object.getClass());
+        mock.message(0).body().isEqualTo(object);
+
+        final Object marshalled = template.requestBody("direct:in", object);
+        template.sendBody("direct:back", marshalled);
+
+        mock.assertIsSatisfied();
+
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:in").marshal().hessian();
+                from("direct:back").unmarshal().hessian().to("mock:reverse");
+            }
+        };
+    }
+
+
+}

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatConfigXmlTest.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatConfigXmlTest.java
@@ -1,0 +1,47 @@
+package org.apache.camel.dataformat.hessian;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class HessianDataFormatConfigXmlTest extends CamelSpringTestSupport {
+
+    @Test
+    public void testMarshalAndUnmarshalString() throws Exception {
+        final String object = "This is a string";
+
+        final MockEndpoint mock = context().getEndpoint("mock:reverse", MockEndpoint.class);
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isInstanceOf(object.getClass());
+        mock.message(0).body().isEqualTo(object);
+
+        final Object marshalled = template.requestBody("direct:in", object);
+        template.sendBody("direct:back", marshalled);
+
+        mock.assertIsSatisfied();
+
+    }
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/dataformat/hessian/HessianTestConfig.xml");
+    }
+}

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatMarshallingTest.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatMarshallingTest.java
@@ -28,7 +28,7 @@ import java.util.*;
 /**
  * Test for {@link HessianDataFormat}.
  */
-public class HessianDataFormatTest extends CamelTestSupport {
+public class HessianDataFormatMarshallingTest extends CamelTestSupport {
 
     @Test
     public void testMarshalAndUnmarshalNull() throws Exception {

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatTest.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.hessian;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Predicate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+import java.util.*;
+
+/**
+ * Test for {@link HessianDataFormat}.
+ */
+public class HessianDataFormatTest extends CamelTestSupport {
+
+    @Test
+    public void testMarshalAndUnmarshalNull() throws Exception {
+        testMarshalAndUnmarshal(null);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalBoolean() throws Exception {
+        testMarshalAndUnmarshal(Boolean.TRUE);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalString() throws Exception {
+        testMarshalAndUnmarshal("This is a string");
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalInteger() throws Exception {
+        testMarshalAndUnmarshal(42);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalLong() throws Exception {
+        testMarshalAndUnmarshal(100_000_000_000_000L);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalDouble() throws Exception {
+        testMarshalAndUnmarshal(6.022e23);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalDate() throws Exception {
+        testMarshalAndUnmarshal(new Date()) ;
+    }
+
+
+    @Test
+    public void testMarshalAndUnmarshalArray() throws Exception {
+        testMarshalAndUnmarshal(new String[]{"one", "two", "three"});
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalList() throws Exception {
+        testMarshalAndUnmarshal(Arrays.asList("one", "two", "three"));
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalMap() throws Exception {
+        final Map<Integer, String> map = new HashMap<>();
+        map.put(1, "one");
+        map.put(2, "two");
+        map.put(3, "three");
+
+        testMarshalAndUnmarshal(map);
+    }
+
+    @Test
+    public void testMarshalAndUnmarshalObject() throws Exception {
+        final TestObject object = new TestObject();
+        object.setBool(true);
+        object.setIntNumber(42);
+        object.setFloatNumber(3.14159f);
+        object.setCharacter('Z');
+        object.setText("random text");
+
+        testMarshalAndUnmarshal(object);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                final HessianDataFormat format = new HessianDataFormat();
+
+                from("direct:in").marshal(format);
+                from("direct:back").unmarshal(format).to("mock:reverse");
+            }
+        };
+    }
+
+    private void testMarshalAndUnmarshal(final Object object) throws Exception {
+        final MockEndpoint mock = getMockEndpoint("mock:reverse");
+        mock.expectedMessageCount(1);
+
+        if (object == null) {
+            mock.message(0).body().isNull();
+        } else {
+            mock.message(0).body().isNotNull();
+
+            if (object.getClass().isArray()) {
+                mock.message(0).body().in(arrayEqual((Object[]) object));
+            } else {
+                mock.message(0).body().isEqualTo(object);
+            }
+        }
+
+        final Object marshalled = template.requestBody("direct:in", object);
+        template.sendBody("direct:back", marshalled);
+
+        mock.assertIsSatisfied();
+    }
+
+    /** This predicate checks is two arrays have the same content. */
+    private static Predicate arrayEqual(final Object[] array) {
+        return new Predicate() {
+            @Override
+            public boolean matches(final Exchange exchange) {
+                final Object body = exchange.getIn().getBody();
+                if (body != null && body.getClass().isArray()) {
+                    return Arrays.equals(array, (Object[]) body);
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/TestObject.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/TestObject.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.hessian;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A simple object used used by {@link HessianDataFormatTest}. */
+class TestObject implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean bool;
+    private int intNumber;
+    private double floatNumber;
+    private char character;
+    private String text;
+
+    public boolean isBool() {
+        return bool;
+    }
+
+    public void setBool(final boolean bool) {
+        this.bool = bool;
+    }
+
+    public int getIntNumber() {
+        return intNumber;
+    }
+
+    public void setIntNumber(final int intNumber) {
+        this.intNumber = intNumber;
+    }
+
+    public double getFloatNumber() {
+        return floatNumber;
+    }
+
+    public void setFloatNumber(final double floatNumber) {
+        this.floatNumber = floatNumber;
+    }
+
+    public char getCharacter() {
+        return character;
+    }
+
+    public void setCharacter(final char character) {
+        this.character = character;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final TestObject that = (TestObject) o;
+
+        return Objects.equals(bool, that.bool) &&
+                Objects.equals(intNumber, that.intNumber) &&
+                Objects.equals(floatNumber, that.floatNumber) &&
+                Objects.equals(character, that.character) &&
+                Objects.equals(text, that.text);
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        result = (bool ? 1 : 0);
+        result = 31 * result + intNumber;
+        temp = Double.doubleToLongBits(floatNumber);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + (int) character;
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        return result;
+    }
+}

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/TestObject.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/TestObject.java
@@ -19,7 +19,7 @@ package org.apache.camel.dataformat.hessian;
 import java.io.Serializable;
 import java.util.Objects;
 
-/** A simple object used used by {@link HessianDataFormatTest}. */
+/** A simple object used used by {@link HessianDataFormatMarshallingTest}. */
 class TestObject implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/components/camel-hessian/src/test/resources/log4j.properties
+++ b/components/camel-hessian/src/test/resources/log4j.properties
@@ -1,0 +1,36 @@
+## ------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ------------------------------------------------------------------------
+
+#
+# The logging properties used for eclipse testing, We want to see debug output on the console.
+#
+log4j.rootLogger=INFO, file
+
+# uncomment the following to enable camel debugging
+#log4j.logger.org.apache.camel=DEBUG
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+#log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+
+# File appender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+log4j.appender.file.file=target/camel-hessian-test.log

--- a/components/camel-hessian/src/test/resources/org/apache/camel/dataformat/hessian/HessianTestConfig.xml
+++ b/components/camel-hessian/src/test/resources/org/apache/camel/dataformat/hessian/HessianTestConfig.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<bean:beans xmlns="http://camel.apache.org/schema/spring"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:bean="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="
+          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext id="camel">
+
+        <route>
+            <from uri="direct:in"/>
+            <marshal ref="hessian"/>
+        </route>
+
+        <route>
+            <from uri="direct:back"/>
+            <unmarshal ref="hessian"/>
+            <to uri="mock:reverse"/>
+        </route>
+
+    </camelContext>
+</bean:beans>

--- a/components/camel-snakeyaml/src/main/docs/hessian.adoc
+++ b/components/camel-snakeyaml/src/main/docs/hessian.adoc
@@ -1,0 +1,42 @@
+[[hessian-HessianDataFormat]]
+Hessian DataFormat
+~~~~~~~~~~~~~~~~~~
+
+Hessian is Data Format for marshalling and unmarshalling messages using Caucho's Hessian format.
+
+If you want to use Hessian Data Format from Maven, add the following dependency to your `pom.xml`:
+
+[source,xml]
+------------------------------------------------------------
+<dependency>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-hessian</artifactId>
+    <version>x.x.x</version>
+    <!-- use the same version as your Camel core version -->
+</dependency>
+------------------------------------------------------------
+
+
+[[hessian-UsingHessianDataFormat]]
+Using the Hessian data format in Java DSL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[source,java]
+--------------------------------------------------------------------------------
+    from("direct:in")
+        .marshal().hessian();
+--------------------------------------------------------------------------------
+
+[[hessian-UsingHessianDataFormatXml]]
+Using the Hessian data format in Spring DSL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[source,xml]
+--------------------------------------------------------------------------------
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="direct:in"/>
+            <marshal ref="hessian"/>
+        </route>
+    </camelContext>
+--------------------------------------------------------------------------------

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -123,6 +123,7 @@
     <module>camel-hbase</module>
     <module>camel-hdfs</module>
     <module>camel-hdfs2</module>
+    <module>camel-hessian</module>
     <module>camel-hipchat</module>
     <module>camel-hl7</module>
     <module>camel-ibatis</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -226,6 +226,7 @@
     <hazelcast-version>3.6</hazelcast-version>
     <hbase-version>1.1.3</hbase-version>
     <hbase-bundle-version>1.1.1_1</hbase-bundle-version>
+    <hessian-version>4.0.38</hessian-version>
     <hibernate-validator-version>5.2.4.Final</hibernate-validator-version>
     <!-- Spring 3.2.x and 4.0.x still stick to JPA 2.0. Hibernate 4.3.x upgraded to JPA 2.1. -->
     <hibernate-version>4.2.20.Final</hibernate-version>
@@ -1011,6 +1012,11 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hdfs2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-hessian</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -697,6 +697,11 @@
     <feature version='${project.version}'>camel-core</feature>
     <bundle>mvn:org.apache.camel/camel-hipchat/${project.version}</bundle>
   </feature>
+  <feature name='camel-hessian' version='${project.version}' resolver='(obr)' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <bundle dependency='true'>mvn:com.caucho/hessian/${hessian-version}}</bundle>
+    <bundle>mvn:org.apache.camel/camel-hessian/${project.version}</bundle>
+  </feature>
   <feature name='camel-hl7' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature version='${project.version}'>camel-netty4</feature>


### PR DESCRIPTION
[CAMEL-9679](https://issues.apache.org/jira/browse/CAMEL-9679) Adds new data format supporting Hessian serialization.
