### PR TITLE
Fix for CAMEL-8287

### DIFF
--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.InputStream;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.Processor;
@@ -57,6 +58,9 @@ public class SchematronEndpoint extends DefaultEndpoint {
     private boolean abort;
     @UriParam
     private Templates rules;
+
+    @UriParam
+    private URIResolver uriResolver;
 
     public SchematronEndpoint() {
     }
@@ -112,6 +116,11 @@ public class SchematronEndpoint extends DefaultEndpoint {
         this.rules = rules;
     }
 
+    public void setUriResolver(URIResolver uriResolver) { this.uriResolver = uriResolver; }
+
+    public URIResolver getUriResolver() { return uriResolver; }
+
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -148,7 +157,7 @@ public class SchematronEndpoint extends DefaultEndpoint {
 
         LOG.debug("Using TransformerFactoryClass {}", factoryClass);
         transformerFactory = getCamelContext().getInjector().newInstance(factoryClass);
-        transformerFactory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        transformerFactory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, this.uriResolver));
         transformerFactory.setAttribute(LINE_NUMBERING, true);
     }
 

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
@@ -116,6 +116,9 @@ public class SchematronEndpoint extends DefaultEndpoint {
         this.rules = rules;
     }
 
+    /**
+     * Set the {@link URIResolver} to be used for resolving schematron includes in the rules file.
+     */
     public void setUriResolver(URIResolver uriResolver) { this.uriResolver = uriResolver; }
 
     public URIResolver getUriResolver() { return uriResolver; }

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -44,8 +44,7 @@ public class ClassPathURIResolver implements URIResolver {
     public Source resolve(String href, String base) throws TransformerException {
         InputStream stream = ClassPathURIResolver.class.getClassLoader()
                 .getResourceAsStream(rulesDir.concat(File.separator).concat(href));
-
-        if (null != stream) {
+        if (stream != null) {
             return new StreamSource(stream);
         } else {
             if (null != clientUriResolver) {
@@ -54,8 +53,5 @@ public class ClassPathURIResolver implements URIResolver {
                 return new StreamSource(stream);
             }
         }
-
-
-
     }
 }

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -47,7 +47,7 @@ public class ClassPathURIResolver implements URIResolver {
         if (stream != null) {
             return new StreamSource(stream);
         } else {
-            if (null != clientUriResolver) {
+            if (clientUriResolver != null) {
                 return clientUriResolver.resolve(href, base);
             } else {
                 return new StreamSource(stream);

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.schematron.processor;
 
 import java.io.File;
+import java.io.InputStream;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
@@ -28,17 +29,33 @@ import javax.xml.transform.stream.StreamSource;
 public class ClassPathURIResolver implements URIResolver {
 
     private final String rulesDir;
+    private final URIResolver clientUriResolver;
 
     /**
-     * Constructor setter for rules directory path.
+     * Constructor setter for rules directory path, and the fallback URIResolver used
+     * for schematron includes.
      */
-    public ClassPathURIResolver(final String rulesDir) {
+    public ClassPathURIResolver(final String rulesDir, URIResolver clientUriResolver) {
         this.rulesDir = rulesDir;
+        this.clientUriResolver = clientUriResolver;
     }
 
     @Override
     public Source resolve(String href, String base) throws TransformerException {
-        return new StreamSource(ClassPathURIResolver.class.getClassLoader()
-                .getResourceAsStream(rulesDir.concat(File.separator).concat(href)));
+        InputStream stream = ClassPathURIResolver.class.getClassLoader()
+                .getResourceAsStream(rulesDir.concat(File.separator).concat(href));
+
+        if (null != stream) {
+            return new StreamSource(stream);
+        } else {
+            if (null != clientUriResolver) {
+                return clientUriResolver.resolve(href, base);
+            } else {
+                return new StreamSource(stream);
+            }
+        }
+
+
+
     }
 }

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronProducerTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronProducerTest.java
@@ -42,7 +42,7 @@ public class SchematronProducerTest extends CamelTestSupport {
     public static void setUP() {
         SchematronEndpoint endpoint = new SchematronEndpoint();
         TransformerFactory fac = new TransformerFactoryImpl();
-        fac.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        fac.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, endpoint.getUriResolver()));
         Templates templates = TemplatesFactory.newInstance().getTemplates(ClassLoader.
                 getSystemResourceAsStream("sch/schematron-1.sch"), fac);
         endpoint.setRules(templates);

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/SchematronProcessorTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/SchematronProcessorTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.schematron.processor;
 
-import javax.xml.transform.Templates;
-import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.*;
+import javax.xml.transform.stream.StreamSource;
 
 import net.sf.saxon.TransformerFactoryImpl;
 import org.apache.camel.component.schematron.constant.Constants;
@@ -43,11 +43,23 @@ public class SchematronProcessorTest {
         logger.info("Validating payload: {}", payload);
 
         // validate
-        String result = getProcessor("sch/schematron-1.sch").validate(payload);
+        String result = getProcessor("sch/schematron-1.sch", null).validate(payload);
         logger.info("Schematron Report: {}", result);
         assertEquals(0, Integer.valueOf(Utils.evaluate("count(//svrl:failed-assert)", result)).intValue());
         assertEquals(0, Integer.valueOf(Utils.evaluate("count(//svrl:successful-report)", result)).intValue());
 
+    }
+
+    @Test
+    public void testInvalidXMLWithClientResolver() throws Exception {
+        String payload = IOUtils.toString(ClassLoader.getSystemResourceAsStream("xml/article-3.xml"));
+        logger.info("Validating payload: {}", payload);
+
+        // validate
+        String result = getProcessor("sch/schematron-3.sch", new ClientUriResolver()).validate(payload);
+        logger.info("Schematron Report: {}", result);
+        assertEquals("A title should be at least two characters", Utils.evaluate("//svrl:failed-assert/svrl:text",result));
+        assertEquals(0, Integer.valueOf(Utils.evaluate("count(//svrl:successful-report)", result)).intValue());
     }
 
     @Test
@@ -56,7 +68,7 @@ public class SchematronProcessorTest {
         String payload = IOUtils.toString(ClassLoader.getSystemResourceAsStream("xml/article-2.xml"));
         logger.info("Validating payload: {}", payload);
         // validate
-        String result = getProcessor("sch/schematron-2.sch").validate(payload);
+        String result = getProcessor("sch/schematron-2.sch", null).validate(payload);
         logger.info("Schematron Report: {}", result);
         // should throw two assertions because of the missing chapters in the XML.
         assertEquals("A chapter should have a title", Utils.evaluate("//svrl:failed-assert/svrl:text", result));
@@ -68,12 +80,20 @@ public class SchematronProcessorTest {
      * Returns schematron processor
      *
      * @param schematron
+     * @param clientResolver
      * @return
      */
-    private SchematronProcessor getProcessor(final String schematron) {
+    private SchematronProcessor getProcessor(final String schematron, final URIResolver clientResolver) {
         TransformerFactory factory = new TransformerFactoryImpl();
-        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, new ClientUriResolver()));
         Templates rules = TemplatesFactory.newInstance().getTemplates(ClassLoader.getSystemResourceAsStream(schematron), factory);
         return SchematronProcessorFactory.newScehamtronEngine(rules);
+    }
+
+    class ClientUriResolver implements URIResolver {
+        @Override
+        public Source resolve(String href, String base) throws TransformerException {
+           return new StreamSource(ClientUriResolver.class.getClassLoader().getResourceAsStream("custom-resolver/".concat(href)));
+        }
     }
 }

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/SchematronProcessorTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/SchematronProcessorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.camel.component.schematron.processor;
 
-import javax.xml.transform.*;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 
 import net.sf.saxon.TransformerFactoryImpl;
@@ -58,7 +62,7 @@ public class SchematronProcessorTest {
         // validate
         String result = getProcessor("sch/schematron-3.sch", new ClientUriResolver()).validate(payload);
         logger.info("Schematron Report: {}", result);
-        assertEquals("A title should be at least two characters", Utils.evaluate("//svrl:failed-assert/svrl:text",result));
+        assertEquals("A title should be at least two characters", Utils.evaluate("//svrl:failed-assert/svrl:text", result));
         assertEquals(0, Integer.valueOf(Utils.evaluate("count(//svrl:successful-report)", result)).intValue());
     }
 
@@ -93,7 +97,7 @@ public class SchematronProcessorTest {
     class ClientUriResolver implements URIResolver {
         @Override
         public Source resolve(String href, String base) throws TransformerException {
-           return new StreamSource(ClientUriResolver.class.getClassLoader().getResourceAsStream("custom-resolver/".concat(href)));
+            return new StreamSource(ClientUriResolver.class.getClassLoader().getResourceAsStream("custom-resolver/".concat(href)));
         }
     }
 }

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/TemplatesFactoryTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/TemplatesFactoryTest.java
@@ -36,7 +36,7 @@ public class TemplatesFactoryTest {
     public void testInstantiateAnInstanceOfTemplates() throws Exception {
         TemplatesFactory fac = TemplatesFactory.newInstance();
         TransformerFactory factory = new TransformerFactoryImpl();
-        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, null));
         Templates templates = fac.getTemplates(ClassLoader.getSystemResourceAsStream(rules), factory);
         Assert.assertNotNull(templates);
 

--- a/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
+++ b/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <sch:rule context="title" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:assert test="string-length(.) >= 2">A title should be at least two characters</sch:assert>
 </sch:rule>

--- a/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
+++ b/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
@@ -1,0 +1,3 @@
+<sch:rule context="title" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <sch:assert test="string-length(.) >= 2">A title should be at least two characters</sch:assert>
+</sch:rule>

--- a/components/camel-schematron/src/test/resources/sch/schematron-3.sch
+++ b/components/camel-schematron/src/test/resources/sch/schematron-3.sch
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            queryBinding="xslt2">
+
+    <sch:title>Sample Schematron using XPath 2.0</sch:title>
+    <sch:ns prefix="p" uri="http://www.apache.org/camel/schematron"/>
+    <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+
+    <!-- Your constraints go here -->
+    <sch:pattern>
+        <sch:include href="title-rules.sch"/>
+        <sch:rule context="chapter">
+            <sch:let name="numOfTitles" value="count(title)"/>
+            <sch:assert test="title">A chapter should have a title</sch:assert>
+            <sch:report test="count(title) > 1">
+                        'chapter' element has more than one title present
+             </sch:report>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/components/camel-schematron/src/test/resources/xml/article-3.xml
+++ b/components/camel-schematron/src/test/resources/xml/article-3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<doc>
+    <chapter id="c1">
+        <title>chapter title</title>
+        <para>Chapter content</para>
+    </chapter>
+    <chapter id="c2">
+        <title>chapter 2 title</title>
+        <para>Content</para>
+    </chapter>
+    <chapter id="c3">
+        <title>T</title>
+        <para>Chapter 3 content</para>
+    </chapter>
+</doc>


### PR DESCRIPTION
Allows a user to supply a custom URIResolver to be used to resolve imports in his/her schematron rules files.