### PR TITLE
CAMEL-9815 Add URI parameter to skip declaration of exchange

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -45,7 +45,9 @@ public class RabbitMQDeclareSupport {
     }
 
     private void declareAndBindExchangeWithQueue(final Channel channel) throws IOException {
-        declareExchange(channel, endpoint.getExchangeName(), endpoint.getExchangeType(), resolvedExchangeArguments());
+      if(shouldDeclareExchange()){  
+          declareExchange(channel, endpoint.getExchangeName(), endpoint.getExchangeType(), resolvedExchangeArguments());
+      }
 
         if (shouldDeclareQueue()) {
             // need to make sure the queueDeclare is same with the exchange declare
@@ -79,6 +81,10 @@ public class RabbitMQDeclareSupport {
 
     private boolean shouldDeclareQueue() {
         return !endpoint.isSkipQueueDeclare() && endpoint.getQueue() != null;
+    }
+    
+    private boolean shouldDeclareExchange() {
+        return !endpoint.isSkipExchangeDeclare();
     }
 
     private void populateQueueArgumentsFromConfigurer(final Map<String, Object> queueArgs) {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -80,6 +80,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
     @UriParam(label = "producer")
     private boolean skipQueueDeclare;
     @UriParam
+    private boolean skipExchangeDeclare;
+    @UriParam
     private Address[] addresses;
     @UriParam(defaultValue = "" + ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT)
     private int connectionTimeout = ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT;
@@ -402,6 +404,18 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
 
     public boolean isSkipQueueDeclare() {
         return skipQueueDeclare;
+    }
+    
+    /**
+     * If true the producer will not declare the exchange.
+     * This can be used if we need to declare the queue but not the exchange
+     */
+    public void setSkipExchangeDeclare(boolean skipExchangeDeclare) {
+        this.skipExchangeDeclare = skipExchangeDeclare;
+    }
+
+    public boolean isSkipExchangeDeclare() {
+        return skipExchangeDeclare;
     }
 
     /**

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -254,4 +254,10 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?skipQueueDeclare=true", RabbitMQEndpoint.class);
         assertTrue(endpoint.isSkipQueueDeclare());
     }
+    
+    @Test
+    public void createEndpointWithSkipExchangeDeclareEnabled() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?skipExchangeDeclare=true", RabbitMQEndpoint.class);
+        assertTrue(endpoint.isSkipExchangeDeclare());
+    }
 }


### PR DESCRIPTION
As described in [CAMEL-9815](https://issues.apache.org/jira/browse/CAMEL-9815) it could be helpful to skip the declaration of the exchange (because it exists already). I propose this could be done via an URI parameter "skipExchangeDeclare", similar to "skipQueueDeclare"