### PR TITLE
fix misleading debug log message concerning the number of polled mess…

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlConsumer.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlConsumer.java
@@ -210,9 +210,8 @@ public class SqlConsumer extends ScheduledBatchPollingConsumer {
     public int processBatch(Queue<Object> exchanges) throws Exception {
         int total = exchanges.size();
 
-        // limit if needed
         if (maxMessagesPerPoll > 0 && total == maxMessagesPerPoll) {
-            log.debug("Limiting to maximum messages to poll " + maxMessagesPerPoll + " as there was more messages in this poll.");
+            log.debug("Maximum messages to poll is {} and there were exactly {} messages in this poll.", maxMessagesPerPoll, total);
         }
 
         for (int index = 0; index < total && isBatchAllowed(); index++) {


### PR DESCRIPTION
…ages

The number rows polled from the database is limited by `JdbcTemplate#setMaxRows`. There is no way to know if there are more rows in the database than the number of currently polled rows. The log entry was wrong if there were exactly the maximum messages in the database.