### PR TITLE
CAMEL-9706: MockEndpoint: isEqualTo predicate does not handle arrays …

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import org.w3c.dom.Node;
@@ -193,13 +194,13 @@ public final class ObjectHelper {
     /**
      * A helper method for comparing objects for equality while handling nulls
      */
-    public static boolean equal(Object a, Object b, boolean ignoreCase) {
+    public static boolean equal(final Object a, final Object b, final boolean ignoreCase) {
         if (a == b) {
             return true;
         }
 
-        if (a instanceof byte[] && b instanceof byte[]) {
-            return equalByteArray((byte[])a, (byte[])b);
+        if (a == null || b == null) {
+            return false;
         }
 
         if (ignoreCase) {
@@ -208,7 +209,7 @@ public final class ObjectHelper {
             }
         }
 
-        return a != null && b != null && a.equals(b);
+        return Objects.deepEquals(a, b);
     }
 
     /**
@@ -216,22 +217,7 @@ public final class ObjectHelper {
      * nulls
      */
     public static boolean equalByteArray(byte[] a, byte[] b) {
-        if (a == b) {
-            return true;
-        }
-
-        // loop and compare each byte
-        if (a != null && b != null && a.length == b.length) {
-            for (int i = 0; i < a.length; i++) {
-                if (a[i] != b[i]) {
-                    return false;
-                }
-            }
-            // all bytes are equal
-            return true;
-        }
-
-        return false;
+        return Arrays.equals(a, b);
     }
 
     /**

--- a/camel-core/src/test/java/org/apache/camel/component/mock/MockPredicateEqualityTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/mock/MockPredicateEqualityTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mock;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+
+public class MockPredicateEqualityTest extends ContextTestSupport {
+
+    public void testByteArray() throws Exception {
+        doTest(new byte[]{(byte) 0xde, (byte) 0xed, (byte) 0xbe, (byte) 0xef});
+    }
+
+    public void testIntArray() throws Exception {
+        doTest(new int[]{121, 122, 123});
+    }
+
+    public void testCharArray() throws Exception {
+        doTest("forbar".toCharArray());
+    }
+    public void testStringArray() throws Exception {
+        doTest(new String[]{"this", "is", "an", "array"});
+    }
+
+    public void doTest(final Object anArray) throws Exception {
+        final MockEndpoint mock = getMockEndpoint("mock:reverse");
+        mock.message(0).body().isEqualTo(anArray);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", anArray);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").marshal().serialization().unmarshal().serialization().to("mock:reverse");
+            }
+        };
+    }
+}

--- a/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatMarshallingTest.java
+++ b/components/camel-hessian/src/test/java/org/apache/camel/dataformat/hessian/HessianDataFormatMarshallingTest.java
@@ -21,8 +21,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Predicate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
@@ -122,31 +120,12 @@ public class HessianDataFormatMarshallingTest extends CamelTestSupport {
             mock.message(0).body().isNull();
         } else {
             mock.message(0).body().isNotNull();
-
-            if (object.getClass().isArray()) {
-                mock.message(0).body().in(arrayEqual((Object[]) object));
-            } else {
-                mock.message(0).body().isEqualTo(object);
-            }
+            mock.message(0).body().isEqualTo(object);
         }
 
         final Object marshalled = template.requestBody("direct:in", object);
         template.sendBody("direct:back", marshalled);
 
         mock.assertIsSatisfied();
-    }
-
-    /** This predicate checks is two arrays have the same content. */
-    private static Predicate arrayEqual(final Object[] array) {
-        return new Predicate() {
-            @Override
-            public boolean matches(final Exchange exchange) {
-                final Object body = exchange.getIn().getBody();
-                if (body != null && body.getClass().isArray()) {
-                    return Arrays.equals(array, (Object[]) body);
-                }
-                return false;
-            }
-        };
     }
 }


### PR DESCRIPTION
…correctly

Source of problem was the final line of ObjectHelper#equal method - array1.equals(array2) does not compare the contents of arrays.

