### PR TITLE
https://issues.apache.org/jira/browse/CAMEL-8598

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/swf/CamelSWFWorkflowClient.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/swf/CamelSWFWorkflowClient.java
@@ -71,11 +71,13 @@ public class CamelSWFWorkflowClient {
         workflowType.setName(eventName);
         workflowType.setVersion(version);
         dynamicWorkflowClientExternal.setWorkflowType(workflowType);
-        dynamicWorkflowClientExternal.startWorkflowExecution(toArray(arguments));
+        
         StartWorkflowOptions startWorkflowOptions = new StartWorkflowOptions();
         startWorkflowOptions.setTaskStartToCloseTimeoutSeconds(FlowHelpers.durationToSeconds(configuration.getTaskStartToCloseTimeout()));
         startWorkflowOptions.setExecutionStartToCloseTimeoutSeconds(FlowHelpers.durationToSeconds(configuration.getExecutionStartToCloseTimeout()));
         dynamicWorkflowClientExternal.setSchedulingOptions(startWorkflowOptions);
+        
+        dynamicWorkflowClientExternal.startWorkflowExecution(toArray(arguments));
 
         String newWorkflowId = dynamicWorkflowClientExternal.getWorkflowExecution().getWorkflowId();
         String newRunId = dynamicWorkflowClientExternal.getWorkflowExecution().getRunId();


### PR DESCRIPTION
The defaults as part of above bug are not used by AWS client before
starting a workflow