### PR TITLE
CAMEL-9638: Introduced SNIHostName config in sslContextParameters

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/jsse/BaseSSLContextParameters.java
+++ b/camel-core/src/main/java/org/apache/camel/util/jsse/BaseSSLContextParameters.java
@@ -34,9 +34,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.KeyManager;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSessionContext;
@@ -109,7 +112,10 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
      * The optional {@link SSLSessionContext} timeout time for {@link javax.net.ssl.SSLSession}s in seconds.
      */
     private String sessionTimeout;
-    
+
+    protected List<SNIServerName> getSNIHostNames() {
+        return Collections.emptyList();
+    }
 
     /**
      * Returns the optional explicitly configured cipher suites for this configuration.
@@ -515,7 +521,11 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
             
             @Override
             public SSLSocket configure(SSLSocket socket) {
-                
+
+                SSLParameters sslParameters = socket.getSSLParameters();
+                sslParameters.setServerNames(getSNIHostNames());
+                socket.setSSLParameters(sslParameters);
+
                 Collection<String> filteredCipherSuites = BaseSSLContextParameters.this
                     .filter(enabledCipherSuites, Arrays.asList(socket.getSSLParameters().getCipherSuites()),
                             Arrays.asList(socket.getEnabledCipherSuites()),
@@ -539,7 +549,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                             Arrays.asList(socket.getEnabledProtocols()),
                             enabledSecureSocketProtocolsPatterns, defaultEnabledSecureSocketProtocolsPatterns,
                             !allowPassthrough);
-                
+
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(SSL_SOCKET_PROTOCOL_LOG_MSG,
                             new Object[] {socket,

--- a/camel-core/src/main/java/org/apache/camel/util/jsse/BaseSSLContextParameters.java
+++ b/camel-core/src/main/java/org/apache/camel/util/jsse/BaseSSLContextParameters.java
@@ -522,9 +522,11 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
             @Override
             public SSLSocket configure(SSLSocket socket) {
 
-                SSLParameters sslParameters = socket.getSSLParameters();
-                sslParameters.setServerNames(getSNIHostNames());
-                socket.setSSLParameters(sslParameters);
+                if (!getSNIHostNames().isEmpty()) {
+                    SSLParameters sslParameters = socket.getSSLParameters();
+                    sslParameters.setServerNames(getSNIHostNames());
+                    socket.setSSLParameters(sslParameters);
+                }
 
                 Collection<String> filteredCipherSuites = BaseSSLContextParameters.this
                     .filter(enabledCipherSuites, Arrays.asList(socket.getSSLParameters().getCipherSuites()),

--- a/camel-core/src/main/java/org/apache/camel/util/jsse/SSLContextClientParameters.java
+++ b/camel-core/src/main/java/org/apache/camel/util/jsse/SSLContextClientParameters.java
@@ -17,9 +17,12 @@
 package org.apache.camel.util.jsse;
 
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLServerSocketFactory;
@@ -33,6 +36,19 @@ import org.slf4j.LoggerFactory;
 public class SSLContextClientParameters extends BaseSSLContextParameters {
     
     private static final Logger LOG = LoggerFactory.getLogger(SSLContextClientParameters.class);
+
+    private List<SNIServerName> sniHostNames = new ArrayList<>();
+
+    public void setSniHostNames(List<String> sniHostNames) {
+        for (String sniHostName : sniHostNames) {
+            this.sniHostNames.add(new SNIHostName(sniHostName));
+        }
+    }
+
+    @Override
+    protected List<SNIServerName> getSNIHostNames() {
+        return sniHostNames;
+    }
 
     @Override
     protected boolean getAllowPassthrough() {

--- a/camel-core/src/main/java/org/apache/camel/util/jsse/SSLContextClientParameters.java
+++ b/camel-core/src/main/java/org/apache/camel/util/jsse/SSLContextClientParameters.java
@@ -39,10 +39,14 @@ public class SSLContextClientParameters extends BaseSSLContextParameters {
 
     private List<SNIServerName> sniHostNames = new ArrayList<>();
 
-    public void setSniHostNames(List<String> sniHostNames) {
+    public void addAllSniHostNames(List<String> sniHostNames) {
         for (String sniHostName : sniHostNames) {
             this.sniHostNames.add(new SNIHostName(sniHostName));
         }
+    }
+
+    public void setSniHostName(String sniHostName) {
+        this.sniHostNames.add(new SNIHostName(sniHostName));
     }
 
     @Override

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextClientParametersFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextClientParametersFactoryBean.java
@@ -27,14 +27,14 @@ import org.apache.camel.util.jsse.SSLContextClientParameters;
 @XmlTransient
 public abstract class AbstractSSLContextClientParametersFactoryBean extends AbstractBaseSSLContextParametersFactoryBean<SSLContextClientParameters> {
 
-    @XmlElement(name = "SNIHostNamesDefinition")
+    @XmlElement(name = "sniHostNames")
     private SNIHostNamesDefinition sniHostNamesDefinition;
 
     @Override
     protected SSLContextClientParameters createInstance() {
         SSLContextClientParameters newInstance = new SSLContextClientParameters();
         newInstance.setCamelContext(getCamelContext());
-        newInstance.setSniHostNames(sniHostNamesDefinition.getSniHostName());
+        newInstance.addAllSniHostNames(sniHostNamesDefinition.getSniHostName());
         return newInstance;
     }
 
@@ -43,7 +43,7 @@ public abstract class AbstractSSLContextClientParametersFactoryBean extends Abst
         return SSLContextClientParameters.class;
     }
 
-    public org.apache.camel.core.xml.util.jsse.SNIHostNamesDefinition getSniHostNamesDefinition() {
+    public SNIHostNamesDefinition getSniHostNamesDefinition() {
         return sniHostNamesDefinition;
     }
 }

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/SNIHostNamesDefinition.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/SNIHostNamesDefinition.java
@@ -24,10 +24,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "SNIHostNames", propOrder = {"sniHostName"})
+@XmlType(name = "sniHostNames", propOrder = {"sniHostName"})
 public class SNIHostNamesDefinition {
 
-    @XmlElement(name = "SNIHostName")
+    @XmlElement(name = "sniHostName")
     private List<String> sniHostName;
 
     public List<String> getSniHostName() {

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/SNIHostNamesDefinition.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/SNIHostNamesDefinition.java
@@ -16,34 +16,21 @@
  */
 package org.apache.camel.core.xml.util.jsse;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-
-import org.apache.camel.util.jsse.SSLContextClientParameters;
+import javax.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlTransient
-public abstract class AbstractSSLContextClientParametersFactoryBean extends AbstractBaseSSLContextParametersFactoryBean<SSLContextClientParameters> {
+@XmlType(name = "SNIHostNames", propOrder = {"sniHostName"})
+public class SNIHostNamesDefinition {
 
-    @XmlElement(name = "SNIHostNamesDefinition")
-    private SNIHostNamesDefinition sniHostNamesDefinition;
+    @XmlElement(name = "SNIHostName")
+    private List<String> sniHostName;
 
-    @Override
-    protected SSLContextClientParameters createInstance() {
-        SSLContextClientParameters newInstance = new SSLContextClientParameters();
-        newInstance.setCamelContext(getCamelContext());
-        newInstance.setSniHostNames(sniHostNamesDefinition.getSniHostName());
-        return newInstance;
-    }
-
-    @Override
-    public Class<SSLContextClientParameters> getObjectType() {
-        return SSLContextClientParameters.class;
-    }
-
-    public org.apache.camel.core.xml.util.jsse.SNIHostNamesDefinition getSniHostNamesDefinition() {
-        return sniHostNamesDefinition;
+    public List<String> getSniHostName() {
+        return sniHostName;
     }
 }

--- a/components/camel-http4/pom.xml
+++ b/components/camel-http4/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>camel-http-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient4-version}</version>

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpSNIHostNameTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpSNIHostNameTest.java
@@ -19,12 +19,14 @@ package org.apache.camel.component.http4;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.http.common.HttpOperationFailedException;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.hamcrest.core.Is.is;
 
+@Ignore("Ignored test because of external dependency.")
 public class HttpSNIHostNameTest extends CamelSpringTestSupport {
 
     @Test
@@ -32,6 +34,7 @@ public class HttpSNIHostNameTest extends CamelSpringTestSupport {
         String result = template.requestBody("direct:goodSNI", null, String.class);
         assertNotNull(result);
     }
+
     @Test
     public void testMnotDotNetNoSniDoesReturnStatusCode403() {
         try {

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpSNIHostNameTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpSNIHostNameTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http4;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.hamcrest.core.Is.is;
+
+public class HttpSNIHostNameTest extends CamelSpringTestSupport {
+
+    @Test
+    public void testMnotDotNetDoesNotReturnStatusCode421() throws Exception {
+        String result = template.requestBody("direct:goodSNI", null, String.class);
+        assertNotNull(result);
+    }
+    @Test
+    public void testMnotDotNetNoSniDoesReturnStatusCode403() {
+        try {
+            template.requestBody("direct:noSNI", null, String.class);
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = (HttpOperationFailedException) e.getCause();
+            assertThat(cause.getStatusCode(), is(403));
+        }
+    }
+
+    @Test
+    public void testMnotDotNetWrongSniDoesReturnStatusCode421() {
+        try {
+            template.requestBody("direct:wrongSNI", null, String.class);
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = (HttpOperationFailedException) e.getCause();
+            assertThat(cause.getStatusCode(), is(421));
+        }
+    }
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        ClassPathXmlApplicationContext ctx =
+                new ClassPathXmlApplicationContext(new String[]{"org/apache/camel/component/http4/CamelHttp4Context.xml"});
+        return ctx;
+    }
+}

--- a/components/camel-http4/src/test/resources/org/apache/camel/component/http4/CamelHttp4Context.xml
+++ b/components/camel-http4/src/test/resources/org/apache/camel/component/http4/CamelHttp4Context.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+
+  <camel:sslContextParameters id="correctSniSslContextParameters">
+    <camel:clientParameters>
+      <camel:SNIHostNamesDefinition>
+        <camel:SNIHostName>www.mnot.net</camel:SNIHostName>
+      </camel:SNIHostNamesDefinition>
+    </camel:clientParameters>
+  </camel:sslContextParameters>
+
+  <camel:sslContextParameters id="noSniSslContextParameters">
+  </camel:sslContextParameters>
+
+  <camel:sslContextParameters id="wrongSniSslContextParameters">
+    <camel:clientParameters>
+      <camel:SNIHostNamesDefinition>
+        <camel:SNIHostName>blabla</camel:SNIHostName>
+      </camel:SNIHostNamesDefinition>
+    </camel:clientParameters>
+  </camel:sslContextParameters>
+
+  <bean id="https4" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="sslContextParameters" ref="correctSniSslContextParameters"/>
+  </bean>
+
+  <bean id="https4-no" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="sslContextParameters" ref="noSniSslContextParameters"/>
+  </bean>
+
+  <bean id="https4-wrong" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="sslContextParameters" ref="wrongSniSslContextParameters"/>
+  </bean>
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route errorHandlerRef="noErrorHandler">
+      <from uri="direct:goodSNI"/>
+      <to uri="https4://www.mnot.net?sslContextParameters=correctSniSslContextParameters"/>
+    </route>
+    <route errorHandlerRef="noErrorHandler">
+      <from uri="direct:wrongSNI"/>
+      <to uri="https4-wrong://www.mnot.net?sslContextParameters=wrongSniSslContextParameters"/>
+    </route>
+    <route errorHandlerRef="noErrorHandler">
+      <from uri="direct:noSNI"/>
+      <to uri="https4-no://www.mnot.net?sslContextParameters=noSniSslContextParameters"/>
+    </route>
+  </camelContext>
+
+  <bean id="noErrorHandler" class="org.apache.camel.builder.NoErrorHandlerBuilder"/>
+
+</beans>

--- a/components/camel-http4/src/test/resources/org/apache/camel/component/http4/CamelHttp4Context.xml
+++ b/components/camel-http4/src/test/resources/org/apache/camel/component/http4/CamelHttp4Context.xml
@@ -28,9 +28,9 @@
 
   <camel:sslContextParameters id="correctSniSslContextParameters">
     <camel:clientParameters>
-      <camel:SNIHostNamesDefinition>
-        <camel:SNIHostName>www.mnot.net</camel:SNIHostName>
-      </camel:SNIHostNamesDefinition>
+      <camel:sniHostNames>
+        <camel:sniHostName>www.mnot.net</camel:sniHostName>
+      </camel:sniHostNames>
     </camel:clientParameters>
   </camel:sslContextParameters>
 
@@ -39,9 +39,9 @@
 
   <camel:sslContextParameters id="wrongSniSslContextParameters">
     <camel:clientParameters>
-      <camel:SNIHostNamesDefinition>
-        <camel:SNIHostName>blabla</camel:SNIHostName>
-      </camel:SNIHostNamesDefinition>
+      <camel:sniHostNames>
+        <camel:sniHostName>blabla</camel:sniHostName>
+      </camel:sniHostNames>
     </camel:clientParameters>
   </camel:sslContextParameters>
 


### PR DESCRIPTION
Introduced SNIHostName in sslContextParameters.
Added a test to https://www.mnot.net which throws 403 or 421 when SNIHostName is not used.
Eventually it might be needed to ignore this test. I didn't find a simple way to test this.