### PR TITLE
CAMEL-9824 Add URI parameter to declare server named queues

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.rabbitmq;
 
+import com.rabbitmq.client.AMQP.Queue.DeclareOk;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,6 +51,9 @@ public class RabbitMQDeclareSupport {
         }
 
         if (shouldDeclareQueue()) {
+            if(endpoint.isServerNamedQueue()){
+              declareServerNamedQueue(channel);
+            }
             // need to make sure the queueDeclare is same with the exchange declare
             declareAndBindQueue(channel, endpoint.getQueue(), endpoint.getExchangeName(), endpoint.getRoutingKey(), resolvedQueueArguments());
         }
@@ -97,6 +101,11 @@ public class RabbitMQDeclareSupport {
         channel.exchangeDeclare(exchange, exchangeType, endpoint.isDurable(), endpoint.isAutoDelete(), exchangeArgs);
     }
 
+    private void declareServerNamedQueue(final Channel channel) throws IOException{
+      DeclareOk declareOk = channel.queueDeclare();
+      endpoint.setQueue(declareOk.getQueue());
+    }
+    
     private void declareAndBindQueue(final Channel channel, final String queue, final String exchange, final String routingKey, final Map<String, Object> arguments)
             throws IOException {
         channel.queueDeclare(queue, endpoint.isDurable(), false, endpoint.isAutoDelete(), arguments);

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -83,6 +83,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     @UriParam
     private boolean skipExchangeDeclare;
     @UriParam
+    private boolean serverNamedQueue;
+    @UriParam
     private Address[] addresses;
     @UriParam(defaultValue = "" + ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT)
     private int connectionTimeout = ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT;
@@ -416,6 +418,21 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
 
     public boolean isSkipExchangeDeclare() {
         return skipExchangeDeclare;
+    }
+
+    public boolean isServerNamedQueue() {
+      return serverNamedQueue;
+    }
+
+    /**
+     * This can be used to let the server side determine the queue name.
+     * If this option is set some other options are ignored (isDurable, 
+     * isAutoDelete,...) The declared queu will always be a exclusive, 
+     * autodelete, non-durable queue.
+     * @param serverNamedQueue 
+     */
+    public void setServerNamedQueue(boolean serverNamedQueue) {
+      this.serverNamedQueue = serverNamedQueue;
     }
 
     /**

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -260,4 +260,10 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?skipExchangeDeclare=true", RabbitMQEndpoint.class);
         assertTrue(endpoint.isSkipExchangeDeclare());
     }
+    
+    @Test
+    public void createEndpointWithServerNamedQueueEnabled() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?serverNamedQueue=true", RabbitMQEndpoint.class);
+        assertTrue(endpoint.isServerNamedQueue());
+    }
 }


### PR DESCRIPTION
As described in CAMEL-9824 We need a possibility to declare server named queues. 

To achieve this I would like to add a new URI parameter "serverNamedQueue".

If this parameter is set, the queue is declared via 
`channel.queueDeclare();`
 instead of 
`channel.queueDeclare(queue, endpoint.isDurable(), false, endpoint.isAutoDelete(), arguments);`

The drawback of this solution is that several other options (isDurable etc) are ignored. If someone has a different idea on how to solve this I am more than happy to hear it!
