### PR TITLE
CAMEL-10087 Fix for kafka partitioner static initializer in OSGI env

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -102,6 +102,7 @@ public class KafkaConsumer extends DefaultConsumer {
             
             ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
             try {
+                //Fix for running camel-kafka in OSGI see KAFKA-3218
                 Thread.currentThread().setContextClassLoader(null);
                 this.consumer = new org.apache.kafka.clients.consumer.KafkaConsumer(kafkaProps);
             } finally {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -82,6 +82,7 @@ public class KafkaProducer extends DefaultAsyncProducer {
         if (kafkaProducer == null) {
             ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
             try {
+                //Fix for running camel-kafka in OSGI see KAFKA-3218
                 Thread.currentThread().setContextClassLoader(null);
                 kafkaProducer = new org.apache.kafka.clients.producer.KafkaProducer(props);
             } finally {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -80,7 +80,13 @@ public class KafkaProducer extends DefaultAsyncProducer {
     protected void doStart() throws Exception {
         Properties props = getProps();
         if (kafkaProducer == null) {
-            kafkaProducer = new org.apache.kafka.clients.producer.KafkaProducer(props);
+            ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(null);
+                kafkaProducer = new org.apache.kafka.clients.producer.KafkaProducer(props);
+            } finally {
+                Thread.currentThread().setContextClassLoader(threadClassLoader);
+            }
         }
 
         // if we are in asynchronous mode we need a worker pool


### PR DESCRIPTION
Sorry missed this:

We need to put the same fix (setting classloader to null) for the Producer as well. The kafka ProducerConfig has a static initializer that creates the DefaultPartiioner by default no matter what.
Here is the kafka path:
Static initializer:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java#L293
Defines default partitioner:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java#L110
Creates default instance of partitioner
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java#L663
Since this is a static it only gets call on the first reference to the class, so it doesn't take into account what is passed in from the camel-kafka producer.