### PR TITLE
CAMEL-10239: Provide implementation for publisher acknowledgement + basic.return

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -150,6 +150,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     private boolean publisherAcknowledgements;
     @UriParam(label = "producer")
     private long publisherAcknowledgementsTimeout;
+    @UriParam(label = "producer")
+    private boolean guaranteedDeliveries;
     // camel-jms supports this setting but it is not currently configurable in camel-rabbitmq
     private boolean useMessageIDAsCorrelationID = true;
     // camel-jms supports this setting but it is not currently configurable in camel-rabbitmq
@@ -411,7 +413,7 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
 
     /**
      * If true the queue will not be bound to the exchange after declaring it
-     * @return 
+     * @return
      */
     public boolean isSkipQueueBind() {
         return skipQueueBind;
@@ -420,7 +422,7 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     public void setSkipQueueBind(boolean skipQueueBind) {
         this.skipQueueBind = skipQueueBind;
     }
-     
+
     /**
      * This can be used if we need to declare the queue but not the exchange
      */
@@ -799,7 +801,7 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     }
 
     /**
-     * When true and an inOut Exchange failed on the consumer side send the caused Exception back in the response 
+     * When true and an inOut Exchange failed on the consumer side send the caused Exception back in the response
      */
     public void setTransferException(boolean transferException) {
         this.transferException = transferException;
@@ -829,6 +831,22 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
 
     public void setPublisherAcknowledgementsTimeout(final long publisherAcknowledgementsTimeout) {
         this.publisherAcknowledgementsTimeout = publisherAcknowledgementsTimeout;
+    }
+
+    /**
+     * When true, an exception will be thrown when the message cannot be delivered (basic.return) and the message is
+     * marked as mandatory.
+     * PublisherAcknowledgement will also be activated in this case
+     *
+     * See also <a href=https://www.rabbitmq.com/confirms.html">publisher acknowledgements</a> - When will messages be
+     * confirmed?
+     */
+    public boolean isGuaranteedDeliveries() {
+        return guaranteedDeliveries;
+    }
+
+    public void setGuaranteedDeliveries(boolean guaranteedDeliveries) {
+        this.guaranteedDeliveries = guaranteedDeliveries;
     }
 
     /**


### PR DESCRIPTION
This is a first implementation to support guaranteed delivery of mandatory messages with rabbitmq. For more details please check the corresponding JIRA ticket:
https://issues.apache.org/jira/browse/CAMEL-10239