### PR TITLE
CAMEL-6132 - Initial version of camel-test-karaf

### DIFF
--- a/components/camel-test-karaf/pom.xml
+++ b/components/camel-test-karaf/pom.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>components</artifactId>
+    <version>2.18-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-test-karaf</artifactId>
+  <name>Camel :: Test :: Karaf</name>
+  <packaging>bundle</packaging>
+  <description>Camel Testing Library using Pax Exam, Karaf and JUnit</description>
+
+  <properties>
+    <karf-test-version>${karaf4-version}</karf-test-version>
+    <depends-maven-plugin-version>1.3.1</depends-maven-plugin-version>
+    <camel.osgi.export.pkg>org.apache.camel.test.karaf</camel.osgi.export.pkg>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-karaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.karaf.features</groupId>
+      <artifactId>org.apache.karaf.features.core</artifactId>
+      <version>${karaf-version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.karaf</groupId>
+      <artifactId>apache-karaf</artifactId>
+      <version>${karf-test-version}</version>
+      <type>tar.gz</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.configadmin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.karaf</groupId>
+      <artifactId>apache-camel</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <!-- test and logging -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Eclipse m2e Lifecycle Management -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>${lifecycle-mapping-version}</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.servicemix.tooling</groupId>
+                    <artifactId>depends-maven-plugin</artifactId>
+                    <versionRange>${depends-maven-plugin-version}</versionRange>
+                    <goals>
+                      <goal>generate-depends-file</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore/>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!-- generate dependencies versions -->
+      <plugin>
+        <groupId>org.apache.servicemix.tooling</groupId>
+        <artifactId>depends-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-depends-file</id>
+            <goals>
+              <goal>generate-depends-file</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!-- version 2.19.1 causes pax-exam to fail when testing the 2nd/3rd container when testing all  -->
+        <!-- so we use an older version of surefire which works -->
+        <version>2.18.1</version>
+        <configuration>
+          <!-- do not re-run these tests -->
+          <!-- not supported by older version of surefire -->
+          <!--<rerunFailingTestsCount>0</rerunFailingTestsCount>-->
+          <systemPropertyVariables>
+            <karafVersion>${karaf-version}</karafVersion>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <configuration>
+              <instructions>
+                  <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                  <!-- Export-Package>org.apache.camel.test.karaf</Export-Package -->>
+                  <DynamicImport-Package>*</DynamicImport-Package>
+                  <Import-Package/>
+                  <_removeheaders>Import-Package, Private-Package, Include-Resource, Karaf-Info, Require-Capability</_removeheaders>
+              </instructions>
+          </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>ci-build-profile</id>
+      <activation>
+        <property>
+          <name>maven.repo.local</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <!-- version 2.19.1 causes pax-exam to fail when testing the 2nd/3rd container when testing all  -->
+            <!-- so we use an older version of surefire which works -->
+            <version>2.18.1</version>
+            <configuration>
+              <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+              <!--
+                  when the local repo location has been specified, we need to pass
+                  on this information to PAX mvn url
+              -->
+              <argLine>-Dorg.ops4j.pax.url.mvn.localRepository=${maven.repo.local}</argLine>
+              <systemPropertyVariables>
+                <karafVersion>${karaf-version}</karafVersion>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- test with older karaf 3.x -->
+    <profile>
+      <id>karaf3</id>
+      <properties>
+        <karf-test-version>${karaf3-version}</karf-test-version>
+      </properties>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/components/camel-test-karaf/pom.xml
+++ b/components/camel-test-karaf/pom.xml
@@ -28,7 +28,7 @@
 
   <artifactId>camel-test-karaf</artifactId>
   <name>Camel :: Test :: Karaf</name>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <description>Camel Testing Library using Pax Exam, Karaf and JUnit</description>
 
   <properties>

--- a/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
+++ b/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
@@ -63,6 +63,7 @@ import static org.ops4j.pax.exam.CoreOptions.vmOption;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 public abstract class AbstractFeatureTest {
 
@@ -233,6 +234,7 @@ public abstract class AbstractFeatureTest {
                     .karafVersion(karafVersion)
                     .name("Apache Karaf")
                     .useDeployFolder(false).unpackDirectory(new File("target/paxexam/unpack/")),
+            logLevel(LogLevelOption.LogLevel.WARN),
 
             // keep the folder so we can look inside when something fails
             keepRuntimeFolder(),
@@ -249,7 +251,7 @@ public abstract class AbstractFeatureTest {
             editConfigurationFilePut("etc/custom.properties", "karaf.shutdown.port", "-1"),
 
             // Assign unique ports for Karaf
-            editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", Integer.toString(AvailablePortFinder.getNextAvailable()) ),
+            editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", Integer.toString(AvailablePortFinder.getNextAvailable())),
             editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort", Integer.toString(AvailablePortFinder.getNextAvailable())),
             editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort", Integer.toString(AvailablePortFinder.getNextAvailable())),
 

--- a/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/CamelKarafTestSupport.java
+++ b/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/CamelKarafTestSupport.java
@@ -1,7 +1,10 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -32,7 +35,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
-
 import javax.inject.Inject;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -57,10 +59,13 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 
-import org.junit.Assert;
-
+import static org.junit.Assert.fail;
 import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
 
 /*
    TODO:  This file is a copy of KarafTestSupport.java from the Karaf 4 repository.  
@@ -72,7 +77,7 @@ public class CamelKarafTestSupport {
     static final Long COMMAND_TIMEOUT = 30000L;
     static final Long SERVICE_TIMEOUT = 30000L;
 
-    ExecutorService executor = Executors.newCachedThreadPool();
+    protected ExecutorService executor = Executors.newCachedThreadPool();
 
     @Inject
     protected BundleContext bundleContext;
@@ -326,7 +331,7 @@ public class CamelKarafTestSupport {
                 return;
             }
         }
-        Assert.fail("Feature " + featureName + " should be installed but is not");
+        fail("Feature " + featureName + " should be installed but is not");
     }
 
     public void assertFeatureInstalled(String featureName, String featureVersion) {
@@ -336,7 +341,7 @@ public class CamelKarafTestSupport {
                 return;
             }
         }
-        Assert.fail("Feature " + featureName + "/" + featureVersion + " should be installed but is not");
+        fail("Feature " + featureName + "/" + featureVersion + " should be installed but is not");
     }
     
     protected void installAndAssertFeature(String feature) throws Exception {

--- a/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/CamelKarafTestSupport.java
+++ b/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/CamelKarafTestSupport.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.karaf;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URL;
+import java.security.Principal;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.security.auth.Subject;
+
+import org.apache.felix.service.command.CommandProcessor;
+import org.apache.felix.service.command.CommandSession;
+import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeaturesService;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.MavenUtils;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.ProbeBuilder;
+import org.ops4j.pax.exam.TestProbeBuilder;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import org.junit.Assert;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
+
+/*
+   TODO:  This file is a copy of KarafTestSupport.java from the Karaf 4 repository.  
+   Eventually there will be a karaf-test module that contains this class, and we'll
+   be able to use that.  For now, use this as a starting point.
+*/
+public class CamelKarafTestSupport {
+
+    static final Long COMMAND_TIMEOUT = 30000L;
+    static final Long SERVICE_TIMEOUT = 30000L;
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+
+    @Inject
+    protected BundleContext bundleContext;
+
+    @Inject
+    protected FeaturesService featuresService;
+
+    @ProbeBuilder
+    public TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
+        probe.setHeader(Constants.DYNAMICIMPORT_PACKAGE, "*,org.apache.felix.service.*;status=provisional");
+        return probe;
+    }
+
+    public File getConfigFile(String path) {
+        URL res = this.getClass().getResource(path);
+        if (res == null) {
+            throw new RuntimeException("Config resource " + path + " not found");
+        }
+        return new File(res.getFile());
+    }
+
+    @Configuration
+    public Option[] config() {
+        return new Option[]{
+                // KarafDistributionOption.debugConfiguration("8889", true),
+                karafDistributionConfiguration().frameworkUrl(maven().groupId("org.apache.karaf").artifactId("apache-karaf").versionAsInProject().type("tar.gz"))
+                        .karafVersion(MavenUtils.getArtifactVersion("org.apache.karaf", "apache-karaf")).name("Apache Karaf").unpackDirectory(new File("target/exam")),
+                keepRuntimeFolder(),
+                logLevel(LogLevelOption.LogLevel.INFO),
+                replaceConfigurationFile("etc/org.ops4j.pax.logging.cfg", getConfigFile("/etc/org.ops4j.pax.logging.cfg")),
+                editConfigurationFilePut("etc/system.properties", "hibernate3.version", System.getProperty("hibernate3.version")),
+                editConfigurationFilePut("etc/system.properties", "hibernate42.version", System.getProperty("hibernate42.version")),
+                editConfigurationFilePut("etc/system.properties", "hibernate43.version", System.getProperty("hibernate43.version")),
+                editConfigurationFilePut("etc/system.properties", "spring31.version", System.getProperty("spring31.version")),
+                editConfigurationFilePut("etc/system.properties", "spring32.version", System.getProperty("spring32.version")),
+                editConfigurationFilePut("etc/system.properties", "spring40.version", System.getProperty("spring40.version")),
+                editConfigurationFilePut("etc/system.properties", "spring41.version", System.getProperty("spring41.version"))
+        };
+    }
+
+    /**
+     * Executes a shell command and returns output as a String.
+     * Commands have a default timeout of 10 seconds.
+     *
+     * @param command The command to execute
+     * @param principals The principals (e.g. RolePrincipal objects) to run the command under
+     * @return
+     */
+    protected String executeCommand(final String command, Principal ... principals) {
+        return executeCommand(command, COMMAND_TIMEOUT, false, principals);
+    }
+
+    /**
+     * Executes a shell command and returns output as a String.
+     * Commands have a default timeout of 10 seconds.
+     *
+     * @param command    The command to execute.
+     * @param timeout    The amount of time in millis to wait for the command to execute.
+     * @param silent     Specifies if the command should be displayed in the screen.
+     * @param principals The principals (e.g. RolePrincipal objects) to run the command under
+     * @return
+     */
+    protected String executeCommand(final String command, final Long timeout, final Boolean silent, final Principal ... principals) {
+
+        waitForCommandService(command);
+        String response;
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final PrintStream printStream = new PrintStream(byteArrayOutputStream);
+        final Callable<String> commandCallable = new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                try {
+                    if (!silent) {
+                        System.err.println(command);
+                    }
+                    final CommandProcessor commandProcessor = getOsgiService(CommandProcessor.class);
+                    final CommandSession commandSession = commandProcessor.createSession(System.in, printStream, System.err);
+                    commandSession.execute(command);
+                } catch (Exception e) {
+                    throw new RuntimeException(e.getMessage(), e);
+                }
+                printStream.flush();
+                return byteArrayOutputStream.toString();
+            }
+        };
+
+        FutureTask<String> commandFuture;
+        if (principals.length == 0) {
+            commandFuture = new FutureTask<String>(commandCallable);
+        } else {
+            // If principals are defined, run the command callable via Subject.doAs()
+            commandFuture = new FutureTask<String>(new Callable<String>() {
+                @Override
+                public String call() throws Exception {
+                    Subject subject = new Subject();
+                    subject.getPrincipals().addAll(Arrays.asList(principals));
+                    return Subject.doAs(subject, new PrivilegedExceptionAction<String>() {
+                        @Override
+                        public String run() throws Exception {
+                            return commandCallable.call();
+                        }
+                    });
+                }
+            });
+        }
+
+
+        try {
+            executor.submit(commandFuture);
+            response = commandFuture.get(timeout, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+            response = "SHELL COMMAND TIMED OUT: ";
+        }
+
+        return response;
+    }
+
+    private void waitForCommandService(String command) {
+        // the commands are represented by services. Due to the asynchronous nature of services they may not be
+        // immediately available. This code waits the services to be available, in their secured form. It
+        // means that the code waits for the command service to appear with the roles defined.
+    
+        if (command == null || command.length() == 0) {
+            return;
+        }
+       
+        int spaceIdx = command.indexOf(' ');
+        if (spaceIdx > 0) {
+            command = command.substring(0, spaceIdx);
+        }
+        int colonIndx = command.indexOf(':');
+        
+        try {
+            if (colonIndx > 0) {
+                String scope = command.substring(0, colonIndx);
+                String function = command.substring(colonIndx + 1);
+                waitForService("(&(osgi.command.scope=" + scope + ")(osgi.command.function=" + function + "))", SERVICE_TIMEOUT);
+            } else {
+                waitForService("(osgi.command.function=" + command + ")", SERVICE_TIMEOUT);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+        
+    private void waitForService(String filter, long timeout) throws InvalidSyntaxException,
+        InterruptedException {
+        
+        ServiceTracker st = new ServiceTracker(bundleContext,
+                                               bundleContext.createFilter(filter),
+                                               null);
+        
+        try {
+            st.open();
+            st.waitForService(timeout);
+        } finally {
+            st.close();
+        }
+    }
+
+    protected <T> T getOsgiService(Class<T> type, long timeout) {
+        return getOsgiService(type, null, timeout);
+    }
+
+    protected <T> T getOsgiService(Class<T> type) {
+        return getOsgiService(type, null, SERVICE_TIMEOUT);
+    }
+
+    protected <T> T getOsgiService(Class<T> type, String filter, long timeout) {
+        ServiceTracker tracker = null;
+        try {
+            String flt;
+            if (filter != null) {
+                if (filter.startsWith("(")) {
+                    flt = "(&(" + Constants.OBJECTCLASS + "=" + type.getName() + ")" + filter + ")";
+                } else {
+                    flt = "(&(" + Constants.OBJECTCLASS + "=" + type.getName() + ")(" + filter + "))";
+                }
+            } else {
+                flt = "(" + Constants.OBJECTCLASS + "=" + type.getName() + ")";
+            }
+            Filter osgiFilter = FrameworkUtil.createFilter(flt);
+            tracker = new ServiceTracker(bundleContext, osgiFilter, null);
+            tracker.open(true);
+            // Note that the tracker is not closed to keep the reference
+            // This is buggy, as the service reference may change i think
+            Object svc = type.cast(tracker.waitForService(timeout));
+            if (svc == null) {
+                Dictionary dic = bundleContext.getBundle().getHeaders();
+                System.err.println("Test bundle headers: " + explode(dic));
+
+                for (ServiceReference ref : asCollection(bundleContext.getAllServiceReferences(null, null))) {
+                    System.err.println("ServiceReference: " + ref);
+                }
+
+                for (ServiceReference ref : asCollection(bundleContext.getAllServiceReferences(null, flt))) {
+                    System.err.println("Filtered ServiceReference: " + ref);
+                }
+
+                throw new RuntimeException("Gave up waiting for service " + flt);
+            }
+            return type.cast(svc);
+        } catch (InvalidSyntaxException e) {
+            throw new IllegalArgumentException("Invalid filter", e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /*
+    * Explode the dictionary into a ,-delimited list of key=value pairs
+    */
+    private static String explode(Dictionary dictionary) {
+        Enumeration keys = dictionary.keys();
+        StringBuffer result = new StringBuffer();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            result.append(String.format("%s=%s", key, dictionary.get(key)));
+            if (keys.hasMoreElements()) {
+                result.append(", ");
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Provides an iterable collection of references, even if the original array is null
+     */
+    private static Collection<ServiceReference> asCollection(ServiceReference[] references) {
+        return references != null ? Arrays.asList(references) : Collections.<ServiceReference>emptyList();
+    }
+
+    public JMXConnector getJMXConnector() throws Exception {
+        return getJMXConnector("karaf", "karaf");
+    }
+
+    public JMXConnector getJMXConnector(String userName, String passWord) throws Exception {
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:1099/karaf-root");
+        Hashtable env = new Hashtable();
+        String[] credentials = new String[]{userName, passWord};
+        env.put("jmx.remote.credentials", credentials);
+        JMXConnector connector = JMXConnectorFactory.connect(url, env);
+        return connector;
+    }
+
+    public void assertFeatureInstalled(String featureName) {
+        Feature[] features = featuresService.listInstalledFeatures();
+        for (Feature feature : features) {
+            if (featureName.equals(feature.getName())) {
+                return;
+            }
+        }
+        Assert.fail("Feature " + featureName + " should be installed but is not");
+    }
+
+    public void assertFeatureInstalled(String featureName, String featureVersion) {
+        Feature[] features = featuresService.listInstalledFeatures();
+        for (Feature feature : features) {
+            if (featureName.equals(feature.getName()) && featureVersion.equals(feature.getVersion())) {
+                return;
+            }
+        }
+        Assert.fail("Feature " + featureName + "/" + featureVersion + " should be installed but is not");
+    }
+    
+    protected void installAndAssertFeature(String feature) throws Exception {
+        featuresService.installFeature(feature);
+        assertFeatureInstalled(feature);
+    }
+
+    protected void installAndAssertFeature(String feature, String version) throws Exception {
+        featuresService.installFeature(feature, version);
+        assertFeatureInstalled(feature, version);
+    }
+
+    protected void installAssertAndUninstallFeature(String feature) throws Exception {
+        Set<Feature> featuresBefore = new HashSet<Feature>(Arrays.asList(featuresService.listInstalledFeatures()));
+        try {
+            featuresService.installFeature(feature);
+            assertFeatureInstalled(feature);
+        } finally {
+            uninstallNewFeatures(featuresBefore);
+        }
+    }
+
+    protected void installAssertAndUninstallFeature(String feature, String version) throws Exception {
+        Set<Feature> featuresBefore = new HashSet<Feature>(Arrays.asList(featuresService.listInstalledFeatures()));
+        try {
+            featuresService.installFeature(feature, version);
+            assertFeatureInstalled(feature, version);
+        } finally {
+            uninstallNewFeatures(featuresBefore);
+        }
+    }
+
+    protected void installAssertAndUninstallFeatures(String... feature) throws Exception {
+        Set<Feature> featuresBefore = new HashSet<Feature>(Arrays.asList(featuresService.listInstalledFeatures()));
+        try {
+            for (String curFeature : feature) {
+                featuresService.installFeature(curFeature);
+                assertFeatureInstalled(curFeature);
+            }
+        } finally {
+            uninstallNewFeatures(featuresBefore);
+        }
+    }
+
+    /**
+     * The feature service does not uninstall feature dependencies when uninstalling a single feature.
+     * So we need to make sure we uninstall all features that were newly installed.
+     *
+     * @param featuresBefore
+     */
+    protected void uninstallNewFeatures(Set<Feature> featuresBefore) {
+        Feature[] features = featuresService.listInstalledFeatures();
+        for (Feature curFeature : features) {
+            if (!featuresBefore.contains(curFeature)) {
+                try {
+                    System.out.println("Uninstalling " + curFeature.getName());
+                    featuresService.uninstallFeature(curFeature.getName(), curFeature.getVersion());
+                } catch (Exception e) {
+                    // e.printStackTrace();
+                }
+            }
+        }
+    }
+
+}

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -37,6 +37,7 @@
     <module>camel-testng</module>
     <module>camel-test-blueprint</module>
     <module>camel-test-cdi</module>
+    <module>camel-test-karaf</module>
     <module>camel-test-spring</module>
     <module>camel-test-spring40</module>
     <module>camel-core-osgi</module>

--- a/tests/camel-itest-karaf/pom.xml
+++ b/tests/camel-itest-karaf/pom.xml
@@ -36,6 +36,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-karaf</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-junit4</artifactId>
       <scope>test</scope>

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAhcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAhcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcWsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcWsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAhcWsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcWsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAhcWsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAhcWsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAmqpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAmqpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAmqpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAmqpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAmqpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAmqpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelApnsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelApnsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelApnsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelApnsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelApnsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelApnsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtmosphereWebsocketTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtmosphereWebsocketTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAtmosphereWebsocketTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtmosphereWebsocketTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtmosphereWebsocketTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAtmosphereWebsocketTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtomTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtomTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAtomTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtomTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAtomTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAtomTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAvroTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAvroTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAvroTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAvroTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAvroTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAvroTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAwsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAwsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAwsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAwsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelAwsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelAwsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBamTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBamTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBarcodeTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBarcodeTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBarcodeTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBarcodeTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBarcodeTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBarcodeTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBase64Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBase64Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBase64Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBase64Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBase64Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBase64Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanValidatorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanValidatorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanValidatorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanValidatorTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanValidatorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanioTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanioTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanioTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanioTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanioTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanioTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanstalkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanstalkTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanstalkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanstalkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBeanstalkTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBeanstalkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBindyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBindyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBindyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBindyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBindyTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBindyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoonTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBoonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoonTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBoonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBoxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBoxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBraintreeTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBraintreeTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBraintreeTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBraintreeTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBraintreeTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelBraintreeTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCacheTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCacheTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCassandraqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCassandraqlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCassandraqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCassandraqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCassandraqlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCassandraqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCastorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCastorTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCastorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCastorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCastorTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCastorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelChunkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelChunkTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelChunkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelChunkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelChunkTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelChunkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmSmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmSmsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCmSmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmSmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmSmsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCmSmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmisTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCmisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCmisTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCmisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCometdTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCometdTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCometdTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCometdTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCometdTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCometdTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelContextTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelContextTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelContextTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelContextTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelContextTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelContextTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCouchDBTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCouchDBTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCouchDBTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCouchDBTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCouchDBTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCouchDBTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCryptoTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCryptoTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCryptoTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCryptoTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCryptoTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCryptoTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCsvTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCsvTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCsvTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCsvTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCsvTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCsvTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCxfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCxfTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCxfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCxfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelCxfTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelCxfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDisruptorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDisruptorTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDisruptorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDisruptorTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDisruptorTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDisruptorTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDnsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDnsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDnsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDnsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDnsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDnsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDockerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDockerTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("camel-docker do not work in OSGi")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDockerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDockerTest.java
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("camel-docker do not work in OSGi")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDozerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDozerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDozerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDozerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDozerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDozerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDropboxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDropboxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDropboxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDropboxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelDropboxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelDropboxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElasticsearchTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElasticsearchTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelElasticsearchTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElasticsearchTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElasticsearchTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelElasticsearchTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElsqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElsqlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelElsqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElsqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelElsqlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelElsqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEtcdTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEtcdTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelEtcdTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEtcdTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEtcdTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelEtcdTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEventadminTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEventadminTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelEventadminTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEventadminTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelEventadminTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelEventadminTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelExecTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelExecTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelExecTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelExecTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelExecTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelExecTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFacebookTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFacebookTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFacebookTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFacebookTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFacebookTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFacebookTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFlatpackTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFlatpackTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFlatpackTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFlatpackTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFlatpackTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFlatpackTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFopTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFopTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFopTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFopTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFopTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFopTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFreemarkerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFreemarkerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFreemarkerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFreemarkerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFreemarkerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFreemarkerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFtpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFtpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFtpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFtpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelFtpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelFtpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGangliaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGangliaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGangliaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGangliaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGangliaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGangliaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGeocoderTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGeocoderTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGeocoderTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGeocoderTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGeocoderTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGeocoderTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGitTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGitTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGitTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGitTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGitTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGitTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGithubTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGithubTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGithubTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGithubTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGithubTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGithubTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleCalendarTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleCalendarTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleCalendarTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleCalendarTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleCalendarTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleCalendarTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleDriveTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleDriveTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleDriveTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleDriveTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleDriveTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleDriveTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleMailTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleMailTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleMailTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleMailTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGoogleMailTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGoogleMailTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGroovyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGroovyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGroovyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGroovyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGroovyTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGroovyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGsonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGsonTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGsonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGsonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGsonTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGsonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuavaEventBusTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuavaEventBusTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGuavaEventBusTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuavaEventBusTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuavaEventBusTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelGuavaEventBusTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuiceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuiceTest.java
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("camel-guice does not work in OSGi")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuiceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelGuiceTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("camel-guice does not work in OSGi")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHazelcastTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHazelcastTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHazelcastTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHazelcastTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHazelcastTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHazelcastTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHbaseTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHbaseTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need OSGi bundles of hadoop, and it does not run well in OSGi neither")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHbaseTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHbaseTest.java
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need OSGi bundles of hadoop, and it does not run well in OSGi neither")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfs2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfs2Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHdfs2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfs2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfs2Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHdfs2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHdfsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHdfsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHdfsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHessianTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHessianTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHessianTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHessianTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHessianTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHessianTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHipchatTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHipchatTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHipchatTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHipchatTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHipchatTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHipchatTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHl7Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHl7Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHl7Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHl7Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHl7Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHl7Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttp4Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttp4Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHttp4Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttp4Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttp4Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHttp4Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHttpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelHttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHystrixTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHystrixTest.java
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need a new hystrix SMX bundle")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHystrixTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelHystrixTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need a new hystrix SMX bundle")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIbatisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIbatisTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIbatisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIbatisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIbatisTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIbatisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIcalTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIcalTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIcalTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIcalTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIcalTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIcalTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIgniteTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIgniteTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIgniteTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIgniteTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIgniteTest.java
@@ -18,10 +18,10 @@ package org.apache.camel.itest.karaf;
 
 import java.net.URI;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIgniteTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelInfinispanTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelInfinispanTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelInfinispanTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelInfinispanTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelInfinispanTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
-import org.junit.Test;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
+ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelInfinispanTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIrcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIrcTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIrcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIrcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelIrcTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelIrcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJCacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJCacheTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJCacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJCacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJCacheTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJCacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJacksonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJacksonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonxmlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonxmlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJacksonxmlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonxmlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJacksonxmlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJacksonxmlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJasyptTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJasyptTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJasyptTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJasyptTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJasyptTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJasyptTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJaxbTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJaxbTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJaxbTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJaxbTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJaxbTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJaxbTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJbpmTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJbpmTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJbpmTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJbpmTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJbpmTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJbpmTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcloudsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcloudsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJcloudsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcloudsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcloudsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJcloudsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcrTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcrTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJcrTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcrTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJcrTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJcrTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJdbcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJdbcTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJdbcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJdbcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJdbcTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJdbcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJettyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJettyTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJettyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJettyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJettyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJettyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJgroupsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJgroupsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJgroupsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJgroupsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJgroupsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJgroupsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJibxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJibxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJibxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJibxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJibxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJibxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJingTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJingTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJingTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJingTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJingTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJingTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJmxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJmxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJmxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJoltTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJoltTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJoltTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJoltTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJoltTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJoltTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJosqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJosqlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJosqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJosqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJosqlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJosqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJpaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJpaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJpaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJpaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJpaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJpaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJsonpathTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJsonpathTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJsonpathTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJsonpathTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJsonpathTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJsonpathTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJt400Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJt400Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJt400Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJt400Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJt400Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJt400Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJuelTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJuelTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJuelTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJuelTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJuelTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJuelTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJxpathTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJxpathTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJxpathTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJxpathTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelJxpathTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelJxpathTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKafkaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKafkaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKafkaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKafkaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKafkaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKafkaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKratiTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKratiTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKratiTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKratiTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKratiTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKratiTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKubernetesTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKubernetesTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKubernetesTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKubernetesTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelKubernetesTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelKubernetesTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLdapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLdapTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLdapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLdapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLdapTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLdapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLinkedinTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLinkedinTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLinkedinTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLinkedinTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLinkedinTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLinkedinTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLuceneTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLuceneTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need new version of lucene bundle")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLuceneTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLuceneTest.java
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 @Ignore("Need new version of lucene bundle")

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLzfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLzfTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLzfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLzfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelLzfTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelLzfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMailTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMailTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMailTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMailTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMailTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMailTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMetricsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMetricsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMetricsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMetricsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMetricsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMetricsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMina2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMina2Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMina2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMina2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMina2Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMina2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMinaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMinaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMinaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMinaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMinaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMinaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMllpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMllpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMllpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMllpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMllpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMllpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMongodbTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMongodbTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMongodbTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMongodbTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMongodbTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMongodbTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMqttTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMqttTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMqttTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMqttTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMqttTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMqttTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMsvTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMsvTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMsvTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMsvTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMsvTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMsvTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMustacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMustacheTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMustacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMustacheTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMustacheTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMustacheTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMvelTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMvelTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMvelTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMvelTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMvelTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMvelTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMyBatisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMyBatisTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMyBatisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMyBatisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelMyBatisTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelMyBatisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNatsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNatsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNatsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNatsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNatsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNatsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4HttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4HttpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNetty4HttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4HttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4HttpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNetty4HttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNetty4Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNetty4Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNetty4Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyHttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyHttpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNettyHttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyHttpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyHttpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNettyHttpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNettyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelNettyTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelNettyTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOgnlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOgnlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOgnlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOgnlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOgnlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOgnlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo2Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOlingo2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo2Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOlingo2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOpenshiftTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOpenshiftTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOpenshiftTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOpenshiftTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOpenshiftTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOpenshiftTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOptaplannerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOptaplannerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOptaplannerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOptaplannerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOptaplannerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelOptaplannerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPahoTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPahoTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPahoTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPahoTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPahoTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPahoTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPaxloggingTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPaxloggingTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPaxloggingTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPaxloggingTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPaxloggingTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPaxloggingTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPdfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPdfTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPdfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPdfTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPdfTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPdfTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPgeventTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPgeventTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPgeventTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPgeventTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPgeventTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPgeventTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPrinterTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPrinterTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPrinterTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPrinterTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelPrinterTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelPrinterTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelProtobufTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelProtobufTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelProtobufTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelProtobufTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelProtobufTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelProtobufTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartz2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartz2Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuartz2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartz2Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartz2Test.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuartz2Test extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartzTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartzTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuartzTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartzTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuartzTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuartzTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuickFixTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuickFixTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuickFixTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuickFixTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelQuickFixTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelQuickFixTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRabbitmqTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRabbitmqTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRabbitmqTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRabbitmqTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRabbitmqTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRabbitmqTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRestletTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRestletTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRestletTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRestletTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRestletTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRestletTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRmiTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRmiTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRmiTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRmiTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRmiTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRmiTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRouteboxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRouteboxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRouteboxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRouteboxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRouteboxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRouteboxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRssTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRssTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRssTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRssTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRssTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRssTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelRxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelRxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSalesforceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSalesforceTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSalesforceTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSalesforceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSalesforceTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSalesforceTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSapNetweaverTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSapNetweaverTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSapNetweaverTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSapNetweaverTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSapNetweaverTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSapNetweaverTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSaxonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSaxonTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSaxonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSaxonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSaxonTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSaxonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScalaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScalaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelScalaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScalaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScalaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelScalaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSchematronTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSchematronTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSchematronTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSchematronTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSchematronTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSchematronTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScriptTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScriptTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelScriptTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScriptTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelScriptTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelScriptTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServicenowTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServicenowTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelServicenowTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServicenowTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServicenowTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelServicenowTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServletTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServletTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelServletTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServletTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelServletTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelServletTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSipTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSipTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSipTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSipTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSipTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSipTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSjmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSjmsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSjmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSjmsTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSjmsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSjmsTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSlackTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSlackTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSlackTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSlackTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSlackTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSlackTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSmppTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSmppTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSmppTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSmppTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSmppTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSmppTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnakeyamlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnakeyamlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSnakeyamlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnakeyamlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnakeyamlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSnakeyamlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnmpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnmpTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSnmpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnmpTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSnmpTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSnmpTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSoapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSoapTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSoapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSoapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSoapTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSoapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSolrTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSolrTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSolrTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSolrTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSolrTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSolrTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSplunkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSplunkTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSplunkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSplunkTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSplunkTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSplunkTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringBatchTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringBatchTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringBatchTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringBatchTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringBatchTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringBatchTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringJavaconfigTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringJavaconfigTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringJavaconfigTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringJavaconfigTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringJavaconfigTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringJavaconfigTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringLdapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringLdapTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringLdapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringLdapTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringLdapTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringLdapTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringRedisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringRedisTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringRedisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringRedisTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringRedisTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringRedisTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringWebServiceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringWebServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringWebServiceTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringWebServiceTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSpringWebServiceTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSpringWebServiceTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSqlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSqlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSqlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSqlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSshTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSshTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSshTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSshTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSshTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSshTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStAXTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStAXTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStAXTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStAXTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStAXTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStAXTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStompTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStompTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStompTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStompTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStompTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStompTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStreamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStreamTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStreamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStreamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStreamTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStreamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStringTemplateTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStringTemplateTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStringTemplateTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStringTemplateTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelStringTemplateTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelStringTemplateTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerJavaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerJavaTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSwaggerJavaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerJavaTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerJavaTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSwaggerJavaTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSwaggerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSwaggerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSwaggerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSyslogTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSyslogTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSyslogTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSyslogTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelSyslogTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelSyslogTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTagsoupTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTagsoupTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTagsoupTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTagsoupTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTagsoupTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTagsoupTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTarfileTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTarfileTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTarfileTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTarfileTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTarfileTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTarfileTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestSpringTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestSpringTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTestSpringTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestSpringTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestSpringTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTestSpringTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTestTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTestTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTestTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTwitterTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTwitterTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTwitterTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTwitterTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelTwitterTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelTwitterTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUndertowTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUndertowTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUndertowTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUndertowTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUndertowTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUndertowTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUnivocityParsersTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUnivocityParsersTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUnivocityParsersTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUnivocityParsersTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUnivocityParsersTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUnivocityParsersTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUrlrewriteTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUrlrewriteTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUrlrewriteTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUrlrewriteTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelUrlrewriteTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelUrlrewriteTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVelocityTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVelocityTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelVelocityTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVelocityTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVelocityTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelVelocityTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVertxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVertxTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelVertxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVertxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelVertxTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelVertxTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWeatherTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWeatherTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelWeatherTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWeatherTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWeatherTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelWeatherTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWebsocketTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWebsocketTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelWebsocketTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWebsocketTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelWebsocketTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelWebsocketTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlbeansTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlbeansTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlbeansTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlbeansTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlbeansTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlbeansTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmljsonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmljsonTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmljsonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmljsonTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmljsonTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmljsonTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlrpcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlrpcTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlrpcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlrpcTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlrpcTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlrpcTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlsecurityTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlsecurityTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlsecurityTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlsecurityTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmlsecurityTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmlsecurityTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmppTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmppTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmppTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmppTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXmppTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXmppTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXstreamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXstreamTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXstreamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXstreamTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelXstreamTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelXstreamTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYamlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYamlTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelYamlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYamlTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYamlTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelYamlTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYammerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYammerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelYammerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYammerTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelYammerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelYammerTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipfileTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipfileTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZipfileTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipfileTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipfileTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZipfileTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipkinTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipkinTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZipkinTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipkinTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZipkinTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZipkinTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZookeeperTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZookeeperTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZookeeperTest extends AbstractFeatureTest {

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZookeeperTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelZookeeperTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.itest.karaf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.apache.camel.test.karaf.AbstractFeatureTest;
 
 @RunWith(PaxExam.class)
 public class CamelZookeeperTest extends AbstractFeatureTest {


### PR DESCRIPTION
This PR provides the structure modifications.  The AbstractFeatureTest class used by camel-itest-karaf is now in the camel-test-karaf module, and has been enhanced to reduce the possibility of dangling Karaf instances.