### PR TITLE
fix schematron classpath uri resolver

### DIFF
--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -39,6 +39,6 @@ public class ClassPathURIResolver implements URIResolver {
     @Override
     public Source resolve(String href, String base) throws TransformerException {
         return new StreamSource(ClassPathURIResolver.class.getClassLoader()
-                .getResourceAsStream(rulesDir.concat(File.separator).concat(href)));
+                .getResourceAsStream(rulesDir.concat("/").concat(href)));
     }
 }


### PR DESCRIPTION
I had an error on windows with schematron component and was able to fix it with this change. Replaced "File.separator" with "/". 

From https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html:
"The name of a resource is independent of the Java implementation; in particular, the path separator is always a slash (/). However, the Java implementation controls the details of how the contents of the resource are mapped into a file, database, or other object containing the actual resource."