### PR TITLE
CAMEL-9984: Rabbit MQ connection is not closed when channel has been closed by server.

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -156,11 +156,13 @@ class RabbitConsumer implements com.rabbitmq.client.Consumer {
         if (channel == null) {
             return;
         }
-        if (tag != null) {
+        if (tag != null && isChannelOpen()) {
             channel.basicCancel(tag);
         }
         try {
-            channel.close();
+            if (isChannelOpen()) {
+                channel.close();
+            }
         } catch (TimeoutException e) {
             log.error("Timeout occured");
             throw e;


### PR DESCRIPTION
This fixes closing Rabbit MQ connections when the server has already closed the channel / connection. I created an issue at https://issues.apache.org/jira/browse/CAMEL-9984 with full details.