### PR TITLE
Prefix picklist enum names with owning SObjectDescription name

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
@@ -571,7 +571,8 @@ public class CamelSalesforceMojo extends AbstractMojo {
             // write required Enumerations for any picklists
             for (SObjectField field : description.getFields()) {
                 if (utility.isPicklist(field) || utility.isMultiSelectPicklist(field)) {
-                    fileName = utility.enumTypeName(field.getName()) + JAVA_EXT;
+                    String enumName = description.getName() + "_" + utility.enumTypeName(field.getName());
+                    fileName = enumName + JAVA_EXT;
                     File enumFile = new File(pkgDir, fileName);
                     writer = new BufferedWriter(new FileWriter(enumFile));
 
@@ -579,6 +580,7 @@ public class CamelSalesforceMojo extends AbstractMojo {
                     context.put("packageName", packageName);
                     context.put("utility", utility);
                     context.put("field", field);
+                    context.put("enumName", enumName);
                     context.put("generatedDate", generatedDate);
 
                     Template queryTemplate = engine.getTemplate(SOBJECT_PICKLIST_VM);
@@ -695,14 +697,14 @@ public class CamelSalesforceMojo extends AbstractMojo {
             return !BASE_FIELDS.contains(name);
         }
 
-        public String getFieldType(SObjectField field) throws MojoExecutionException {
+        public String getFieldType(SObjectDescription description, SObjectField field) throws MojoExecutionException {
             // check if this is a picklist
             if (isPicklist(field)) {
                 // use a pick list enum, which will be created after generating the SObject class
-                return enumTypeName(field.getName());
+                return description.getName() + "_" + enumTypeName(field.getName());
             } else if (isMultiSelectPicklist(field)) {
                 // use a pick list enum array, enum will be created after generating the SObject class
-                return enumTypeName(field.getName()) + "[]";
+                return description.getName() + "_" + enumTypeName(field.getName()) + "[]";
             } else {
                 // map field to Java type
                 final String soapType = field.getSoapType();

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-picklist.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-picklist.vm
@@ -24,7 +24,6 @@ package $packageName;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonValue;
 
-#set ( $enumName = $utility.enumTypeName($field.Name) )
 /**
  * Salesforce Enumeration DTO for picklist $field.Name
  */

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo.vm
@@ -52,7 +52,7 @@ public class $desc.Name extends AbstractSObjectBase {
 #foreach ( $field in $desc.Fields )
 #if ( $utility.notBaseField($field.Name) )
 #set ( $fieldName = $field.Name )
-#set ( $fieldType = $utility.getFieldType($field) )
+#set ( $fieldType = $utility.getFieldType($desc, $field) )
 #set ( $isMultiSelectPicklist = $utility.isMultiSelectPicklist($field) )
     // $fieldName
 #if ( $utility.isBlobField($field) )


### PR DESCRIPTION
This allows multiple objects to have similarly named picklist fields (e.g. `Type`) without causing name conflicts (practically a race condition on the contents of the picklist enum class).

@davsclaus We've discussed this feature a long time ago - the patches will finally be rolling in now :smile:

Signed-off-by: Sune Keller <absukl@almbrand.dk>