### PR TITLE
Support for PATCH method in Rest DSL

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/PatchVerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/PatchVerbDefinition.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.rest;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.camel.spi.Metadata;
+
+/**
+ * Rest PATCH command
+ */
+@Metadata(label = "rest")
+@XmlRootElement(name = "patch")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class PatchVerbDefinition extends VerbDefinition {
+
+}

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -236,6 +236,14 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return addVerb("put", uri);
     }
 
+    public RestDefinition patch() {
+        return addVerb("patch", null);
+    }
+
+    public RestDefinition patch(String uri) {
+        return addVerb("patch", uri);
+    }
+
     public RestDefinition delete() {
         return addVerb("delete", null);
     }
@@ -564,6 +572,8 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
             answer = new HeadVerbDefinition();
         } else if ("put".equals(verb)) {
             answer = new PutVerbDefinition();
+        } else if ("patch".equals(verb)) {
+            answer = new PatchVerbDefinition();
         } else if ("options".equals(verb)) {
             answer = new OptionsVerbDefinition();
         } else {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -393,6 +393,8 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
             return "post";
         } else if (this instanceof PutVerbDefinition) {
             return "put";
+        } else if (this instanceof PatchVerbDefinition) {
+            return "patch";
         } else if (this instanceof DeleteVerbDefinition) {
             return "delete";
         } else if (this instanceof HeadVerbDefinition) {

--- a/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/rest/jaxb.index
@@ -21,6 +21,7 @@ HeadVerbDefinition
 OptionsVerbDefinition
 PostVerbDefinition
 PutVerbDefinition
+PatchVerbDefinition
 RestBindingDefinition
 RestBindingMode
 RestConfigurationDefinition


### PR DESCRIPTION
Added new verb to the Rest model, the PatchVerbDefinition and made made
the jaxb parser aware of this new file.
Added instructions in RestDefinition and VerbDefinition on how to handle
this new verb.