### PR TITLE
Added DurationConverter

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/DurationConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/DurationConverter.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.converter;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.camel.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converters for java.time.Duration.
+ * Provides a converter from a string (ISO-8601) to a Duration,
+ * a Duration to a string (ISO-8601) and
+ * a Duration to millis (long)
+ */
+@Converter
+public final class DurationConverter {
+    private static final Logger LOG = LoggerFactory.getLogger(DurationConverter.class);
+
+    /**
+     * Utility classes should not have a public constructor.
+     */
+    private DurationConverter() {
+    }
+    
+    @Converter
+    public static long toMilliSeconds(Duration source) {
+        long milliseconds = source.toMillis();
+        LOG.trace("source: {} milliseconds: ", source, milliseconds);
+        return milliseconds;
+    }
+
+    @Converter
+    public static Duration fromString(String source) {
+        Duration duration = Duration.parse(source);
+        LOG.trace("source: {} milliseconds: ", source, duration);
+        return duration;
+    }
+
+    @Converter
+    public static String asString(Duration source) {
+        String result = source.toString();
+        LOG.trace("source: {} milliseconds: ", source, result);
+        return result;
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/impl/converter/CorePackageScanClassResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/converter/CorePackageScanClassResolver.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.file.GenericFileConverter;
 import org.apache.camel.converter.CamelConverter;
 import org.apache.camel.converter.CollectionConverter;
 import org.apache.camel.converter.DateTimeConverter;
+import org.apache.camel.converter.DurationConverter;
 import org.apache.camel.converter.IOConverter;
 import org.apache.camel.converter.NIOConverter;
 import org.apache.camel.converter.ObjectConverter;
@@ -73,6 +74,7 @@ public class CorePackageScanClassResolver implements PackageScanClassResolver {
         converters.add(FutureTypeConverter.class);
         converters.add(BeanConverter.class);
         converters.add(GenericFileConverter.class);
+        converters.add(DurationConverter.class);
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.converter;
+
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.TypeConversionException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ */
+public class DurationConverterTest extends ContextTestSupport {
+
+    public void testToMillis() throws Exception {
+        Duration duration = Duration.parse("PT2H6M20.31S");
+
+        Long millis = context.getTypeConverter().convertTo(long.class, duration);
+        assertNotNull(millis);
+        assertThat(millis, is(7580310L));
+    }
+
+    public void testToMillisOverflow() throws Exception {
+        Duration duration = Duration.parse("P60000000000000D");
+        try {
+            context.getTypeConverter().convertTo(long.class, duration);
+        } catch (TypeConversionException e) {
+            assertIsInstanceOf(ArithmeticException.class, e.getCause().getCause());
+            assertThat(e.getMessage(), is("Error during type conversion from type: java.time.Duration to the required type: " +
+                    "long with value PT1440000000000000H due java.lang.ArithmeticException: long overflow"));
+        }
+    }
+
+    public void testFromString() throws Exception {
+        String durationAsString = "PT2H6M20.31S";
+
+        Duration duration = context.getTypeConverter().convertTo(Duration.class, durationAsString);
+        assertNotNull(duration);
+        assertThat(duration.toString(), is("PT2H6M20.31S"));
+    }
+
+    public void testToString() throws Exception {
+        Duration duration= Duration.parse("PT2H6M20.31S");
+
+        String durationAsString = context.getTypeConverter().convertTo(String.class, duration);
+        assertNotNull(durationAsString);
+        assertThat(durationAsString, is("PT2H6M20.31S"));
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
@@ -27,9 +27,6 @@ import org.apache.camel.TypeConversionException;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-/**
- *
- */
 public class DurationConverterTest extends ContextTestSupport {
 
     public void testToMillis() throws Exception {
@@ -46,8 +43,6 @@ public class DurationConverterTest extends ContextTestSupport {
             context.getTypeConverter().convertTo(long.class, duration);
         } catch (TypeConversionException e) {
             assertIsInstanceOf(ArithmeticException.class, e.getCause().getCause());
-            assertThat(e.getMessage(), is("Error during type conversion from type: java.time.Duration to the required type: " +
-                    "long with value PT1440000000000000H due java.lang.ArithmeticException: long overflow"));
         }
     }
 


### PR DESCRIPTION
Added a Duration converter to camel-core:
- Duration to millis as long
- String to Duration (see ISO-8601 and Duration javadoc)
- Duration to String (see ISO-8601 and Duration javadoc)