### PR TITLE
CAMEL-10060: Added fat-jar aware package scan class resolver

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultPackageScanClassResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultPackageScanClassResolver.java
@@ -417,7 +417,7 @@ public class DefaultPackageScanClassResolver extends ServiceSupport implements P
      * @param urlPath the url of the jar file to be examined for classes
      * @return all the .class entries from the JAR
      */
-    private List<String> doLoadJarClassEntries(InputStream stream, String urlPath) {
+    protected List<String> doLoadJarClassEntries(InputStream stream, String urlPath) {
         List<String> entries = new ArrayList<String>();
 
         JarInputStream jarStream = null;

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -77,6 +77,8 @@ public class CamelAutoConfiguration {
             camelContext.getManagementStrategy().getManagementAgent().setCreateConnector(config.isJmxCreateConnector());
         }
 
+        camelContext.setPackageScanClassResolver(new FatJarPackageScanClassResolver());
+
         return camelContext;
     }
 

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/FatJarPackageScanClassResolver.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/FatJarPackageScanClassResolver.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import org.apache.camel.impl.DefaultPackageScanClassResolver;
+import org.apache.camel.util.IOHelper;
+
+/**
+ * An implementation of the {@code org.apache.camel.spi.PackageScanClassResolver} that is able to
+ * scan spring-boot fat jars to find classes contained also in nested jars.
+ */
+public class FatJarPackageScanClassResolver extends DefaultPackageScanClassResolver {
+
+    /**
+     * Loads all the class entries from the main JAR and all nested jars.
+     *
+     * @param stream  the inputstream of the jar file to be examined for classes
+     * @param urlPath the url of the jar file to be examined for classes
+     * @return all the .class entries from the main JAR and all nested jars
+     */
+    @Override
+    protected List<String> doLoadJarClassEntries(InputStream stream, String urlPath) {
+        return doLoadJarClassEntries(stream, urlPath, true, true);
+    }
+
+    protected List<String> doLoadJarClassEntries(InputStream stream, String urlPath, boolean inspectNestedJars, boolean closeStream) {
+        List<String> entries = new ArrayList<String>();
+
+        JarInputStream jarStream = null;
+        try {
+            jarStream = new JarInputStream(stream);
+
+            JarEntry entry;
+            while ((entry = jarStream.getNextJarEntry()) != null) {
+                String name = entry.getName();
+
+                if (name != null) {
+                    name = name.trim();
+                    if (!entry.isDirectory() && name.endsWith(".class")) {
+                        entries.add(name);
+                    } else if (inspectNestedJars && !entry.isDirectory() && name.startsWith("lib/") && name.endsWith(".jar")) {
+                        String nestedUrl = urlPath + "!/" + name;
+                        log.trace("Inspecting nested jar: {}", nestedUrl);
+
+                        List<String> nestedEntries = doLoadJarClassEntries(jarStream, nestedUrl, false, false);
+                        entries.addAll(nestedEntries);
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            log.warn("Cannot search jar file '" + urlPath + " due to an IOException: " + ioe.getMessage(), ioe);
+        } finally {
+            if (closeStream) {
+                // stream is left open when scanning nested jars, otherwise the fat jar stream gets closed
+                IOHelper.close(jarStream, urlPath, log);
+            }
+        }
+
+        return entries;
+    }
+
+}


### PR DESCRIPTION
I've noticed that many modules currently use the package scan class resolver to find specific classes, so CAMEL-10060 is not related to custom converters only. Without a fat-jar-aware package scanner, some users could be unable to run a spring-boot multi-module project or use extension libraries.

I extended the default class resolver, to let it search inside nested jars. The new resolver is configured automatically in the camel context when the spring-boot library is imported.

I tested it with the offending jar and it works. If this gets merged, I'll add a specific integration test in the new spring-boot suite.

Note: I needed to change the modifier of a private method of a core class (`DefaultPackageScanClassResolver`), in order to extend it without rewriting a lot of code. I think we should not care about version compatibility here, but I'm not sure.