### PR TITLE
Retrieve relevant fields to determine PushTopic update

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/PushTopicHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/PushTopicHelper.java
@@ -74,7 +74,9 @@ public class PushTopicHelper {
         try {
             // use SOQL to lookup Topic, since Name is not an external ID!!!
             restClient.query("SELECT Id, Name, Query, ApiVersion, IsActive, "
-                    + "NotifyForFields, NotifyForOperations, Description "
+                    + "NotifyForFields, NotifyForOperations, NotifyForOperationCreate, "
+                    + "NotifyForOperationDelete, NotifyForOperationUndelete, "
+                    + "NotifyForOperationUpdate, Description "
                     + "FROM PushTopic WHERE Name = '" + topicName + "'",
                     callback);
 


### PR DESCRIPTION
The check for changes in these fields was already in the code, but the field values were not retrieved through the Salesforce REST API.

Signed-off-by: Sune Keller <absukl@almbrand.dk>