### PR TITLE
CAMEL-10052: Spring-boot integration tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,6 +50,7 @@
     <aries-blueprint-proxy-version>1.0.1</aries-blueprint-proxy-version>
     <aries-blueprint-proxy-impl-version>1.0.4</aries-blueprint-proxy-impl-version>
     <aries-util-version>1.1.1</aries-util-version>
+    <arquillian-container-se-managed-version>1.0.0.Final</arquillian-container-se-managed-version>
     <arquillian-version>1.1.11.Final</arquillian-version>
     <arquillian-weld-se-embedded-version>1.0.0.CR9</arquillian-weld-se-embedded-version>
     <asm-bundle-version>3.3.1_1</asm-bundle-version>
@@ -498,6 +499,8 @@
     <servlet-version-range>[3,4)</servlet-version-range>
     <shiro-version>1.2.4</shiro-version>
     <shrinkwrap-descriptors-version>2.0.0-alpha-8</shrinkwrap-descriptors-version>
+    <shrinkwrap-resolver-version>2.2.2</shrinkwrap-resolver-version>
+    <shrinkwrap-version>1.2.3</shrinkwrap-version>
     <sip-api-version>1.1</sip-api-version>
     <slf4j-api-version>1.7.21</slf4j-api-version>
     <slf4j-version>1.7.21</slf4j-version>

--- a/tests/camel-itest-spring-boot/pom.xml
+++ b/tests/camel-itest-spring-boot/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests</artifactId>
+        <groupId>org.apache.camel</groupId>
+        <version>2.18-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-itest-spring-boot</artifactId>
+
+    <name>Camel :: Integration Tests :: Spring-Boot</name>
+    <description>Spring-Boot Camel test</description>
+
+
+    <properties>
+        <arquillian.version>1.1.11.Final</arquillian.version>
+        <arquillian-container.version>1.0.0.Final</arquillian-container.version>
+        <shrinkwrap.version>1.2.3</shrinkwrap.version>
+        <shrinkwrap-resolver.version>2.2.2</shrinkwrap-resolver.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Dependency needed to incorporate classes in main jar -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${spring-boot-version}</version>
+        </dependency>
+
+        <!-- Test dependencies needed also at compile/unitTestEnabled time -->
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <version>${shrinkwrap.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <version>${shrinkwrap.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <version>${arquillian.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>container-se-managed</artifactId>
+            <version>${arquillian-container.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-spi</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven-archive</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <childDelegation>false</childDelegation>
+                    <forkedProcessTimeoutInSeconds>15000</forkedProcessTimeoutInSeconds>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/camel-itest-spring-boot/pom.xml
+++ b/tests/camel-itest-spring-boot/pom.xml
@@ -14,14 +14,6 @@
     <name>Camel :: Integration Tests :: Spring-Boot</name>
     <description>Spring-Boot Camel test</description>
 
-
-    <properties>
-        <arquillian.version>1.1.11.Final</arquillian.version>
-        <arquillian-container.version>1.0.0.Final</arquillian-container.version>
-        <shrinkwrap.version>1.2.3</shrinkwrap.version>
-        <shrinkwrap-resolver.version>2.2.2</shrinkwrap-resolver.version>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -40,13 +32,13 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-            <version>${shrinkwrap.version}</version>
+            <version>${shrinkwrap-version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <version>${shrinkwrap.version}</version>
+            <version>${shrinkwrap-version}</version>
         </dependency>
 
         <dependency>
@@ -58,62 +50,62 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>${arquillian-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>container-se-managed</artifactId>
-            <version>${arquillian-container.version}</version>
+            <version>${arquillian-container-se-managed-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-spi</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven-archive</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>${shrinkwrap-resolver.version}</version>
+            <version>${shrinkwrap-resolver-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ApplicationContextHolder.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ApplicationContextHolder.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * receives a spring-context and make it available to classes outside the spring scope.
+ */
+@Component
+public class ApplicationContextHolder implements ApplicationContextAware {
+
+    private static ApplicationContext context;
+
+    private static long contextMaxWaitTime = 60000L;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        synchronized (ApplicationContextHolder.class) {
+            ApplicationContextHolder.context = applicationContext;
+            ApplicationContextHolder.class.notifyAll();
+        }
+    }
+
+    public static ApplicationContext getApplicationContext() throws InterruptedException {
+        waitForContextReady();
+        return context;
+    }
+
+    private static void waitForContextReady() throws InterruptedException {
+        long maxWait = contextMaxWaitTime;
+        long deadline = System.currentTimeMillis() + maxWait;
+        synchronized (ApplicationContextHolder.class) {
+            long time = System.currentTimeMillis();
+            while (time < deadline && context == null) {
+                ApplicationContextHolder.class.wait(deadline - time);
+                time = System.currentTimeMillis();
+            }
+
+            if (context == null) {
+                throw new IllegalStateException("No spring context available after " + maxWait + " millis");
+            }
+        }
+    }
+
+    public static long getContextMaxWaitTime() {
+        return contextMaxWaitTime;
+    }
+
+    public static void setContextMaxWaitTime(long contextMaxWaitTime) {
+        ApplicationContextHolder.contextMaxWaitTime = contextMaxWaitTime;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/Command.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/Command.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+/**
+ * Represents a generic command that can be executed in the spring-boot context.
+ */
+public interface Command {
+
+    Object execute(Object[] parameters) throws Exception;
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/CommandRouter.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/CommandRouter.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.springframework.context.ApplicationContext;
+
+import static org.apache.camel.itest.springboot.util.SerializationUtils.marshal;
+import static org.apache.camel.itest.springboot.util.SerializationUtils.transferable;
+import static org.apache.camel.itest.springboot.util.SerializationUtils.unmarshal;
+
+/**
+ * Routes a command coming from another classloader to the appropriate spring bean.
+ */
+public final class CommandRouter {
+
+    private CommandRouter() {
+    }
+
+    public static byte[] execute(String commandStr, byte[] params) {
+
+        try {
+            ApplicationContext context = ApplicationContextHolder.getApplicationContext();
+
+            Command command = (Command) context.getBean(commandStr);
+
+            Object[] args = null;
+            if (params != null) {
+                args = (Object[]) unmarshal(params);
+            }
+
+            Object result = command.execute(args);
+
+            return marshal(result);
+        } catch (Throwable t) {
+            return marshal(transferable(t));
+        }
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestApplication.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestApplication.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Contains the main class of the sample spring-boot application created for the module under test.
+ *
+ */
+@SpringBootApplication
+public class ITestApplication {
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(ITestApplication.class, args);
+    }
+
+    @Override
+    public String toString() {
+        // to tell source-check this is not a utility-class
+        return "spring-boot-main";
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfig.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfig.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import java.io.Serializable;
+
+/**
+ * A configuration bean for a test execution.
+ */
+public class ITestConfig implements Serializable {
+
+    private static final long serialVersionUID = -3641997669166217595L;
+
+    private String moduleName;
+
+    private String mavenGroup;
+
+    private String mavenVersion;
+
+    private String modulesPath;
+
+    private Boolean includeTestDependencies;
+
+    private Boolean unitTestEnabled;
+
+    private String unitTestInclusionPattern;
+
+    private String unitTestExclusionPattern;
+
+    private String unitTestBasePackage;
+
+    private Integer unitTestsExpectedNumber;
+
+    public ITestConfig() {
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getMavenGroup() {
+        return mavenGroup;
+    }
+
+    public void setMavenGroup(String mavenGroup) {
+        this.mavenGroup = mavenGroup;
+    }
+
+    public String getMavenVersion() {
+        return mavenVersion;
+    }
+
+    public void setMavenVersion(String mavenVersion) {
+        this.mavenVersion = mavenVersion;
+    }
+
+    public String getModulesPath() {
+        return modulesPath;
+    }
+
+    public void setModulesPath(String modulesPath) {
+        this.modulesPath = modulesPath;
+    }
+
+    public Boolean getIncludeTestDependencies() {
+        return includeTestDependencies;
+    }
+
+    public void setIncludeTestDependencies(Boolean includeTestDependencies) {
+        this.includeTestDependencies = includeTestDependencies;
+    }
+
+    public Boolean getUnitTestEnabled() {
+        return unitTestEnabled;
+    }
+
+    public void setUnitTestEnabled(Boolean unitTestEnabled) {
+        this.unitTestEnabled = unitTestEnabled;
+    }
+
+    public String getUnitTestInclusionPattern() {
+        return unitTestInclusionPattern;
+    }
+
+    public void setUnitTestInclusionPattern(String unitTestInclusionPattern) {
+        this.unitTestInclusionPattern = unitTestInclusionPattern;
+    }
+
+    public String getUnitTestExclusionPattern() {
+        return unitTestExclusionPattern;
+    }
+
+    public void setUnitTestExclusionPattern(String unitTestExclusionPattern) {
+        this.unitTestExclusionPattern = unitTestExclusionPattern;
+    }
+
+    public String getUnitTestBasePackage() {
+        return unitTestBasePackage;
+    }
+
+    public void setUnitTestBasePackage(String unitTestBasePackage) {
+        this.unitTestBasePackage = unitTestBasePackage;
+    }
+
+    public Integer getUnitTestsExpectedNumber() {
+        return unitTestsExpectedNumber;
+    }
+
+    public void setUnitTestsExpectedNumber(Integer unitTestsExpectedNumber) {
+        this.unitTestsExpectedNumber = unitTestsExpectedNumber;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ITestConfig{");
+        sb.append("moduleName='").append(moduleName).append('\'');
+        sb.append(", mavenGroup='").append(mavenGroup).append('\'');
+        sb.append(", mavenVersion='").append(mavenVersion).append('\'');
+        sb.append(", modulesPath='").append(modulesPath).append('\'');
+        sb.append(", includeTestDependencies=").append(includeTestDependencies);
+        sb.append(", unitTestEnabled=").append(unitTestEnabled);
+        sb.append(", unitTestInclusionPattern='").append(unitTestInclusionPattern).append('\'');
+        sb.append(", unitTestExclusionPattern='").append(unitTestExclusionPattern).append('\'');
+        sb.append(", unitTestBasePackage='").append(unitTestBasePackage).append('\'');
+        sb.append(", unitTestsExpectedNumber=").append(unitTestsExpectedNumber);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfigBuilder.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfigBuilder.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Builder for the {@code ITestConfig} that enforces defaults values.
+ */
+public class ITestConfigBuilder {
+
+    private static final String PROPERTIES_FILE = "/spring-boot-itest.properties";
+
+    private Properties properties;
+
+    private ITestConfig config;
+
+    public ITestConfigBuilder() {
+        this.config = new ITestConfig();
+    }
+
+    public ITestConfigBuilder(ITestConfig config) {
+        this.config = config;
+    }
+
+    public ITestConfigBuilder module(String module) {
+        config.setModuleName(module);
+        return this;
+    }
+
+    public ITestConfigBuilder mavenGroup(String mavenGroup) {
+        config.setMavenGroup(mavenGroup);
+        return this;
+    }
+
+    public ITestConfigBuilder mavenVersion(String mavenVersion) {
+        config.setMavenVersion(mavenVersion);
+        return this;
+    }
+
+    public ITestConfigBuilder modulesPath(String path) {
+        config.setModulesPath(path);
+        return this;
+    }
+
+    public ITestConfigBuilder unitTestExpectedNumber(int number) {
+        config.setUnitTestsExpectedNumber(number);
+        return this;
+    }
+
+    public ITestConfigBuilder unitTestBasePackage(String pack) {
+        config.setUnitTestBasePackage(pack);
+        return this;
+    }
+
+    public ITestConfigBuilder unitTestInclusionPattern(String pattern) {
+        config.setUnitTestInclusionPattern(pattern);
+        return this;
+    }
+
+    public ITestConfigBuilder unitTestExclusionPattern(String pattern) {
+        config.setUnitTestExclusionPattern(pattern);
+        return this;
+    }
+
+    public ITestConfig build() {
+
+        // Checking conditions
+        if (config.getModuleName() == null) {
+            fail("ModuleName is required");
+        }
+
+        // Set the defaults
+        if (config.getUnitTestEnabled() == null) {
+            config.setUnitTestEnabled(booleanProperty("unitTestEnabled").orElse(false));
+        }
+
+        if (config.getMavenGroup() == null) {
+            config.setMavenGroup(property("mavenGroup").orElse("org.apache.camel"));
+        }
+
+        if (config.getMavenVersion() == null) {
+            config.setMavenVersion(property("mavenVersion").orElse(null));
+        }
+
+        if (config.getUnitTestInclusionPattern() == null) {
+            config.setUnitTestInclusionPattern(property("unitTestInclusionPattern").orElse("^.*Test$")); // All tests
+        }
+
+        if (config.getUnitTestExclusionPattern() == null) {
+            config.setUnitTestExclusionPattern(property("unitTestExclusionPattern").orElse(".*(\\.integration\\..*|XXXTest$)")); // Integration test
+        }
+
+        if (config.getIncludeTestDependencies() == null) {
+            config.setIncludeTestDependencies(booleanProperty("includeTestDependencies").orElse(config.getUnitTestEnabled()));
+        }
+
+        if (config.getModulesPath() == null) {
+            config.setModulesPath(property("modulesPath").orElse("../../components/"));
+        }
+
+        if (config.getUnitTestBasePackage() == null) {
+            config.setUnitTestBasePackage(property("unitTestBasePackage").orElse("org.apache.camel"));
+        }
+
+        return config;
+    }
+
+    private void fail(String msg) {
+        throw new IllegalStateException("Configuration is not complete: " + msg);
+    }
+
+    private Optional<String> property(String name) {
+        if (properties == null) {
+            properties = new Properties();
+            try {
+                InputStream in = getClass().getResourceAsStream(PROPERTIES_FILE);
+                properties.load(in);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to load property file: " + PROPERTIES_FILE, e);
+            }
+        }
+
+        return Optional.ofNullable(properties.getProperty(name));
+    }
+
+    private Optional<Boolean> booleanProperty(String name) {
+        return property(name).map(Boolean::valueOf);
+    }
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/AbstractTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/AbstractTestCommand.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import org.apache.camel.itest.springboot.Command;
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.junit.Assert;
+
+/**
+ * An abstract class for commands that need standard test parameters.
+ */
+public abstract class AbstractTestCommand implements Command {
+
+    @Override
+    public Object execute(Object[] parameters) throws Exception {
+        Assert.assertNotNull("Parameters cannot be null", parameters);
+        Assert.assertEquals("Parameters should contain two elements", 2, parameters.length);
+        Object configObj = parameters[0];
+        Assert.assertNotNull("The first parameter cannot be null", configObj);
+        Assert.assertTrue("First parameter should be of type ITestConfig, found type " + configObj.getClass().getName(), configObj instanceof ITestConfig);
+
+        Object compNameObj = parameters[1];
+        Assert.assertNotNull("The second parameter cannot be null", compNameObj);
+        Assert.assertTrue("Second parameter should be of type String, found type " + compNameObj.getClass().getName(), compNameObj instanceof String);
+
+        String compName = (String) compNameObj;
+
+        ITestConfig config = (ITestConfig) configObj;
+        this.executeTest(config, compName);
+        return true;
+    }
+
+    public abstract Object executeTest(ITestConfig config, String component) throws Exception;
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/ComponentTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/ComponentTestCommand.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.itest.springboot.Command;
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A command that tries to lookup a camel component.
+ */
+@Component("module")
+public class ComponentTestCommand extends AbstractTestCommand implements Command {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private CamelContext context;
+
+    @Override
+    public Boolean executeTest(ITestConfig config, String component) throws Exception {
+
+        logger.info("Getting Camel component: {}", component);
+
+        org.apache.camel.Component comp = context.getComponent(component, true, false);
+        assertNotNull("Cannot get module with name: " + component, comp);
+
+        logger.info("Found Camel module: {} instance: {} with className: {}", component, comp, comp.getClass());
+        return true;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/DataFormatTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/DataFormatTestCommand.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.itest.springboot.Command;
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.apache.camel.spi.DataFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A command that tries to lookup a camel data-format.
+ */
+@Component("dataformat")
+public class DataFormatTestCommand extends AbstractTestCommand implements Command {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private CamelContext context;
+
+    @Override
+    public Boolean executeTest(ITestConfig config, String dataFormat) throws Exception {
+
+        logger.info("Getting Camel dataFormat: {}", dataFormat);
+
+        DataFormat df = context.resolveDataFormat(dataFormat);
+        assertNotNull("Cannot get dataformat with name: " + dataFormat, df);
+
+        logger.info("Found Camel dataformat: {} instance: {} with className: {}", dataFormat, df, df.getClass());
+        return true;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/LanguageTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/LanguageTestCommand.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.itest.springboot.Command;
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.apache.camel.spi.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A command that tries to lookup a camel language.
+ */
+@Component("language")
+public class LanguageTestCommand extends AbstractTestCommand implements Command {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private CamelContext context;
+
+    @Override
+    public Boolean executeTest(ITestConfig config, String language) throws Exception {
+
+        logger.info("Getting Camel language: {}", language);
+
+        Language lan = context.resolveLanguage(language);
+        assertNotNull("Cannot get language with name: " + language, lan);
+
+        logger.info("Found Camel language: {} instance: {} with className: {}", language, lan, lan.getClass());
+        return true;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestCommand.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.itest.springboot.Command;
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.junit.Assert;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
+import org.springframework.stereotype.Component;
+
+/**
+ * A command that executes all unit tests contained in the module.
+ */
+@Component("unittest")
+public class UnitTestCommand extends AbstractTestCommand implements Command {
+
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private CamelContext context;
+
+    @Override
+    public UnitTestResult executeTest(ITestConfig config, String component) throws Exception {
+
+        logger.info("Spring-Boot test configuration {}", config);
+
+        Pattern pattern = Pattern.compile(config.getUnitTestInclusionPattern());
+
+        logger.info("Scaning the classpath for test classes");
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+
+        scanner.addIncludeFilter(new RegexPatternTypeFilter(pattern));
+
+        List<String> testClasses = new LinkedList<>(scanner.findCandidateComponents(config.getUnitTestBasePackage()).stream().map(bd -> bd.getBeanClassName()).collect(Collectors.toList()));
+
+        if (config.getUnitTestExclusionPattern() != null) {
+            Pattern exclusionPattern = Pattern.compile(config.getUnitTestExclusionPattern());
+            for (Iterator<String> it = testClasses.iterator(); it.hasNext();) {
+                String cn = it.next();
+                if (exclusionPattern.matcher(cn).matches()) {
+                    logger.warn("Excluding Test Class: {}", cn);
+                    it.remove();
+                }
+            }
+        }
+
+        List<Class<?>> classes = new ArrayList<>();
+        for (String cn : testClasses) {
+            Class<?> clazz = Class.forName(cn);
+            if (isAdmissible(clazz)) {
+                logger.info("Found admissible test class: {}", cn);
+                classes.add(clazz);
+            }
+        }
+
+
+        Result result = JUnitCore.runClasses(classes.toArray(new Class[]{}));
+        logger.info("Run JUnit tests on {} test classes", classes.size());
+        logger.info("Success: " + result.wasSuccessful() + " - Test Run: " + result.getRunCount() + " - Failures: " + result.getFailureCount() + " - Ignored Tests: " + result.getIgnoreCount());
+
+        for (Failure f : result.getFailures()) {
+            logger.warn("Failed test description: {}", f.getDescription());
+            logger.warn("Message: {}", f.getMessage());
+            if (f.getException() != null) {
+                logger.warn("Exception thrown from test", f.getException());
+            }
+        }
+
+        if (!result.wasSuccessful()) {
+            Assert.fail("Some unit tests failed (" + result.getFailureCount() + "/" + result.getRunCount() + "), check the logs for more details");
+        }
+
+        if (result.getRunCount() == 0 && config.getUnitTestsExpectedNumber() == null) {
+            Assert.fail("No tests have been found");
+        }
+
+        Integer expectedTests = config.getUnitTestsExpectedNumber();
+        if (expectedTests != null && expectedTests != result.getRunCount()) {
+            Assert.fail("Wrong number of tests: expected " + expectedTests + " found " + result.getRunCount());
+        }
+
+        return new UnitTestResult(result);
+    }
+
+    private boolean isAdmissible(Class<?> testClass) {
+
+        if (testClass.getPackage().getName().startsWith("org.apache.camel.itest.springboot")) {
+            // no tests from the integration test suite
+            return false;
+        }
+
+        URL location = testClass.getResource("/" + testClass.getName().replace(".", "/") + ".class");
+        if (location != null) {
+            int firstLevel = location.toString().indexOf("!/");
+            int lastLevel = location.toString().lastIndexOf("!/");
+            if (firstLevel >= 0 && lastLevel >= 0 && firstLevel != lastLevel) {
+                // test class is in a nested jar, skipping
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestResult.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestResult.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.command;
+
+import java.io.Serializable;
+
+import org.junit.runner.Result;
+
+/**
+ * Contains the result of the execution of a test suite.
+ * Can be rebuilt at the other classloader as it does not contain reference to internal classes.
+ */
+public class UnitTestResult implements Serializable {
+
+    private static final long serialVersionUID = -5015959334755321719L;
+
+    private int runCount;
+
+    private int failureCount;
+
+    private long runTime;
+
+    private int ignoreCount;
+
+    private boolean successful;
+
+    public UnitTestResult() {
+    }
+
+    public UnitTestResult(Result jr) {
+        this.runCount = jr.getRunCount();
+        this.failureCount = jr.getFailureCount();
+        this.runTime = jr.getRunTime();
+        this.ignoreCount = jr.getIgnoreCount();
+        this.successful = jr.wasSuccessful();
+    }
+
+    public int getRunCount() {
+        return runCount;
+    }
+
+    public void setRunCount(int runCount) {
+        this.runCount = runCount;
+    }
+
+    public int getFailureCount() {
+        return failureCount;
+    }
+
+    public void setFailureCount(int failureCount) {
+        this.failureCount = failureCount;
+    }
+
+    public long getRunTime() {
+        return runTime;
+    }
+
+    public void setRunTime(long runTime) {
+        this.runTime = runTime;
+    }
+
+    public int getIgnoreCount() {
+        return ignoreCount;
+    }
+
+    public void setIgnoreCount(int ignoreCount) {
+        this.ignoreCount = ignoreCount;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public void setSuccessful(boolean successful) {
+        this.successful = successful;
+    }
+}

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/util/SerializationUtils.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/util/SerializationUtils.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Provide basic serialization utils.
+ * Cannot rely on common available libraries to not influence the test outcome.
+ */
+public final class SerializationUtils {
+
+    private SerializationUtils() {
+    }
+
+    public static byte[] marshal(Object o) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(); ObjectOutputStream oout = new ObjectOutputStream(out)) {
+            oout.writeObject(o);
+            oout.flush();
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to marshal the bean " + o, e);
+        }
+    }
+
+    public static Object unmarshal(byte[] content) {
+        if (content == null) {
+            return null;
+        }
+
+        try (ByteArrayInputStream in = new ByteArrayInputStream(content); ObjectInputStream oin = new ObjectInputStream(in)) {
+            Object bean = oin.readObject();
+            return bean;
+
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Unable to unmarshal the bean", e);
+        }
+    }
+
+    public static Throwable transferable(Throwable ex) {
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            ex.printStackTrace(pw);
+            pw.flush();
+
+            return new Exception("Error while executing tests. Wrapped exception is: " + sw.toString());
+        } catch (IOException e) {
+            return new RuntimeException("Error while cleaning up the exception. Message=" + e.getMessage());
+        }
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/AbstractSpringBootTestSupport.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/AbstractSpringBootTestSupport.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import java.lang.reflect.Method;
+
+import org.apache.camel.itest.springboot.arquillian.ArquillianSyncBootJarLauncher;
+import org.apache.camel.itest.springboot.util.SpringBootContainerFacade;
+import org.junit.Before;
+
+/**
+ * This is the base class of all spring-boot integration tests.
+ */
+public abstract class AbstractSpringBootTestSupport {
+
+    protected ITestConfig config;
+
+    private SpringBootContainerFacade facade;
+
+    /**
+     * Starts a spring-boot container with the module under test.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void startSpringBoot() throws Exception {
+        this.config = retrieveConfig();
+
+        ArquillianSyncBootJarLauncher launcher = new ArquillianSyncBootJarLauncher();
+        launcher.run(new String[]{});
+
+        this.facade = new SpringBootContainerFacade(launcher.getClassLoader());
+    }
+
+    protected static String inferModuleName(Class<?> testClass) {
+        String name = testClass.getSimpleName();
+        int id1 = name.indexOf("Test");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < id1; i++) {
+            char c = name.charAt(i);
+            if (i > 0 && Character.isUpperCase(c) && sb.length() > 0) {
+                sb.append("-");
+            }
+            sb.append(Character.toLowerCase(c));
+        }
+        return sb.toString();
+    }
+
+    protected String defaultComponentName() throws Exception {
+        return config.getModuleName().replace("camel-", "");
+    }
+
+    protected void runComponentTest(ITestConfig config) throws Exception {
+        this.runComponentTest(config, defaultComponentName());
+    }
+
+    protected void runComponentTest(ITestConfig config, String componentName) throws Exception {
+        facade.executeTest("module", config, componentName);
+    }
+
+    protected void runDataformatTest(ITestConfig config) throws Exception {
+        this.runDataformatTest(config, defaultComponentName());
+    }
+
+    protected void runDataformatTest(ITestConfig config, String dataFormatName) throws Exception {
+        facade.executeTest("dataformat", config, dataFormatName);
+    }
+
+    protected void runLanguageTest(ITestConfig config) throws Exception {
+        this.runLanguageTest(config, defaultComponentName());
+    }
+
+    protected void runLanguageTest(ITestConfig config, String language) throws Exception {
+        facade.executeTest("language", config, language);
+    }
+
+    protected void runModuleUnitTestsIfEnabled(ITestConfig config) throws Exception {
+        if (config.getUnitTestEnabled()) {
+            this.runModuleUnitTests(config);
+        }
+    }
+
+    protected void runModuleUnitTests(ITestConfig config) throws Exception {
+        facade.executeTest("unittest", config, config.getModuleName().replace("camel-", ""));
+    }
+
+    protected ITestConfig retrieveConfig() throws Exception {
+        Method confMethod = this.getClass().getMethod("createTestConfig");
+        ITestConfig conf = (ITestConfig) confMethod.invoke(null);
+        return conf;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAhcTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAhcTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcWsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcWsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAhcWsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAhcWsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAmqpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAmqpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAmqpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAmqpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelApnsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelApnsTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelApnsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelApnsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAtmosTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAtmosTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosphereWebsocketTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosphereWebsocketTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAtmosphereWebsocketTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAtmosphereWebsocketTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAtomTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAtomTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAvroTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAvroTest.class))
+                .build();
+    }
+
+    @Test
+    public void moduleTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAwsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAwsTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelAwsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelAwsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(createTestConfig(), "aws-cw");
+        this.runComponentTest(createTestConfig(), "aws-ddb");
+        this.runComponentTest(createTestConfig(), "aws-s3");
+        this.runComponentTest(createTestConfig(), "aws-sdb");
+        this.runComponentTest(createTestConfig(), "aws-ses");
+        this.runComponentTest(createTestConfig(), "aws-sns");
+        this.runComponentTest(createTestConfig(), "aws-sqs");
+        this.runComponentTest(createTestConfig(), "aws-swf");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBamTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBamTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBamTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBarcodeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBarcodeTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBarcodeTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBarcodeTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBase64Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBase64Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBase64Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBase64Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanValidatorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanValidatorTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBeanValidatorTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBeanValidatorTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanioTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanioTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBeanioTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBeanioTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanstalkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanstalkTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBeanstalkTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBeanstalkTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBindyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBindyTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBindyTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBindyTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "bindy-csv");
+        this.runDataformatTest(config, "bindy-fixed");
+        this.runDataformatTest(config, "bindy-kvp");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBlueprintTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBlueprintTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBlueprintTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBlueprintTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoonTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBoonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBoonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBoxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBoxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBraintreeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBraintreeTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelBraintreeTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelBraintreeTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCacheTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCacheTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCacheTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCassandraqlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCassandraqlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "cql");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCastorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCastorTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCastorTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCastorTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCdiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCdiTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCdiTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCdiTest.class))
+                .unitTestExclusionPattern(".*Cdi12Test$")
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChunkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChunkTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelChunkTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelChunkTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmSmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmSmsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCmSmsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCmSmsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmisTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCmisTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        ITestConfig config = createTestConfig();
+        //ArquillianPackager.copyResource(config.getModulesPath() + config.getModuleName() + "/target/dependency/", "chemistry-opencmis-server-inmemory-.*\\.war", "target/dependency/");
+
+        return ArquillianPackager.springBootPackage(config);
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCmisTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoapTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCoapTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCoapTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCometdTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCometdTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCometdTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCometdTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelConsulTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelConsulTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelConsulTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelConsulTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelContextTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelContextTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelContextTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelContextTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoreOsgiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoreOsgiTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCoreOsgiTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCoreOsgiTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoreXmlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoreXmlTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCoreXmlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCoreXmlTest.class))
+                .unitTestExpectedNumber(0)
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCouchdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCouchdbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCouchdbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCouchdbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCryptoTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCryptoTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCryptoTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCryptoTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCsvTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCsvTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCsvTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCsvTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCxfTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCxfTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "cxf");
+        this.runComponentTest(config, "cxfrs");
+        this.runComponentTest(config, "cxfbean");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTransportTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTransportTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelCxfTransportTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelCxfTransportTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDisruptorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDisruptorTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelDisruptorTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelDisruptorTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "disruptor");
+        this.runComponentTest(config, "disruptor-vm");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDnsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDnsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelDnsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelDnsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDockerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDockerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelDockerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelDockerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDozerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDozerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelDozerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelDozerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDropboxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDropboxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelDropboxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelDropboxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEclipseTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEclipseTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelEclipseTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelEclipseTest.class))
+                .unitTestExpectedNumber(0)
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEhcacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEhcacheTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelEhcacheTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelEhcacheTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEjbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEjbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelEjbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelEjbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElasticsearchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElasticsearchTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelElasticsearchTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelElasticsearchTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElsqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElsqlTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelElsqlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelElsqlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEtcdTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEtcdTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelEtcdTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelEtcdTest.class))
+                .unitTestInclusionPattern("^$") // no tests
+                .unitTestExpectedNumber(0)
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEventadminTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEventadminTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelEventadminTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelEventadminTest.class))
+                .unitTestExpectedNumber(0)
+                .build();
+    }
+
+    @Test
+    @Ignore("OSGi related")
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelExecTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelExecTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelExecTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelExecTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFacebookTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFacebookTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFacebookTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFacebookTest.class))
+                .unitTestInclusionPattern(".*(ReadingBuilderTest$|FacebookMethodsType.*Test$)")
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlatpackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlatpackTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFlatpackTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFlatpackTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlinkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlinkTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFlinkTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFlinkTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFopTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFopTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFopTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFopTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFreemarkerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFreemarkerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFreemarkerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFreemarkerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFtpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFtpTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelFtpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelFtpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "ftp");
+        this.runComponentTest(config, "sftp");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGangliaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGangliaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGangliaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGangliaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGeocoderTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGeocoderTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGeocoderTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGeocoderTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGitTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGitTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGitTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGitTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGithubTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGithubTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGithubTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGithubTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleCalendarTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleCalendarTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGoogleCalendarTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGoogleCalendarTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleDriveTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleDriveTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGoogleDriveTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGoogleDriveTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleMailTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleMailTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGoogleMailTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGoogleMailTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoraTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoraTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGoraTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGoraTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrapeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrapeTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGrapeTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGrapeTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGroovyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGroovyTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGroovyTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGroovyTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config);
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGsonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGsonTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGsonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGsonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "json-gson");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuavaEventbusTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuavaEventbusTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGuavaEventbusTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGuavaEventbusTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuiceTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuiceTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelGuiceTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelGuiceTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHawtdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHawtdbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHawtdbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHawtdbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHazelcastTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHazelcastTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHazelcastTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHazelcastTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHbaseTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHbaseTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHbaseTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHbaseTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfs2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfs2Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHdfs2Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHdfs2Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHdfsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHdfsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHessianTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHessianTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHessianTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHessianTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHipchatTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHipchatTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHipchatTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHipchatTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHl7Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHl7Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHl7Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHl7Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttp4Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttp4Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHttp4Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHttp4Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpCommonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpCommonTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHttpCommonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHttpCommonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHttpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHttpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHystrixTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHystrixTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelHystrixTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelHystrixTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIbatisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIbatisTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelIbatisTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelIbatisTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIcalTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIcalTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelIcalTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelIcalTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIgniteTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIgniteTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelIgniteTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelIgniteTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfinispanTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfinispanTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelInfinispanTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelInfinispanTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIrcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIrcTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelIrcTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelIrcTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIronmqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIronmqTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelIronmqTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelIronmqTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJacksonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJacksonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "json-jackson");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonxmlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonxmlTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJacksonxmlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJacksonxmlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJasyptTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJasyptTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJasyptTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJasyptTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJavaspaceTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJavaspaceTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJavaspaceTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJavaspaceTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJaxbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJaxbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJaxbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJaxbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJbpmTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJbpmTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJbpmTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJbpmTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcacheTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJcacheTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJcacheTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcloudsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcloudsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJcloudsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJcloudsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcrTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcrTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJcrTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJcrTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJdbcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJdbcTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJdbcTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJdbcTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJetty9Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJetty9Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJetty9Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJetty9Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "jetty");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyCommonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyCommonTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJettyCommonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJettyCommonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJettyTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJettyTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJgroupsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJgroupsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJibxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJibxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJibxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJibxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJingTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJingTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJingTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJingTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJiraTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJiraTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJiraTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJiraTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJmsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJmsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJmxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJmxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJoltTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJoltTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJoltTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJoltTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJosqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJosqlTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJosqlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJosqlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config, "sql");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJpaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJpaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJpaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJpaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJschTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJschTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJschTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJschTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "scp");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonpathTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonpathTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJsonpathTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJsonpathTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJt400Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJt400Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJt400Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJt400Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJuelTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJuelTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJuelTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJuelTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config, "el");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJxpathTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJxpathTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelJxpathTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelJxpathTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKafkaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKafkaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelKafkaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelKafkaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKestrelTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKestrelTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelKestrelTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelKestrelTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKratiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKratiTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelKratiTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelKratiTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKubernetesTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKubernetesTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelKubernetesTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelKubernetesTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKuraTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKuraTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelKuraTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelKuraTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdapTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelLdapTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelLdapTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLeveldbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLeveldbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelLeveldbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelLeveldbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLinkedinTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLinkedinTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelLinkedinTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelLinkedinTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLuceneTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLuceneTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelLuceneTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelLuceneTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLzfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLzfTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelLzfTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelLzfTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMailTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMailTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMailTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMailTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "smtp");
+        this.runComponentTest(config, "imap");
+        this.runComponentTest(config, "pop3");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMetricsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMetricsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMetricsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMetricsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMina2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMina2Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMina2Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMina2Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMinaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMinaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMllpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMllpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMllpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMllpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMongodbGridfsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMongodbGridfsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMongodbTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMongodbTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMqttTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMqttTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMqttTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMqttTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMsvTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMsvTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMsvTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMsvTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMustacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMustacheTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMustacheTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMustacheTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMvelTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMvelTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMvelTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMvelTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMybatisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMybatisTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelMybatisTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelMybatisTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNagiosTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNagiosTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNagiosTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNagiosTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNatsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNatsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNatsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNatsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNetty4HttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNetty4HttpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNetty4HttpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNetty4HttpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNetty4Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNetty4Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNetty4Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNetty4Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyHttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyHttpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNettyHttpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNettyHttpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelNettyTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelNettyTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOgnlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOgnlTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelOgnlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelOgnlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo2Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelOlingo2Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelOlingo2Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenshiftTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenshiftTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelOpenshiftTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelOpenshiftTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOptaplannerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOptaplannerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelOptaplannerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelOptaplannerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPahoTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPahoTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelPahoTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelPahoTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPaxloggingTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPaxloggingTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelPaxloggingTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelPaxloggingTest.class))
+                .build();
+    }
+
+    @Test
+    @Ignore("OSGi related")
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPdfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPdfTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelPdfTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelPdfTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgeventTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgeventTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelPgeventTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelPgeventTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPrinterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPrinterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelPrinterTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelPrinterTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "lpr");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelProtobufTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelProtobufTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelProtobufTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelProtobufTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartz2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartz2Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelQuartz2Test extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelQuartz2Test.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartzTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartzTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelQuartzTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelQuartzTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuickfixTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuickfixTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelQuickfixTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelQuickfixTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRabbitmqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRabbitmqTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRabbitmqTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRabbitmqTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestletTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestletTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRestletTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRestletTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRmiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRmiTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRmiTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRmiTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRouteboxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRouteboxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRouteboxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRouteboxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRssTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRssTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRssTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRssTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRubyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRubyTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRubyTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRubyTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelRxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelRxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSalesforceTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSalesforceTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSalesforceTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSalesforceTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSapNetweaverTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSapNetweaverTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSapNetweaverTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSapNetweaverTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSaxonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSaxonTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSaxonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSaxonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "xquery");
+        this.runLanguageTest(config, "xquery");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScalaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScalaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelScalaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelScalaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSchematronTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSchematronTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSchematronTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSchematronTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScrTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScrTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelScrTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelScrTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScriptTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScriptTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelScriptTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelScriptTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runLanguageTest(config, "js");
+        this.runLanguageTest(config, "php");
+        this.runLanguageTest(config, "python");
+        this.runLanguageTest(config, "ruby");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServicenowTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServicenowTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelServicenowTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelServicenowTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelServletTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelServletTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletlistenerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletlistenerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelServletlistenerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelServletlistenerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelShiroTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelShiroTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelShiroTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelShiroTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSipTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSipTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSipTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSipTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjmsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSjmsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSjmsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSlackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSlackTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSlackTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSlackTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSmppTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSmppTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSmppTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSmppTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnakeyamlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnakeyamlTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSnakeyamlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSnakeyamlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "yaml-snakeyaml");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnmpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnmpTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSnmpTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSnmpTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoapTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSoapTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSoapTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "soapjaxb");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSolrTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSolrTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSolrTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSolrTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkRestTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkRestTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSparkRestTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSparkRestTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSparkTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSparkTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSplunkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSplunkTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSplunkTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSplunkTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBatchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBatchTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringBatchTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringBatchTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBootStarterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBootStarterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringBootStarterTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringBootStarterTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBootTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBootTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringBootTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringBootTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringDmTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringDmTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringDmTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringDmTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringIntegrationTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringIntegrationTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringIntegrationTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringIntegrationTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringJavaconfigTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringJavaconfigTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringJavaconfigTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringJavaconfigTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringLdapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringLdapTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringLdapTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringLdapTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringRedisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringRedisTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringRedisTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringRedisTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringSecurityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringSecurityTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringSecurityTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringSecurityTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringWsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringWsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSpringWsTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSpringWsTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSqlTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSqlTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSqlTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSshTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSshTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSshTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSshTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStaxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStaxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelStaxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelStaxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStompTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStompTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelStompTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelStompTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStreamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStreamTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelStreamTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelStreamTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStringtemplateTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStringtemplateTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelStringtemplateTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelStringtemplateTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config, "string-template");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerJavaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerJavaTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSwaggerJavaTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSwaggerJavaTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component tests
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSwaggerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSwaggerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSyslogTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSyslogTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelSyslogTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelSyslogTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTagsoupTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTagsoupTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelTagsoupTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelTagsoupTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "tidyMarkup");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTarfileTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTarfileTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelTarfileTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelTarfileTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTelegramTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTelegramTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelTelegramTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelTelegramTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwitterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwitterTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelTwitterTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelTwitterTest.class))
+                .unitTestExclusionPattern(".*(DirectMessageDirectTest|DirectMessagePollingTest)$")
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUndertowTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUndertowTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelUndertowTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelUndertowTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelUnivocityParsersTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelUnivocityParsersTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "univocity-csv");
+        this.runDataformatTest(config, "univocity-fixed");
+        this.runDataformatTest(config, "univocity-tsv");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUrlrewriteTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUrlrewriteTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelUrlrewriteTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelUrlrewriteTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVelocityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVelocityTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelVelocityTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelVelocityTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelVertxTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelVertxTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeatherTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeatherTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelWeatherTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelWeatherTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelWebsocketTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelWebsocketTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlbeansTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlbeansTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXmlbeansTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXmlbeansTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmljsonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmljsonTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXmljsonTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXmljsonTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlrpcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlrpcTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXmlrpcTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXmlrpcTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlsecurityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlsecurityTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXmlsecurityTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXmlsecurityTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "secureXML");
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmppTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmppTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXmppTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXmppTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXstreamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXstreamTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelXstreamTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelXstreamTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config, "json-xstream");
+        this.runDataformatTest(config, "xstream");
+
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelYammerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelYammerTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelYammerTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelYammerTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipfileTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipfileTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelZipfileTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelZipfileTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runDataformatTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinStarterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinStarterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelZipkinStarterTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelZipkinStarterTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelZipkinTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelZipkinTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        // no component test
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot;
+
+import org.apache.camel.itest.springboot.util.ArquillianPackager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class CamelZookeeperTest extends AbstractSpringBootTestSupport {
+
+    @Deployment
+    public static Archive<?> createSpringBootPackage() throws Exception {
+        return ArquillianPackager.springBootPackage(createTestConfig());
+    }
+
+    public static ITestConfig createTestConfig() {
+        return new ITestConfigBuilder()
+                .module(inferModuleName(CamelZookeeperTest.class))
+                .build();
+    }
+
+    @Test
+    public void componentTests() throws Exception {
+        this.runComponentTest(config);
+        this.runModuleUnitTestsIfEnabled(config);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/ArquillianSyncBootJarLauncher.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/ArquillianSyncBootJarLauncher.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.arquillian;
+
+import org.springframework.boot.loader.JarLauncher;
+
+/**
+ * A Spring-boot jar launcher that uses the current thread instead of creating a new thread for spring-boot.
+ */
+public class ArquillianSyncBootJarLauncher extends JarLauncher {
+
+    private ClassLoader classLoader;
+
+    public ArquillianSyncBootJarLauncher() {
+    }
+
+    public void run(String[] args) {
+        this.launch(args);
+    }
+
+    @Override
+    protected void launch(String[] args, String mainClass, ClassLoader classLoader)
+            throws Exception {
+
+        this.classLoader = classLoader;
+
+        Runnable runner = createMainMethodRunner(mainClass, args, classLoader);
+
+        Thread.currentThread().setContextClassLoader(classLoader);
+        runner.run();
+    }
+
+    /**
+     * Returns the classloader used by spring, to communicate with it.
+     *
+     * @return the spring classloader
+     */
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipExporterDelegate.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipExporterDelegate.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.arquillian;
+
+import java.io.InputStream;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.impl.base.exporter.AbstractExporterDelegate;
+
+/**
+ * A spring-boot compatible zip exporter delegate.
+ * Uses {@link SpringBootZipOnDemandInputStream} not to compress entries for spring-boot
+ * nested jar structure compatibility.
+ */
+public class SpringBootZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
+
+    protected SpringBootZipExporterDelegate(final Archive<?> archive) {
+        super(archive);
+
+        if (archive.getContent().isEmpty()) {
+            throw new IllegalArgumentException("Cannot export a ZIP archive with no content: " + archive.toString());
+        }
+    }
+
+    @Override
+    protected void processNode(final ArchivePath path, final Node node) {
+        // do nothing
+    }
+
+    @Override
+    protected InputStream getResult() {
+        return new SpringBootZipOnDemandInputStream(getArchive());
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipExporterImpl.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipExporterImpl.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.arquillian;
+
+import java.io.InputStream;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.impl.base.exporter.AbstractExporterDelegate;
+import org.jboss.shrinkwrap.impl.base.exporter.AbstractStreamExporterImpl;
+
+/**
+ * An implementation of the zip exporter that does not compress entries,
+ * for compatibility with spring-boot nested jar structure.
+ */
+public class SpringBootZipExporterImpl extends AbstractStreamExporterImpl implements ZipExporter {
+
+    public SpringBootZipExporterImpl(Archive<?> archive) {
+        super(archive);
+    }
+
+    @Override
+    public InputStream exportAsInputStream() {
+        // Create export delegate
+        final AbstractExporterDelegate<InputStream> exportDelegate = new SpringBootZipExporterDelegate(this.getArchive());
+
+        // Export and get result
+        return exportDelegate.export();
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipOnDemandInputStream.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/SpringBootZipOnDemandInputStream.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.arquillian;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.exporter.ArchiveExportException;
+import org.jboss.shrinkwrap.impl.base.io.IOUtil;
+import org.jboss.shrinkwrap.impl.base.path.PathUtil;
+
+/**
+ * A spring-boot compatible on-demand input stream.
+ * It does not compress jar entries for spring-boot nested jar structure compatibility.
+ */
+public class SpringBootZipOnDemandInputStream extends InputStream {
+
+    /**
+     * Created by abstract method.
+     */
+    protected ZipOutputStream outputStream;
+
+    /**
+     * Iterator over nodes contained in base archive.
+     */
+    private final Iterator<Node> nodesIterator;
+
+    /**
+     * Base for outputStream.
+     */
+    private final ByteArrayOutputStream bufferedOutputStream = new ByteArrayOutputStream();
+
+    /**
+     * Stream of currently processed Node.
+     */
+    private InputStream currentNodeStream;
+
+    /**
+     * Stream to the buffer.
+     */
+    private ByteArrayInputStream bufferInputStream;
+
+    /**
+     * If output stream was closed - we should finish.
+     */
+    private boolean outputStreamClosed;
+
+    /**
+     * Currently processed archive path - for displaying exception.
+     */
+    private ArchivePath currentPath;
+
+    /**
+     * Creates stream directly from archive.
+     *
+     * @param archive
+     */
+    public SpringBootZipOnDemandInputStream(final Archive<?> archive) {
+        final Collection<Node> nodes = archive.getContent().values();
+        this.nodesIterator = nodes.iterator();
+    }
+
+    @Override
+    public int read() throws IOException {
+
+        if (outputStream == null && !outputStreamClosed) {
+            // first run
+            outputStream = createOutputStream(bufferedOutputStream);
+        }
+
+        int value = bufferInputStream != null ? bufferInputStream.read() : -1;
+        if (value == -1) {
+            if (currentNodeStream != null) {
+                // current node was not processed completely
+                try {
+                    doCopy();
+                    bufferInputStream = new ByteArrayInputStream(bufferedOutputStream.toByteArray());
+                    bufferedOutputStream.reset();
+                    return this.read();
+                } catch (final Throwable t) {
+                    throw new ArchiveExportException("Failed to write asset to output: " + currentPath.get(), t);
+                }
+            } else if (nodesIterator.hasNext()) {
+                // current node was processed completely, process next one
+                final Node currentNode = nodesIterator.next();
+
+                currentPath = currentNode.getPath();
+                final String pathName = PathUtil.optionallyRemovePrecedingSlash(currentPath.get());
+
+                final boolean isDirectory = currentNode.getAsset() == null;
+                String resolvedPath = pathName;
+
+                if (isDirectory) {
+                    resolvedPath = PathUtil.optionallyAppendSlash(resolvedPath);
+                    startAsset(resolvedPath, 0L, 0L);
+                    endAsset();
+                } else {
+
+                    try {
+                        byte[] content = IOUtil.asByteArray(currentNode.getAsset().openStream());
+                        long size = content.length;
+                        CRC32 crc = new CRC32();
+                        crc.update(content);
+                        long crc32Value = crc.getValue();
+                        startAsset(resolvedPath, size, crc32Value);
+
+                        currentNodeStream = new ByteArrayInputStream(content);
+                        doCopy();
+                    } catch (final Throwable t) {
+                        throw new ArchiveExportException("Failed to write asset to output: " + currentPath.get(), t);
+                    }
+                    bufferInputStream = new ByteArrayInputStream(bufferedOutputStream.toByteArray());
+                    bufferedOutputStream.reset();
+                }
+
+            } else {
+                // each node was processed
+                if (!outputStreamClosed) {
+                    outputStream.close();
+                    outputStreamClosed = true;
+
+                    // output closed, now process what was saved on close
+                    bufferInputStream = new ByteArrayInputStream(bufferedOutputStream.toByteArray());
+                    bufferedOutputStream.close();
+
+                    currentNodeStream = null;
+                    outputStream = null;
+                    return this.read();
+                }
+
+                // everything was read, end
+                return -1;
+            }
+
+            // chosen new node or new data in buffer - read again
+            return this.read();
+        }
+
+        return value;
+    }
+
+    /**
+     * Performs copy operation between currentNodeStream and outputStream using buffer length.
+     *
+     * @throws IOException
+     */
+    private void doCopy() throws IOException {
+        IOUtil.copy(currentNodeStream, outputStream);
+        currentNodeStream.close();
+        currentNodeStream = null;
+        endAsset();
+    }
+
+    /**
+     * Start entry in stream.
+     *
+     * @param path
+     * @throws IOException
+     */
+    private void startAsset(final String path, long size, long crc32) throws IOException {
+        putNextEntry(outputStream, path, size, crc32);
+    }
+
+    /**
+     * Close entry in stream.
+     *
+     * @throws IOException
+     */
+    private void endAsset() throws IOException {
+        closeEntry(outputStream);
+    }
+
+
+    protected ZipOutputStream createOutputStream(final OutputStream outputStream) {
+        ZipOutputStream stream = new ZipOutputStream(outputStream);
+        stream.setMethod(ZipEntry.STORED);
+        stream.setLevel(Deflater.NO_COMPRESSION);
+        return stream;
+    }
+
+
+    protected void closeEntry(final ZipOutputStream outputStream) throws IOException {
+        outputStream.closeEntry();
+    }
+
+
+    protected void putNextEntry(final ZipOutputStream outputStream, final String context, long size, long crc32) throws IOException {
+
+        ZipEntry entry = new ZipEntry(context);
+        entry.setMethod(ZipEntry.STORED);
+        entry.setSize(size);
+        entry.setCrc(crc32);
+
+        outputStream.putNextEntry(entry);
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.camel.itest.springboot.ITestConfig;
+import org.apache.camel.itest.springboot.arquillian.SpringBootZipExporterImpl;
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Configuration;
+import org.jboss.shrinkwrap.api.ConfigurationBuilder;
+import org.jboss.shrinkwrap.api.Domain;
+import org.jboss.shrinkwrap.api.ExtensionLoader;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.base.ServiceExtensionLoader;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
+import org.jboss.shrinkwrap.resolver.api.maven.PackagingType;
+import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependency;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencyExclusion;
+import org.junit.Assert;
+
+/**
+ * Packages a module in a spring-boot compatible nested-jar structure.
+ */
+public final class ArquillianPackager {
+
+    /**
+     * A flag to enable system-out logging.
+     * Cannot use logging libraries here.
+     */
+    private static final boolean DEBUG_ENABLED = false;
+
+    private ArquillianPackager() {
+    }
+
+    public static Archive<?> springBootPackage(ITestConfig config) throws Exception {
+
+        ExtensionLoader extensionLoader = new ServiceExtensionLoader(Collections.singleton(getExtensionClassloader()));
+        extensionLoader.addOverride(ZipExporter.class, SpringBootZipExporterImpl.class);
+        ConfigurationBuilder builder = new ConfigurationBuilder().extensionLoader(extensionLoader);
+        Configuration conf = builder.build();
+
+        Domain domain = ShrinkWrap.createDomain(conf);
+
+        JavaArchive ark = domain.getArchiveFactory().create(JavaArchive.class, "test.jar");
+
+        ark = ark.addAsManifestResource("BOOT-MANIFEST.MF", "MANIFEST.MF");
+        ark = ark.addAsResource("spring-boot-itest.properties");
+
+        ark = ark.addAsDirectories("/lib");
+
+        String version = config.getMavenVersion();
+        if (version == null) {
+            // It is missing when launching from IDE
+            List<MavenResolvedArtifact> resolved = Arrays.asList(Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve().withTransitivity().asResolvedArtifact());
+            Optional<MavenResolvedArtifact> camelDep = resolved.stream().filter(dep -> dep.getCoordinate().getGroupId().equals("org.apache.camel")).findAny();
+            version = camelDep.map(art -> art.getCoordinate().getVersion()).orElse(null);
+            debug("Resolved version: " + version);
+            if (version == null) {
+                throw new IllegalStateException("Cannot determine the current version of the camel component");
+            }
+        }
+
+        // Test dependencies
+        List<MavenDependency> testDependencies = new LinkedList<>();
+        if (config.getIncludeTestDependencies() || config.getUnitTestEnabled()) {
+
+            List<MavenResolvedArtifact> testArtifacts = Arrays.asList(Maven.resolver()
+                    .loadPomFromFile(config.getModulesPath() + config.getModuleName() + "/pom.xml")
+                    .importTestDependencies()
+                    .resolve().withoutTransitivity().asResolvedArtifact());
+
+            MavenDependencyExclusion[] excl = new MavenDependencyExclusion[]{MavenDependencies.createExclusion("org.slf4j", "slf4j-log4j12"), MavenDependencies.createExclusion("log4j", "log4j")};
+
+            testDependencies = testArtifacts.stream()
+                    .map(MavenResolvedArtifact::getCoordinate)
+                    .filter(ArquillianPackager::validTestDependency) // remove direct logging dependencies from test libs
+                    .map(c -> MavenDependencies.createDependency(c, ScopeType.RUNTIME, false, excl)) // remove transitive logging dependencies from test libs
+                    .collect(Collectors.toList());
+        }
+
+
+        MavenCoordinate jar = MavenCoordinates.createCoordinate(config.getMavenGroup(), config.getModuleName(), version, PackagingType.JAR, null);
+        MavenDependency dep = MavenDependencies.createDependency(jar, ScopeType.COMPILE, false);
+
+        List<File> dependencies = new LinkedList<>();
+        dependencies.addAll(Arrays.asList(Maven.resolver()
+                .loadPomFromFile("pom.xml")
+                .importRuntimeDependencies()
+                .addDependencies(dep)
+                .addDependencies(testDependencies)
+                .resolve()
+                .withTransitivity()
+                .asFile()));
+
+
+        // The spring boot-loader dependency will be added to the main jar, so it should be excluded from the embedded ones
+        excludeDependencyRegex(dependencies, "^spring-boot-loader-[0-9].*");
+
+        // Add all dependencies as spring-boot nested jars
+        ark = addDependencies(ark, dependencies);
+
+        if (config.getUnitTestEnabled()) {
+            // Add unit test classes of the module under test
+            ark = addTestResources(ark, config);
+        }
+
+        // Add common packages to main jar
+        ark = ark.addPackages(true, "org.apache.camel.itest.springboot");
+        ark = ark.addPackages(true, "org.springframework.boot.loader");
+        ark = ark.addPackages(true, "org.jboss.shrinkwrap");
+
+        return ClassPath.builder().add(ark).build();
+    }
+
+    public static void copyResource(String folder, String fileNameRegex, String targetFolder) throws IOException {
+
+        Pattern pattern = Pattern.compile(fileNameRegex);
+
+        File sourceFolder = new File(folder);
+        File[] candidates = sourceFolder.listFiles((dir, name) -> pattern.matcher(name).matches());
+        if (candidates.length == 0) {
+            Assert.fail("No file matching regex " + fileNameRegex + " has been found");
+        }
+
+        File f = candidates[0];
+        FileUtils.copyFileToDirectory(f, new File(targetFolder));
+    }
+
+    private static ClassLoader getExtensionClassloader() {
+        ClassLoader cl = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader());
+        if (cl == null) {
+            cl = ClassLoader.getSystemClassLoader();
+        }
+
+        return cl;
+    }
+
+    private static boolean validTestDependency(MavenCoordinate coordinate) {
+
+        Pattern log4j = Pattern.compile("^log4j$");
+        Pattern slf4jLog4j = Pattern.compile("^slf4j-log4j12$");
+
+        boolean valid = !log4j.matcher(coordinate.getArtifactId()).matches() && !slf4jLog4j.matcher(coordinate.getArtifactId()).matches();
+
+        if (!valid) {
+            debug("Discarded test dependency " + coordinate.toCanonicalForm());
+        }
+
+        return valid;
+    }
+
+    private static void excludeDependencyRegex(List<File> dependencies, String regex) {
+        Pattern pattern = Pattern.compile(regex);
+        for (Iterator<File> it = dependencies.iterator(); it.hasNext();) {
+            File f = it.next();
+            if (pattern.matcher(f.getName()).matches()) {
+                it.remove();
+                break;
+            }
+        }
+    }
+
+    private static JavaArchive addDependencies(JavaArchive ark, Collection<File> deps) {
+        Set<File> dependencySet = new HashSet<>(deps);
+        for (File d : dependencySet) {
+            debug("Adding spring-boot dependency: " + d.getName());
+            ark = ark.add(new FileAsset(d), "/lib/" + d.getName());
+        }
+
+        return ark;
+    }
+
+    private static JavaArchive addTestResources(JavaArchive ark, ITestConfig config) throws IOException {
+        File test = new File(config.getModulesPath() + config.getModuleName() + "/target/test-classes/");
+        File[] fs = Optional.ofNullable(test.listFiles()).orElse(new File[]{});
+        LinkedList<File> testFiles = new LinkedList<>(Arrays.asList(fs));
+        while (!testFiles.isEmpty()) {
+            File f = testFiles.pop();
+            String relative = test.getCanonicalFile().toURI().relativize(f.getCanonicalFile().toURI()).getPath();
+            if (f.isFile()) {
+                ark = ark.addAsResource(f, relative);
+            } else {
+                ark = ark.addAsDirectory(relative);
+                File[] files = Optional.ofNullable(f.listFiles()).orElse(new File[]{});
+                testFiles.addAll(Arrays.asList(files));
+            }
+        }
+
+        return ark;
+    }
+
+    private static void debug(String str) {
+        if (DEBUG_ENABLED) {
+            System.out.println("DEBUG>>> " + str);
+        }
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/JarExporter.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/JarExporter.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.util;
+
+import java.io.File;
+
+import org.apache.camel.itest.springboot.ITestConfigBuilder;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.junit.Test;
+
+/**
+ * Utililty to export a spring-boot jar and check the content.
+ */
+public class JarExporter {
+
+    @Test
+    public void exportJar() throws Exception {
+
+        Archive<?> archive = ArquillianPackager.springBootPackage(new ITestConfigBuilder()
+                .module("camel-jetty9")
+                .build());
+
+
+        new ZipExporterImpl(archive).exportTo(new File("target/export.zip"), true);
+
+    }
+
+
+}

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/SpringBootContainerFacade.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/SpringBootContainerFacade.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.itest.springboot.util;
+
+import java.lang.reflect.Method;
+
+import org.apache.camel.itest.springboot.ITestConfig;
+
+/**
+ * Provide access to testing methods defined in the Spring-Boot context (that uses a different classloader).
+ */
+public class SpringBootContainerFacade {
+
+    private Class<?> delegateClass;
+
+    public SpringBootContainerFacade(ClassLoader springClassloader) {
+        try {
+            this.delegateClass = springClassloader.loadClass("org.apache.camel.itest.springboot.CommandRouter");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Exception while loading target class", e);
+        }
+    }
+
+    public Object executeTest(String test, ITestConfig config, String component) throws Exception {
+        Object resObj = execute(test, config, component);
+        return resObj;
+    }
+
+    private Object execute(String command, Object... args) throws Exception {
+        Method method = delegateClass.getMethod("execute", String.class, byte[].class);
+        byte[] argsSer = null;
+        if (args != null) {
+            argsSer = SerializationUtils.marshal(args);
+        }
+
+        byte[] resByte = (byte[]) method.invoke(null, command, argsSer);
+        if (resByte != null) {
+            Object res = SerializationUtils.unmarshal(resByte);
+            if (res instanceof Exception) {
+                throw (Exception) res;
+            } else if (res instanceof Throwable) {
+                throw new RuntimeException((Throwable) res);
+            } else {
+                return res;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/tests/camel-itest-spring-boot/src/test/resources/BOOT-MANIFEST.MF
+++ b/tests/camel-itest-spring-boot/src/test/resources/BOOT-MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: org.springframework.boot.loader.JarLauncher
+Start-Class: org.apache.camel.itest.springboot.ITestApplication

--- a/tests/camel-itest-spring-boot/src/test/resources/spring-boot-itest.properties
+++ b/tests/camel-itest-spring-boot/src/test/resources/spring-boot-itest.properties
@@ -1,0 +1,9 @@
+# Test configuration can be overriden here.
+# This file is included in the spring-boot jar built  by Arquillian.
+
+# It is better disabling unit testing for all-modules-verification,
+# as many of them fail for various reasons (unrelated to spring-boot)
+# when running in the arquillian jar.
+unitTestEnabled=false
+
+includeTestDependencies=false

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -66,6 +66,14 @@
       </modules>
     </profile>
 
+    <!-- spring-boot tests -->
+    <profile>
+      <id>spring-boot.test</id>
+      <modules>
+        <module>camel-itest-spring-boot</module>
+      </modules>
+    </profile>
+
     <!-- performance tests -->
     <profile>
       <id>performance.test</id>


### PR DESCRIPTION
I created an integration test module that checks the compatibility of every component with spring-boot. For each component, it assembles a spring-boot jar and start checking the component. I've collected some small issues by running all tests with the current modules (I'll open Jiras).

This is an excerpt fro the provided readme:

The camel-itest-spring-boot module provides an integration testing framework for camel components, to check their compatibility with spring-boot.

Each test-case defined in `src/test/java/org/apache/camel/itest/springboot` executes the following steps:
- Creates a spring-boot jar by putting the spring-boot loader, test classes and some utility classes in the main jar,
and all other libraries (including the camel component under test) as nested jars;
- Launches a new JVM with the spring-boot jar in the classpath, then starts the spring-boot platform;
- Executes a list of predefined checks in the spring-boot environment to verify that the component has been created correctly:
checks that the camel context has been created, that the camel components can be activated (including data format and languages).

**Additional options**

Test options can be changed from the `src/test/resources/spring-boot-itest.properties` file.

Some useful options include:
- **includeTestDependencies (default=false)**: when this option is enabled,
the integration test will locate the module `pom.xml` file and include in the spring-boot jar also the test-scoped dependencies of the module.
  The inclusion of other libraries often activates some hidden behaviour of spring-boot.
  *Note: logging libraries (eg. `log4j`) included in test scope are ignored, to prevent conflict with spring-boot logging system.*
- **unitTestEnabled (default=false)**: when this option is enabled,
the integration test will locate the test-classes of the module and run the unit tests after the execution of the usual checks.
  *Note: a full build of each component is required prior to running the unit tests. Test dependencies are implicitly included.*

