### PR TITLE
CAMEL-10127: call parent constructor of OsgiDefaultCamelContext with registry

### DIFF
--- a/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiDefaultCamelContext.java
+++ b/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiDefaultCamelContext.java
@@ -35,10 +35,11 @@ public class OsgiDefaultCamelContext extends DefaultCamelContext {
     private final Registry registry;
 
     public OsgiDefaultCamelContext(BundleContext bundleContext) {
-        this(bundleContext, null);
+        this(bundleContext, new OsgiServiceRegistry(bundleContext));
     }
 
     public OsgiDefaultCamelContext(BundleContext bundleContext, Registry registry) {
+        super(registry);
         this.bundleContext = bundleContext;
         this.registry = registry;
         OsgiCamelContextHelper.osgiUpdate(this, bundleContext);


### PR DESCRIPTION
calling super with registry or a new OsgiServiceRegistry if not specified