### PR TITLE
fix for Restlet form data

### DIFF
--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
@@ -94,15 +94,15 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
             if (!headerFilterStrategy.applyFilterToExternalHeaders(entry.getKey(), entry.getValue(), exchange)) {
                 String key = entry.getKey();
                 Object value = entry.getValue();
-                if(HeaderConstants.ATTRIBUTE_HEADERS.equalsIgnoreCase(key)){
-                	 Series<Header> series = (Series<Header>) value;
-                     for(Header header: series){
-                    	 if (!headerFilterStrategy.applyFilterToExternalHeaders(header.getName(), header.getValue(), exchange))
-                        	 inMessage.setHeader(header.getName(), header.getValue());
-                     }
-                }
-                else {
-                	inMessage.setHeader(key, value);
+                if (HeaderConstants.ATTRIBUTE_HEADERS.equalsIgnoreCase(key)) {
+                    Series<Header> series = (Series<Header>) value;
+                    for (Header header: series) {
+                        if (!headerFilterStrategy.applyFilterToExternalHeaders(header.getName(), header.getValue(), exchange)) {
+                            inMessage.setHeader(header.getName(), header.getValue());
+                        }
+                    }
+                } else {
+                    inMessage.setHeader(key, value);
                 }
                 LOG.debug("Populate exchange from Restlet request header: {} value: {}", key, value);
             }
@@ -171,38 +171,35 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
         if ((Method.PUT == method || Method.POST == method) && MediaType.APPLICATION_WWW_FORM.equals(mediaType, true)) {
             form = new Form();
             
-            if(exchange.getIn().getBody() instanceof Map) {
-            	//Body is key value pairs
-                try{
-                	Map pairs = exchange.getIn().getBody(Map.class);
-                	for(Object key: pairs.keySet()) {
-                		Object value = pairs.get(key);
-                		form.add(key.toString(), value != null ? value.toString() : null);
-                	}
-                }
-            	catch(Exception ex) {
+            if (exchange.getIn().getBody() instanceof Map) {
+                //Body is key value pairs
+                try {
+                    Map pairs = exchange.getIn().getBody(Map.class);
+                    for (Object key: pairs.keySet()) {
+                        Object value = pairs.get(key);
+                        form.add(key.toString(), value != null ? value.toString() : null);
+                    }
+                } catch (Exception ex) {
                     LOG.error("body for " + MediaType.APPLICATION_WWW_FORM + " must be Map<String,String> or string format like name=bob&password=secRet", ex);
-                    
                 }
-            }
-            else {
-	            // use string based for forms
-	            String body = exchange.getIn().getBody(String.class);
-	            if (body != null) {
-	            	List<NameValuePair> pairs = URLEncodedUtils.parse(body, Charset.forName(IOHelper.getCharsetName(exchange, true)));
-	                for(NameValuePair p : pairs) {
-	                	form.add(p.getName(), p.getValue());
-	                }
-	            }
+            } else {
+                // use string based for forms
+                String body = exchange.getIn().getBody(String.class);
+                if (body != null) {
+                    List<NameValuePair> pairs = URLEncodedUtils.parse(body, Charset.forName(IOHelper.getCharsetName(exchange, true)));
+                    for (NameValuePair p : pairs) {
+                        form.add(p.getName(), p.getValue());
+                    }
+                }
             }
         }
 
         //Get outgoing custom http headers
         Series<Header> restletHeaders = (Series)request.getAttributes().get(HeaderConstants.ATTRIBUTE_HEADERS);
-    	if(restletHeaders == null){
-    		restletHeaders = new Series<>(Header.class);
-    		request.getAttributes().put(HeaderConstants.ATTRIBUTE_HEADERS, restletHeaders);
-    	}
+        if (restletHeaders == null) {
+            restletHeaders = new Series<>(Header.class);
+            request.getAttributes().put(HeaderConstants.ATTRIBUTE_HEADERS, restletHeaders);
+        }
 
         // login and password are filtered by header filter strategy
         String login = exchange.getIn().getHeader(RestletConstants.RESTLET_LOGIN, String.class);
@@ -228,23 +225,23 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
                         if (value instanceof Collection) {
                             for (Object v : (Collection<?>) value) {
                                 form.add(key, v.toString());
-                                if(!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)){
-                            		restletHeaders.set(key, value.toString());
-                            	}
+                                if (!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)) {
+                                    restletHeaders.set(key, value.toString());
+                                }
                             }
                         } else {
-                        	//Add headers to headers and to body
+                            //Add headers to headers and to body
                             form.add(key, value.toString());
-                            if(!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)){
-                        		restletHeaders.set(key, value.toString());
-                        	}
+                            if (!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)) {
+                                restletHeaders.set(key, value.toString());
+                            }
                         }
                     }
                 } else {
                     // For non-form post put all the headers in custom headers
-                	if(!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)){
-                		restletHeaders.set(key, value.toString());
-                	}
+                    if (!headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange)) {
+                        restletHeaders.set(key, value.toString());
+                    }
                 }
                 LOG.debug("Populate Restlet request from exchange header: {} value: {}", key, value);
             }

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/DefaultRestletBinding.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import java.security.InvalidParameterException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -180,7 +181,7 @@ public class DefaultRestletBinding implements RestletBinding, HeaderFilterStrate
                         form.add(key.toString(), value != null ? value.toString() : null);
                     }
                 } catch (Exception ex) {
-                    LOG.error("body for " + MediaType.APPLICATION_WWW_FORM + " must be Map<String,String> or string format like name=bob&password=secRet", ex);
+                    throw new InvalidParameterException("body for " + MediaType.APPLICATION_WWW_FORM + " request must be Map<String,String> or string format like name=bob&password=secRet");
                 }
             } else {
                 // use string based for forms

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletHeaderFilterStrategy.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletHeaderFilterStrategy.java
@@ -41,6 +41,9 @@ public class RestletHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
         // As we don't set the transfer_encoding protocol header for the restlet service
         // we need to remove the transfer_encoding which could let the client wait forever
         getOutFilter().add(Exchange.TRANSFER_ENCODING);
+        
+        //Don't add the content-length it's added automatically
+        getOutFilter().add(Exchange.CONTENT_LENGTH);
         setCaseInsensitive(true);
     }
 

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderAuthTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderAuthTest.java
@@ -21,8 +21,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
+import org.restlet.data.MediaType;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class RestletRouteBuilderAuthTest extends CamelSpringTestSupport {
@@ -36,6 +38,7 @@ public class RestletRouteBuilderAuthTest extends CamelSpringTestSupport {
         Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(RestletConstants.RESTLET_LOGIN, "admin");
         headers.put(RestletConstants.RESTLET_PASSWORD, "foo");
+        headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_XML);
         headers.put("id", id);
         
         String response = template.requestBodyAndHeaders(

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.restlet.Client;
 import org.restlet.Request;
@@ -166,6 +167,17 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
         headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_WWW_FORM);
         
         String response = template.requestBodyAndHeaders("restlet:http://localhost:" + portNum + "/login?restletMethod=post", "user=jaymandawg&passwd=secret$%", headers, String.class);
+        assertEquals("received user: jaymandawgpassword: secret$%", response);
+    }
+    
+    @Test
+    public void testFormsProducerMapBody() throws IOException {
+    	Map<String, Object> headers = new HashMap<String, Object>();
+        headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_WWW_FORM);
+        Map<String, String> body = new HashMap<>();
+        body.put("user", "jaymandawg");
+        body.put("passwd", "secret$%");
+        String response = template.requestBodyAndHeaders("restlet:http://localhost:" + portNum + "/login?restletMethod=post", body, headers, String.class);
         assertEquals("received user: jaymandawgpassword: secret$%", response);
     }
 }

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.restlet;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -75,18 +77,34 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
                             + exchange.getIn().getHeader("x"));
                     }
                 });
+                
+                // Restlet consumer to handler FORM POST method
+                from("restlet:http://localhost:" + portNum + "/login?restletMethod=post").process(new Processor() {
+                    public void process(Exchange exchange) throws Exception {
+                        exchange.getOut().setBody(
+                            "received user: "
+                            + exchange.getIn().getHeader("user")
+                            + "password: "
+                            + exchange.getIn().getHeader("passwd"));
+                    }
+                });
             }
         };
     }
 
     @Test
     public void testProducer() throws IOException {
-        String response = template.requestBody("direct:start", "<order foo='1'/>", String.class);
+    	Map<String, Object> headers = new HashMap<String, Object>();
+        headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_XML);
+        
+        String response = template.requestBodyAndHeaders("direct:start", "<order foo='1'/>", headers, String.class);
         assertEquals("received [<order foo='1'/>] as an order id = " + ID, response);
         
-        response = template.requestBodyAndHeader(
+        headers.put("id", "89531");
+        
+        response = template.requestBodyAndHeaders(
             "restlet:http://localhost:" + portNum + "/orders?restletMethod=post&foo=bar", 
-            "<order foo='1'/>", "id", "89531", String.class);
+            "<order foo='1'/>", headers, String.class);
         assertEquals("received [<order foo='1'/>] as an order id = " + ID, response);
     }
 
@@ -140,5 +158,14 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
         // expect error status as no Restlet consumer to handle POST method
         assertEquals(Status.CLIENT_ERROR_NOT_FOUND, response.getStatus());
         assertNotNull(response.getEntity().getText());
+    }
+    
+    @Test
+    public void testFormsProducer() throws IOException {
+    	Map<String, Object> headers = new HashMap<String, Object>();
+        headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_WWW_FORM);
+        
+        String response = template.requestBodyAndHeaders("restlet:http://localhost:" + portNum + "/login?restletMethod=post", "user=jaymandawg&passwd=secret$%", headers, String.class);
+        assertEquals("received user: jaymandawgpassword: secret$%", response);
     }
 }

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletRouteBuilderTest.java
@@ -95,7 +95,7 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
 
     @Test
     public void testProducer() throws IOException {
-    	Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_XML);
         
         String response = template.requestBodyAndHeaders("direct:start", "<order foo='1'/>", headers, String.class);
@@ -163,7 +163,7 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
     
     @Test
     public void testFormsProducer() throws IOException {
-    	Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_WWW_FORM);
         
         String response = template.requestBodyAndHeaders("restlet:http://localhost:" + portNum + "/login?restletMethod=post", "user=jaymandawg&passwd=secret$%", headers, String.class);
@@ -172,7 +172,7 @@ public class RestletRouteBuilderTest extends RestletTestSupport {
     
     @Test
     public void testFormsProducerMapBody() throws IOException {
-    	Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(Exchange.CONTENT_TYPE, MediaType.APPLICATION_WWW_FORM);
         Map<String, String> body = new HashMap<>();
         body.put("user", "jaymandawg");

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/route/TestRouteBuilder.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/route/TestRouteBuilder.java
@@ -38,7 +38,7 @@ public class TestRouteBuilder extends RouteBuilder {
         from("restlet:http://localhost:" + port + "/securedOrders?restletMethod=post&restletRealm=#realm").process(new Processor() {
             public void process(Exchange exchange) throws Exception {
                 exchange.getOut().setBody(
-                        "received [" + exchange.getIn().getBody()
+                        "received [" + exchange.getIn().getBody(String.class)
                         + "] as an order id = "
                         + exchange.getIn().getHeader("id"));
             }


### PR DESCRIPTION
Fix for application/x-www-form-urlencoded post data.  Fixed unit test to pass correct content-type and added new test for form data.

(related to: CAMEL-9642) 
Also for "application/x-www-form-urlencoded post data" for some reason, we put the camel-headers in the form fields, i modified to also put the camel-headers in the http headers, but kept them in the body too.  We may want to remove putting camel-headers in the form fields.  

Seems to make more sense to put body->form and camel-headers->http-headers.  But i didn't want to break backwards compatibility.  

Also for Non-Form restletRequest, i populate the camel-headers in the actual http headers.  Previously they were going into the request.attributes which don't make it over in the actual http request.

Sorry should have opened a separate PR for that, but that was the only way i could get the "id" to pass through correctly for the unit test.  Anyways, feel free to remove/modify as needed.