### PR TITLE
Mina2BodyPatch for 2.17

### DIFF
--- a/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Helper.java
+++ b/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2Helper.java
@@ -51,7 +51,7 @@ public final class Mina2Helper {
         // thread hanging forever
         LOG.trace("Waiting for write to complete for body: {} using session: {}", body, session);
         if (!future.awaitUninterruptibly(10000L)) {
-            String message = "Cannot write body: " + body + " using session: " + session;
+            String message = "Cannot write body: " + body.getClass().getCanonicalName() + " using session: " + session;
             if (future.getException() != null) {
                 throw new CamelExchangeException(message, exchange, future.getException());
             } else {


### PR DESCRIPTION
Fix for http://camel.465427.n5.nabble.com/Camel-logs-whole-message-body-in-case-of-org-apache-camel-CamelExchangeException-quot-Cannot-write-b-td5783240.html