### PR TITLE
Allow configuration of connectionFactory& co in SjmsEndpoint

### DIFF
--- a/components/camel-sjms/src/main/docs/sjms.adoc
+++ b/components/camel-sjms/src/main/docs/sjms.adoc
@@ -123,8 +123,10 @@ The Simple JMS component supports 9 options which are listed below.
 
 
 
+
+
 // endpoint options: START
-The Simple JMS component supports 29 endpoint options which are listed below:
+The Simple JMS component supports 32 endpoint options which are listed below:
 
 [width="100%",cols="2s,1,1m,1m,5",options="header"]
 |=======================================================================
@@ -147,6 +149,9 @@ The Simple JMS component supports 29 endpoint options which are listed below:
 | responseTimeOut | producer (advanced) | 5000 | long | Sets the amount of time we should wait before timing out a InOut response.
 | asyncStartListener | advanced | false | boolean | Whether to startup the consumer message listener asynchronously when starting a route. For example if a JmsConsumer cannot get a connection to a remote JMS broker then it may block while retrying and/or failover. This will cause Camel to block while starting routes. By setting this option to true you will let routes startup while the JmsConsumer connects to the JMS broker using a dedicated thread in asynchronous mode. If this option is used then beware that if the connection could not be established then an exception is logged at WARN level and the consumer will not be able to receive messages; You can then restart the route to retry.
 | asyncStopListener | advanced | false | boolean | Whether to stop the consumer message listener asynchronously when stopping a route.
+| connectionCount | advanced |  | Integer | The maximum number of connections available to this endpoint
+| connectionFactory | advanced |  | ConnectionFactory | Initializes the connectionFactory for the endpoint which takes precedence over the component's connectionFactory if any
+| connectionResource | advanced |  | ConnectionResource | Initializes the connectionResource for the endpoint which takes precedence over the component's connectionResource if any
 | destinationCreationStrategy | advanced |  | DestinationCreationStrategy | To use a custom DestinationCreationStrategy.
 | exchangePattern | advanced | InOnly | ExchangePattern | Sets the default exchange pattern when creating an exchange
 | headerFilterStrategy | advanced |  | HeaderFilterStrategy | To use a custom HeaderFilterStrategy to filter header to and from Camel message.
@@ -160,6 +165,8 @@ The Simple JMS component supports 29 endpoint options which are listed below:
 | transactionCommitStrategy | transaction |  | TransactionCommitStrategy | Sets the commit strategy.
 |=======================================================================
 // endpoint options: END
+
+
 
 
 Below is an example of how to configure the `SjmsComponent` with its

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsComponent.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsComponent.java
@@ -23,7 +23,6 @@ import javax.jms.ConnectionFactory;
 import org.apache.camel.CamelException;
 import org.apache.camel.Endpoint;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.component.sjms.jms.ConnectionFactoryResource;
 import org.apache.camel.component.sjms.jms.ConnectionResource;
 import org.apache.camel.component.sjms.jms.DefaultJmsKeyFormatStrategy;
 import org.apache.camel.component.sjms.jms.DestinationCreationStrategy;
@@ -33,18 +32,14 @@ import org.apache.camel.component.sjms.taskmanager.TimedTaskManager;
 import org.apache.camel.impl.UriEndpointComponent;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.HeaderFilterStrategyAware;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The <a href="http://camel.apache.org/sjms">Simple JMS</a> component.
  */
 public class SjmsComponent extends UriEndpointComponent implements HeaderFilterStrategyAware {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SjmsComponent.class);
 
     private ConnectionFactory connectionFactory;
     private ConnectionResource connectionResource;
-    private volatile boolean closeConnectionResource;
     private HeaderFilterStrategy headerFilterStrategy = new SjmsHeaderFilterStrategy();
     private JmsKeyFormatStrategy jmsKeyFormatStrategy = new DefaultJmsKeyFormatStrategy();
     private Integer connectionCount = 1;
@@ -106,21 +101,7 @@ public class SjmsComponent extends UriEndpointComponent implements HeaderFilterS
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-
         timedTaskManager = new TimedTaskManager();
-
-        LOGGER.trace("Verify ConnectionResource");
-        if (getConnectionResource() == null) {
-            LOGGER.debug("No ConnectionResource provided. Initialize the ConnectionFactoryResource.");
-            // We always use a connection pool, even for a pool of 1
-            ConnectionFactoryResource connections = new ConnectionFactoryResource(getConnectionCount(), getConnectionFactory());
-            connections.fillPool();
-            setConnectionResource(connections);
-            // we created the resource so we should close it when stopping
-            closeConnectionResource = true;
-        } else if (getConnectionResource() instanceof ConnectionFactoryResource) {
-            ((ConnectionFactoryResource) getConnectionResource()).fillPool();
-        }
     }
 
     @Override
@@ -129,16 +110,6 @@ public class SjmsComponent extends UriEndpointComponent implements HeaderFilterS
             timedTaskManager.cancelTasks();
             timedTaskManager = null;
         }
-
-        if (closeConnectionResource) {
-            if (getConnectionResource() != null) {
-                if (getConnectionResource() instanceof ConnectionFactoryResource) {
-                    ((ConnectionFactoryResource) getConnectionResource()).drainPool();
-                }
-            }
-            connectionResource = null;
-        }
-
         super.doStop();
     }
 

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchComponent.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchComponent.java
@@ -33,6 +33,10 @@ public class SjmsBatchComponent extends UriEndpointComponent {
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        ConnectionFactory cf = resolveAndRemoveReferenceParameter(parameters, "connectionFactory", ConnectionFactory.class);
+        if(cf != null){
+            setConnectionFactory(cf);
+        }
         ObjectHelper.notNull(connectionFactory, "connectionFactory");
         SjmsBatchEndpoint sjmsBatchEndpoint = new SjmsBatchEndpoint(uri, this, remaining);
         setProperties(sjmsBatchEndpoint, parameters);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsEndpointConnectionSettingsTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsEndpointConnectionSettingsTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.sjms;
+
+import java.util.Random;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.sjms.SjmsEndpoint;
+import org.apache.camel.component.sjms.jms.ConnectionFactoryResource;
+import org.apache.camel.component.sjms.jms.ConnectionResource;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class SjmsEndpointConnectionSettingsTest extends CamelTestSupport {
+    private static final ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://broker?broker.persistent=false&broker.useJmx=false");
+    private static final ConnectionResource connectionResource = new ConnectionFactoryResource(2, connectionFactory);
+
+    @Test
+    public void testConnectionFactory() {
+        Endpoint endpoint = context.getEndpoint("sjms:queue:test?connectionFactory=activemq");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof SjmsEndpoint);
+        SjmsEndpoint qe = (SjmsEndpoint) endpoint;
+        assertEquals(connectionFactory, qe.getConnectionFactory());
+    }
+
+    @Test
+    public void testConnectionResource() {
+        Endpoint endpoint = context.getEndpoint("sjms:queue:test?connectionResource=connresource");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof SjmsEndpoint);
+        SjmsEndpoint qe = (SjmsEndpoint) endpoint;
+        assertEquals(connectionResource, qe.getConnectionResource());
+    }
+
+    @Test
+    public void testConnectionCount() {
+        Random random = new Random();
+        int poolSize = random.nextInt(100);
+        Endpoint endpoint = context.getEndpoint("sjms:queue:test?connectionCount=" + poolSize);
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof SjmsEndpoint);
+        SjmsEndpoint qe = (SjmsEndpoint) endpoint;
+        assertEquals(poolSize, qe.getConnectionCount());
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("activemq", connectionFactory);
+        registry.put("connresource", connectionResource);
+        return new DefaultCamelContext(registry);
+    }
+}


### PR DESCRIPTION
Allow sjms endpoints to be used without requiring prior initialization of the component with a connection factory to make this endpoint xml friendly. The new endpoint usage is also friendly to context restart