### PR TITLE
CAMEL-8219: camel-smpp - use jsmpp version 2.2.4

### DIFF
--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -29,9 +29,8 @@
     <description>Camel SMPP support</description>
 
     <properties>
-      <!-- jsmpp 2.2.3 JAR is invalid OSGi bundle so we need to use the older 2.1 SMX release -->
       <camel.osgi.import.before.defaults>
-        org.jsmpp.*;version="[2.1,2.3)"
+        org.jsmpp.*;version="[2.2,2.3)"
       </camel.osgi.import.before.defaults>
       <camel.osgi.export.pkg>org.apache.camel.component.smpp.*</camel.osgi.export.pkg>
         <camel.osgi.export.service>

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppDataSmCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppDataSmCommandTest.java
@@ -109,7 +109,7 @@ public class SmppDataSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.DEST_ADDR_TON, TypeOfNumber.INTERNATIONAL.value());
         exchange.getIn().setHeader(SmppConstants.DEST_ADDR_NPI, NumberingPlanIndicator.INTERNET.value());
         exchange.getIn().setHeader(SmppConstants.DEST_ADDR, "1919");
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         expect(session.dataShortMessage(eq("XXX"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"), eq(new ESMClass()),
                 eq(new RegisteredDelivery((byte) 2)), eq(DataCodings.newInstance((byte) 0))))

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppReplaceSmCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppReplaceSmCommandTest.java
@@ -100,10 +100,10 @@ public class SmppReplaceSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.SOURCE_ADDR, "1818");
         exchange.getIn().setHeader(SmppConstants.SCHEDULE_DELIVERY_TIME, new Date(1111111));
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setBody("new short message body");
-        session.replaceShortMessage(eq("1"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"), eq("-300101001831100-"), eq("-300101003702200-"),
-                eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)), eq((byte) 0), aryEq("new short message body".getBytes()));
+        session.replaceShortMessage(eq("1"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"), eq("-300101001831100+"), eq("-300101003702200+"),
+                eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)), eq((byte) 0), aryEq("new short message body".getBytes()));
         
         replay(session);
         
@@ -124,10 +124,10 @@ public class SmppReplaceSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.SOURCE_ADDR, "1818");
         exchange.getIn().setHeader(SmppConstants.SCHEDULE_DELIVERY_TIME, new Date(1111111));
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, "000003000000000R"); // three days
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setBody("new short message body");
-        session.replaceShortMessage(eq("1"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"), eq("-300101001831100-"), eq("000003000000000R"),
-                eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)), eq((byte) 0), aryEq("new short message body".getBytes()));
+        session.replaceShortMessage(eq("1"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"), eq("-300101001831100+"), eq("000003000000000R"),
+                eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)), eq((byte) 0), aryEq("new short message body".getBytes()));
         
         replay(session);
         

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitMultiCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitMultiCommandTest.java
@@ -124,12 +124,12 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn(new SubmitMultiResult("1"));
 
@@ -159,12 +159,12 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, "000003000000000R"); // three days
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn(new SubmitMultiResult("1"));
 
@@ -433,7 +433,7 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         Map<String, String> optionalParameters = new LinkedHashMap<String, String>();
         optionalParameters.put("SOURCE_SUBADDRESS", "1292");
@@ -446,7 +446,7 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setBody("short message body");
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
                 eq(new OptionalParameter.Source_subaddress("1292".getBytes())),
                 eq(new OptionalParameter.Additional_status_info_text("urgent".getBytes())),
@@ -482,7 +482,7 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         Map<Short, Object> optionalParameters = new LinkedHashMap<Short, Object>();
         // standard optional parameter
@@ -503,7 +503,7 @@ public class SmppSubmitMultiCommandTest {
         exchange.getIn().setBody("short message body");
         expect(session.submitMultiple(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 aryEq(new Address[]{new Address(TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.INTERNET, "1919")}),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes()),
                 eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
                 eq(new OptionalParameter.COctetString(Tag.ADDITIONAL_STATUS_INFO_TEXT.code(), "urgent")),

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitSmCommandTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppSubmitSmCommandTest.java
@@ -217,12 +217,12 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn("1");
 
@@ -251,7 +251,7 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         Map<String, String> optionalParameters = new LinkedHashMap<String, String>();
@@ -264,7 +264,7 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.OPTIONAL_PARAMETERS, optionalParameters);
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0),
                 aryEq("short message body".getBytes()), eq(new OptionalParameter.Source_subaddress("1292".getBytes())),
                 eq(new OptionalParameter.Additional_status_info_text("urgent".getBytes())), eq(new OptionalParameter.Dest_addr_subunit((byte) 4)),
@@ -297,7 +297,7 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, new Date(2222222));
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         Map<Short, Object> optionalParameters = new LinkedHashMap<Short, Object>();
@@ -318,7 +318,7 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.OPTIONAL_PARAMETER, optionalParameters);
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("-300101003702200-"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("-300101003702200+"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0),
                 aryEq("short message body".getBytes()),
                 eq(new OptionalParameter.OctetString(Tag.SOURCE_SUBADDRESS, "1292")),
@@ -360,12 +360,12 @@ public class SmppSubmitSmCommandTest {
         exchange.getIn().setHeader(SmppConstants.VALIDITY_PERIOD, "000003000000000R"); // three days
         exchange.getIn().setHeader(SmppConstants.PROTOCOL_ID, (byte) 1);
         exchange.getIn().setHeader(SmppConstants.PRIORITY_FLAG, (byte) 2);
-        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS).value());
+        exchange.getIn().setHeader(SmppConstants.REGISTERED_DELIVERY, new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE).value());
         exchange.getIn().setHeader(SmppConstants.REPLACE_IF_PRESENT_FLAG, ReplaceIfPresentFlag.REPLACE.value());
         exchange.getIn().setBody("short message body");
         expect(session.submitShortMessage(eq("CMT"), eq(TypeOfNumber.NATIONAL), eq(NumberingPlanIndicator.NATIONAL), eq("1818"),
                 eq(TypeOfNumber.INTERNATIONAL), eq(NumberingPlanIndicator.INTERNET), eq("1919"),
-                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100-"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.SUCCESS)),
+                eq(new ESMClass()), eq((byte) 1), eq((byte) 2), eq("-300101001831100+"), eq("000003000000000R"), eq(new RegisteredDelivery(SMSCDeliveryReceipt.FAILURE)),
                 eq(ReplaceIfPresentFlag.REPLACE.value()), eq(DataCodings.newInstance((byte) 0)), eq((byte) 0), aryEq("short message body".getBytes())))
                 .andReturn("1");
 

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppUtilsTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppUtilsTest.java
@@ -46,8 +46,8 @@ public class SmppUtilsTest {
 
     @Test
     public void formatTime() {
-        assertEquals("-300101000000000-", SmppUtils.formatTime(new Date(0L)));
-        assertEquals("-300101024640000-", SmppUtils.formatTime(new Date(10000000L)));
+        assertEquals("-300101000000000+", SmppUtils.formatTime(new Date(0L)));
+        assertEquals("-300101024640000+", SmppUtils.formatTime(new Date(10000000L)));
     }
     
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -326,7 +326,7 @@
     <josql-version>1.5</josql-version>
     <jruby-version>1.7.18</jruby-version>
     <jsendnsca-version>1.3.1</jsendnsca-version>
-    <jsmpp-version>2.2.3</jsmpp-version>
+    <jsmpp-version>2.2.4</jsmpp-version>
     <jsch-version>0.1.53</jsch-version>
     <jsch-bundle-version>0.1.53_1</jsch-bundle-version>
     <jsendnsca-bundle-version>1.3.1_3</jsendnsca-bundle-version>
@@ -342,7 +342,6 @@
     <jsoup-version>1.9.1</jsoup-version>
     <jsp-api-2.1-version>1.0.1</jsp-api-2.1-version>
     <jsr311-api-version>1.1.1</jsr311-api-version>
-    <jsmpp-bundle-version>2.1.0_4</jsmpp-bundle-version>
     <jt400-version>9.0</jt400-version>
     <jt400-bundle-version>9.0_1</jt400-bundle-version>
     <juel-bundle-version>2.1.3_1</juel-bundle-version>

--- a/platforms/karaf/features/src/main/resources/bundles.properties
+++ b/platforms/karaf/features/src/main/resources/bundles.properties
@@ -69,7 +69,6 @@ org.apache.servicemix.bundles/org.apache.servicemix.bundles.ognl/${ognl-bundle-v
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.oscache/${oscache-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.httpcore/${httpcore-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.jing/${jing-bundle-version}/jar
-org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsmpp/${jsmpp-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/${quartz-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.qpid/${qpid-bundle-version}/jar
 org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/${saxon-bundle-version}/jar

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1482,7 +1482,7 @@
   </feature>
   <feature name='camel-smpp' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsmpp/${jsmpp-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.jsmpp/jsmpp/${jsmpp-version}</bundle>
     <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-smpp/${project.version}</bundle>
   </feature>


### PR DESCRIPTION
Test changes were necessary because of two jsmpp changes: https://github.com/opentelecoms-org/jsmpp/commit/fcb495f09b97738796548069b2c60050be7892e3 and https://github.com/opentelecoms-org/jsmpp/commit/d50fbd7e9b76e292459858b26c1397e6d2c69c9e

My osgi/service-mix knowledge is almost non-existent, so please forgive if I made a mistake.