### PR TITLE
camel-irc: Add support for listing users of a channel after it has been joined.

### DIFF
--- a/components/camel-irc/src/main/docs/irc.adoc
+++ b/components/camel-irc/src/main/docs/irc.adoc
@@ -53,6 +53,7 @@ The IRC component supports 23 endpoint options which are listed below:
 | port | common | 6667,6668,6669 | int | Port number for the IRC chat server
 | autoRejoin | common | true | boolean | Whether to auto re-join when being kicked
 | colors | common | true | boolean | Whether or not the server supports color codes.
+| namesOnJoin | common | false | boolean | Whether or not to send the NAMES command after a channel has been joined.
 | nickname | common |  | String | The nickname used in chat.
 | nickPassword | common |  | String | Your IRC server nickname password.
 | onJoin | common | true | boolean | Handle user join events.
@@ -168,6 +169,24 @@ For example we join 3 channels where as only channel 1 and 3 uses a key.
 [source,java]
 -----------------------------------------------------------------------------
 irc:nick@irc.server.org?channels=#chan1,#chan2,#chan3&keys=chan1Key,,chan3key
+-----------------------------------------------------------------------------
+
+Getting a list of users of the channel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using the `namesOnJoin` option one can invoke the IRC-`NAMES` command after the component has joined a channel. 
+The server will reply with `irc.num = 353`. So in order to process the result the property `onReply` has to be `true`.
+Furthermore one has to filter the `onReply` exchanges in order to get the names.
+
+For example we want to get all exchanges that contain the usernames of the channel:
+
+[source,java]
+-----------------------------------------------------------------------------
+from("ircs:nick@myserver:1234/#mychannelname?listOnJoin=true&onReply=true")
+	.choice()
+		.when(header("irc.messageType").isEqualToIgnoreCase("REPLY"))
+			.filter(header("irc.num").isEqualTo("353"))
+			.to("mock:result").stop();
 -----------------------------------------------------------------------------
 
 [[IRC-SeeAlso]]

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
@@ -83,13 +83,13 @@ public class IrcConfiguration implements Cloneable {
     private boolean onPrivmsg = true;
     @UriParam(defaultValue = "true")
     private boolean autoRejoin = true;
-	/**
-	 * Sends <code>NAMES</code> command to channel after joining it.<br>
-	 * {@link #onReply} has to be <code>true</code> in order to process the
-	 * result which will have the header value <code>irc.num = '353'</code>.
-	 */
+    /**
+     * Sends <code>NAMES</code> command to channel after joining it.<br>
+     * {@link #onReply} has to be <code>true</code> in order to process the
+     * result which will have the header value <code>irc.num = '353'</code>.
+     */
     @UriParam(defaultValue = "false")
-    private boolean namesOnJoin = false;
+    private boolean namesOnJoin;
     private SSLContextParameters sslContextParameters;
     @UriParam
     private String nickPassword;
@@ -462,15 +462,16 @@ public class IrcConfiguration implements Cloneable {
     }
     
     public boolean isNamesOnJoin() {
-		return namesOnJoin;
-	}
+        return namesOnJoin;
+    }
 
-	public void setNamesOnJoin(boolean namesOnJoin) {
-		this.namesOnJoin = namesOnJoin;
-	}
+    public void setNamesOnJoin(boolean namesOnJoin) {
+        this.namesOnJoin = namesOnJoin;
+    }
 
-	public String toString() {
-        return "IrcConfiguration[hostname: " + hostname + ", ports=" + Arrays.toString(ports) + ", username=" + username + "]";
+    public String toString() {
+        return "IrcConfiguration[hostname: " + hostname + ", ports=" + Arrays.toString(ports) + ", username=" + username
+                + "]";
     }
     
     private static IrcChannel createChannel(String channelInfo) {

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
@@ -83,6 +83,13 @@ public class IrcConfiguration implements Cloneable {
     private boolean onPrivmsg = true;
     @UriParam(defaultValue = "true")
     private boolean autoRejoin = true;
+	/**
+	 * Sends <code>NAMES</code> command to channel after joining it.<br>
+	 * {@link #onReply} has to be <code>true</code> in order to process the
+	 * result which will have the header value <code>irc.num = '353'</code>.
+	 */
+    @UriParam(defaultValue = "false")
+    private boolean namesOnJoin = false;
     private SSLContextParameters sslContextParameters;
     @UriParam
     private String nickPassword;
@@ -453,8 +460,16 @@ public class IrcConfiguration implements Cloneable {
     public void setNickPassword(String nickPassword) {
         this.nickPassword = nickPassword;
     }
+    
+    public boolean isNamesOnJoin() {
+		return namesOnJoin;
+	}
 
-    public String toString() {
+	public void setNamesOnJoin(boolean namesOnJoin) {
+		this.namesOnJoin = namesOnJoin;
+	}
+
+	public String toString() {
         return "IrcConfiguration[hostname: " + hostname + ", ports=" + Arrays.toString(ports) + ", username=" + username + "]";
     }
     

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
@@ -205,8 +205,8 @@ public class IrcEndpoint extends DefaultEndpoint {
             connection.doJoin(chn);
         }
         if (configuration.isNamesOnJoin()) {
-			connection.doNames(chn);
-		}
+            connection.doNames(chn);
+        }
     }
 }
 

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
@@ -204,6 +204,9 @@ public class IrcEndpoint extends DefaultEndpoint {
             }
             connection.doJoin(chn);
         }
+        if (configuration.isNamesOnJoin()) {
+			connection.doNames(chn);
+		}
     }
 }
 

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcsListUsersIntegrationTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcsListUsersIntegrationTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.irc;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for the {@link IrcConfiguration#isNamesOnJoin()} option.
+ * Joins a channel and asserts that the username of the current test user is
+ * listed for the channel.
+ */
+public class IrcsListUsersIntegrationTest extends CamelTestSupport {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(IrcsListUsersIntegrationTest.class);
+
+	/** message code for a reply to a <code>NAMES</code> command. */
+	public static final String IRC_RPL_NAMREPLY = "353";
+
+	/** irc component uri. configured by properties */
+	private static final String PRODUCER_URI = "ircs:{{test.user}}@{{test.server}}/{{test.room}}";
+
+	@EndpointInject(uri = "mock:result")
+	protected MockEndpoint resultEndpoint;
+
+	protected Properties properties;
+	
+	public IrcsListUsersIntegrationTest() throws IOException {
+		super();
+		properties = new Properties();
+		InputStream resourceAsStream = this.getClass().getResourceAsStream("/it-list-users.properties");
+		properties.load(resourceAsStream);
+	}
+	
+	@Override
+	protected RoutesBuilder createRouteBuilder() throws Exception {
+
+		return new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				LOGGER.debug("Creating new test route");
+				from(PRODUCER_URI + "?listOnJoin=true&onReply=true")
+					.choice()
+						.when(header("irc.messageType").isEqualToIgnoreCase("REPLY"))
+							.filter(header("irc.num").isEqualTo(IRC_RPL_NAMREPLY)).to("mock:result").stop();
+			}
+		};
+	}
+
+	@Test
+	public void test() throws Exception {
+		resultEndpoint.setMinimumExpectedMessageCount(1);
+		resultEndpoint.assertIsSatisfied();
+		String body = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
+		LOGGER.debug("Received usernames: [{}]", body);
+		String username = properties.getProperty("test.user");
+		assertTrue("userlist does not contain test user", body.contains(username));
+	}
+	
+	@Override
+	protected Properties useOverridePropertiesWithPropertiesComponent() {
+		return properties;
+	}
+
+}

--- a/components/camel-irc/src/test/resources/it-list-users.properties
+++ b/components/camel-irc/src/test/resources/it-list-users.properties
@@ -1,0 +1,3 @@
+test.server=chat.freenode.net:6697
+test.room=#testroom123
+test.user=camel-irc-ituser


### PR DESCRIPTION
This pull requests adds a new option to the camel-irc component that invokes the irc `NAMES` command for a channel after it has been joined by the component. This results in several replies by the server which then can be processed in order to get the list of users. The component documentation contains an example route in order to get the usernames.