### PR TITLE
Previous code was over writing result values

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
@@ -71,6 +71,12 @@ public abstract class AbstractDdbCommand {
         msg.setHeader(DdbConstants.ATTRIBUTES, attributes);
     }
     
+    protected void addToResults(Map<String, Object> map) {
+        Message msg = getMessageForResponse(exchange);
+        for(Map.Entry<String,Object> en : map.entrySet()){
+            msg.setHeader(en.getKey(), en.getValue());
+        }
+    }
     protected void addToResult(String headerKey, Object value) {
         Message msg = getMessageForResponse(exchange);
         msg.setHeader(headerKey, value);

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/BatchGetItemsCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
@@ -35,8 +36,10 @@ public class BatchGetItemsCommand extends AbstractDdbCommand {
         BatchGetItemResult result = ddbClient.batchGetItem(
                 new BatchGetItemRequest().withRequestItems(determineBatchItems()));
 
-        addToResult(DdbConstants.BATCH_RESPONSE, result.getResponses());
-        addToResult(DdbConstants.UNPROCESSED_KEYS, result.getUnprocessedKeys());
+        Map tmp = new HashMap<>();
+        tmp.put(DdbConstants.BATCH_RESPONSE, result.getResponses());
+        tmp.put(DdbConstants.UNPROCESSED_KEYS, result.getUnprocessedKeys());
+        addToResults(tmp);        
     }
 
     @SuppressWarnings("unchecked")

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/DeleteTableCommand.java
@@ -22,6 +22,9 @@ import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
 import org.apache.camel.Exchange;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class DeleteTableCommand extends AbstractDdbCommand {
     public DeleteTableCommand(AmazonDynamoDB ddbClient, DdbConfiguration configuration,
                               Exchange exchange) {
@@ -33,12 +36,14 @@ public class DeleteTableCommand extends AbstractDdbCommand {
         TableDescription tableDescription = ddbClient
                 .deleteTable(new DeleteTableRequest(determineTableName())).getTableDescription();
 
-        addToResult(DdbConstants.PROVISIONED_THROUGHPUT, tableDescription.getProvisionedThroughput());
-        addToResult(DdbConstants.CREATION_DATE, tableDescription.getCreationDateTime());
-        addToResult(DdbConstants.ITEM_COUNT, tableDescription.getItemCount());
-        addToResult(DdbConstants.KEY_SCHEMA, tableDescription.getKeySchema());
-        addToResult(DdbConstants.TABLE_NAME, tableDescription.getTableName());
-        addToResult(DdbConstants.TABLE_SIZE, tableDescription.getTableSizeBytes());
-        addToResult(DdbConstants.TABLE_STATUS, tableDescription.getTableStatus());
+        Map tmp = new HashMap<>();
+        tmp.put(DdbConstants.PROVISIONED_THROUGHPUT, tableDescription.getProvisionedThroughput());
+        tmp.put(DdbConstants.CREATION_DATE, tableDescription.getCreationDateTime());
+        tmp.put(DdbConstants.ITEM_COUNT, tableDescription.getItemCount());
+        tmp.put(DdbConstants.KEY_SCHEMA, tableDescription.getKeySchema());
+        tmp.put(DdbConstants.TABLE_NAME, tableDescription.getTableName());
+        tmp.put(DdbConstants.TABLE_SIZE, tableDescription.getTableSizeBytes());
+        tmp.put(DdbConstants.TABLE_STATUS, tableDescription.getTableStatus());
+        addToResults(tmp);
     }
 }

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
@@ -41,11 +42,13 @@ public class QueryCommand extends AbstractDdbCommand {
                 .withExclusiveStartKey(determineStartKey())
                 .withLimit(determineLimit())
                 .withScanIndexForward(determineScanIndexForward()));
-
-        addToResult(DdbConstants.ITEMS, result.getItems());
-        addToResult(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
-        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
-        addToResult(DdbConstants.COUNT, result.getCount());
+        
+        Map tmp = new HashMap<>();
+        tmp.put(DdbConstants.ITEMS, result.getItems());
+        tmp.put(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
+        tmp.put(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
+        tmp.put(DdbConstants.COUNT, result.getCount());
+        addToResults(tmp);
     }
 
     private  Map<String, AttributeValue> determineStartKey() {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.aws.ddb;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
@@ -36,11 +37,13 @@ public class ScanCommand extends AbstractDdbCommand {
                 .withTableName(determineTableName())
                 .withScanFilter(determineScanFilter()));
 
-        addToResult(DdbConstants.ITEMS, result.getItems());
-        addToResult(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
-        addToResult(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
-        addToResult(DdbConstants.COUNT, result.getCount());
-        addToResult(DdbConstants.SCANNED_COUNT, result.getScannedCount());
+        Map tmp = new HashMap<>();
+        tmp.put(DdbConstants.ITEMS, result.getItems());
+        tmp.put(DdbConstants.LAST_EVALUATED_KEY, result.getLastEvaluatedKey());
+        tmp.put(DdbConstants.CONSUMED_CAPACITY, result.getConsumedCapacity());
+        tmp.put(DdbConstants.COUNT, result.getCount());
+        tmp.put(DdbConstants.SCANNED_COUNT, result.getScannedCount());
+        addToResults(tmp);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
I apologize for my earlier faux pas.  I have properly tested this and verified that it passes the unit test.  I also took a more direct solution to this bug which was occurring due to multiple calls to the addToResult method which would overwrite the out message header with the in message header and would end up with just the result values of the last call to the addToResult.  I decided the best way to tackle this was to wrap updates into a map and pass that as a single call to a new method called addToResults which pretty much did what the previous code did but in a single method call.  The new method accepts a hashMap.  I have verified that it is properly returning all the result values to the next component in the message pipe.