### PR TITLE
CAMEL-10051 - Fixed issue with reuse channel.

### DIFF
--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyProducer.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyProducer.java
@@ -282,7 +282,13 @@ public class NettyProducer extends DefaultAsyncProducer {
         
         // need to declare as final
         final Channel channel = existing;
-        final AsyncCallback producerCallback = new NettyProducerCallback(channel, callback);
+        final AsyncCallback producerCallback;
+
+        if(configuration.isReuseChannel()) {
+            producerCallback = callback;
+        } else {
+            producerCallback = new NettyProducerCallback(channel, callback);
+        }
 
         // setup state as attachment on the channel, so we can access the state later when needed
         putState(channel, new NettyCamelState(producerCallback, exchange));


### PR DESCRIPTION
When reuseChannel is set to true, channel is returned to the pool every time a message is sent