### PR TITLE
CAMEL-10207: fixes for spring-boot 1.4 compatibility

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -535,7 +535,7 @@
     <spring-boot-version>1.4.0.RELEASE</spring-boot-version>
     <spring-castor-bundle-version>1.2.0</spring-castor-bundle-version>
     <spring-data-commons-version>1.6.5.RELEASE</spring-data-commons-version>
-    <spring-data-redis-version>1.6.4.RELEASE</spring-data-redis-version>
+    <spring-data-redis-version>1.7.2.RELEASE</spring-data-redis-version>
     <spring-integration-version>4.3.1.RELEASE</spring-integration-version>
     <spring-javaconfig-version>1.0.0-20090215</spring-javaconfig-version>
     <spring-ldap-version>2.0.4.RELEASE</spring-ldap-version>

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScriptTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelScriptTest.java
@@ -40,7 +40,7 @@ public class CamelScriptTest extends AbstractSpringBootTestSupport {
 
     @Test
     public void componentTests() throws Exception {
-        this.runLanguageTest(config, "js");
+        this.runLanguageTest(config, "javaScript");
         this.runLanguageTest(config, "php");
         this.runLanguageTest(config, "python");
         this.runLanguageTest(config, "ruby");


### PR DESCRIPTION
I changed the package scanner to support the new packaging, upgraded spring-data-redis to version 1.7.2 and fixed some tests.

Only camel-bam (deprecated) now has some issues with spring-boot.