### PR TITLE
CAMEL-9808: SFTP: Enable configuration of bulk requests

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
@@ -55,7 +55,7 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     private int serverAliveCountMax = 1;
     @UriParam(label = "producer,advanced")
     private String chmod;
-    // comma separated list of ciphers. 
+    // comma separated list of ciphers.
     // null means default jsch list will be used
     @UriParam(label = "security")
     private String ciphers;
@@ -65,7 +65,7 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     private String preferredAuthentications;
     @UriParam(defaultValue = "WARN")
     private LoggingLevel jschLoggingLevel = LoggingLevel.WARN;
-    @UriParam(label="advanced", description="Specifies how many requests may be outstanding at any one time.")
+    @UriParam(label = "advanced")
     private Integer bulkRequests;
 
     public SftpConfiguration() {
@@ -255,7 +255,7 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     public void setPreferredAuthentications(String pAuthentications) {
         this.preferredAuthentications = pAuthentications;
     }
-    
+
     public String getPreferredAuthentications() {
         return preferredAuthentications;
     }
@@ -271,16 +271,16 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     public void setJschLoggingLevel(LoggingLevel jschLoggingLevel) {
         this.jschLoggingLevel = jschLoggingLevel;
     }
-    
+
     /**
      * Specifies how many requests may be outstanding at any one time. Increasing this value may
      * slightly improve file transfer speed but will increase memory usage.
      */
     public void setBulkRequests(Integer bulkRequests) {
-		this.bulkRequests = bulkRequests;
-	}
-    
+        this.bulkRequests = bulkRequests;
+    }
+
     public Integer getBulkRequests() {
-		return bulkRequests;
-	}
+        return bulkRequests;
+    }
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
@@ -65,6 +65,8 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     private String preferredAuthentications;
     @UriParam(defaultValue = "WARN")
     private LoggingLevel jschLoggingLevel = LoggingLevel.WARN;
+    @UriParam(label="advanced", description="Specifies how many requests may be outstanding at any one time.")
+    private Integer bulkRequests;
 
     public SftpConfiguration() {
         setProtocol("sftp");
@@ -269,4 +271,16 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     public void setJschLoggingLevel(LoggingLevel jschLoggingLevel) {
         this.jschLoggingLevel = jschLoggingLevel;
     }
+    
+    /**
+     * Specifies how many requests may be outstanding at any one time. Increasing this value may
+     * slightly improve file transfer speed but will increase memory usage.
+     */
+    public void setBulkRequests(Integer bulkRequests) {
+		this.bulkRequests = bulkRequests;
+	}
+    
+    public Integer getBulkRequests() {
+		return bulkRequests;
+	}
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -161,7 +161,27 @@ public class SftpOperations implements RemoteFileOperations<ChannelSftp.LsEntry>
             }
         }
 
+        configureBulkRequests();
+        
         return true;
+    }
+    
+    private void configureBulkRequests() {
+    	try {
+    		tryConfigureBulkRequests();
+    	} catch (JSchException e) {
+    		throw new GenericFileOperationFailedException("Failed to configure number of bulk requests", e);
+    	}
+    }
+    
+    private void tryConfigureBulkRequests() throws JSchException {
+    	Integer bulkRequests = endpoint.getConfiguration().getBulkRequests();
+    	
+    	if (bulkRequests != null) {
+    		LOG.trace("configuring channel to use up to {} bulk request(s)", bulkRequests);
+    		
+    		channel.setBulkRequests(bulkRequests);
+    	}
     }
 
     protected Session createSession(final RemoteFileConfiguration configuration) throws JSchException {

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -165,23 +165,23 @@ public class SftpOperations implements RemoteFileOperations<ChannelSftp.LsEntry>
         
         return true;
     }
-    
+
     private void configureBulkRequests() {
-    	try {
-    		tryConfigureBulkRequests();
-    	} catch (JSchException e) {
-    		throw new GenericFileOperationFailedException("Failed to configure number of bulk requests", e);
-    	}
+        try {
+            tryConfigureBulkRequests();
+        } catch (JSchException e) {
+            throw new GenericFileOperationFailedException("Failed to configure number of bulk requests", e);
+        }
     }
-    
+
     private void tryConfigureBulkRequests() throws JSchException {
-    	Integer bulkRequests = endpoint.getConfiguration().getBulkRequests();
-    	
-    	if (bulkRequests != null) {
-    		LOG.trace("configuring channel to use up to {} bulk request(s)", bulkRequests);
-    		
-    		channel.setBulkRequests(bulkRequests);
-    	}
+        Integer bulkRequests = endpoint.getConfiguration().getBulkRequests();
+
+        if (bulkRequests != null) {
+            LOG.trace("configuring channel to use up to {} bulk request(s)", bulkRequests);
+
+            channel.setBulkRequests(bulkRequests);
+        }
     }
 
     protected Session createSession(final RemoteFileConfiguration configuration) throws JSchException {


### PR DESCRIPTION
This pull request makes it possible to configure the number of bulk requests issued by JSch. Increasing the number of bulk requests may slightly improve transfer speed at the cost of memory usage.

Usage:

    sftp://nosuchhost/workingdir?bulkRequests=64&...

See [CAMEL-9808](https://issues.apache.org/jira/browse/CAMEL-9808) for details.