### PR TITLE
AWS Kinesis Consumer support for Sequence Number and Shard Id

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/kinesis/KinesisEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/kinesis/KinesisEndpoint.java
@@ -46,9 +46,25 @@ public class KinesisEndpoint extends ScheduledPollEndpoint {
     @UriParam(label = "consumer", description = "Defines where in the Kinesis stream to start getting records")
     private ShardIteratorType iteratorType = ShardIteratorType.TRIM_HORIZON;
 
+    @UriParam(label = "consumer", description = "Defines which shardId in the Kinesis stream to get records from")
+    private String shardId ="";
+
+    //TODO, for now its ignored if Iterator Type not After or At seq number. Any good?
+    @UriParam(label = "consumer", description = "The sequence number to start polling from")
+    private String sequenceNumber="";
+
+
     public KinesisEndpoint(String uri, String streamName, KinesisComponent component) {
         super(uri, component);
         this.streamName = streamName;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        if((iteratorType.equals(ShardIteratorType.AFTER_SEQUENCE_NUMBER) || iteratorType.equals(ShardIteratorType.AT_SEQUENCE_NUMBER)) && sequenceNumber.isEmpty()){
+            throw new IllegalArgumentException("Sequence Number must be specified with iterator Types AFTER_SEQUENCE_NUMBER or AT_SEQUENCE_NUMBER");
+        }
+        super.doStart();
     }
 
     @Override
@@ -113,6 +129,22 @@ public class KinesisEndpoint extends ScheduledPollEndpoint {
 
     public void setIteratorType(ShardIteratorType iteratorType) {
         this.iteratorType = iteratorType;
+    }
+
+    public String getShardId() {
+        return shardId;
+    }
+
+    public void setShardId(String shardId) {
+        this.shardId = shardId;
+    }
+
+    public String getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public void setSequenceNumber(String sequenceNumber) {
+        this.sequenceNumber = sequenceNumber;
     }
 
 }

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/kinesis/KinesisConsumerTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/kinesis/KinesisConsumerTest.java
@@ -43,10 +43,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KinesisConsumerTest {
@@ -99,6 +96,44 @@ public class KinesisConsumerTest {
         assertThat(getShardIteratorReqCap.getValue().getShardId(), is("shardId"));
         assertThat(getShardIteratorReqCap.getValue().getShardIteratorType(), is("LATEST"));
     }
+
+    @Test
+    public void itDoesNotMakeADescribeStreamRequestIfShardIdIsSet() throws Exception {
+        undertest.getEndpoint().setShardId("shardIdPassedAsUrlParam");
+
+        undertest.poll();
+
+        verify(kinesisClient, never()).describeStream(any(DescribeStreamRequest.class));
+
+        final ArgumentCaptor<GetShardIteratorRequest> getShardIteratorReqCap = ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+
+        verify(kinesisClient).getShardIterator(getShardIteratorReqCap.capture());
+        assertThat(getShardIteratorReqCap.getValue().getStreamName(), is("streamName"));
+        assertThat(getShardIteratorReqCap.getValue().getShardId(), is("shardIdPassedAsUrlParam"));
+        assertThat(getShardIteratorReqCap.getValue().getShardIteratorType(), is("LATEST"));
+    }
+
+    @Test
+    public void itObtainsAShardIteratorOnFirstPollForSequenceNumber() throws Exception {
+        undertest.getEndpoint().setSequenceNumber("12345");
+        undertest.getEndpoint().setIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER);
+
+        undertest.poll();
+
+        final ArgumentCaptor<DescribeStreamRequest> describeStreamReqCap = ArgumentCaptor.forClass(DescribeStreamRequest.class);
+        final ArgumentCaptor<GetShardIteratorRequest> getShardIteratorReqCap = ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+
+        verify(kinesisClient).describeStream(describeStreamReqCap.capture());
+        assertThat(describeStreamReqCap.getValue().getStreamName(), is("streamName"));
+
+        verify(kinesisClient).getShardIterator(getShardIteratorReqCap.capture());
+        assertThat(getShardIteratorReqCap.getValue().getStreamName(), is("streamName"));
+        assertThat(getShardIteratorReqCap.getValue().getShardId(), is("shardId"));
+        assertThat(getShardIteratorReqCap.getValue().getShardIteratorType(), is("AFTER_SEQUENCE_NUMBER"));
+        assertThat(getShardIteratorReqCap.getValue().getStartingSequenceNumber(), is("12345"));
+
+    }
+
 
     @Test
     public void itUsesTheShardIteratorOnPolls() throws Exception {

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/kinesis/KinesisEndpointTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/kinesis/KinesisEndpointTest.java
@@ -17,8 +17,10 @@
 package org.apache.camel.component.aws.kinesis;
 
 import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.model.InvalidArgumentException;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import org.apache.camel.CamelContext;
+import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 import org.junit.Before;
@@ -51,12 +53,16 @@ public class KinesisEndpointTest {
                 + "?amazonKinesisClient=#kinesisClient"
                 + "&maxResultsPerRequest=101"
                 + "&iteratorType=latest"
+                + "&shardId=abc"
+                + "&sequenceNumber=123"
         );
 
         assertThat(endpoint.getClient(), is(amazonKinesisClient));
         assertThat(endpoint.getStreamName(), is("some_stream_name"));
         assertThat(endpoint.getIteratorType(), is(ShardIteratorType.LATEST));
         assertThat(endpoint.getMaxResultsPerRequest(), is(101));
+        assertThat(endpoint.getSequenceNumber(), is("123"));
+        assertThat(endpoint.getShardId(), is("abc"));
     }
 
     @Test
@@ -69,5 +75,22 @@ public class KinesisEndpointTest {
         assertThat(endpoint.getStreamName(), is("some_stream_name"));
         assertThat(endpoint.getIteratorType(), is(ShardIteratorType.TRIM_HORIZON));
         assertThat(endpoint.getMaxResultsPerRequest(), is(1));
+    }
+
+    @Test(expected = ResolveEndpointFailedException.class)
+    public void afterSequenceNumberRequiresSequenceNumber() throws Exception {
+        KinesisEndpoint endpoint = (KinesisEndpoint) camelContext.getEndpoint("aws-kinesis://some_stream_name"
+                + "?amazonKinesisClient=#kinesisClient"
+                + "&iteratorType=AFTER_SEQUENCE_NUMBER"
+        );
+
+    }
+
+    @Test(expected = ResolveEndpointFailedException.class)
+    public void atSequenceNumberRequiresSequenceNumber() throws Exception {
+        KinesisEndpoint endpoint = (KinesisEndpoint) camelContext.getEndpoint("aws-kinesis://some_stream_name"
+                + "?amazonKinesisClient=#kinesisClient"
+                + "&iteratorType=AT_SEQUENCE_NUMBER"
+        );
     }
 }


### PR DESCRIPTION
Hi, 

I have added support for Kinesis shardId and for sequence number when iterator type is AFTER_SEQUENCE_NUMBER or AT_SEQUENCE_NUMBER.

AT_SEQUENCE_NUMBER works optimally, it does not seem to return empty result sets but this isn't guaranteed by Kinesis. 