### PR TITLE
Fix over writing previous addToResult calls

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/common/AwsExchangeUtil.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/common/AwsExchangeUtil.java
@@ -26,9 +26,7 @@ public final class AwsExchangeUtil {
 
     public static Message getMessageForResponse(final Exchange exchange) {
         if (exchange.getPattern().isOutCapable()) {
-            Message out = exchange.getOut();
-            out.copyFrom(exchange.getIn());
-            return out;
+            return exchange.getOut();
         }
         return exchange.getIn();
     }


### PR DESCRIPTION
I noticed that multiple calls to the addToResult method in the org.apache.camel.component.aws.ddb.AbstractDdbCommand within the child class org.apache.camel.component.aws.ddb.ScanCommand caused the next call to over write the previous calls to addToResult in the header results.  The end result is only having the last result value returned in the out message which is the SCANNED_COUNT header.

The exchange.getOut() already passes back the "In" Message or creates a new Message object if no out message exists does not need to copy over the "In" message into the "Out" message.