### PR TITLE
CAMEL-10116: Retrieve last MessageHistory when getting NodeId and Rou…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultExchange.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultExchange.java
@@ -17,6 +17,7 @@
 package org.apache.camel.impl;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -150,7 +151,7 @@ public final class DefaultExchange implements Exchange {
         // safe copy message history using a defensive copy
         List<MessageHistory> history = (List<MessageHistory>) answer.remove(Exchange.MESSAGE_HISTORY);
         if (history != null) {
-            answer.put(Exchange.MESSAGE_HISTORY, new ArrayList<MessageHistory>(history));
+            answer.put(Exchange.MESSAGE_HISTORY, new LinkedList<>(history));
         }
 
         return answer;

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -194,13 +195,13 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
         @Override
         @SuppressWarnings("unchecked")
         public long getElapsed() {
-            List<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, List.class);
+            LinkedList<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, LinkedList.class);
             if (list == null || list.isEmpty()) {
                 return 0;
             }
 
             // get latest entry
-            MessageHistory history = list.get(list.size() - 1);
+            MessageHistory history = list.getLast();
             if (history != null) {
                 return history.getElapsed();
             } else {
@@ -211,13 +212,13 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
         @Override
         @SuppressWarnings("unchecked")
         public String getNodeId() {
-            List<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, List.class);
+            LinkedList<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, LinkedList.class);
             if (list == null || list.isEmpty()) {
                 return null;
             }
 
             // get latest entry
-            MessageHistory history = list.get(list.size() - 1);
+            MessageHistory history = list.getLast();
             if (history != null) {
                 return history.getNode().getId();
             } else {
@@ -238,13 +239,13 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
         @Override
         @SuppressWarnings("unchecked")
         public String getAtRouteId() {
-            List<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, List.class);
+            LinkedList<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, LinkedList.class);
             if (list == null || list.isEmpty()) {
                 return null;
             }
 
             // get latest entry
-            MessageHistory history = list.get(list.size() - 1);
+            MessageHistory history = list.getLast();
             if (history != null) {
                 return history.getRouteId();
             } else {

--- a/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
@@ -19,6 +19,7 @@ package org.apache.camel.processor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -744,7 +745,7 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor {
         public MessageHistory before(Exchange exchange) throws Exception {
             List<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, List.class);
             if (list == null) {
-                list = new ArrayList<MessageHistory>();
+                list = new LinkedList<>();
                 exchange.setProperty(Exchange.MESSAGE_HISTORY, list);
             }
             MessageHistory history = factory.newMessageHistory(routeId, definition, new Date());

--- a/camel-core/src/main/java/org/apache/camel/util/ExchangeHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ExchangeHelper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.util;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -915,7 +915,7 @@ public final class ExchangeHelper {
         // safe copy message history using a defensive copy
         List<MessageHistory> history = (List<MessageHistory>) answer.remove(Exchange.MESSAGE_HISTORY);
         if (history != null) {
-            answer.put(Exchange.MESSAGE_HISTORY, new ArrayList<MessageHistory>(history));
+            answer.put(Exchange.MESSAGE_HISTORY, new LinkedList<>(history));
         }
 
         return answer;

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultAsyncProcessorAwaitManagerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultAsyncProcessorAwaitManagerTest.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.MessageHistory;
+import org.apache.camel.NamedNode;
+import org.apache.camel.spi.AsyncProcessorAwaitManager;
+import org.apache.camel.spi.MessageHistoryFactory;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class DefaultAsyncProcessorAwaitManagerTest {
+
+    private static final MessageHistoryFactory MESSAGE_HISTORY_FACTORY = new DefaultMessageHistoryFactory();
+    private DefaultAsyncProcessorAwaitManager defaultAsyncProcessorAwaitManager;
+    private DefaultExchange exchange;
+    private CountDownLatch latch;
+    private Thread thread;
+
+    @Test
+    public void testNoMessageHistory() throws Exception {
+        startAsyncProcess();
+        AsyncProcessorAwaitManager.AwaitThread awaitThread = defaultAsyncProcessorAwaitManager.browse().iterator().next();
+        assertThat(awaitThread.getRouteId(), is(nullValue()));
+        assertThat(awaitThread.getNodeId(), is(nullValue()));
+        waitForEndOfAsyncProcess();
+    }
+
+    @Test
+    public void testMessageHistoryWithEmptyList() throws Exception {
+        startAsyncProcess();
+        exchange.setProperty(Exchange.MESSAGE_HISTORY, new LinkedList<MessageHistory>());
+        AsyncProcessorAwaitManager.AwaitThread awaitThread = defaultAsyncProcessorAwaitManager.browse().iterator().next();
+        assertThat(awaitThread.getRouteId(), is(nullValue()));
+        assertThat(awaitThread.getNodeId(), is(nullValue()));
+        waitForEndOfAsyncProcess();
+    }
+
+    @Test
+    public void testMessageHistoryWithNullMessageHistory() throws Exception {
+        startAsyncProcess();
+        LinkedList<MessageHistory> messageHistories = new LinkedList<>();
+        messageHistories.add(null);
+        exchange.setProperty(Exchange.MESSAGE_HISTORY, messageHistories);
+        AsyncProcessorAwaitManager.AwaitThread awaitThread = defaultAsyncProcessorAwaitManager.browse().iterator().next();
+        assertThat(awaitThread.getRouteId(), is(nullValue()));
+        assertThat(awaitThread.getNodeId(), is(nullValue()));
+        waitForEndOfAsyncProcess();
+    }
+
+    @Test
+    public void testMessageHistoryWithNullElements() throws Exception {
+        startAsyncProcess();
+        LinkedList<MessageHistory> messageHistories = new LinkedList<>();
+        messageHistories.add(MESSAGE_HISTORY_FACTORY.newMessageHistory(null,
+                new MockNamedNode().withId(null),
+                null));
+        exchange.setProperty(Exchange.MESSAGE_HISTORY, messageHistories);
+        AsyncProcessorAwaitManager.AwaitThread awaitThread = defaultAsyncProcessorAwaitManager.browse().iterator().next();
+        assertThat(awaitThread.getRouteId(), is(nullValue()));
+        assertThat(awaitThread.getNodeId(), is(nullValue()));
+        waitForEndOfAsyncProcess();
+    }
+
+    @Test
+    public void testMessageHistoryWithNotNullElements() throws Exception {
+        startAsyncProcess();
+        LinkedList<MessageHistory> messageHistories = new LinkedList<>();
+        messageHistories.add(MESSAGE_HISTORY_FACTORY.newMessageHistory("routeId",
+                new MockNamedNode().withId("nodeId"),
+                null));
+        exchange.setProperty(Exchange.MESSAGE_HISTORY, messageHistories);
+        AsyncProcessorAwaitManager.AwaitThread awaitThread = defaultAsyncProcessorAwaitManager.browse().iterator().next();
+        assertThat(awaitThread.getRouteId(), is("routeId"));
+        assertThat(awaitThread.getNodeId(), is("nodeId"));
+        waitForEndOfAsyncProcess();
+    }
+
+    private void waitForEndOfAsyncProcess() {
+        latch.countDown();
+        while (thread.isAlive()) {
+        }
+    }
+
+    private void startAsyncProcess() throws InterruptedException {
+        defaultAsyncProcessorAwaitManager = new DefaultAsyncProcessorAwaitManager();
+        latch = new CountDownLatch(1);
+        BackgroundAwait backgroundAwait = new BackgroundAwait();
+        exchange = new DefaultExchange(new DefaultCamelContext());
+        thread = new Thread(backgroundAwait);
+        thread.start();
+        Thread.sleep(100);
+    }
+
+
+    private class BackgroundAwait implements Runnable {
+
+        @Override
+        public void run() {
+            defaultAsyncProcessorAwaitManager.await(exchange, latch);
+        }
+    }
+
+    private static class MockNamedNode implements NamedNode {
+
+        private String id;
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String getShortName() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public String getLabel() {
+            return this.getClass().getName();
+        }
+
+        @Override
+        public String getDescriptionText() {
+            return this.getClass().getCanonicalName();
+        }
+
+        public MockNamedNode withId(String id) {
+            this.id = id;
+            return this;
+        }
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/async/AsyncProcessorAwaitManagerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/async/AsyncProcessorAwaitManagerTest.java
@@ -73,7 +73,8 @@ public class AsyncProcessorAwaitManagerTest extends ContextTestSupport {
                                 log.info("Thread {} has waited for {} msec.", thread.getBlockedThread().getName(), wait);
 
                                 assertEquals("myRoute", thread.getRouteId());
-                                assertEquals("myAsync", thread.getNodeId());
+                                //assertEquals("myAsync", thread.getNodeId());
+                                assertEquals("process1", thread.getNodeId());
                             }
                         })
                         .to("mock:result");


### PR DESCRIPTION
Following changes are made:

- MessageHistories is changed to LinkedList to facilitate getting last item;
- The fetching of the NodeId and RouteId from the last MessageHistory in the AwaitThreadEntry is moved to the methods getNodeId and getRouteId.

The test on AsyncProcessorAwaitManager is changed which shows that the dumping of the last NodeId and RouteId is error-prone.

I suddenly see that I used java 8 optional and lambda's to get the last NodeId, so I guess this can't be cherry-picked to 2.17.3 as is. Sorry.