### PR TITLE
CAMEL-9938

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
@@ -33,7 +33,7 @@ public final class TimePatternConverter {
     private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
     private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
     private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond(s)?)?)?";
+    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond)?(s)?)?";
 
     /**
      * Utility classes should not have a public constructor.

--- a/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
@@ -25,12 +25,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Converter from String syntax to milli seconds.
+ * Code is copied to org.apache.camel.catalog.TimePatternConverter in camel-catalog
  */
 @Converter
 public final class TimePatternConverter {   
     private static final Logger LOG = LoggerFactory.getLogger(TimePatternConverter.class);
     private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
-    //private static final String REPLACEMENT_PATTERN = "[our|inute|econd](s)?";
     private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
     private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
     private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond(s)?)?)?";
@@ -55,10 +55,6 @@ public final class TimePatternConverter {
             //       This String -> long converter will be used for all strings.
             milliseconds = Long.valueOf(source);
         } else {            
-            //matcher = createMatcher(REPLACEMENT_PATTERN, source);
-
-            LOG.trace("Replaced original source {} to {}", source, source);
-            
             matcher = createMatcher(HOUR_REGEX_PATTERN, source);
             if (matcher.find()) {
                 milliseconds = milliseconds + (3600000 * Long.valueOf(matcher.group(1)));

--- a/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
 public final class TimePatternConverter {   
     private static final Logger LOG = LoggerFactory.getLogger(TimePatternConverter.class);
     private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
-    private static final String REPLACEMENT_PATTERN = "[our|inute|econd](s)?";
-    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))[h|H]";
-    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))[m|M]";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))[s|S]";
+    //private static final String REPLACEMENT_PATTERN = "[our|inute|econd](s)?";
+    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
+    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
+    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond(s)?)?)?";
 
     /**
      * Utility classes should not have a public constructor.
@@ -45,6 +45,8 @@ public final class TimePatternConverter {
     public static long toMilliSeconds(String source) throws IllegalArgumentException {
         long milliseconds = 0;
         boolean foundFlag = false;
+
+        checkCorrectnessOfPattern(source);
         Matcher matcher;
 
         matcher = createMatcher(NUMBERS_ONLY_STRING_PATTERN, source);
@@ -53,18 +55,17 @@ public final class TimePatternConverter {
             //       This String -> long converter will be used for all strings.
             milliseconds = Long.valueOf(source);
         } else {            
-            matcher = createMatcher(REPLACEMENT_PATTERN, source);
-            String replacedSource = matcher.replaceAll(""); 
+            //matcher = createMatcher(REPLACEMENT_PATTERN, source);
+
+            LOG.trace("Replaced original source {} to {}", source, source);
             
-            LOG.trace("Replaced original source {} to {}", source, replacedSource);
-            
-            matcher = createMatcher(HOUR_REGEX_PATTERN, replacedSource);
+            matcher = createMatcher(HOUR_REGEX_PATTERN, source);
             if (matcher.find()) {
                 milliseconds = milliseconds + (3600000 * Long.valueOf(matcher.group(1)));
                 foundFlag = true;
             }
             
-            matcher = createMatcher(MINUTES_REGEX_PATTERN, replacedSource);            
+            matcher = createMatcher(MINUTES_REGEX_PATTERN, source);
             if (matcher.find()) {
                 long minutes = Long.valueOf(matcher.group(1));
                 if ((minutes > 59) && foundFlag) {
@@ -74,7 +75,7 @@ public final class TimePatternConverter {
                 milliseconds = milliseconds + (60000 * minutes);
             }
                
-            matcher = createMatcher(SECONDS_REGEX_PATTERN, replacedSource);
+            matcher = createMatcher(SECONDS_REGEX_PATTERN, source);
             if (matcher.find()) {
                 long seconds = Long.valueOf(matcher.group(1));
                 if ((seconds > 59) && foundFlag) {
@@ -94,6 +95,37 @@ public final class TimePatternConverter {
         LOG.trace("source: {} milliseconds: ", source, milliseconds);
         
         return milliseconds;
+    }
+
+    private static void checkCorrectnessOfPattern(String source) {
+        //replace only numbers once
+        Matcher matcher = createMatcher(NUMBERS_ONLY_STRING_PATTERN, source);
+        String replaceSource = matcher.replaceFirst("");
+
+        //replace hour string once
+        matcher = createMatcher(HOUR_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Hours should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        //replace minutes once
+        matcher = createMatcher(MINUTES_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Minutes should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        //replace seconds once
+        matcher = createMatcher(SECONDS_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Seconds should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        if (replaceSource.length() > 0) {
+            throw new IllegalArgumentException("Illegal characters: " + source);
+        }
     }
 
     private static Matcher createMatcher(String regexPattern, String source) {

--- a/camel-core/src/test/java/org/apache/camel/converter/TimePatternConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/TimePatternConverterTest.java
@@ -47,6 +47,12 @@ public class TimePatternConverterTest extends ContextTestSupport {
         assertEquals(35000, milliseconds);
     }
 
+    public void testSecsTimePattern() throws Exception {
+        String source = "35secs";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(35000, milliseconds);
+    }
+
     public void testSecondTimePattern() throws Exception {
         String source = "35second";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
@@ -203,6 +209,11 @@ public class TimePatternConverterTest extends ContextTestSupport {
 
     public void testIllegalCharacters() throws Exception {
         String source = "5ssegegegegqergerg";
+        checkForIllegalArgument(source, "Illegal characters: " + source);
+    }
+
+    public void testSsCharacters() throws Exception {
+        String source = "5ss";
         checkForIllegalArgument(source, "Illegal characters: " + source);
     }
 

--- a/camel-core/src/test/java/org/apache/camel/converter/TimePatternConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/TimePatternConverterTest.java
@@ -18,130 +18,202 @@ package org.apache.camel.converter;
 
 import org.apache.camel.ContextTestSupport;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 public class TimePatternConverterTest extends ContextTestSupport {
 
     public void testMillisecondsTimePattern() throws Exception {
-        String source = new String("444");
+        String source = "444";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(444, milliseconds);
     }
     
     public void testMilliseconds2TimePattern() throws Exception {
-        String source = new String("-72");
+        String source = "-72";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(-72, milliseconds);
     }
     
     public void testSTimePattern() throws Exception {
-        String source = new String("35s");
+        String source = "35s";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(35000, milliseconds);
     }
-    
+
+    public void testSecTimePattern() throws Exception {
+        String source = "35sec";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(35000, milliseconds);
+    }
+
+    public void testSecondTimePattern() throws Exception {
+        String source = "35second";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(35000, milliseconds);
+    }
+
+    public void testSecondsTimePattern() throws Exception {
+        String source = "35seconds";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(35000, milliseconds);
+    }
+
     public void testConsiderLegalSTimePattern() throws Exception {
-        String source = new String("89s");
+        String source = "89s";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(89000, milliseconds);
     }
 
     public void testMTimePattern() throws Exception {
-        String source = new String("28m");
+        String source = "28m";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(1680000, milliseconds);
+    }
+
+    public void testMinTimePattern() throws Exception {
+        String source = "28min";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(1680000, milliseconds);
+    }
+
+    public void testMinuteTimePattern() throws Exception {
+        String source = "28MINUTE";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(1680000, milliseconds);
+    }
+
+    public void testMinutesTimePattern() throws Exception {
+        String source = "28Minutes";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(1680000, milliseconds);
     }
 
     public void testConsiderLegalMTimePattern() throws Exception {
-        String source = new String("89m");
+        String source = "89m";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(5340000, milliseconds);
     }
 
+    public void testHTimePattern() throws Exception {
+        String source = "28h";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(100800000, milliseconds);
+    }
+
+    public void testHourTimePattern() throws Exception {
+        String source = "28Hour";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(100800000, milliseconds);
+    }
+
+    public void testHoursTimePattern() throws Exception {
+        String source = "28HOURS";
+        long milliseconds = TimePatternConverter.toMilliSeconds(source);
+        assertEquals(100800000, milliseconds);
+    }
+
     public void testHMSTimePattern() throws Exception {
-        String source = new String("1h3m5s");
+        String source = "1h3m5s";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(3785000, milliseconds);
     }
 
     public void testHMSTimePattern2() throws Exception {
-        String source = new String("1hours30minutes1second");
+        String source = "1hours30minutes1second";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(5401000, milliseconds);
     }
     
     public void testHMSTimePattern3() throws Exception {
-        String source = new String("1HOUR3m5s");
+        String source = "1HOUR3m5s";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(3785000, milliseconds);
     }
 
     public void testMSTimePattern() throws Exception {
-        String source = new String("30m55s");
+        String source = "30m55s";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(1855000, milliseconds);        
     }
     
     public void testHMTimePattern() throws Exception {
-        String source = new String("1h30m");
+        String source = "1h30m";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(5400000, milliseconds);
     }
 
     public void testSTimePattern2() throws Exception {
-        String source = new String("15sec");
+        String source = "15sec";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(15000, milliseconds);
     }
 
     public void testMTimePattern2() throws Exception {
-        String source = new String("5min");
+        String source = "5min";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(300000, milliseconds);
     }
     
     public void testMTimePattern3() throws Exception {
-        String source = new String("5MIN");
+        String source = "5MIN";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(300000, milliseconds);
     }
     
     public void testMSTimePattern2() throws Exception {
-        String source = new String("4min2sec");
+        String source = "4min2sec";
         long milliseconds = TimePatternConverter.toMilliSeconds(source);
         assertEquals(242000, milliseconds);
     }    
     
     //Negative Tests    
     public void testIllegalHMSTimePattern() {
-        String source = new String("36h88m5s");
-        try {
-            TimePatternConverter.toMilliSeconds(source);
-            fail("Should throw IllegalArgumentException");
-        } catch (Exception e) {
-            assertIsInstanceOf(IllegalArgumentException.class, e);
-            assertEquals("Minutes should contain a valid value between 0 and 59: 36h88m5s", e.getMessage());
-        }
+        String source = "36h88m5s";
+        checkForIllegalArgument(source, "Minutes should contain a valid value between 0 and 59: " + source);
+    }
+
+    public void testHoursTwice() {
+        String source = "36h12hours";
+        String expectedMessage = "Hours should not be specified more then once: " + source;
+        checkForIllegalArgument(source, expectedMessage);
+    }
+
+    public void testMinutesTwice() {
+        String source = "36minute12min";
+        String expectedMessage = "Minutes should not be specified more then once: " + source;
+        checkForIllegalArgument(source, expectedMessage);
+    }
+
+    public void testSecondsTwice() {
+        String source = "36sec12second";
+        String expectedMessage = "Seconds should not be specified more then once: " + source;
+        checkForIllegalArgument(source, expectedMessage);
     }
 
     public void testIllegalMSTimePattern() {
-        String source = new String("55m75s");
+        String source = "55m75s";
+        checkForIllegalArgument(source, "Seconds should contain a valid value between 0 and 59: " + source);
+    }
+
+    public void testIllegalHMTimePattern() throws Exception {
+        String source = "1h89s";
+        checkForIllegalArgument(source, "Seconds should contain a valid value between 0 and 59: " + source);
+    }
+
+    public void testIllegalCharacters() throws Exception {
+        String source = "5ssegegegegqergerg";
+        checkForIllegalArgument(source, "Illegal characters: " + source);
+    }
+
+    private void checkForIllegalArgument(String source, String expectedMessage) {
         try {
             TimePatternConverter.toMilliSeconds(source);
             fail("Should throw IllegalArgumentException");
         } catch (Exception e) {
             assertIsInstanceOf(IllegalArgumentException.class, e);
-            assertEquals("Seconds should contain a valid value between 0 and 59: 55m75s", e.getMessage());
+            assertThat(e.getMessage(), is(expectedMessage));
         }
     }
-    
-    public void testIllegalHMTimePattern() throws Exception {
-        String source = new String("1h89s");
-        try {
-            TimePatternConverter.toMilliSeconds(source);
-            fail("Should throw IllegalArgumentException");
-        } catch (Exception e) {
-            assertIsInstanceOf(IllegalArgumentException.class, e);
-            assertEquals("Seconds should contain a valid value between 0 and 59: 1h89s", e.getMessage());
-        }
-    }    
-    
+
 }

--- a/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
+++ b/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
@@ -26,7 +26,7 @@ public final class TimePatternConverter {
     private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
     private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
     private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond(s)?)?)?";
+    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond)?(s)?)?";
 
     /**
      * Utility classes should not have a public constructor.

--- a/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
+++ b/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
@@ -23,12 +23,10 @@ import java.util.regex.Pattern;
  * This class is a copy from camel-core so we can use it independent to validate uris with time patterns
  */
 public final class TimePatternConverter {
-
     private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
-    private static final String REPLACEMENT_PATTERN = "[our|inute|econd](s)?";
-    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))[h|H]";
-    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))[m|M]";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))[s|S]";
+    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
+    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
+    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond(s)?)?)?";
 
     /**
      * Utility classes should not have a public constructor.
@@ -39,6 +37,8 @@ public final class TimePatternConverter {
     public static long toMilliSeconds(String source) throws IllegalArgumentException {
         long milliseconds = 0;
         boolean foundFlag = false;
+
+        checkCorrectnessOfPattern(source);
         Matcher matcher;
 
         matcher = createMatcher(NUMBERS_ONLY_STRING_PATTERN, source);
@@ -47,16 +47,13 @@ public final class TimePatternConverter {
             //       This String -> long converter will be used for all strings.
             milliseconds = Long.valueOf(source);
         } else {
-            matcher = createMatcher(REPLACEMENT_PATTERN, source);
-            String replacedSource = matcher.replaceAll("");
-
-            matcher = createMatcher(HOUR_REGEX_PATTERN, replacedSource);
+            matcher = createMatcher(HOUR_REGEX_PATTERN, source);
             if (matcher.find()) {
                 milliseconds = milliseconds + (3600000 * Long.valueOf(matcher.group(1)));
                 foundFlag = true;
             }
 
-            matcher = createMatcher(MINUTES_REGEX_PATTERN, replacedSource);
+            matcher = createMatcher(MINUTES_REGEX_PATTERN, source);
             if (matcher.find()) {
                 long minutes = Long.valueOf(matcher.group(1));
                 if ((minutes > 59) && foundFlag) {
@@ -66,7 +63,7 @@ public final class TimePatternConverter {
                 milliseconds = milliseconds + (60000 * minutes);
             }
 
-            matcher = createMatcher(SECONDS_REGEX_PATTERN, replacedSource);
+            matcher = createMatcher(SECONDS_REGEX_PATTERN, source);
             if (matcher.find()) {
                 long seconds = Long.valueOf(matcher.group(1));
                 if ((seconds > 59) && foundFlag) {
@@ -84,6 +81,37 @@ public final class TimePatternConverter {
         }
 
         return milliseconds;
+    }
+
+    private static void checkCorrectnessOfPattern(String source) {
+        //replace only numbers once
+        Matcher matcher = createMatcher(NUMBERS_ONLY_STRING_PATTERN, source);
+        String replaceSource = matcher.replaceFirst("");
+
+        //replace hour string once
+        matcher = createMatcher(HOUR_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Hours should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        //replace minutes once
+        matcher = createMatcher(MINUTES_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Minutes should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        //replace seconds once
+        matcher = createMatcher(SECONDS_REGEX_PATTERN, replaceSource);
+        if (matcher.find() && matcher.find()) {
+            throw new IllegalArgumentException("Seconds should not be specified more then once: " + source);
+        }
+        replaceSource = matcher.replaceFirst("");
+
+        if (replaceSource.length() > 0) {
+            throw new IllegalArgumentException("Illegal characters: " + source);
+        }
     }
 
     private static Matcher createMatcher(String regexPattern, String source) {


### PR DESCRIPTION
We support the following convention (case insensitive):
- only numbers
- (number)h, (number)hour or (number)hours to define hours;
- (number)m, (number)min, (number)minute, (number)minutes to define minutes;
- (number)s, (number)sec, (number)second, (number)seconds to define seconds.

You are only allowed to define each of hours, minutes and seconds once.
After replacing the first occurrence of hours, minutes and seconds and passing the previous check the length of the resulting string is checked for any remaining characters.
