### PR TITLE
CAMEL-9982

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyAbstractDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyAbstractDataFormat.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.dataformat.bindy;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +30,7 @@ import java.util.function.Function;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.dataformat.bindy.annotation.FormatFactories;
+import org.apache.camel.dataformat.bindy.annotation.Link;
 import org.apache.camel.dataformat.bindy.format.factories.DefaultFactoryRegistry;
 import org.apache.camel.dataformat.bindy.format.factories.FactoryRegistry;
 import org.apache.camel.dataformat.bindy.format.factories.FormatFactoryInterface;
@@ -127,6 +130,20 @@ public abstract class BindyAbstractDataFormat extends ServiceSupport implements 
 
     public void setModelFactory(BindyAbstractFactory modelFactory) {
         this.modelFactory = modelFactory;
+    }
+
+    protected Map<String, Object> createLinkedFieldsModel(Object model) throws IllegalAccessException {
+        Map<String, Object> row = new HashMap<>();
+        for (Field field : model.getClass().getDeclaredFields()) {
+            Link linkField = field.getAnnotation(Link.class);
+            if (linkField != null) {
+                boolean accessible = field.isAccessible();
+                field.setAccessible(true);
+                row.put(field.getType().getName(), field.get(model));
+                field.setAccessible(accessible);
+            }
+        }
+        return row;
     }
 
     protected abstract BindyAbstractFactory createModelFactory(FormatFactory formatFactory) throws Exception;

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -91,16 +91,7 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
                 String name = model.getClass().getName();
                 Map<String, Object> row = new HashMap<String, Object>(1);
                 row.put(name, model);
-                // search for @Link-ed fields and add them to the model
-                for (Field field : model.getClass().getDeclaredFields()) {
-                    Link linkField = field.getAnnotation(Link.class);
-                    if (linkField != null) {
-                        boolean accessible = field.isAccessible();
-                        field.setAccessible(true);
-                        row.put(field.getType().getName(), field.get(model));
-                        field.setAccessible(accessible);
-                    }
-                } 
+                row.putAll(createLinkedFieldsModel(model));
                 models.add(row);
             }
         }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
@@ -85,6 +85,7 @@ public class BindyFixedLengthDataFormat extends BindyAbstractDataFormat {
                 String name = model.getClass().getName();
                 Map<String, Object> row = new HashMap<String, Object>();
                 row.put(name, model);
+                row.putAll(createLinkedFieldsModel(model));
                 models.add(row);
             }
         } else {


### PR DESCRIPTION
Patch for CAMEL-9982. Added unittest and added fields with "Link"  annotation to model for Fixed Length.