### PR TITLE
CAMEL-10125: Add default ErrorHandler as unmanaged bean 

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -1241,7 +1241,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent implements 
                     super.writeErrorPage(request, writer, code, message, false);
                 }
             };
-            s.addBean(eh);
+            s.addBean(eh, false);
         }
         return s;
     }


### PR DESCRIPTION
Prevents "No Server set for ..." warnings on startup.