### PR TITLE
hardcoded values of waitForProvisionCorrelationToBeUpdated

### DIFF
--- a/components/camel-jms/src/main/docs/jms.adoc
+++ b/components/camel-jms/src/main/docs/jms.adoc
@@ -296,8 +296,9 @@ Endpoint options
 
 
 
+
 // endpoint options: START
-The JMS component supports 76 endpoint options which are listed below:
+The JMS component supports 78 endpoint options which are listed below:
 
 [width="100%",cols="2s,1,1m,1m,5",options="header"]
 |=======================================================================
@@ -373,6 +374,8 @@ The JMS component supports 76 endpoint options which are listed below:
 | transferExchange | advanced | false | boolean | You can transfer the exchange over the wire instead of just the body and headers. The following fields are transferred: In body Out body Fault body In headers Out headers Fault headers exchange properties exchange exception. This requires that the objects are serializable. Camel will exclude any non-serializable objects and log it at WARN level. You must enable this option on both the producer and consumer side so Camel knows the payloads is an Exchange and not a regular payload.
 | transferFault | advanced | false | boolean | If enabled and you are using Request Reply messaging (InOut) and an Exchange failed with a SOAP fault (not exception) on the consumer side then the fault flag on link org.apache.camel.MessageisFault() will be send back in the response as a JMS header with the key link JmsConstantsJMS_TRANSFER_FAULT. If the client is Camel the returned fault flag will be set on the link org.apache.camel.MessagesetFault(boolean). You may want to enable this when using Camel components that support faults such as SOAP based such as cxf or spring-ws.
 | useMessageIDAsCorrelationID | advanced | false | boolean | Specifies whether JMSMessageID should always be used as JMSCorrelationID for InOut messages.
+| waitForProvisionCorrelationToBeUpdatedCounter | advanced | 50 | int | Sets a counter that is used in conjunction with waitForProvisionCorrelationToBeUpdatedThreadSleepingTime
+| waitForProvisionCorrelationToBeUpdatedThreadSleepingTime | advanced | 100 | long | Sets the sleeping time of the Thread when waiting for provision correlation to be updated.
 | transacted | transaction | false | boolean | Specifies whether to use transacted mode
 | lazyCreateTransactionManager | transaction (advanced) | true | boolean | If true Camel will create a JmsTransactionManager if there is no transactionManager injected when option transacted=true.
 | transactionManager | transaction (advanced) |  | PlatformTransactionManager | The Spring transaction manager to use.
@@ -380,6 +383,7 @@ The JMS component supports 76 endpoint options which are listed below:
 | transactionTimeout | transaction (advanced) | -1 | int | The timeout value of the transaction (in seconds) if using transacted mode.
 |=======================================================================
 // endpoint options: END
+
 
 
 

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsConfiguration.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsConfiguration.java
@@ -173,6 +173,10 @@ public class JmsConfiguration implements Cloneable {
     @UriParam(defaultValue = "1", label = "advanced",
             description = "Specify the limit for the number of consumers that are allowed to be idle at any given time.")
     private int idleConsumerLimit = 1;
+    @UriParam(defaultValue = "100", label = "advanced")
+    private long waitForProvisionCorrelationToBeUpdatedThreadSleepingTime = 100L;
+    @UriParam(defaultValue = "50", label = "advanced")
+    private int waitForProvisionCorrelationToBeUpdatedCounter = 50;
     @UriParam(label = "consumer",
             description = "Specifies the maximum number of concurrent consumers when consuming from JMS (not for request/reply over JMS)."
                     + " See also the maxMessagesPerTask option to control dynamic scaling up/down of threads."
@@ -1057,6 +1061,38 @@ public class JmsConfiguration implements Cloneable {
         this.idleConsumerLimit = idleConsumerLimit;
     }
 
+    /**
+     * Receives a counter that is used in conjunction with {@code waitForProvisionCorrelationToBeUpdatedThreadSleepingTime}
+     * @return waitForProvisionCorrelationToBeUpdatedCounter
+     */
+    public int getWaitForProvisionCorrelationToBeUpdatedCounter() {
+        return waitForProvisionCorrelationToBeUpdatedCounter;
+    }
+
+    /**
+     * Sets a counter that is used in conjunction with {@code waitForProvisionCorrelationToBeUpdatedThreadSleepingTime}
+     * @param counter
+     */
+    public void setWaitForProvisionCorrelationToBeUpdatedCounter(int counter) {
+        this.waitForProvisionCorrelationToBeUpdatedCounter = counter;
+    }
+
+    /**
+     * Gets the sleeping time of the Thread when waiting for provision correlation to be updated.
+     * @return
+     */
+    public long getWaitForProvisionCorrelationToBeUpdatedThreadSleepingTime() {
+        return waitForProvisionCorrelationToBeUpdatedThreadSleepingTime;
+    }
+
+    /**
+     * Sets the sleeping time of the Thread when waiting for provision correlation to be updated.
+     * @param sleepingTime
+     */
+    public void setWaitForProvisionCorrelationToBeUpdatedThreadSleepingTime(long sleepingTime) {
+        this.waitForProvisionCorrelationToBeUpdatedThreadSleepingTime = sleepingTime;
+    }
+    
     public int getMaxConcurrentConsumers() {
         return maxConcurrentConsumers;
     }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/ReplyManagerSupport.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/ReplyManagerSupport.java
@@ -200,6 +200,20 @@ public abstract class ReplyManagerSupport extends ServiceSupport implements Repl
     protected abstract AbstractMessageListenerContainer createListenerContainer() throws Exception;
 
     /**
+     * @return waitForProvisionCorrelationToBeUpdated counter
+     */
+    private int getWaitForProvisionCorrelationToBeUpdatedCounter(){
+        return endpoint.getConfiguration().getWaitForProvisionCorrelationToBeUpdatedCounter();
+    }
+
+    /**
+     * @return waitForProvisionCorrelationToBeUpdated thread sleeping time
+     */
+    private long getWaitForProvisionCorrelationToBeUpdatedThreadSleepingTime(){
+        return endpoint.getConfiguration().getWaitForProvisionCorrelationToBeUpdatedThreadSleepingTime();
+    }
+
+    /**
      * <b>IMPORTANT:</b> This logic is only being used due to high performance in-memory only
      * testing using InOut over JMS. Its unlikely to happen in a real life situation with communication
      * to a remote broker, which always will be slower to send back reply, before Camel had a chance
@@ -216,13 +230,13 @@ public abstract class ReplyManagerSupport extends ServiceSupport implements Repl
 
         ReplyHandler answer = null;
 
-        // wait up till 5 seconds
+        // wait up until configured values
         boolean done = false;
         int counter = 0;
-        while (!done && counter++ < 50) {
+        while (!done && counter++ < getWaitForProvisionCorrelationToBeUpdatedCounter()) {
             log.trace("Early reply not found handler at attempt {}. Waiting a bit longer.", counter);
             try {
-                Thread.sleep(100);
+                Thread.sleep(getWaitForProvisionCorrelationToBeUpdatedThreadSleepingTime());
             } catch (InterruptedException e) {
                 // ignore
             }


### PR DESCRIPTION
The need for configuring the sleeping time of Thread.sleep and the counter in method waitForProvisionCorrelationToBeUpdated in class ReplyManagerSupport.

When the correlation map is not updated due to that the counterpart do not respond. Every Thread will stall for 5 sec.(Counter hardcoded to 50 and Thread.sleep set to 100ms.) We want the ability to configure these values to better suit our need.
