### PR TITLE
CAMEL-10034: prevent component scan of health indicator

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/health/CamelHealthIndicator.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/health/CamelHealthIndicator.java
@@ -20,12 +20,10 @@ import org.apache.camel.CamelContext;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.stereotype.Component;
 
 /**
  * Camel {@link HealthIndicator}.
  */
-@Component
 public class CamelHealthIndicator extends AbstractHealthIndicator {
 
     private CamelContext camelContext;


### PR DESCRIPTION
The CamelHealthIndicator should not be marked as `@Component`, because it would be initialized also by the component scanner if it is enabled on the package.

Putting spring-boot base package on 'org.apache.camel' causes issues if the actuator lib is not present in the classpath.

