### PR TITLE
CAMEL-9903 Fix jmx operations when jmx domain is custom + test

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -78,9 +78,11 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
 
     private final ModelCamelContext context;
     private final LoadTriplet load = new LoadTriplet();
+    private final String jmxDomain;
 
     public ManagedCamelContext(ModelCamelContext context) {
         this.context = context;
+        this.jmxDomain = context.getManagementStrategy().getManagementAgent().getMBeanObjectDomainName();
     }
 
     @Override
@@ -480,13 +482,13 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
         if (server != null) {
             // gather all the routes for this CamelContext, which requires JMX
             String prefix = getContext().getManagementStrategy().getManagementAgent().getIncludeHostName() ? "*/" : "";
-            ObjectName query = ObjectName.getInstance("org.apache.camel:context=" + prefix + getContext().getManagementName() + ",type=routes,*");
+            ObjectName query = ObjectName.getInstance(jmxDomain + ":context=" + prefix + getContext().getManagementName() + ",type=routes,*");
             Set<ObjectName> routes = server.queryNames(query, null);
 
             List<ManagedProcessorMBean> processors = new ArrayList<ManagedProcessorMBean>();
             if (includeProcessors) {
                 // gather all the processors for this CamelContext, which requires JMX
-                query = ObjectName.getInstance("org.apache.camel:context=" + prefix + getContext().getManagementName() + ",type=processors,*");
+                query = ObjectName.getInstance(jmxDomain + ":context=" + prefix + getContext().getManagementName() + ",type=processors,*");
                 Set<ObjectName> names = server.queryNames(query, null);
                 for (ObjectName on : names) {
                     ManagedProcessorMBean processor = context.getManagementStrategy().getManagementAgent().newProxyClient(on, ManagedProcessorMBean.class);
@@ -765,7 +767,7 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
             MBeanServer server = getContext().getManagementStrategy().getManagementAgent().getMBeanServer();
             if (server != null) {
                 String prefix = getContext().getManagementStrategy().getManagementAgent().getIncludeHostName() ? "*/" : "";
-                ObjectName query = ObjectName.getInstance("org.apache.camel:context=" + prefix + getContext().getManagementName() + ",type=routes,*");
+                ObjectName query = ObjectName.getInstance(jmxDomain + ":context=" + prefix + getContext().getManagementName() + ",type=routes,*");
                 Set<ObjectName> names = server.queryNames(query, null);
                 for (ObjectName name : names) {
                     server.invoke(name, "reset", new Object[]{true}, new String[]{"boolean"});

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
@@ -70,11 +70,13 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
     private final LoadTriplet load = new LoadTriplet();
     private final ConcurrentSkipListMap<InFlightKey, Long> exchangesInFlightStartTimestamps = new ConcurrentSkipListMap<InFlightKey, Long>();
     private final ConcurrentHashMap<String, InFlightKey> exchangesInFlightKeys = new ConcurrentHashMap<String, InFlightKey>();
+    private final String jmxDomain;
 
     public ManagedRoute(ModelCamelContext context, Route route) {
         this.route = route;
         this.context = context;
         this.description = route.getDescription();
+        this.jmxDomain = context.getManagementStrategy().getManagementAgent().getMBeanObjectDomainName();
     }
 
     @Override
@@ -349,7 +351,7 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
             if (server != null) {
                 // get all the processor mbeans and sort them accordingly to their index
                 String prefix = getContext().getManagementStrategy().getManagementAgent().getIncludeHostName() ? "*/" : "";
-                ObjectName query = ObjectName.getInstance("org.apache.camel:context=" + prefix + getContext().getManagementName() + ",type=processors,*");
+                ObjectName query = ObjectName.getInstance(jmxDomain + ":context=" + prefix + getContext().getManagementName() + ",type=processors,*");
                 Set<ObjectName> names = server.queryNames(query, null);
                 List<ManagedProcessorMBean> mps = new ArrayList<ManagedProcessorMBean>();
                 for (ObjectName on : names) {
@@ -427,7 +429,7 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
             if (server != null) {
                 // get all the processor mbeans and sort them accordingly to their index
                 String prefix = getContext().getManagementStrategy().getManagementAgent().getIncludeHostName() ? "*/" : "";
-                ObjectName query = ObjectName.getInstance("org.apache.camel:context=" + prefix + getContext().getManagementName() + ",type=processors,*");
+                ObjectName query = ObjectName.getInstance(jmxDomain + ":context=" + prefix + getContext().getManagementName() + ",type=processors,*");
                 QueryExp queryExp = Query.match(new AttributeValueExp("RouteId"), new StringValueExp(getRouteId()));
                 Set<ObjectName> names = server.queryNames(query, queryExp);
                 for (ObjectName name : names) {

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRouteDumpStatsAsXmlAndResetWithCustomDomainTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRouteDumpStatsAsXmlAndResetWithCustomDomainTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.management;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.w3c.dom.Document;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * @version
+ */
+public class ManagedRouteDumpStatsAsXmlAndResetWithCustomDomainTest extends ManagementTestSupport {
+
+    private final String CUSTOM_DOMAIN_NAME="custom";
+
+    public void testPerformanceCounterStats() throws Exception {
+        // JMX tests dont work well on AIX CI servers (hangs them)
+        if (isPlatform("aix")) {
+            return;
+        }
+
+        // get the stats for the route
+        MBeanServer mbeanServer = getMBeanServer();
+        ObjectName on = ObjectName.getInstance(CUSTOM_DOMAIN_NAME+":context=camel-1,type=routes,name=\"foo\"");
+
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.asyncSendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+
+        String xml = (String) mbeanServer.invoke(on, "dumpRouteStatsAsXml", new Object[]{false, true}, new String[]{"boolean", "boolean"});
+        log.info(xml);
+
+        // should be valid XML
+        Document doc = context.getTypeConverter().convertTo(Document.class, xml);
+        assertNotNull(doc);
+
+        int processors = doc.getDocumentElement().getElementsByTagName("processorStat").getLength();
+        assertEquals(3, processors);
+
+        int exchangeCompleted = Integer.parseInt(doc.getDocumentElement().getElementsByTagName("processorStat").item(0).getAttributes().getNamedItem("exchangesCompleted").getNodeValue());
+        assertEquals(1, exchangeCompleted);
+
+        //ResetValues
+        mbeanServer.invoke(on, "reset", new Object[]{true}, new String[]{"boolean"});
+
+        xml = (String) mbeanServer.invoke(on, "dumpRouteStatsAsXml", new Object[]{false, true}, new String[]{"boolean", "boolean"});
+        log.info(xml);
+
+        // should be valid XML
+        doc = context.getTypeConverter().convertTo(Document.class, xml);
+        assertNotNull(doc);
+        exchangeCompleted = Integer.parseInt(doc.getDocumentElement().getElementsByTagName("processorStat").item(0).getAttributes().getNamedItem("exchangesCompleted").getNodeValue());
+        assertEquals(0, exchangeCompleted);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+//              System.setProperty("org.apache.camel.jmx.mbeanObjectDomainName", CUSTOM_DOMAIN_NAME);
+//              Or
+                getContext().getManagementStrategy().getManagementAgent().setMBeanObjectDomainName(CUSTOM_DOMAIN_NAME);
+                from("direct:start").routeId("foo")
+                        .to("log:foo").id("to-log")
+                        .delay(100)
+                        .to("mock:result").id("to-mock");
+            }
+        };
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRouteDumpStatsAsXmlCustomDomainTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRouteDumpStatsAsXmlCustomDomainTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.management;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.w3c.dom.Document;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * @version
+ */
+public class ManagedRouteDumpStatsAsXmlCustomDomainTest extends ManagementTestSupport {
+
+    private final String CUSTOM_DOMAIN_NAME="custom";
+
+    public void testPerformanceCounterStats() throws Exception {
+        // JMX tests dont work well on AIX CI servers (hangs them)
+        if (isPlatform("aix")) {
+            return;
+        }
+
+        // get the stats for the route
+        MBeanServer mbeanServer = getMBeanServer();
+        ObjectName on = ObjectName.getInstance(CUSTOM_DOMAIN_NAME+":context=camel-1,type=routes,name=\"foo\"");
+
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.asyncSendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+
+        String xml = (String) mbeanServer.invoke(on, "dumpRouteStatsAsXml", new Object[]{false, true}, new String[]{"boolean", "boolean"});
+        log.info(xml);
+
+        // should be valid XML
+        Document doc = context.getTypeConverter().convertTo(Document.class, xml);
+        assertNotNull(doc);
+
+        int processors = doc.getDocumentElement().getElementsByTagName("processorStat").getLength();
+        assertEquals(3, processors);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+//              System.setProperty("org.apache.camel.jmx.mbeanObjectDomainName", CUSTOM_DOMAIN_NAME);
+//              Or
+                getContext().getManagementStrategy().getManagementAgent().setMBeanObjectDomainName(CUSTOM_DOMAIN_NAME);
+                from("direct:start").routeId("foo")
+                        .to("log:foo").id("to-log")
+                        .delay(100)
+                        .to("mock:result").id("to-mock");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
I retrieve the jmx domain from the management agent where it has been customized using JVM property or ManagementAgent bean according to http://camel.apache.org/camel-jmx.html 

This domain is then used in all the calls made to retrieve statistics

Unit Test has been added to test those operations with a custom jmx domain name