### PR TITLE
CAMEL-9698 fix for camel-servlet karaf features

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1390,6 +1390,7 @@
   </feature>
   <feature name='camel-servlet' version='${project.version}' resolver='(obr)' start-level='50'>
     <details> camel-servlet need to access the http OSGi services </details>
+    <feature version='${project.version}'>camel-core</feature>
     <feature>http</feature>
     <bundle>mvn:org.apache.camel/camel-http-common/${project.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-servlet/${project.version}</bundle>


### PR DESCRIPTION
Added dependency for camel-core in camel-servlet karaf feature (so that it can be installed without pre-installing camel-core)