### PR TITLE
CAMEL-10023 Consider sortBy header when performing findOneByQuery operation

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
@@ -351,13 +351,17 @@ public class MongoDbProducer extends DefaultProducer {
         DBObject o = exchange.getIn().getMandatoryBody(DBObject.class);
         DBObject ret;
 
+        DBObject sortBy = exchange.getIn().getHeader(MongoDbConstants.SORT_BY, DBObject.class);
         DBObject fieldFilter = exchange.getIn().getHeader(MongoDbConstants.FIELDS_FILTER, DBObject.class);
-        if (fieldFilter == null) {
-            ret = dbCol.findOne(o);
-        } else {
-            ret = dbCol.findOne(o, fieldFilter);
-        }
 
+        if (sortBy != null) {
+            ret = dbCol.findOne(o, fieldFilter, sortBy);
+        } else if (fieldFilter != null) {
+            ret = dbCol.findOne(o, fieldFilter);
+        } else {
+            ret = dbCol.findOne(o);
+        }
+        
         Message resultMessage = prepareResponseMessage(exchange, MongoDbOperation.findOneByQuery);
         resultMessage.setBody(ret);
         resultMessage.setHeader(MongoDbConstants.RESULT_TOTAL_SIZE, ret == null ? 0 : 1);


### PR DESCRIPTION
There is a often a requirement to fetch the min/max record from Mongo based on a particular field. Typically the operation is performed using syntax similar to:

  db.collection.find().sort({_id: -1}).limit(1)

 or

  db.collection.findOne({$query:{},$orderby:{_id:-1}})

As implemented the findOneByQuery operation currently ignores the sortBy header. This trivial patch passes sortBy to the sort parameter of findOne(), if set.

Helpfully, if the projection parameter is null findOne() returns all fields, so the state of fieldFilter is not checked before passing when the sortBy header has been set.
