### PR TITLE
CAMEL-8219: camel-smpp - use jsmpp version 2.2.3

### DIFF
--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/MessageReceiverListenerImpl.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/MessageReceiverListenerImpl.java
@@ -107,7 +107,7 @@ public class MessageReceiverListenerImpl implements MessageReceiverListener {
             throw pre;
         }
 
-        return new DataSmResult(newMessageId, dataSm.getOptionalParametes());
+        return new DataSmResult(newMessageId, dataSm.getOptionalParameters());
     }
 
     public void setMessageIDGenerator(MessageIDGenerator messageIDGenerator) {

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
@@ -31,6 +31,7 @@ import org.jsmpp.extra.SessionState;
 import org.jsmpp.session.BindParameter;
 import org.jsmpp.session.MessageReceiverListener;
 import org.jsmpp.session.SMPPSession;
+import org.jsmpp.session.Session;
 import org.jsmpp.session.SessionStateListener;
 import org.jsmpp.util.DefaultComposer;
 import org.slf4j.Logger;
@@ -61,7 +62,8 @@ public class SmppConsumer extends DefaultConsumer {
 
         this.configuration = config;
         this.internalSessionStateListener = new SessionStateListener() {
-            public void onStateChange(SessionState newState, SessionState oldState, Object source) {
+            @Override
+            public void onStateChange(SessionState newState, SessionState oldState, Session source) {
                 if (configuration.getSessionStateListener() != null) {
                     configuration.getSessionStateListener().onStateChange(newState, oldState, source);
                 }

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppDataSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppDataSmCommand.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.DataSm;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
@@ -65,8 +65,8 @@ public class SmppDataSmCommand extends AbstractSmppCommand {
                     dataSm.getDestAddress(),
                     new ESMClass(dataSm.getEsmClass()),
                     new RegisteredDelivery(dataSm.getRegisteredDelivery()),
-                    DataCoding.newInstance(dataSm.getDataCoding()),
-                    dataSm.getOptionalParametes());
+                    DataCodings.newInstance(dataSm.getDataCoding()),
+                    dataSm.getOptionalParameters());
         } catch (Exception e) {
             throw new SmppException(e);
         }
@@ -199,14 +199,14 @@ public class SmppDataSmCommand extends AbstractSmppCommand {
         Map<java.lang.Short, Object> optinalParamater = in.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         if (optinalParamater != null) {
             List<OptionalParameter> optParams = createOptionalParametersByCode(optinalParamater);
-            dataSm.setOptionalParametes(optParams.toArray(new OptionalParameter[optParams.size()]));
+            dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
         } else {
             Map<String, String> optinalParamaters = in.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
             if (optinalParamaters != null) {
                 List<OptionalParameter> optParams = createOptionalParametersByName(optinalParamaters);
-                dataSm.setOptionalParametes(optParams.toArray(new OptionalParameter[optParams.size()]));
+                dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
             } else {
-                dataSm.setOptionalParametes();
+                dataSm.setOptionalParameters();
             }
         }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppMessage.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppMessage.java
@@ -39,8 +39,6 @@ public class SmppMessage extends DefaultMessage {
     private Command command;
     private SmppConfiguration configuration;
     
-    
-    
     public SmppMessage(SmppConfiguration configuration) {
         this.configuration = configuration;
     }
@@ -89,7 +87,8 @@ public class SmppMessage extends DefaultMessage {
             if (shortMessage == null || shortMessage.length == 0) {
                 return null;
             }
-            if (SmppUtils.parseAlphabetFromDataCoding(msgRequest.getDataCoding()) == Alphabet.ALPHA_8_BIT) {
+            Alphabet alphabet = Alphabet.parseDataCoding(msgRequest.getDataCoding());
+            if (SmppUtils.is8Bit(alphabet)) {
                 return shortMessage;
             }
             

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppProducer.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppProducer.java
@@ -31,6 +31,7 @@ import org.jsmpp.bean.TypeOfNumber;
 import org.jsmpp.extra.SessionState;
 import org.jsmpp.session.BindParameter;
 import org.jsmpp.session.SMPPSession;
+import org.jsmpp.session.Session;
 import org.jsmpp.session.SessionStateListener;
 import org.jsmpp.util.DefaultComposer;
 import org.slf4j.Logger;
@@ -52,7 +53,8 @@ public class SmppProducer extends DefaultProducer {
         super(endpoint);
         this.configuration = config;
         this.internalSessionStateListener = new SessionStateListener() {
-            public void onStateChange(SessionState newState, SessionState oldState, Object source) {
+            @Override
+            public void onStateChange(SessionState newState, SessionState oldState, Session source) {
                 if (configuration.getSessionStateListener() != null) {
                     configuration.getSessionStateListener().onStateChange(newState, oldState, source);
                 }

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
@@ -81,17 +81,12 @@ public abstract class SmppSmCommand extends AbstractSmppCommand {
         String body = message.getBody(String.class);
 
         SmppSplitter splitter;
-        switch (alphabet) {
-        case ALPHA_8_BIT:
+        if (SmppUtils.is8Bit(alphabet)) {
             splitter = new Smpp8BitSplitter(body.length());
-            break;
-        case ALPHA_UCS2:
+        } else if (alphabet == Alphabet.ALPHA_UCS2) {
             splitter = new SmppUcs2Splitter(body.length());
-            break;
-        case ALPHA_DEFAULT:
-        default:
+        } else {
             splitter = new SmppDefaultSplitter(body.length());
-            break;
         }
 
         return splitter;
@@ -112,10 +107,10 @@ public abstract class SmppSmCommand extends AbstractSmppCommand {
     private static boolean has8bitDataCoding(Message message) {
         Byte dcs = message.getHeader(SmppConstants.DATA_CODING, Byte.class);
         if (dcs != null) {
-            return SmppUtils.parseAlphabetFromDataCoding(dcs.byteValue()) == Alphabet.ALPHA_8_BIT;
+            return SmppUtils.is8Bit(Alphabet.parseDataCoding(dcs.byteValue()));
         } else {
             Byte alphabet = message.getHeader(SmppConstants.ALPHABET, Byte.class);
-            return alphabet != null && alphabet.equals(Alphabet.ALPHA_8_BIT.value());
+            return alphabet != null && SmppUtils.is8Bit(Alphabet.valueOf(alphabet));
         }
     }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitMultiCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitMultiCommand.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.jsmpp.bean.Address;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.GSMSpecificFeature;
 import org.jsmpp.bean.MessageMode;
@@ -72,7 +72,7 @@ public class SmppSubmitMultiCommand extends SmppSmCommand {
                         submitMulti.getValidityPeriod(),
                         new RegisteredDelivery(submitMulti.getRegisteredDelivery()),
                         new ReplaceIfPresentFlag(submitMulti.getReplaceIfPresentFlag()),
-                        DataCoding.newInstance(submitMulti.getDataCoding()),
+                        DataCodings.newInstance(submitMulti.getDataCoding()),
                         submitMulti.getSmDefaultMsgId(),
                         submitMulti.getShortMessage(),
                         submitMulti.getOptionalParameters());

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.GSMSpecificFeature;
 import org.jsmpp.bean.MessageMode;
@@ -69,10 +69,10 @@ public class SmppSubmitSmCommand extends SmppSmCommand {
                         submitSm.getValidityPeriod(),
                         new RegisteredDelivery(submitSm.getRegisteredDelivery()),
                         submitSm.getReplaceIfPresent(),
-                        DataCoding.newInstance(submitSm.getDataCoding()),
+                        DataCodings.newInstance(submitSm.getDataCoding()),
                         (byte) 0,
                         submitSm.getShortMessage(),
-                        submitSm.getOptionalParametes());
+                        submitSm.getOptionalParameters());
             } catch (Exception e) {
                 throw new SmppException(e);
             }
@@ -207,14 +207,14 @@ public class SmppSubmitSmCommand extends SmppSmCommand {
         Map<java.lang.Short, Object> optinalParamater = in.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         if (optinalParamater != null) {
             List<OptionalParameter> optParams = createOptionalParametersByCode(optinalParamater);
-            submitSm.setOptionalParametes(optParams.toArray(new OptionalParameter[optParams.size()]));
+            submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
         } else {
             Map<String, String> optinalParamaters = in.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
             if (optinalParamaters != null) {
                 List<OptionalParameter> optParams = createOptionalParametersByName(optinalParamaters);
-                submitSm.setOptionalParametes(optParams.toArray(new OptionalParameter[optParams.size()]));
+                submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
             } else {
-                submitSm.setOptionalParametes();
+                submitSm.setOptionalParameters();
             }
         }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppUtils.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppUtils.java
@@ -115,14 +115,8 @@ public final class SmppUtils {
         }
     }
 
-    public static Alphabet parseAlphabetFromDataCoding(byte dataCoding) {
-        /* Both the 3.4 and 5.0 SMPP specs clearly state that 0x02 is
-         * 'Octet-unspecified (8-bit)', but jsmpp doesn't account for this for
-         * some reason.
-         */
-        return dataCoding == 0x02
-            ? Alphabet.ALPHA_8_BIT
-            : Alphabet.valueOf((byte)(dataCoding & Alphabet.MASK_ALPHABET));
+    public static boolean is8Bit(Alphabet alphabet) {
+        return alphabet == Alphabet.ALPHA_UNSPECIFIED_2 || alphabet == Alphabet.ALPHA_8_BIT;
     }
 
     /**
@@ -160,7 +154,7 @@ public final class SmppUtils {
         dest.setDestAddrNpi(src.getDestAddrNpi());
         dest.setDestAddrTon(src.getDestAddrTon());
         dest.setEsmClass(src.getEsmClass());
-        dest.setOptionalParametes(src.getOptionalParametes());
+        dest.setOptionalParameters(src.getOptionalParameters());
         dest.setPriorityFlag(src.getPriorityFlag());
         dest.setProtocolId(src.getProtocolId());
         dest.setRegisteredDelivery(src.getRegisteredDelivery());
@@ -251,7 +245,7 @@ public final class SmppUtils {
         dest.setDestAddrNpi(src.getDestAddrNpi());
         dest.setDestAddrTon(src.getDestAddrTon());
         dest.setEsmClass(src.getEsmClass());
-        dest.setOptionalParametes(src.getOptionalParametes());
+        dest.setOptionalParameters(src.getOptionalParameters());
         dest.setRegisteredDelivery(src.getRegisteredDelivery());
         dest.setSequenceNumber(src.getSequenceNumber());
         dest.setServiceType(src.getServiceType());

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/AbstractSmppCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/AbstractSmppCommandTest.java
@@ -20,8 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
-import org.jsmpp.bean.OptionalParameter.COctetString;
-import org.jsmpp.bean.OptionalParameter.OctetString;
+import org.jsmpp.bean.OptionalParameter;
 import org.jsmpp.bean.OptionalParameter.Tag;
 import org.jsmpp.session.SMPPSession;
 import org.junit.Before;
@@ -64,11 +63,11 @@ public class AbstractSmppCommandTest {
 
     @Test
     public void determineTypeClass() throws Exception {
-        assertSame(OctetString.class, command.determineTypeClass(Tag.SOURCE_SUBADDRESS));
-        assertSame(COctetString.class, command.determineTypeClass(Tag.ADDITIONAL_STATUS_INFO_TEXT));
-        assertSame(org.jsmpp.bean.OptionalParameter.Byte.class, command.determineTypeClass(Tag.DEST_ADDR_SUBUNIT));
-        assertSame(org.jsmpp.bean.OptionalParameter.Short.class, command.determineTypeClass(Tag.DEST_TELEMATICS_ID));
-        assertSame(org.jsmpp.bean.OptionalParameter.Int.class, command.determineTypeClass(Tag.QOS_TIME_TO_LIVE));
-        assertSame(org.jsmpp.bean.OptionalParameter.Null.class, command.determineTypeClass(Tag.ALERT_ON_MESSAGE_DELIVERY));
+        assertSame(OptionalParameter.Source_subaddress.class, command.determineTypeClass(Tag.SOURCE_SUBADDRESS));
+        assertSame(OptionalParameter.Additional_status_info_text.class, command.determineTypeClass(Tag.ADDITIONAL_STATUS_INFO_TEXT));
+        assertSame(OptionalParameter.Dest_addr_subunit.class, command.determineTypeClass(Tag.DEST_ADDR_SUBUNIT));
+        assertSame(OptionalParameter.Dest_telematics_id.class, command.determineTypeClass(Tag.DEST_TELEMATICS_ID));
+        assertSame(OptionalParameter.Qos_time_to_live.class, command.determineTypeClass(Tag.QOS_TIME_TO_LIVE));
+        assertSame(OptionalParameter.Alert_on_message_delivery.class, command.determineTypeClass(Tag.ALERT_ON_MESSAGE_DELIVERY));
     }
 }

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/MessageReceiverListenerImplTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/MessageReceiverListenerImplTest.java
@@ -108,7 +108,7 @@ public class MessageReceiverListenerImplTest {
             .andReturn(exchange);
         processor.process(exchange);
         expect(exchange.getException()).andReturn(null);
-        expect(dataSm.getOptionalParametes())
+        expect(dataSm.getOptionalParameters())
             .andReturn(optionalParameters);
         
         replay(endpoint, processor, exceptionHandler, session, dataSm, exchange);

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppBindingTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppBindingTest.java
@@ -133,7 +133,7 @@ public class SmppBindingTest {
         DeliverSm deliverSm = new DeliverSm();
         deliverSm.setSmscDeliveryReceipt();
         deliverSm.setShortMessage("id:2 sub:001 dlvrd:001 submit date:0908312310 done date:0908312311 stat:DELIVRD err:xxx Text:Hello SMPP world!".getBytes());
-        deliverSm.setOptionalParametes(
+        deliverSm.setOptionalParameters(
             new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "OctetString"),
             new OptionalParameter.COctetString((short) 0x001D, "COctetString"),
             new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 0x01),
@@ -157,7 +157,7 @@ public class SmppBindingTest {
         Map<String, Object> optionalParameters = smppMessage.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
         assertEquals(6, optionalParameters.size());
         assertEquals("OctetString", optionalParameters.get("SOURCE_SUBADDRESS"));
-        assertEquals("COctetStrin", optionalParameters.get("ADDITIONAL_STATUS_INFO_TEXT"));
+        assertEquals("COctetString", optionalParameters.get("ADDITIONAL_STATUS_INFO_TEXT"));
         assertEquals(Byte.valueOf((byte) 0x01), optionalParameters.get("DEST_ADDR_SUBUNIT"));
         assertEquals(Short.valueOf((short) 1), optionalParameters.get("DEST_TELEMATICS_ID"));
         assertEquals(Integer.valueOf(1), optionalParameters.get("QOS_TIME_TO_LIVE"));
@@ -166,7 +166,7 @@ public class SmppBindingTest {
         Map<Short, Object> optionalParameter = smppMessage.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         assertEquals(6, optionalParameter.size());
         assertArrayEquals("OctetString".getBytes("UTF-8"), (byte[]) optionalParameter.get(Short.valueOf((short) 0x0202)));
-        assertEquals("COctetStrin", optionalParameter.get(Short.valueOf((short) 0x001D)));
+        assertEquals("COctetString", optionalParameter.get(Short.valueOf((short) 0x001D)));
         assertEquals(Byte.valueOf((byte) 0x01), optionalParameter.get(Short.valueOf((short) 0x0005)));
         assertEquals(Short.valueOf((short) 1), optionalParameter.get(Short.valueOf((short) 0x0008)));
         assertEquals(Integer.valueOf(1), optionalParameter.get(Short.valueOf((short) 0x0017)));
@@ -177,7 +177,7 @@ public class SmppBindingTest {
     public void createSmppMessageFromDeliveryReceiptWithPayloadInOptionalParameterShouldReturnASmppMessage() {
         DeliverSm deliverSm = new DeliverSm();
         deliverSm.setSmscDeliveryReceipt();
-        deliverSm.setOptionalParametes(new OctetString(OptionalParameter.Tag.MESSAGE_PAYLOAD,
+        deliverSm.setOptionalParameters(new OctetString(OptionalParameter.Tag.MESSAGE_PAYLOAD,
             "id:2 sub:001 dlvrd:001 submit date:0908312310 done date:0908312311 stat:DELIVRD err:xxx Text:Hello SMPP world!"));
         try {
             SmppMessage smppMessage = binding.createSmppMessage(deliverSm);
@@ -196,10 +196,10 @@ public class SmppBindingTest {
     }
 
     @Test
-    public void createSmppMessageFromDeliveryReceiptWithoutShortMessageShouldNotThrowException() {
+    public void createSmppMessageFromDeliveryReceiptWithoutShortMessageShouldNotThrowException() throws Exception {
         DeliverSm deliverSm = new DeliverSm();
         deliverSm.setSmscDeliveryReceipt();
-        deliverSm.setOptionalParametes(new OptionalParameter.Short((short) 0x2153, (short) 0));
+        deliverSm.setOptionalParameters(new OptionalParameter.Short((short) 0x2153, (short) 0));
 
         try {
             SmppMessage smppMessage = binding.createSmppMessage(deliverSm);
@@ -235,7 +235,7 @@ public class SmppBindingTest {
         assertEquals((byte) 8, smppMessage.getHeader(SmppConstants.SOURCE_ADDR_NPI));
         assertEquals((byte) 2, smppMessage.getHeader(SmppConstants.SOURCE_ADDR_TON));
         assertEquals("1919", smppMessage.getHeader(SmppConstants.DEST_ADDR));
-        assertEquals((byte) 20, smppMessage.getHeader(SmppConstants.DEST_ADDR_NPI));
+        assertEquals((byte) 14, smppMessage.getHeader(SmppConstants.DEST_ADDR_NPI));
         assertEquals((byte) 3, smppMessage.getHeader(SmppConstants.DEST_ADDR_TON));
         assertEquals("090831230627004+", smppMessage.getHeader(SmppConstants.SCHEDULE_DELIVERY_TIME));
         assertEquals("090901230627004+", smppMessage.getHeader(SmppConstants.VALIDITY_PERIOD));
@@ -257,7 +257,7 @@ public class SmppBindingTest {
         deliverSm.setScheduleDeliveryTime("090831230627004+");
         deliverSm.setValidityPeriod("090901230627004+");
         deliverSm.setServiceType("WAP");
-        deliverSm.setOptionalParametes(new OctetString(OptionalParameter.Tag.MESSAGE_PAYLOAD, "Hello SMPP world!"));
+        deliverSm.setOptionalParameters(new OctetString(OptionalParameter.Tag.MESSAGE_PAYLOAD, "Hello SMPP world!"));
         SmppMessage smppMessage = binding.createSmppMessage(deliverSm);
         
         assertEquals("Hello SMPP world!", smppMessage.getBody());
@@ -268,7 +268,7 @@ public class SmppBindingTest {
         assertEquals((byte) 8, smppMessage.getHeader(SmppConstants.SOURCE_ADDR_NPI));
         assertEquals((byte) 2, smppMessage.getHeader(SmppConstants.SOURCE_ADDR_TON));
         assertEquals("1919", smppMessage.getHeader(SmppConstants.DEST_ADDR));
-        assertEquals((byte) 20, smppMessage.getHeader(SmppConstants.DEST_ADDR_NPI));
+        assertEquals((byte) 14, smppMessage.getHeader(SmppConstants.DEST_ADDR_NPI));
         assertEquals((byte) 3, smppMessage.getHeader(SmppConstants.DEST_ADDR_TON));
         assertEquals("090831230627004+", smppMessage.getHeader(SmppConstants.SCHEDULE_DELIVERY_TIME));
         assertEquals("090901230627004+", smppMessage.getHeader(SmppConstants.VALIDITY_PERIOD));

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppComponentTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppComponentTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 import org.jsmpp.extra.SessionState;
+import org.jsmpp.session.Session;
 import org.jsmpp.session.SessionStateListener;
 import org.junit.Before;
 import org.junit.Test;
@@ -180,7 +181,8 @@ public class SmppComponentTest {
     public void createEndpointWithSessionStateListener() throws Exception {
         SimpleRegistry registry = new SimpleRegistry();
         registry.put("sessionStateListener", new SessionStateListener() {
-            public void onStateChange(SessionState arg0, SessionState arg1, Object arg2) {
+            @Override
+            public void onStateChange(SessionState arg0, SessionState arg1, Session arg2) {
             }
         });
         context.setRegistry(registry);

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppConfigurationTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppConfigurationTest.java
@@ -25,6 +25,7 @@ import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.SMSCDeliveryReceipt;
 import org.jsmpp.bean.TypeOfNumber;
 import org.jsmpp.extra.SessionState;
+import org.jsmpp.session.Session;
 import org.jsmpp.session.SessionStateListener;
 import org.junit.Before;
 import org.junit.Test;
@@ -233,7 +234,7 @@ public class SmppConfigurationTest {
         config.setHttpProxyUsername("user");
         config.setHttpProxyPassword("secret");
         config.setSessionStateListener(new SessionStateListener() {
-            public void onStateChange(SessionState arg0, SessionState arg1, Object arg2) {
+            public void onStateChange(SessionState arg0, SessionState arg1, Session arg2) {
             }
         });
         Map<String, String> proxyHeaders = new HashMap<String, String>();

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppConsumerTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppConsumerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.smpp;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.Processor;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.NumberingPlanIndicator;
@@ -28,7 +27,7 @@ import org.jsmpp.session.SessionStateListener;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.easymock.classextension.EasyMock.*;
+import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertSame;
 
 /**
@@ -43,7 +42,6 @@ public class SmppConsumerTest {
     private SmppConfiguration configuration;
     private Processor processor;
     private SMPPSession session;
-    private CamelContext camelContext;
 
     @Before
     public void setUp() {

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppDataSmCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppDataSmCommandTest.java
@@ -24,7 +24,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.OptionalParameter;
@@ -85,7 +85,7 @@ public class SmppDataSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.COMMAND, "DataSm");
         expect(session.dataShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()),
-                eq(new RegisteredDelivery((byte) 1)), eq(DataCoding.newInstance((byte) 0))))
+                eq(new RegisteredDelivery((byte) 1)), eq(DataCodings.newInstance((byte) 0))))
             .andReturn(new DataSmResult(new MessageId("1"), null));
 
         replay(session);
@@ -112,7 +112,7 @@ public class SmppDataSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
         expect(session.dataShortMessage(eq("XXX"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"), eq(new ESMClass()),
-                eq(new RegisteredDelivery((byte) 2)), eq(DataCoding.newInstance((byte) 0))))
+                eq(new RegisteredDelivery((byte) 2)), eq(DataCodings.newInstance((byte) 0))))
             .andReturn(new DataSmResult(new MessageId("1"), null));
 
         replay(session);
@@ -147,17 +147,19 @@ public class SmppDataSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.OPTIONAL_PARAMETERS, optionalParameters);
         expect(session.dataShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()),
-                eq(new RegisteredDelivery((byte) 1)), eq(DataCoding.newInstance((byte) 0)),
-                eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
-                eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")),
-                eq(new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4)),
-                eq(new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2)),
-                eq(new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000)),
-                eq(new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY))))
-            .andReturn(new DataSmResult(new MessageId("1"), new OptionalParameter[]{
-                new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292"), new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent"),
-                new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4), new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2),
-                new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000), new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY)}));
+                eq(new RegisteredDelivery((byte) 1)), eq(DataCodings.newInstance((byte) 0)),
+                eq(new OptionalParameter.Source_subaddress("1292".getBytes())),
+                eq(new OptionalParameter.Additional_status_info_text("urgent")),
+                eq(new OptionalParameter.Dest_addr_subunit((byte) 4)),
+                eq(new OptionalParameter.Dest_telematics_id((short) 2)),
+                eq(new OptionalParameter.Qos_time_to_live(3600000)),
+                eq(new OptionalParameter.Alert_on_message_delivery((byte) 0))))
+            .andReturn(new DataSmResult(new MessageId("1"), new OptionalParameter[] {new OptionalParameter.Source_subaddress("1292".getBytes()),
+                new OptionalParameter.Additional_status_info_text("urgent"),
+                new OptionalParameter.Dest_addr_subunit((byte) 4),
+                new OptionalParameter.Dest_telematics_id((short) 2),
+                new OptionalParameter.Qos_time_to_live(3600000),
+                new OptionalParameter.Alert_on_message_delivery((byte) 0)}));
 
         replay(session);
 
@@ -171,22 +173,20 @@ public class SmppDataSmCommandTest {
         Map<String, String> optParamMap = exchange.getOut().getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
         assertEquals(6, optParamMap.size());
         assertEquals("1292", optParamMap.get("SOURCE_SUBADDRESS"));
-        // FIXME: fix required in JSMPP. See http://code.google.com/p/jsmpp/issues/detail?id=140
-        //assertEquals("urgent", optParamMap.get("ADDITIONAL_STATUS_INFO_TEXT"));
+        assertEquals("urgent", optParamMap.get("ADDITIONAL_STATUS_INFO_TEXT"));
         assertEquals("4", optParamMap.get("DEST_ADDR_SUBUNIT"));
         assertEquals("2", optParamMap.get("DEST_TELEMATICS_ID"));
         assertEquals("3600000", optParamMap.get("QOS_TIME_TO_LIVE"));
-        assertNull(optParamMap.get("ALERT_ON_MESSAGE_DELIVERY"));
+        assertEquals("0", optParamMap.get("ALERT_ON_MESSAGE_DELIVERY"));
 
         Map<Short, Object> optionalResultParameter = exchange.getOut().getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         assertEquals(6, optionalResultParameter.size());
         assertArrayEquals("1292".getBytes("UTF-8"), (byte[]) optionalResultParameter.get(Short.valueOf((short) 0x0202)));
-        // FIXME: fix required in JSMPP. See http://code.google.com/p/jsmpp/issues/detail?id=140
-        //assertEquals("urgent", optionalResultParameter.get(Short.valueOf((short) 0x001D)));
+        assertEquals("urgent", optionalResultParameter.get(Short.valueOf((short) 0x001D)));
         assertEquals(Byte.valueOf((byte) 4), optionalResultParameter.get(Short.valueOf((short) 0x0005)));
         assertEquals(Short.valueOf((short) 2), optionalResultParameter.get(Short.valueOf((short) 0x0008)));
         assertEquals(Integer.valueOf(3600000), optionalResultParameter.get(Short.valueOf((short) 0x0017)));
-        assertNull(optionalResultParameter.get(Short.valueOf((short) 0x130C)));
+        assertEquals((byte) 0, optionalResultParameter.get(Short.valueOf((short) 0x130C)));
     }
 
     @SuppressWarnings("unchecked")
@@ -212,7 +212,7 @@ public class SmppDataSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.OPTIONAL_PARAMETER, optionalParameters);
         expect(session.dataShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()),
-                eq(new RegisteredDelivery((byte) 1)), eq(DataCoding.newInstance((byte) 0)),
+                eq(new RegisteredDelivery((byte) 1)), eq(DataCodings.newInstance((byte) 0)),
                 eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
                 eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")),
                 eq(new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4)),
@@ -226,9 +226,9 @@ public class SmppDataSmCommandTest {
                 eq(new OptionalParameter.Int((short) 0x2154, 7400000)),
                 eq(new OptionalParameter.Null((short) 0x2155))))
             .andReturn(new DataSmResult(new MessageId("1"), new OptionalParameter[]{
-                new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292"), new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent"),
-                new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4), new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2),
-                new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000), new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY)}));
+                new OptionalParameter.Source_subaddress("1292".getBytes()), new OptionalParameter.Additional_status_info_text("urgent"),
+                new OptionalParameter.Dest_addr_subunit((byte) 4), new OptionalParameter.Dest_telematics_id((short) 2),
+                new OptionalParameter.Qos_time_to_live(3600000), new OptionalParameter.Alert_on_message_delivery((byte) 0)}));
 
         replay(session);
 
@@ -242,21 +242,19 @@ public class SmppDataSmCommandTest {
         Map<String, String> optParamMap = exchange.getOut().getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
         assertEquals(6, optParamMap.size());
         assertEquals("1292", optParamMap.get("SOURCE_SUBADDRESS"));
-        // FIXME: fix required in JSMPP. See http://code.google.com/p/jsmpp/issues/detail?id=140
-        //assertEquals("urgent", optParamMap.get("ADDITIONAL_STATUS_INFO_TEXT"));
+        assertEquals("urgent", optParamMap.get("ADDITIONAL_STATUS_INFO_TEXT"));
         assertEquals("4", optParamMap.get("DEST_ADDR_SUBUNIT"));
         assertEquals("2", optParamMap.get("DEST_TELEMATICS_ID"));
         assertEquals("3600000", optParamMap.get("QOS_TIME_TO_LIVE"));
-        assertNull(optParamMap.get("ALERT_ON_MESSAGE_DELIVERY"));
+        assertEquals("0", optParamMap.get("ALERT_ON_MESSAGE_DELIVERY"));
 
         Map<Short, Object> optionalResultParameter = exchange.getOut().getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         assertEquals(6, optionalResultParameter.size());
         assertArrayEquals("1292".getBytes("UTF-8"), (byte[]) optionalResultParameter.get(Short.valueOf((short) 0x0202)));
-        // FIXME: fix required in JSMPP. See http://code.google.com/p/jsmpp/issues/detail?id=140
-        //assertEquals("urgent", optionalResultParameter.get(Short.valueOf((short) 0x001D)));
+        assertEquals("urgent", optionalResultParameter.get(Short.valueOf((short) 0x001D)));
         assertEquals(Byte.valueOf((byte) 4), optionalResultParameter.get(Short.valueOf((short) 0x0005)));
         assertEquals(Short.valueOf((short) 2), optionalResultParameter.get(Short.valueOf((short) 0x0008)));
         assertEquals(Integer.valueOf(3600000), optionalResultParameter.get(Short.valueOf((short) 0x0017)));
-        assertNull(optionalResultParameter.get(Short.valueOf((short) 0x130C)));
+        assertEquals((byte) 0, optionalResultParameter.get(Short.valueOf((short) 0x130C)));
     }
 }

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppMessageTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppMessageTest.java
@@ -124,6 +124,7 @@ public class SmppMessageTest {
             for (String encoding : encodings) {
                 config.setEncoding(encoding);
                 message = new SmppMessage(command, config);
+                
                 assertArrayEquals(
                     String.format("data coding=0x%02X; encoding=%s",
                                   dataCoding,

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitMultiCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitMultiCommandTest.java
@@ -28,7 +28,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.jsmpp.bean.Address;
 import org.jsmpp.bean.Alphabet;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.OptionalParameter;
@@ -95,8 +95,7 @@ public class SmppSubmitMultiCommandTest {
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 aryEq(new Address[]{new Address(TypeOfNumber.UNKNOWN, NumberingPlanIndicator.UNKNOWN, "1717")}),
                 eq(new ESMClass()), eq((byte) 0), eq((byte) 1), (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
-                eq(ReplaceIfPresentFlag.DEFAULT), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
-                aryEq(new OptionalParameter[0])))
+                eq(ReplaceIfPresentFlag.DEFAULT), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn(new SubmitMultiResult("1", new UnsuccessDelivery(new Address(TypeOfNumber.UNKNOWN, NumberingPlanIndicator.UNKNOWN, "1717"), 0)));
 
         replay(session);
@@ -131,8 +130,7 @@ public class SmppSubmitMultiCommandTest {
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
-                aryEq(new OptionalParameter[0])))
+                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -167,8 +165,7 @@ public class SmppSubmitMultiCommandTest {
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
-                aryEq(new OptionalParameter[0])))
+                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -184,7 +181,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void bodyWithSmscDefaultDataCodingNarrowedToCharset() throws Exception {
-        final int dataCoding = 0x00; /* SMSC-default */
+        final byte dataCoding = (byte)0x00; /* SMSC-default */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -210,10 +207,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(dataCoding)),
+                                      eq(DataCodings.newInstance(dataCoding)),
                                       eq((byte) 0),
-                                      aryEq(bodyNarrowed),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(bodyNarrowed)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -225,7 +221,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void bodyWithLatin1DataCodingNarrowedToCharset() throws Exception {
-        final int dataCoding = 0x03; /* ISO-8859-1 (Latin1) */
+        final byte dataCoding = (byte)0x03; /* ISO-8859-1 (Latin1) */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -251,10 +247,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(dataCoding)),
+                                      eq(DataCodings.newInstance(dataCoding)),
                                       eq((byte) 0),
-                                      aryEq(bodyNarrowed),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(bodyNarrowed)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -266,7 +261,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void bodyWithSMPP8bitDataCodingNotModified() throws Exception {
-        final int dataCoding = 0x04; /* SMPP 8-bit */
+        final byte dataCoding = (byte)0x04; /* SMPP 8-bit */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -291,10 +286,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(dataCoding)),
+                                      eq(DataCodings.newInstance(dataCoding)),
                                       eq((byte) 0),
-                                      aryEq(body),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(body)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -306,7 +300,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void bodyWithGSM8bitDataCodingNotModified() throws Exception {
-        final int dataCoding = 0xF7; /* GSM 8-bit class 3 */
+        final byte dataCoding = (byte)0xF7; /* GSM 8-bit class 3 */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -331,10 +325,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(dataCoding)),
+                                      eq(DataCodings.newInstance(dataCoding)),
                                       eq((byte) 0),
-                                      aryEq(body),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(body)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -346,7 +339,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void eightBitDataCodingOverridesDefaultAlphabet() throws Exception {
-        final int binDataCoding = 0x04; /* SMPP 8-bit */
+        final byte binDataCoding = (byte)0x04; /* SMPP 8-bit */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -372,10 +365,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(binDataCoding)),
+                                      eq(DataCodings.newInstance(binDataCoding)),
                                       eq((byte) 0),
-                                      aryEq(body),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(body)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -387,7 +379,7 @@ public class SmppSubmitMultiCommandTest {
 
     @Test
     public void latin1DataCodingOverridesEightBitAlphabet() throws Exception {
-        final int latin1DataCoding = 0x03; /* ISO-8859-1 (Latin1) */
+        final byte latin1DataCoding = (byte)0x03; /* ISO-8859-1 (Latin1) */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -414,10 +406,9 @@ public class SmppSubmitMultiCommandTest {
                                       (String) isNull(),
                                       eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                       eq(ReplaceIfPresentFlag.DEFAULT),
-                                      eq(DataCoding.newInstance(latin1DataCoding)),
+                                      eq(DataCodings.newInstance(latin1DataCoding)),
                                       eq((byte) 0),
-                                      aryEq(bodyNarrowed),
-                                      aryEq(new OptionalParameter[0])))
+                                      aryEq(bodyNarrowed)))
             .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -456,11 +447,13 @@ public class SmppSubmitMultiCommandTest {
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
-                aryEq(new OptionalParameter[]{new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292"),
-                    new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent"), new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4),
-                    new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2), new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000),
-                    new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY)})))
+                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
+                eq(new OptionalParameter.Source_subaddress("1292".getBytes())),
+                eq(new OptionalParameter.Additional_status_info_text("urgent".getBytes())),
+                eq(new OptionalParameter.Dest_addr_subunit((byte) 4)),
+                eq(new OptionalParameter.Dest_telematics_id((short) 2)),
+                eq(new OptionalParameter.Qos_time_to_live(3600000)),
+                eq(new OptionalParameter.Alert_on_message_delivery("O".getBytes()))))
                 .andReturn(new SubmitMultiResult("1"));
 
         replay(session);
@@ -511,20 +504,19 @@ public class SmppSubmitMultiCommandTest {
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
-                aryEq(new OptionalParameter[]{
-                    new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292"),
-                    new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent"),
-                    new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4),
-                    new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2),
-                    new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000),
-                    new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY),
-                    new OptionalParameter.OctetString((short) 0x2150, "1292", "UTF-8"),
-                    new OptionalParameter.COctetString((short) 0x2151, "0816"),
-                    new OptionalParameter.Byte((short) 0x2152, (byte) 6),
-                    new OptionalParameter.Short((short) 0x2153, (short) 9),
-                    new OptionalParameter.Int((short) 0x2154, 7400000),
-                    new OptionalParameter.Null((short) 0x2155)})))
+                eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
+                eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
+                eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")),
+                eq(new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4)),
+                eq(new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2)),
+                eq(new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000)),
+                eq(new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY)),
+                eq(new OptionalParameter.OctetString((short) 0x2150, "1292", "UTF-8")),
+                eq(new OptionalParameter.COctetString((short) 0x2151, "0816")),
+                eq(new OptionalParameter.Byte((short) 0x2152, (byte) 6)),
+                eq(new OptionalParameter.Short((short) 0x2153, (short) 9)),
+                eq(new OptionalParameter.Int((short) 0x2154, 7400000)),
+                eq(new OptionalParameter.Null((short) 0x2155))))
                 .andReturn(new SubmitMultiResult("1"));
 
         replay(session);

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitSmCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitSmCommandTest.java
@@ -27,7 +27,7 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.jsmpp.bean.Alphabet;
-import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DataCodings;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.OptionalParameter;
@@ -92,7 +92,7 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0),
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0),
                 aryEq("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890".getBytes())))
                 .andReturn("1");
 
@@ -122,12 +122,12 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
                 .andReturn("1");
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), eq(secondSM)))
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), eq(secondSM)))
                 .andReturn("2");
 
         replay(session);
@@ -156,12 +156,12 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
                 .andReturn("1");
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), eq(secondSM)))
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), eq(secondSM)))
                 .andReturn("2");
 
         replay(session);
@@ -189,7 +189,7 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"),
                 eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1),
                 (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)), eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
+                eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq(firstSM)))
                 .andReturn("1");
 
         replay(session);
@@ -223,7 +223,7 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
+                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn("1");
 
         replay(session);
@@ -265,11 +265,11 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0),
-                aryEq("short message body".getBytes()), eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
-                eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")), eq(new OptionalParameter.Byte(Tag.DEST_ADDR_SUBUNIT, (byte) 4)),
-                eq(new OptionalParameter.Short(Tag.DEST_TELEMATICS_ID.code(), (short) 2)), eq(new OptionalParameter.Int(Tag.QOS_TIME_TO_LIVE, 3600000)),
-                eq(new OptionalParameter.Null(Tag.ALERT_ON_MESSAGE_DELIVERY))))
+                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0),
+                aryEq("short message body".getBytes()), eq(new OptionalParameter.Source_subaddress("1292".getBytes())),
+                eq(new OptionalParameter.Additional_status_info_text("urgent".getBytes())), eq(new OptionalParameter.Dest_addr_subunit((byte) 4)),
+                eq(new OptionalParameter.Dest_telematics_id((short) 2)), eq(new OptionalParameter.Qos_time_to_live(3600000)),
+                eq(new OptionalParameter.Alert_on_message_delivery((byte) 0))))
                 .andReturn("1");
 
         replay(session);
@@ -319,7 +319,7 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0),
+                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0),
                 aryEq("short message body".getBytes()),
                 eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
                 eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")),
@@ -366,7 +366,7 @@ public class SmppSubmitSmCommandTest {
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
                 eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
-                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCoding.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
+                eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn("1");
 
         replay(session);
@@ -381,7 +381,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void alphabetUpdatesDataCoding() throws Exception {
-        final byte incorrectDataCoding = 0x00;
+        final byte incorrectDataCoding = (byte)0x00;
         byte[] body = {'A', 'B', 'C'};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -390,7 +390,7 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setBody(body);
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN), eq("1616"), eq(TypeOfNumber.UNKNOWN), eq(NumberingPlanIndicator.UNKNOWN),
                 eq("1717"), eq(new ESMClass()), eq((byte) 0), eq((byte) 1), (String) isNull(), (String) isNull(), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
-                eq(ReplaceIfPresentFlag.DEFAULT.value()), not(eq(DataCoding.newInstance(incorrectDataCoding))), eq((byte) 0), aryEq(body)))
+                eq(ReplaceIfPresentFlag.DEFAULT.value()), not(eq(DataCodings.newInstance(incorrectDataCoding))), eq((byte) 0), aryEq(body)))
                 .andReturn("1");
 
         replay(session);
@@ -402,7 +402,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void bodyWithSmscDefaultDataCodingNarrowedToCharset() throws Exception {
-        final int dataCoding = 0x00; /* SMSC-default */
+        final byte dataCoding = (byte)0x00; /* SMSC-default */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -424,7 +424,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(dataCoding)),
+                                          eq(DataCodings.newInstance(dataCoding)),
                                           eq((byte) 0),
                                           aryEq(bodyNarrowed)))
             .andReturn("1");
@@ -438,7 +438,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void bodyWithLatin1DataCodingNarrowedToCharset() throws Exception {
-        final int dataCoding = 0x03; /* ISO-8859-1 (Latin1) */
+        final byte dataCoding = (byte)0x03; /* ISO-8859-1 (Latin1) */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -460,7 +460,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(dataCoding)),
+                                          eq(DataCodings.newInstance(dataCoding)),
                                           eq((byte) 0),
                                           aryEq(bodyNarrowed)))
             .andReturn("1");
@@ -474,7 +474,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void bodyWithSMPP8bitDataCodingNotModified() throws Exception {
-        final int dataCoding = 0x04; /* SMPP 8-bit */
+        final byte dataCoding = (byte)0x04; /* SMPP 8-bit */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -495,7 +495,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(dataCoding)),
+                                          eq(DataCodings.newInstance(dataCoding)),
                                           eq((byte) 0),
                                           aryEq(body)))
             .andReturn("1");
@@ -509,7 +509,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void bodyWithGSM8bitDataCodingNotModified() throws Exception {
-        final int dataCoding = 0xF7; /* GSM 8-bit class 3 */
+        final byte dataCoding = (byte)0xF7; /* GSM 8-bit class 3 */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -530,7 +530,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(dataCoding)),
+                                          eq(DataCodings.newInstance(dataCoding)),
                                           eq((byte) 0),
                                           aryEq(body)))
             .andReturn("1");
@@ -544,7 +544,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void eightBitDataCodingOverridesDefaultAlphabet() throws Exception {
-        final int binDataCoding = 0x04; /* SMPP 8-bit */
+        final byte binDataCoding = (byte)0x04; /* SMPP 8-bit */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
 
         Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
@@ -566,7 +566,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(binDataCoding)),
+                                          eq(DataCodings.newInstance(binDataCoding)),
                                           eq((byte) 0),
                                           aryEq(body)))
             .andReturn("1");
@@ -580,7 +580,7 @@ public class SmppSubmitSmCommandTest {
 
     @Test
     public void latin1DataCodingOverridesEightBitAlphabet() throws Exception {
-        final int latin1DataCoding = 0x03; /* ISO-8859-1 (Latin1) */
+        final byte latin1DataCoding = (byte)0x03; /* ISO-8859-1 (Latin1) */
         byte[] body = {(byte)0xFF, 'A', 'B', (byte)0x00, (byte)0xFF, (byte)0x7F, 'C', (byte)0xFF};
         byte[] bodyNarrowed = {'?', 'A', 'B', '\0', '?', (byte)0x7F, 'C', '?'};
 
@@ -603,7 +603,7 @@ public class SmppSubmitSmCommandTest {
                                           (String) isNull(),
                                           eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS_FAILURE)),
                                           eq(ReplaceIfPresentFlag.DEFAULT.value()),
-                                          eq(DataCoding.newInstance(latin1DataCoding)),
+                                          eq(DataCodings.newInstance(latin1DataCoding)),
                                           eq((byte) 0),
                                           aryEq(bodyNarrowed)))
             .andReturn("1");

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppUtilsTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppUtilsTest.java
@@ -20,7 +20,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.jsmpp.bean.Alphabet;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,25 +62,5 @@ public class SmppUtilsTest {
         assertEquals(10, calendar.get(Calendar.HOUR));
         assertEquals(10, calendar.get(Calendar.MINUTE));
         assertEquals(0, calendar.get(Calendar.SECOND));
-    }
-    
-    @Test
-    public void parseAlphabetFromDataCoding() {
-        assertEquals(Alphabet.ALPHA_DEFAULT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x00));
-        assertEquals(Alphabet.ALPHA_DEFAULT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x01));
-        assertEquals(Alphabet.ALPHA_DEFAULT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x03));
-
-        assertEquals(Alphabet.ALPHA_8_BIT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x02));
-        assertEquals(Alphabet.ALPHA_8_BIT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x04));
-        assertEquals(Alphabet.ALPHA_8_BIT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x05));
-        assertEquals(Alphabet.ALPHA_8_BIT, SmppUtils.parseAlphabetFromDataCoding((byte) 0x07));
-
-        assertEquals(Alphabet.ALPHA_UCS2, SmppUtils.parseAlphabetFromDataCoding((byte) 0x08));
-        assertEquals(Alphabet.ALPHA_UCS2, SmppUtils.parseAlphabetFromDataCoding((byte) 0x09));
-        assertEquals(Alphabet.ALPHA_UCS2, SmppUtils.parseAlphabetFromDataCoding((byte) 0x0b));
-
-        assertEquals(Alphabet.ALPHA_RESERVED, SmppUtils.parseAlphabetFromDataCoding((byte) 0x0c));
-        assertEquals(Alphabet.ALPHA_RESERVED, SmppUtils.parseAlphabetFromDataCoding((byte) 0x0d));
-        assertEquals(Alphabet.ALPHA_RESERVED, SmppUtils.parseAlphabetFromDataCoding((byte) 0xff));
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -326,7 +326,7 @@
     <josql-version>1.5</josql-version>
     <jruby-version>1.7.18</jruby-version>
     <jsendnsca-version>1.3.1</jsendnsca-version>
-    <jsmpp-version>2.1.1</jsmpp-version>
+    <jsmpp-version>2.2.3</jsmpp-version>
     <jsch-version>0.1.53</jsch-version>
     <jsch-bundle-version>0.1.53_1</jsch-bundle-version>
     <jsendnsca-bundle-version>1.3.1_3</jsendnsca-bundle-version>


### PR DESCRIPTION
Note: Not ready to merge. There are still six failing tests:

>Failed tests:
  SmppBindingTest.createSmppMessageFrom8bitDataCodingDeliverSmShouldNotModifyBody:338 data coding=0xF6; encoding=Big5: actual array was null

>SmppMessageTest.createBodyShouldNotMangle8bitDataCodingShortMessage:130 data coding=0xF6; encoding=Big5: array lengths differed, expected.length=8 a
ctual.length=6

>SmppReplaceSmCommandTest.eightBitDataCodingOverridesDefaultAlphabet:274
  Unexpected method call SMPPSession.replaceShortMessage(null, UNKNOWN, UNKNOWN, "1616", null, null, org.jsmpp.bean.RegisteredDelivery@1, 0, [63, 65,
66, 0, 63, 127, 67, 63]):
    SMPPSession.replaceShortMessage(isNull(), UNKNOWN, UNKNOWN, "1616", isNull(), isNull(), org.jsmpp.bean.RegisteredDelivery@1, 0, [-1, 65, 66, 0, -1
, 127, 67, -1]): expected: 1, actual: 0

>SmppReplaceSmCommandTest.bodyWithGSM8bitDataCodingNotModified:246
  Unexpected method call SMPPSession.replaceShortMessage(null, UNKNOWN, UNKNOWN, "1616", null, null, org.jsmpp.bean.RegisteredDelivery@1, 0, [63, 65,
66, 0, 63, 127, 67, 63]):

>SMPPSession.replaceShortMessage(isNull(), UNKNOWN, UNKNOWN, "1616", isNull(), isNull(), org.jsmpp.bean.RegisteredDelivery@1, 0, [-1, 65, 66, 0, -1
, 127, 67, -1]): expected: 1, actual: 0

>SmppSubmitMultiCommandTest.bodyWithGSM8bitDataCodingNotModified:336
  Unexpected method call SMPPSession.submitMultiple("CMT", UNKNOWN, UNKNOWN, "1616", [org.jsmpp.bean.Address@bac86b6d], org.jsmpp.bean.ESMClass@1, 0,
1, null, null, org.jsmpp.bean.RegisteredDelivery@1, org.jsmpp.bean.ReplaceIfPresentFlag@1, DataCoding:247, 0, [63, 65, 66, 0, 63, 127, 67, 63]):
    SMPPSession.submitMultiple("CMT", UNKNOWN, UNKNOWN, "1616", [org.jsmpp.bean.Address@bac86b6d], org.jsmpp.bean.ESMClass@1, 0, 1, isNull(), isNull()
, org.jsmpp.bean.RegisteredDelivery@1, org.jsmpp.bean.ReplaceIfPresentFlag@1, DataCoding:247, 0, [-1, 65, 66, 0, -1, 127, 67, -1]): expected: 1, actual: 0

>SmppSubmitSmCommandTest.bodyWithGSM8bitDataCodingNotModified:540
  Unexpected method call SMPPSession.submitShortMessage("CMT", UNKNOWN, UNKNOWN, "1616", UNKNOWN, UNKNOWN, "1717", org.jsmpp.bean.ESMClass@1, 0, 1, nu
ll, null, org.jsmpp.bean.RegisteredDelivery@1, 0, DataCoding:247, 0, [63, 65, 66, 0, 63, 127, 67, 63]):
    SMPPSession.submitShortMessage("CMT", UNKNOWN, UNKNOWN, "1616", UNKNOWN, UNKNOWN, "1717", org.jsmpp.bean.ESMClass@1, 0, 1, isNull(), isNull(), org
.jsmpp.bean.RegisteredDelivery@1, 0, DataCoding:247, 0, [-1, 65, 66, 0, -1, 127, 67, -1]): expected: 1, actual: 0

Any tips/help with these would be greatly appreciated. :)