### PR TITLE
Update CamelSalesforceMojo.java

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
@@ -88,7 +88,7 @@ public class CamelSalesforceMojo extends AbstractMojo {
     protected static final int DEFAULT_TIMEOUT = 60000;
 
     private static final String JAVA_EXT = ".java";
-    private static final String PACKAGE_NAME_PATTERN = "^[a-z]+(\\.[a-z][a-z0-9]*)*$";
+    private static final String PACKAGE_NAME_PATTERN = "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
 
     private static final String SOBJECT_POJO_VM = "/sobject-pojo.vm";
     private static final String SOBJECT_POJO_OPTIONAL_VM = "/sobject-pojo-optional.vm";


### PR DESCRIPTION
the current pattern does not allow valid package names like "abc.xyz_123"
the new pattern is based on the excellent discussion at 
http://stackoverflow.com/questions/5205339/regular-expression-matching-fully-qualified-class-names