### PR TITLE
CAMEL-9819: add httpclient to camel-jetty9 test dependencies

### DIFF
--- a/components/camel-jetty8/pom.xml
+++ b/components/camel-jetty8/pom.xml
@@ -146,6 +146,13 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient4-version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
The camel-jetty8 component fails to compile for me because of a problem with a missing dependency, described here: [CAMEL-9819](https://issues.apache.org/jira/browse/CAMEL-9819)