### PR TITLE
Replaced deprecated method "groupExchanges()" in junit test-cases within camel-core.

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges.
@@ -75,12 +76,10 @@ public class AggregateGroupedExchangeBatchSizeTest extends ContextTestSupport {
                 // our route is aggregating from the direct queue and sending the response to the mock
                 from("direct:start")
                     .log("Aggregator received ${body}")
-                    // aggregated all use same expression
-                    .aggregate(constant(true)).completionSize(2)
+                    // aggregated all use same expression and group the exchanges so we get one single exchange containing all the others
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).completionSize(2)
                     // wait for 0.5 seconds to aggregate
                     .completionTimeout(500L)
-                    // group the exchanges so we get one single exchange containing all the others
-                    .groupExchanges()
                     .to("mock:result");
                 // END SNIPPET: e1
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeCompletionSizeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeCompletionSizeTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.processor.aggregator;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges.
@@ -44,8 +45,7 @@ public class AggregateGroupedExchangeCompletionSizeTest extends ContextTestSuppo
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                    .aggregate(constant(true)).completionSize(3)
-                    .groupExchanges()
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).completionSize(3)
                     .to("mock:result");
             }
         };

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeMultipleCorrelationTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeMultipleCorrelationTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges.
@@ -77,10 +78,8 @@ public class AggregateGroupedExchangeMultipleCorrelationTest extends ContextTest
                 // START SNIPPET: e1
                 // our route is aggregating from the direct queue and sending the response to the mock
                 from("direct:start")
-                    // aggregate all using the foo header
-                    .aggregate(header("foo"))
-                    // group the exchanges so we get one single exchange containing all the others
-                    .groupExchanges()
+                    // aggregate all using the foo header and group the exchanges so we get one single exchange containing all the others
+                    .aggregate(header("foo"),new GroupedExchangeAggregationStrategy())
                     // wait for 1 seconds to aggregate
                     .completionTimeout(1000L)
                     .to("mock:result");

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizePredicateTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizePredicateTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges completed by size
@@ -64,7 +65,7 @@ public class AggregateGroupedExchangeSizePredicateTest extends ContextTestSuppor
             public void configure() throws Exception {
                 from("direct:start")
                     // must use eagerCheckCompletion so we can check the groupSize header on the incoming exchange 
-                    .aggregate(constant(true)).groupExchanges().eagerCheckCompletion().completionSize(header("groupSize"))
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).eagerCheckCompletion().completionSize(header("groupSize"))
                         .to("mock:result")
                     .end();
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizeTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges completed by size
@@ -65,7 +66,7 @@ public class AggregateGroupedExchangeSizeTest extends ContextTestSupport {
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                    .aggregate(constant(true)).groupExchanges().completionSize(3)
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).completionSize(3)
                         .to("mock:result")
                     .end();
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  * Unit test for aggregate grouped exchanges.
@@ -65,12 +66,10 @@ public class AggregateGroupedExchangeTest extends ContextTestSupport {
                 // START SNIPPET: e1
                 // our route is aggregating from the direct queue and sending the response to the mock
                 from("direct:start")
-                    // aggregate all using same expression
-                    .aggregate(constant(true))
+                    // aggregate all using same expression and group the exchanges so we get one single exchange containing all the others
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true)
                     // wait for 0.5 seconds to aggregate
                     .completionTimeout(500L)
-                    // group the exchanges so we get one single exchange containing all the others
-                    .groupExchanges()
                     .to("mock:result");
                 // END SNIPPET: e1
             }

--- a/camel-core/src/test/java/org/apache/camel/util/DumpModelAsXmlAggregateRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/DumpModelAsXmlAggregateRouteTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.util;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.ModelHelper;
+import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 
 /**
  *
@@ -42,9 +43,8 @@ public class DumpModelAsXmlAggregateRouteTest extends ContextTestSupport {
             public void configure() throws Exception {
                 from("direct:start").routeId("myRoute")
                     .to("log:input")
-                    .aggregate().header("userId")
-                        .groupExchanges().completionSize(3)
-                        .to("mock:aggregate")
+                    .aggregate(header("userId"),new GroupedExchangeAggregationStrategy()).completionSize(3)
+                    .to("mock:aggregate")
                     .end()
                     .to("mock:result");
             }


### PR DESCRIPTION
Hi,

As suggested previously I did changes to all the test-cases and replaced deprecated method groupExchanges() in all. Except one AggregateGroupedExchangeCompletionExpressionSizeTest.
I see below code fragment fails. Might be expression is not playing well with GroupedExchangeAggregationStrategy or I am missing something.
.aggregate(new GroupedExchangeAggregationStrategy()).constant(true).completionSize(header("size")).

Hence not committed AggregateGroupedExchangeCompletionExpressionSizeTest testcase. 
AggregateGroupedExchangeBackwardsCompTest which provides backwards compatibility is intact.