### PR TITLE
Added support to exclude a route from documentation

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -497,6 +497,12 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return this;
     }
 
+    public RestDefinition excludeFromDocs() {
+        VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
+        verb.setExcludeFromDocs(true);
+        return this;
+    }
+
     public RouteDefinition route() {
         // add to last verb
         if (getVerbs().isEmpty()) {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -497,9 +497,12 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return this;
     }
 
-    public RestDefinition excludeFromDocs() {
+    /**
+     * Include or exclude the current Rest Definition in API documentation
+     */
+    public RestDefinition apiDocs(Boolean apiDocs) {
         VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
-        verb.setExcludeFromDocs(true);
+        verb.setApiDocs(apiDocs);
         return this;
     }
 

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -98,6 +98,8 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     private RestDefinition rest;
     @XmlAttribute
     private String routeId;
+    @XmlAttribute
+    private Boolean excludeFromDocs;
 
     @Override
     public String getLabel() {
@@ -367,6 +369,14 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
 
     public RestDefinition verb(String verb, String uri) {
         return rest.verb(verb, uri);
+    }
+
+    public Boolean getExcludeFromDocs() {
+        return excludeFromDocs;
+    }
+
+    public void setExcludeFromDocs(Boolean excludeFromDocs) {
+        this.excludeFromDocs = excludeFromDocs;
     }
 
     public String asVerb() {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -99,7 +99,7 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private String routeId;
     @XmlAttribute
-    private Boolean excludeFromDocs;
+    private Boolean apiDocs;
 
     @Override
     public String getLabel() {
@@ -371,12 +371,16 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
         return rest.verb(verb, uri);
     }
 
-    public Boolean getExcludeFromDocs() {
-        return excludeFromDocs;
+    public Boolean getApiDocs() {
+        return apiDocs;
     }
 
-    public void setExcludeFromDocs(Boolean excludeFromDocs) {
-        this.excludeFromDocs = excludeFromDocs;
+    /**
+     * Whether to include or exclude the VerbDefinition in API documentation.
+     * The default value is true.
+     */
+    public void setApiDocs(Boolean apiDocs) {
+        this.apiDocs = apiDocs;
     }
 
     public String asVerb() {

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -116,6 +116,9 @@ public class RestSwaggerReader {
         // gather all types in use
         Set<String> types = new LinkedHashSet<>();
         for (VerbDefinition verb : verbs) {
+            if (verb.getExcludeFromDocs() != null && verb.getExcludeFromDocs()) {
+                continue;
+            }
             String type = verb.getType();
             if (ObjectHelper.isNotEmpty(type)) {
                 if (type.endsWith("[]")) {
@@ -156,7 +159,9 @@ public class RestSwaggerReader {
         String basePath = rest.getPath();
 
         for (VerbDefinition verb : verbs) {
-
+            if (verb.getExcludeFromDocs() != null && verb.getExcludeFromDocs()) {
+                continue;
+            }
             // the method must be in lower case
             String method = verb.asVerb().toLowerCase(Locale.US);
             // operation path is a key

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -116,7 +116,8 @@ public class RestSwaggerReader {
         // gather all types in use
         Set<String> types = new LinkedHashSet<>();
         for (VerbDefinition verb : verbs) {
-            if (verb.getExcludeFromDocs() != null && verb.getExcludeFromDocs()) {
+            // check if the Verb Definition must be excluded from documentation
+            if (verb.getApiDocs() != null && !verb.getApiDocs()) {
                 continue;
             }
             String type = verb.getType();
@@ -159,7 +160,8 @@ public class RestSwaggerReader {
         String basePath = rest.getPath();
 
         for (VerbDefinition verb : verbs) {
-            if (verb.getExcludeFromDocs() != null && verb.getExcludeFromDocs()) {
+            // check if the Verb Definition must be excluded from documentation
+            if (verb.getApiDocs() != null && !verb.getApiDocs()) {
                 continue;
             }
             // the method must be in lower case


### PR DESCRIPTION
Sometimes you may need to exclude some routes from the documentation.
In our case we want to hide a route which now has performance issues.