### PR TITLE
CAMEL-9587 - camel-restlet - Make it easy to turn on gson or jackson

### DIFF
--- a/components/camel-restlet/pom.xml
+++ b/components/camel-restlet/pom.xml
@@ -61,6 +61,17 @@
       <groupId>org.restlet.jee</groupId>
       <artifactId>org.restlet.ext.httpclient</artifactId>
     </dependency>
+    <!-- extensions -->
+    <dependency>
+      <groupId>org.restlet.jse</groupId>
+      <artifactId>org.restlet.ext.jackson</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.restlet.jse</groupId>
+      <artifactId>org.restlet.ext.gson</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- camel test dependencies -->
     <dependency>

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletEndpoint.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletEndpoint.java
@@ -41,7 +41,6 @@ import org.restlet.data.Method;
 @UriEndpoint(scheme = "restlet", title = "Restlet", syntax = "restlet:protocol:host:port/uriPattern",
         consumerClass = RestletConsumer.class, label = "rest", lenientProperties = true)
 public class RestletEndpoint extends DefaultEndpoint implements HeaderFilterStrategyAware {
-
     private static final int DEFAULT_PORT = 80;
     private static final String DEFAULT_PROTOCOL = "http";
     private static final String DEFAULT_HOST = "localhost";

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletConfigurationTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletConfigurationTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.restlet;
+
+import java.util.Optional;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+import org.restlet.engine.Engine;
+import org.restlet.engine.converter.ConverterHelper;
+import org.restlet.ext.gson.GsonConverter;
+import org.restlet.ext.jackson.JacksonConverter;
+
+public class RestletConfigurationTest extends RestletTestSupport {
+    @Override
+    protected void doPreSetup() {
+        assertPresent(GsonConverter.class);
+        assertPresent(JacksonConverter.class);
+    }
+
+    @Test
+    public void testConfiguration() throws Exception {
+        assertNotPresent(GsonConverter.class);
+        assertPresent(JacksonConverter.class);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                restConfiguration()
+                    .component("restlet")
+                    .componentProperty("enabledConverters", "JacksonConverter");
+
+                from("direct:start")
+                    .to("restlet:http://localhost:" + portNum + "/users/1/basic")
+                    .to("log:reply");
+            }
+        };
+    }
+
+    protected <T extends ConverterHelper> Optional<ConverterHelper> findByType(Class<T> type) {
+        return Engine.getInstance().getRegisteredConverters().stream().filter(type::isInstance).findFirst();
+    }
+
+    protected <T extends ConverterHelper> void assertPresent(Class<T> type) {
+        assertTrue(type.getSimpleName(), findByType(type).isPresent());
+    }
+
+    protected <T extends ConverterHelper> void assertNotPresent(Class<T> type) {
+        assertFalse(type.getSimpleName(), findByType(type).isPresent());
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -464,6 +464,11 @@
     <regexp-bundle-version>1.4_1</regexp-bundle-version>
     <rest-assured-version>2.7.0</rest-assured-version>
     <restlet-version>2.3.6</restlet-version>
+    <restlet-jackson-version>2.4.4</restlet-jackson-version>
+    <restlet-woodstox-version>4.3.0</restlet-woodstox-version>
+    <restlet-yaml-version>1.13</restlet-yaml-version>
+    <restlet-gson-version>2.3.1</restlet-gson-version>
+    <restlet-joda-time-version>2.3</restlet-joda-time-version>
     <rhino-bundle-version>1.7R2_3</rhino-bundle-version>
     <rhino-version>1.7R2</rhino-version>
     <rome-bundle-version>1.0_3</rome-bundle-version>
@@ -2816,6 +2821,16 @@
       <dependency>
         <groupId>org.restlet.jee</groupId>
         <artifactId>org.restlet.ext.httpclient</artifactId>
+        <version>${restlet-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.restlet.jse</groupId>
+        <artifactId>org.restlet.ext.jackson</artifactId>
+        <version>${restlet-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.restlet.jse</groupId>
+        <artifactId>org.restlet.ext.gson</artifactId>
         <version>${restlet-version}</version>
       </dependency>
 

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1317,6 +1317,28 @@
     <bundle dependency='true'>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.httpclient/${restlet-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-restlet/${project.version}</bundle>
   </feature>
+  <feature name='camel-restlet-jackson' version='${project.version}' resolver='(obr)' start-level='50'>
+    <feature version='${project.version}'>camel-restlet</feature>
+    <bundle dependency='true'>mvn:org.codehaus.woodstox/stax2-api/${stax2-api-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.codehaus.woodstox/woodstox-core-asl/${restlet-woodstox-version}</bundle>
+    <bundle dependency='true'>mvn:org.yaml/snakeyaml/${restlet-yaml-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-csv/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-smile/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${restlet-jackson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${restlet-jackson-version}</bundle>
+    <bundle>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.jackson/${restlet-version}</bundle>
+  </feature>
+  <feature name='camel-restlet-gson' version='${project.version}' resolver='(obr)' start-level='50'>
+    <feature version='${project.version}'>camel-restlet</feature>
+    <bundle dependency='true'>mvn:joda-time/joda-time/${restlet-joda-time-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.code.gson/gson/${restlet-gson-version}</bundle>
+    <bundle>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.gson/${restlet-version}</bundle>
+  </feature>
   <feature name='camel-rmi' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle>mvn:org.apache.camel/camel-rmi/${project.version}</bundle>


### PR DESCRIPTION
With this PR one can explicit set the converters to use with:

```
from("restlet:....?enabledConverters=JacksonConverter,my.company.MyConverter")
```

Notes:
- the converted need to be installed
- by default all the converter found by the Engine are enabled
- converters not used are removed from the engine which is a singleton s

To make it easy to add Jackson/Gson extension there are now two more features:
- camel-restlet-jackson
- camel-restlet-gson

Hope it cope with the requirements.