### PR TITLE
CAMEL-10166: Add URI parameter skipQueueBind in case we need to decl…

### DIFF
--- a/components/camel-rabbitmq/src/main/docs/rabbitmq.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq.adoc
@@ -48,8 +48,9 @@ The RabbitMQ component has no options.
 
 
 
+
 // endpoint options: START
-The RabbitMQ component supports 53 endpoint options which are listed below:
+The RabbitMQ component supports 54 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2s,1,1m,1m,5",options="header"]
@@ -70,6 +71,7 @@ The RabbitMQ component supports 53 endpoint options which are listed below:
 | queue | common |  | String | The queue to receive messages from
 | routingKey | common |  | String | The routing key to use when binding a consumer queue to the exchange. For producer routing keys you set the header rabbitmq.ROUTING_KEY.
 | skipExchangeDeclare | common | false | boolean | This can be used if we need to declare the queue but not the exchange
+| skipQueueBind | common | false | boolean | If true the queue will not be bound to the exchange after declaring it
 | skipQueueDeclare | common | false | boolean | If true the producer will not declare and bind a queue. This can be used for directing messages via an existing routing key.
 | vhost | common | / | String | The vhost for the channel
 | autoAck | consumer | true | boolean | If messages should be auto acknowledged
@@ -111,6 +113,7 @@ The RabbitMQ component supports 53 endpoint options which are listed below:
 |=======================================================================
 {% endraw %}
 // endpoint options: END
+
 
 
 See

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -87,12 +87,16 @@ public class RabbitMQDeclareSupport {
         return !endpoint.isSkipExchangeDeclare();
     }
 
+    private boolean shouldBindQueue(){
+      return !endpoint.isSkipQueueBind();
+    }
+    
     private void populateQueueArgumentsFromConfigurer(final Map<String, Object> queueArgs) {
         if (endpoint.getQueueArgsConfigurer() != null) {
             endpoint.getQueueArgsConfigurer().configurArgs(queueArgs);
         }
     }
-
+    
     private void declareExchange(final Channel channel, final String exchange, final String exchangeType, final Map<String, Object> exchangeArgs) throws IOException {
         channel.exchangeDeclare(exchange, exchangeType, endpoint.isDurable(), endpoint.isAutoDelete(), exchangeArgs);
     }
@@ -100,7 +104,9 @@ public class RabbitMQDeclareSupport {
     private void declareAndBindQueue(final Channel channel, final String queue, final String exchange, final String routingKey, final Map<String, Object> arguments)
             throws IOException {
         channel.queueDeclare(queue, endpoint.isDurable(), false, endpoint.isAutoDelete(), arguments);
+       if(shouldBindQueue()){
         channel.queueBind(queue, exchange, emptyIfNull(routingKey));
+       }
     }
 
     private String emptyIfNull(final String routingKey) {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -81,6 +81,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     @UriParam(label = "common")
     private boolean skipQueueDeclare;
     @UriParam(label = "common")
+    private boolean skipQueueBind;
+    @UriParam(label = "common")
     private boolean skipExchangeDeclare;
     @UriParam(label = "advanced")
     private Address[] addresses;
@@ -406,7 +408,19 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     public boolean isSkipQueueDeclare() {
         return skipQueueDeclare;
     }
-    
+
+    /**
+     * If true the queue will not be bound to the exchange after declaring it
+     * @return 
+     */
+    public boolean isSkipQueueBind() {
+        return skipQueueBind;
+    }
+
+    public void setSkipQueueBind(boolean skipQueueBind) {
+        this.skipQueueBind = skipQueueBind;
+    }
+     
     /**
      * This can be used if we need to declare the queue but not the exchange
      */

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -260,4 +260,10 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?skipExchangeDeclare=true", RabbitMQEndpoint.class);
         assertTrue(endpoint.isSkipExchangeDeclare());
     }
+    
+    @Test
+    public void createEndpointWithSkipQueueBindEndabled() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?SkipQueueBind=true", RabbitMQEndpoint.class);
+        assertTrue(endpoint.isSkipQueueBind());
+    }
 }


### PR DESCRIPTION
As described in CAMEL-10166 I would like to add a URI parameter to skip binding a queue to an exchange after declaring the queue. I noticed that on some servers (maybe all) you can declare a queue on the default exchange but are not allowed to bind it to the exchange.