### PR TITLE
replacing convertTo() with mandatoryConvertTo()

### DIFF
--- a/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2UdpProtocolCodecFactory.java
+++ b/components/camel-mina2/src/main/java/org/apache/camel/component/mina2/Mina2UdpProtocolCodecFactory.java
@@ -60,7 +60,7 @@ public class Mina2UdpProtocolCodecFactory implements ProtocolCodecFactory {
             public void decode(IoSession session, IoBuffer in, ProtocolDecoderOutput out) throws Exception {
                 // convert to bytes to write, we can not pass in the byte buffer as it could be sent to
                 // multiple mina sessions so we must convert it to bytes
-                byte[] bytes = context.getTypeConverter().convertTo(byte[].class, in);
+                byte[] bytes = context.getTypeConverter().mandatoryConvertTo(byte[].class, in);
                 out.write(bytes);
             }
 


### PR DESCRIPTION
We replaced "convertTo()" invocations to "mandatoryConvertTo()" because the same changes were conducted in the past commits. 

commit ID: b605eb032b080c8c697ea69ceb588e3d4bab9d48
https://apache.googlesource.com/camel/+/b605eb032b080c8c697ea69ceb588e3d4bab9d48%5E%21/#F1

commit ID: ec1509662bf567e277e7d67b33732660e52d1b6c
https://apache.googlesource.com/camel/+/ec1509662bf567e277e7d67b33732660e52d1b6c%5E%21/#F1

commit ID: e7487d332d01a86a757c0d89fd6d6eb0a1bbbfcb
https://apache.googlesource.com/camel/+/e7487d332d01a86a757c0d89fd6d6eb0a1bbbfcb%5E%21/#F1

The change pattern we found is replacing "convertTo(byte[].class, in)"
invocations with "mandatoryConvertTo(byte[].class, in)" invocations.
The difference between the two methods seems whether they can return
null or not.
https://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/TypeConverter.html#mandatoryConvertTo(java.lang.Class,%20org.apache.camel.Exchange,%20java.lang.Object)

--
Yoshiki, Shinpei, Hideaki, and Mei