### PR TITLE
Fix typo in reference to camel-quartz2.jar

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/ScheduledPollEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ScheduledPollEndpoint.java
@@ -144,7 +144,7 @@ public abstract class ScheduledPollEndpoint extends DefaultEndpoint {
                     Class<? extends ScheduledPollConsumerScheduler> clazz = getCamelContext().getClassResolver().resolveMandatoryClass(QUARTZ_2_SCHEDULER, ScheduledPollConsumerScheduler.class);
                     setScheduler(getCamelContext().getInjector().newInstance(clazz));
                 } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException("Cannot load " + QUARTZ_2_SCHEDULER + " from classpath. Make sure camel-quarz2.jar is on the classpath.", e);
+                    throw new IllegalArgumentException("Cannot load " + QUARTZ_2_SCHEDULER + " from classpath. Make sure camel-quartz2.jar is on the classpath.", e);
                 }
             } else {
                 // must refer to a custom scheduler by the given name


### PR DESCRIPTION
`camel-quarz2.jar` -> `camel-quartz2.jar`