### PR TITLE
CAMEL-10190: Fallback lookup components, data-formats and languages using suffix in name to avoid clash

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * scheme name in the <b>META-INF/services/org/apache/camel/component/</b>
  * directory on the classpath.
  *
- * @version 
+ * @version
  */
 public class DefaultComponentResolver implements ComponentResolver {
 
@@ -41,13 +41,11 @@ public class DefaultComponentResolver implements ComponentResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultComponentResolver.class);
 
-    private static final String FALLBACK_COMPONENT_BEAN_SUFFIX = "-component";
-
     private FactoryFinder factoryFinder;
 
     public Component resolveComponent(String name, CamelContext context) {
         // lookup in registry first
-        Object bean = lookupInRegistry(context, name, name + FALLBACK_COMPONENT_BEAN_SUFFIX);
+        Object bean = lookupInRegistry(context, name, name + "-component");
 
         if (bean != null) {
             if (bean instanceof Component) {
@@ -91,7 +89,7 @@ public class DefaultComponentResolver implements ComponentResolver {
 
     private Object lookupInRegistry(CamelContext context, String... names) {
         Object bean = null;
-        for(String name : names) {
+        for (String name : names) {
             try {
                 bean = context.getRegistry().lookupByName(name);
                 getLog().debug("Lookup component with name {} in registry. Found: {}", name, bean);
@@ -99,7 +97,7 @@ public class DefaultComponentResolver implements ComponentResolver {
                 getLog().debug("Ignored error looking up bean: " + name, e);
             }
 
-            if(bean!=null) {
+            if (bean != null) {
                 break;
             }
         }

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
@@ -98,11 +98,11 @@ public class DefaultComponentResolver implements ComponentResolver {
             }
 
             if (bean != null) {
-                break;
+                return bean;
             }
         }
 
-        return bean;
+        return null;
     }
 
     private Class<?> findComponent(String name, CamelContext context) throws ClassNotFoundException, IOException {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultComponentResolver.java
@@ -38,18 +38,17 @@ import org.slf4j.LoggerFactory;
 public class DefaultComponentResolver implements ComponentResolver {
 
     public static final String RESOURCE_PATH = "META-INF/services/org/apache/camel/component/";
+
     private static final Logger LOG = LoggerFactory.getLogger(DefaultComponentResolver.class);
+
+    private static final String FALLBACK_COMPONENT_BEAN_SUFFIX = "-component";
+
     private FactoryFinder factoryFinder;
 
     public Component resolveComponent(String name, CamelContext context) {
         // lookup in registry first
-        Object bean = null;
-        try {
-            bean = context.getRegistry().lookupByName(name);
-            getLog().debug("Found component: {} in registry: {}", name, bean);
-        } catch (Exception e) {
-            getLog().debug("Ignored error looking up bean: " + name, e);
-        }
+        Object bean = lookupInRegistry(context, name, name + FALLBACK_COMPONENT_BEAN_SUFFIX);
+
         if (bean != null) {
             if (bean instanceof Component) {
                 return (Component) bean;
@@ -88,6 +87,24 @@ public class DefaultComponentResolver implements ComponentResolver {
         } else {
             throw new IllegalArgumentException("Type is not a Component implementation. Found: " + type.getName());
         }
+    }
+
+    private Object lookupInRegistry(CamelContext context, String... names) {
+        Object bean = null;
+        for(String name : names) {
+            try {
+                bean = context.getRegistry().lookupByName(name);
+                getLog().debug("Lookup component with name {} in registry. Found: {}", name, bean);
+            } catch (Exception e) {
+                getLog().debug("Ignored error looking up bean: " + name, e);
+            }
+
+            if(bean!=null) {
+                break;
+            }
+        }
+
+        return bean;
     }
 
     private Class<?> findComponent(String name, CamelContext context) throws ClassNotFoundException, IOException {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultDataFormatResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultDataFormatResolver.java
@@ -21,6 +21,7 @@ import org.apache.camel.NoFactoryAvailableException;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.DataFormatResolver;
 import org.apache.camel.spi.FactoryFinder;
+import org.apache.camel.util.ResolverHelper;
 
 /**
  * Default data format resolver
@@ -34,7 +35,9 @@ public class DefaultDataFormatResolver implements DataFormatResolver {
     protected FactoryFinder dataformatFactory;
 
     public DataFormat resolveDataFormat(String name, CamelContext context) {
-        DataFormat dataFormat = lookup(context, DataFormat.class, name, name + "-dataformat");
+        // lookup in registry first
+        DataFormat dataFormat = ResolverHelper.lookupDataFormatInRegistryWithFallback(context, name);
+
         if (dataFormat == null) {
             Class<?> type = null;
             try {
@@ -64,18 +67,4 @@ public class DefaultDataFormatResolver implements DataFormatResolver {
         return dataFormat;
     }
 
-    private static <T> T lookup(CamelContext context, Class<T> type, String... names) {
-        for (String name : names) {
-            try {
-                T bean = context.getRegistry().lookupByNameAndType(name, type);
-                if (bean != null) {
-                    return bean;
-                }
-            } catch (Exception e) {
-                // need to ignore not same type
-            }
-        }
-        // return null if anything goes wrong
-        return null;
-    }
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultDataFormatResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultDataFormatResolver.java
@@ -25,18 +25,16 @@ import org.apache.camel.spi.FactoryFinder;
 /**
  * Default data format resolver
  *
- * @version 
+ * @version
  */
 public class DefaultDataFormatResolver implements DataFormatResolver {
 
     public static final String DATAFORMAT_RESOURCE_PATH = "META-INF/services/org/apache/camel/dataformat/";
 
-    private static final String FALLBACK_DATA_FORMAT_BEAN_SUFFIX = "-dataformat";
-
     protected FactoryFinder dataformatFactory;
 
     public DataFormat resolveDataFormat(String name, CamelContext context) {
-        DataFormat dataFormat = lookup(context, DataFormat.class, name, name + FALLBACK_DATA_FORMAT_BEAN_SUFFIX);
+        DataFormat dataFormat = lookup(context, DataFormat.class, name, name + "-dataformat");
         if (dataFormat == null) {
             Class<?> type = null;
             try {
@@ -67,10 +65,10 @@ public class DefaultDataFormatResolver implements DataFormatResolver {
     }
 
     private static <T> T lookup(CamelContext context, Class<T> type, String... names) {
-        for(String name : names) {
+        for (String name : names) {
             try {
                 T bean = context.getRegistry().lookupByNameAndType(name, type);
-                if(bean!=null) {
+                if (bean != null) {
                     return bean;
                 }
             } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultLanguageResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultLanguageResolver.java
@@ -69,23 +69,6 @@ public class DefaultLanguageResolver implements LanguageResolver {
         }
     }
 
-    private Object lookupInRegistry(CamelContext context, String... names) {
-        for (String name : names) {
-            try {
-                Object bean = context.getRegistry().lookupByName(name);
-                if (bean != null) {
-                    getLog().debug("Found language: {} in registry: {}", name, bean);
-                    return bean;
-                }
-            } catch (Exception e) {
-                if (getLog().isDebugEnabled()) {
-                    getLog().debug("Ignored error looking up bean: " + name + ". Error: " + e);
-                }
-            }
-        }
-
-        return null;
-    }
 
     protected Language noSpecificLanguageFound(String name, CamelContext context) {
         Class<?> type = null;

--- a/camel-core/src/main/java/org/apache/camel/util/ResolverHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ResolverHelper.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.util;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Some helper methods for new resolvers (like {@link org.apache.camel.spi.ComponentResolver}, {@link org.apache.camel.spi.DataFormatResolver}, etc.).
+ *
+ * @version
+ */
+public final class ResolverHelper {
+
+    public static final String COMPONENT_FALLBACK_SUFFIX = "-component";
+
+    public static final String DATA_FORMAT_FALLBACK_SUFFIX = "-dataformat";
+
+    public static final String LANGUAGE_FALLBACK_SUFFIX = "-language";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResolverHelper.class);
+
+    private static final LookupExceptionHandler EXCEPTION_HANDLER = new LookupExceptionHandler();
+
+    /**
+     * Utility classes should not have a public constructor.
+     */
+    private ResolverHelper() {
+    }
+
+    public static Component lookupComponentInRegistryWithFallback(CamelContext context, String name) {
+        return lookupComponentInRegistryWithFallback(context, name, EXCEPTION_HANDLER);
+    }
+
+    public static Component lookupComponentInRegistryWithFallback(CamelContext context, String name, LookupExceptionHandler exceptionHandler) {
+        Object bean = lookupInRegistry(context, Component.class, false, exceptionHandler, name, name + COMPONENT_FALLBACK_SUFFIX);
+        if (bean != null) {
+            if (bean instanceof Component) {
+                return (Component) bean;
+            } else {
+                // let's use Camel's type conversion mechanism to convert things like CamelContext
+                // and other types into a valid Component
+                Component component = CamelContextHelper.convertTo(context, Component.class, bean);
+                if (component != null) {
+                    return component;
+                }
+            }
+        }
+
+        if (bean != null) {
+            LOG.debug("Found Component with incompatible class: {}", bean.getClass().getName());
+        }
+        return null;
+    }
+
+    public static DataFormat lookupDataFormatInRegistryWithFallback(CamelContext context, String name) {
+        return lookupDataFormatInRegistryWithFallback(context, name, EXCEPTION_HANDLER);
+    }
+
+    public static DataFormat lookupDataFormatInRegistryWithFallback(CamelContext context, String name, LookupExceptionHandler exceptionHandler) {
+        Object bean = lookupInRegistry(context, DataFormat.class, false, exceptionHandler, name, name + DATA_FORMAT_FALLBACK_SUFFIX);
+        if (bean instanceof DataFormat) {
+            return (DataFormat) bean;
+        }
+
+        if (bean != null) {
+            LOG.debug("Found DataFormat with incompatible class: {}", bean.getClass().getName());
+        }
+        return null;
+    }
+
+    public static Language lookupLanguageInRegistryWithFallback(CamelContext context, String name) {
+        return lookupLanguageInRegistryWithFallback(context, name, EXCEPTION_HANDLER);
+    }
+
+    public static Language lookupLanguageInRegistryWithFallback(CamelContext context, String name, LookupExceptionHandler exceptionHandler) {
+        Object bean = lookupInRegistry(context, Language.class, false, exceptionHandler, name, name + LANGUAGE_FALLBACK_SUFFIX);
+        if (bean instanceof Language) {
+            return (Language) bean;
+        }
+
+        if (bean != null) {
+            LOG.debug("Found Language with incompatible class: {}", bean.getClass().getName());
+        }
+        return null;
+    }
+
+
+    public static class LookupExceptionHandler {
+
+        public void handleException(Exception e, Logger log, String name) {
+            log.debug("Ignored error looking up bean: " + name, e);
+        }
+
+    }
+
+    private static Object lookupInRegistry(CamelContext context, Class<?> type, boolean lookupByNameAndType, LookupExceptionHandler exceptionHandler, String... names) {
+        for (String name : names) {
+            try {
+                Object bean;
+                if (lookupByNameAndType) {
+                    bean = context.getRegistry().lookupByNameAndType(name, type);
+                } else {
+                    bean = context.getRegistry().lookupByName(name);
+                }
+                LOG.debug("Lookup {} with name {} in registry. Found: {}", type.getSimpleName(), name, bean);
+                if (bean != null) {
+                    return bean;
+                }
+            } catch (Exception e) {
+                exceptionHandler.handleException(e, LOG, name);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextResolverTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextResolverTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.spi.DataFormat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests if the default camel context is able to resolve components and data formats using both their real names and/or fallback names.
+ * Fallback names have been introduced to avoid name clash in some registries (eg. Spring application context) between components and other camel features.
+ */
+public class DefaultCamelContextResolverTest {
+
+    private CamelContext context;
+
+    @Before
+    public void createContext() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        context = new DefaultCamelContext(registry);
+
+        // Add a component using its fallback name
+        registry.put("green-component", new SampleComponent(true));
+
+        // Add a data format using its fallback name
+        registry.put("green-dataformat", new SampleDataFormat(true));
+
+        // Add a component using both names
+        registry.put("yellow", new SampleComponent(false));
+        registry.put("yellow-component", new SampleComponent(true));
+
+        // Add a data format using both names
+        registry.put("red", new SampleDataFormat(false));
+        registry.put("red-dataformat", new SampleDataFormat(true));
+
+        context.start();
+    }
+
+    @After
+    public void destroyContext() throws Exception {
+        context.stop();
+        context = null;
+    }
+
+    @Test
+    public void testComponentWithFallbackNames() throws Exception {
+        Component component = context.getComponent("green");
+        assertNotNull("Component not found in registry", component);
+        assertTrue("Wrong instance type of the Component", component instanceof SampleComponent);
+        assertTrue("Here we should have the fallback Component", ((SampleComponent) component).isFallback());
+    }
+
+    @Test
+    public void testComponentWithBothNames() throws Exception {
+        Component component = context.getComponent("yellow");
+        assertNotNull("Component not found in registry", component);
+        assertTrue("Wrong instance type of the Component", component instanceof SampleComponent);
+        assertFalse("Here we should NOT have the fallback Component", ((SampleComponent) component).isFallback());
+    }
+
+    @Test
+    public void testDataFormatWithFallbackNames() throws Exception {
+        DataFormat dataFormat = context.resolveDataFormat("green");
+        assertNotNull("DataFormat not found in registry", dataFormat);
+        assertTrue("Wrong instance type of the DataFormat", dataFormat instanceof SampleDataFormat);
+        assertTrue("Here we should have the fallback DataFormat", ((SampleDataFormat) dataFormat).isFallback());
+    }
+
+    @Test
+    public void testDataformatWithBothNames() throws Exception {
+        DataFormat dataFormat = context.resolveDataFormat("red");
+        assertNotNull("DataFormat not found in registry", dataFormat);
+        assertTrue("Wrong instance type of the DataFormat", dataFormat instanceof SampleDataFormat);
+        assertFalse("Here we should NOT have the fallback DataFormat", ((SampleDataFormat) dataFormat).isFallback());
+    }
+
+    @Test
+    public void testNullLookupComponent() throws Exception {
+        Component component = context.getComponent("xxxxxxxxx");
+        assertNull("Non-existent Component should be null", component);
+    }
+
+    @Test
+    public void testNullLookupDataFormat() throws Exception {
+        DataFormat dataFormat = context.resolveDataFormat("xxxxxxxxx");
+        assertNull("Non-existent DataFormat should be null", dataFormat);
+    }
+
+    public static class SampleComponent extends DefaultComponent {
+
+        private boolean fallback;
+
+        public SampleComponent(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
+    }
+
+    public static class SampleDataFormat implements DataFormat {
+
+        private boolean fallback;
+
+        public SampleDataFormat(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public void marshal(Exchange exchange, Object graph, OutputStream stream) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Object unmarshal(Exchange exchange, InputStream stream) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextResolverTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextResolverTest.java
@@ -150,7 +150,7 @@ public class DefaultCamelContextResolverTest {
 
         private boolean fallback;
 
-        public SampleComponent(boolean fallback) {
+        SampleComponent(boolean fallback) {
             this.fallback = fallback;
         }
 
@@ -172,7 +172,7 @@ public class DefaultCamelContextResolverTest {
 
         private boolean fallback;
 
-        public SampleDataFormat(boolean fallback) {
+        SampleDataFormat(boolean fallback) {
             this.fallback = fallback;
         }
 
@@ -199,7 +199,7 @@ public class DefaultCamelContextResolverTest {
 
         private boolean fallback;
 
-        public SampleLanguage(boolean fallback) {
+        SampleLanguage(boolean fallback) {
             this.fallback = fallback;
         }
 

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintComponentResolver.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintComponentResolver.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.core.osgi.OsgiComponentResolver;
 import org.apache.camel.spi.ComponentResolver;
-import org.apache.camel.util.CamelContextHelper;
+import org.apache.camel.util.ResolverHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.NoSuchComponentException;
 import org.slf4j.Logger;
@@ -38,26 +38,22 @@ public class BlueprintComponentResolver extends OsgiComponentResolver {
 
     @Override
     public Component resolveComponent(String name, CamelContext context) throws Exception {
-        try {
-            Object bean = context.getRegistry().lookupByName(name);
-            if (bean instanceof Component) {
-                LOG.debug("Found component: {} in registry: {}", name, bean);
-                return (Component) bean;
-            } else {
-                // let's use Camel's type conversion mechanism to convert things like CamelContext
-                // and other types into a valid Component
-                Component component = CamelContextHelper.convertTo(context, Component.class, bean);
-                if (component != null) {
-                    return component;
+
+        Component componentReg = ResolverHelper.lookupComponentInRegistryWithFallback(context, name, new ResolverHelper.LookupExceptionHandler() {
+            @Override
+            public void handleException(Exception e, Logger log, String name) {
+                if (getException(NoSuchComponentException.class, e) != null) {
+                    // if the caused error is NoSuchComponentException then that can be expected so ignore
+                } else {
+                    LOG.trace("Ignored error looking up bean: " + name + " due: " + e.getMessage(), e);
                 }
             }
-        } catch (Exception e) {
-            if (getException(NoSuchComponentException.class, e) != null) {
-                // if the caused error is NoSuchComponentException then that can be expected so ignore
-            } else {
-                LOG.trace("Ignored error looking up bean: " + name + " due: " + e.getMessage(), e);
-            }
+        });
+
+        if (componentReg != null) {
+            return componentReg;
         }
+
         try {
             Object bean = context.getRegistry().lookupByName(".camelBlueprint.componentResolver." + name);
             if (bean instanceof ComponentResolver) {

--- a/components/camel-blueprint/src/test/java/org/apache/camel/blueprint/BlueprintComponentResolverTest.java
+++ b/components/camel-blueprint/src/test/java/org/apache/camel/blueprint/BlueprintComponentResolverTest.java
@@ -60,7 +60,7 @@ public class BlueprintComponentResolverTest extends TestSupport {
 
         private boolean fallback;
 
-        public SampleComponent(boolean fallback) {
+        SampleComponent(boolean fallback) {
             this.fallback = fallback;
         }
 

--- a/components/camel-blueprint/src/test/java/org/apache/camel/blueprint/BlueprintComponentResolverTest.java
+++ b/components/camel-blueprint/src/test/java/org/apache/camel/blueprint/BlueprintComponentResolverTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.blueprint;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
+import org.apache.camel.test.junit4.TestSupport;
+import org.junit.Test;
+
+public class BlueprintComponentResolverTest extends TestSupport {
+
+    @Test
+    public void testOsgiResolverFindComponentFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar-component", new SampleComponent(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        BlueprintComponentResolver resolver = new BlueprintComponentResolver(null);
+        Component component = resolver.resolveComponent("allstar", camelContext);
+        assertNotNull("We should find the super component", component);
+        assertTrue("We should get the super component here", component instanceof SampleComponent);
+    }
+
+    @Test
+    public void testOsgiResolverFindLanguageDoubleFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar", new SampleComponent(false));
+        registry.put("allstar-component", new SampleComponent(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        BlueprintComponentResolver resolver = new BlueprintComponentResolver(null);
+        Component component = resolver.resolveComponent("allstar", camelContext);
+        assertNotNull("We should find the super component", component);
+        assertTrue("We should get the super component here", component instanceof SampleComponent);
+        assertFalse("We should NOT find the fallback component", ((SampleComponent) component).isFallback());
+    }
+
+    private static class SampleComponent implements Component {
+
+        private boolean fallback;
+
+        public SampleComponent(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public void setCamelContext(CamelContext camelContext) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public CamelContext getCamelContext() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Endpoint createEndpoint(String uri) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public boolean useRawUri() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public EndpointConfiguration createConfiguration(String uri) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ComponentConfiguration createComponentConfiguration() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
+    }
+
+}

--- a/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiComponentResolver.java
+++ b/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiComponentResolver.java
@@ -19,8 +19,8 @@ package org.apache.camel.core.osgi;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.spi.ComponentResolver;
-import org.apache.camel.util.CamelContextHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.ResolverHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -35,29 +35,11 @@ public class OsgiComponentResolver implements ComponentResolver {
     public OsgiComponentResolver(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
     }
-    
-    public Component resolveComponent(String name, CamelContext context) throws Exception {
-        Object bean = null;
-        try {
-            bean = context.getRegistry().lookupByName(name);
-            if (bean != null) {
-                LOG.debug("Found component: {} in registry: {}", name, bean);
-            }
-        } catch (Exception e) {
-            LOG.debug("Ignored error looking up bean: " + name + ". Error: " + e);
-        }
 
-        if (bean != null) {
-            if (bean instanceof Component) {
-                return (Component)bean;
-            } else {
-                // lets use Camel's type conversion mechanism to convert things like CamelContext
-                // and other types into a valid Component
-                Component component = CamelContextHelper.convertTo(context, Component.class, bean);
-                if (component != null) {
-                    return component;
-                }
-            }
+    public Component resolveComponent(String name, CamelContext context) throws Exception {
+        Component componentReg = ResolverHelper.lookupComponentInRegistryWithFallback(context, name);
+        if (componentReg != null) {
+            return componentReg;
         }
 
         // Check in OSGi bundles

--- a/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiDataFormatResolver.java
+++ b/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiDataFormatResolver.java
@@ -20,6 +20,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.DataFormatResolver;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.ResolverHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -37,20 +38,11 @@ public class OsgiDataFormatResolver implements DataFormatResolver {
 
     public DataFormat resolveDataFormat(String name, CamelContext context) {
         // lookup in registry first
-        Object bean = null;
-        try {
-            bean = context.getRegistry().lookupByName(name);
-            if (bean != null) {
-                LOG.debug("Found language: {} in registry: {}", name, bean);
-            }
-        } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Ignored error looking up bean: " + name + ". Error: " + e);
-            }
+        DataFormat dataFormatReg = ResolverHelper.lookupDataFormatInRegistryWithFallback(context, name);
+        if (dataFormatReg != null) {
+            return dataFormatReg;
         }
-        if (bean instanceof DataFormat) {
-            return (DataFormat) bean;
-        }
+
         return getDataFormat(name, context);
     }
 

--- a/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiLanguageResolver.java
+++ b/components/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiLanguageResolver.java
@@ -21,6 +21,7 @@ import org.apache.camel.NoSuchLanguageException;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.LanguageResolver;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.ResolverHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -38,21 +39,12 @@ public class OsgiLanguageResolver implements LanguageResolver {
 
     public Language resolveLanguage(String name, CamelContext context) {
         // lookup in registry first
-        Object bean = null;
-        try {
-            bean = context.getRegistry().lookupByName(name);
-            if (bean != null) {
-                LOG.debug("Found language: {} in registry: {}", name, bean);
-            }
-        } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Ignored error looking up bean: " + name + ". Error: " + e);
-            }
+        Language lang = ResolverHelper.lookupLanguageInRegistryWithFallback(context, name);
+        if (lang != null) {
+            return lang;
         }
-        if (bean instanceof Language) {
-            return (Language)bean;
-        }
-        Language lang = getLanguage(name, context);
+
+        lang = getLanguage(name, context);
         if (lang != null) {
             return lang;
         }

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiComponentResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiComponentResolverTest.java
@@ -69,7 +69,7 @@ public class OsgiComponentResolverTest extends CamelOsgiTestSupport {
 
         private boolean fallback;
 
-        public SampleComponent(boolean fallback) {
+        SampleComponent(boolean fallback) {
             this.fallback = fallback;
         }
 

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiComponentResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiComponentResolverTest.java
@@ -18,19 +18,98 @@ package org.apache.camel.core.osgi;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointConfiguration;
 import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
 import org.junit.Test;
 
 public class OsgiComponentResolverTest extends CamelOsgiTestSupport {
-    
+
     @Test
-    public void testOsgiResolverFindLanguageTest() throws Exception {
+    public void testOsgiResolverFindComponentTest() throws Exception {
         CamelContext camelContext = new DefaultCamelContext();
         OsgiComponentResolver resolver = new OsgiComponentResolver(getBundleContext());
         Component component = resolver.resolveComponent("file_test", camelContext);
         assertNotNull("We should find file_test component", component);
         assertTrue("We should get the file component here", component instanceof FileComponent);
+    }
+
+    @Test
+    public void testOsgiResolverFindComponentFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar-component", new SampleComponent(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiComponentResolver resolver = new OsgiComponentResolver(getBundleContext());
+        Component component = resolver.resolveComponent("allstar", camelContext);
+        assertNotNull("We should find the super component", component);
+        assertTrue("We should get the super component here", component instanceof SampleComponent);
+    }
+
+    @Test
+    public void testOsgiResolverFindLanguageDoubleFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar", new SampleComponent(false));
+        registry.put("allstar-component", new SampleComponent(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiComponentResolver resolver = new OsgiComponentResolver(getBundleContext());
+        Component component = resolver.resolveComponent("allstar", camelContext);
+        assertNotNull("We should find the super component", component);
+        assertTrue("We should get the super component here", component instanceof SampleComponent);
+        assertFalse("We should NOT find the fallback component", ((SampleComponent) component).isFallback());
+    }
+
+    private static class SampleComponent implements Component {
+
+        private boolean fallback;
+
+        public SampleComponent(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public void setCamelContext(CamelContext camelContext) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public CamelContext getCamelContext() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Endpoint createEndpoint(String uri) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public boolean useRawUri() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public EndpointConfiguration createConfiguration(String uri) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ComponentConfiguration createComponentConfiguration() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
     }
 
 }

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiDataFormatResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiDataFormatResolverTest.java
@@ -61,7 +61,7 @@ public class OsgiDataFormatResolverTest extends CamelOsgiTestSupport {
 
         private boolean fallback;
 
-        public SampleDataFormat(boolean fallback) {
+        SampleDataFormat(boolean fallback) {
             this.fallback = fallback;
         }
 

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiDataFormatResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiDataFormatResolverTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.core.osgi;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
+import org.apache.camel.spi.DataFormat;
+import org.junit.Test;
+
+public class OsgiDataFormatResolverTest extends CamelOsgiTestSupport {
+
+
+    @Test
+    public void testOsgiResolverFindDataFormatFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar-dataformat", new SampleDataFormat(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiDataFormatResolver resolver = new OsgiDataFormatResolver(getBundleContext());
+        DataFormat dataformat = resolver.resolveDataFormat("allstar", camelContext);
+        assertNotNull("We should find the super dataformat", dataformat);
+        assertTrue("We should get the super dataformat here", dataformat instanceof SampleDataFormat);
+    }
+
+    @Test
+    public void testOsgiResolverFindLanguageDoubleFallbackTest() throws Exception {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("allstar", new SampleDataFormat(false));
+        registry.put("allstar-dataformat", new SampleDataFormat(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiDataFormatResolver resolver = new OsgiDataFormatResolver(getBundleContext());
+        DataFormat dataformat = resolver.resolveDataFormat("allstar", camelContext);
+        assertNotNull("We should find the super dataformat", dataformat);
+        assertTrue("We should get the super dataformat here", dataformat instanceof SampleDataFormat);
+        assertFalse("We should NOT find the fallback dataformat", ((SampleDataFormat) dataformat).isFallback());
+    }
+
+    private static class SampleDataFormat implements DataFormat {
+
+        private boolean fallback;
+
+        public SampleDataFormat(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public void marshal(Exchange exchange, Object graph, OutputStream stream) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Object unmarshal(Exchange exchange, InputStream stream) throws Exception {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
+    }
+
+}

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiLanguageResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiLanguageResolverTest.java
@@ -19,7 +19,10 @@ package org.apache.camel.core.osgi;
 import java.io.IOException;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Expression;
+import org.apache.camel.Predicate;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
 import org.apache.camel.spi.Language;
 import org.junit.Test;
 
@@ -32,4 +35,59 @@ public class OsgiLanguageResolverTest extends CamelOsgiTestSupport {
         Language language = resolver.resolveLanguage("simple", camelContext);
         assertNotNull("We should find simple language", language);
     }
+
+    @Test
+    public void testOsgiResolverFindLanguageFallbackTest() throws IOException {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("fuffy-language", new SampleLanguage(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiLanguageResolver resolver = new OsgiLanguageResolver(getBundleContext());
+        Language language = resolver.resolveLanguage("fuffy", camelContext);
+        assertNotNull("We should find fuffy language", language);
+        assertTrue("We should find the fallback language", ((SampleLanguage) language).isFallback());
+    }
+
+    @Test
+    public void testOsgiResolverFindLanguageDoubleFallbackTest() throws IOException {
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.put("fuffy", new SampleLanguage(false));
+        registry.put("fuffy-language", new SampleLanguage(true));
+
+        CamelContext camelContext = new DefaultCamelContext(registry);
+
+        OsgiLanguageResolver resolver = new OsgiLanguageResolver(getBundleContext());
+        Language language = resolver.resolveLanguage("fuffy", camelContext);
+        assertNotNull("We should find fuffy language", language);
+        assertFalse("We should NOT find the fallback language", ((SampleLanguage) language).isFallback());
+    }
+
+    private static class SampleLanguage implements Language {
+
+        private boolean fallback;
+
+        public SampleLanguage(boolean fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public Predicate createPredicate(String expression) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Expression createExpression(String expression) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        public boolean isFallback() {
+            return fallback;
+        }
+
+        public void setFallback(boolean fallback) {
+            this.fallback = fallback;
+        }
+    }
+
 }

--- a/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiLanguageResolverTest.java
+++ b/components/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/OsgiLanguageResolverTest.java
@@ -67,7 +67,7 @@ public class OsgiLanguageResolverTest extends CamelOsgiTestSupport {
 
         private boolean fallback;
 
-        public SampleLanguage(boolean fallback) {
+        SampleLanguage(boolean fallback) {
             this.fallback = fallback;
         }
 


### PR DESCRIPTION
I changed the behavior of the default, blueprint and OSGi resolvers to introduce the fallback names.
I refactored all three resolvers to use a common Helper instead of repeating the code.

Unit tests added. Executed all unit tests on all changed modules.