### PR TITLE
Fix for CAMEL-8287

### DIFF
--- a/components/camel-schematron/src/main/docs/schematron.adoc
+++ b/components/camel-schematron/src/main/docs/schematron.adoc
@@ -39,8 +39,9 @@ The Schematron component has no options.
 
 
 
+
 // endpoint options: START
-The Schematron component supports 5 endpoint options which are listed below:
+The Schematron component supports 6 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2s,1,1m,1m,5",options="header"]
@@ -49,11 +50,13 @@ The Schematron component supports 5 endpoint options which are listed below:
 | path | producer |  | String | *Required* The path to the schematron rules file. Can either be in class path or location in the file system.
 | abort | producer | false | boolean | Flag to abort the route and throw a schematron validation exception.
 | rules | producer |  | Templates | To use the given schematron rules instead of loading from the path
+| uriResolver | producer |  | URIResolver | Set the URIResolver to be used for resolving schematron includes in the rules file.
 | exchangePattern | advanced | InOnly | ExchangePattern | Sets the default exchange pattern when creating an exchange
 | synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
 |=======================================================================
 {% endraw %}
 // endpoint options: END
+
 
 
 [[Schematron-Headers]]

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.Processor;
@@ -58,6 +59,9 @@ public class SchematronEndpoint extends DefaultEndpoint {
     private boolean abort;
     @UriParam
     private Templates rules;
+
+    @UriParam
+    private URIResolver uriResolver;
 
     public SchematronEndpoint() {
     }
@@ -116,6 +120,18 @@ public class SchematronEndpoint extends DefaultEndpoint {
         this.rules = rules;
     }
 
+    /**
+     * Set the {@link URIResolver} to be used for resolving schematron includes in the rules file.
+     */
+    public void setUriResolver(URIResolver uriResolver) {
+        this.uriResolver = uriResolver;
+    }
+
+    public URIResolver getUriResolver() {
+        return uriResolver;
+    }
+
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -157,7 +173,7 @@ public class SchematronEndpoint extends DefaultEndpoint {
 
         LOG.debug("Using TransformerFactoryClass {}", factoryClass);
         transformerFactory = getCamelContext().getInjector().newInstance(factoryClass);
-        transformerFactory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        transformerFactory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, this.uriResolver));
         transformerFactory.setAttribute(LINE_NUMBERING, true);
     }
 

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.schematron.processor;
 
 import java.io.File;
+import java.io.InputStream;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
@@ -28,17 +29,29 @@ import javax.xml.transform.stream.StreamSource;
 public class ClassPathURIResolver implements URIResolver {
 
     private final String rulesDir;
+    private final URIResolver clientUriResolver;
 
     /**
-     * Constructor setter for rules directory path.
+     * Constructor setter for rules directory path, and the fallback URIResolver used
+     * for schematron includes.
      */
-    public ClassPathURIResolver(final String rulesDir) {
+    public ClassPathURIResolver(final String rulesDir, URIResolver clientUriResolver) {
         this.rulesDir = rulesDir;
+        this.clientUriResolver = clientUriResolver;
     }
 
     @Override
     public Source resolve(String href, String base) throws TransformerException {
-        return new StreamSource(ClassPathURIResolver.class.getClassLoader()
-                .getResourceAsStream(rulesDir.concat("/").concat(href)));
+        InputStream stream = ClassPathURIResolver.class.getClassLoader()
+                .getResourceAsStream(rulesDir.concat(File.separator).concat(href));
+        if (stream != null) {
+            return new StreamSource(stream);
+        } else {
+            if (clientUriResolver != null) {
+                return clientUriResolver.resolve(href, base);
+            } else {
+                return new StreamSource(stream);
+            }
+        }
     }
 }

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronProducerTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronProducerTest.java
@@ -42,7 +42,7 @@ public class SchematronProducerTest extends CamelTestSupport {
     public static void setUP() {
         SchematronEndpoint endpoint = new SchematronEndpoint();
         TransformerFactory fac = new TransformerFactoryImpl();
-        fac.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        fac.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, endpoint.getUriResolver()));
         Templates templates = TemplatesFactory.newInstance().getTemplates(ClassLoader.
                 getSystemResourceAsStream("sch/schematron-1.sch"), fac);
         endpoint.setRules(templates);

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/TemplatesFactoryTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/processor/TemplatesFactoryTest.java
@@ -36,7 +36,7 @@ public class TemplatesFactoryTest {
     public void testInstantiateAnInstanceOfTemplates() throws Exception {
         TemplatesFactory fac = TemplatesFactory.newInstance();
         TransformerFactory factory = new TransformerFactoryImpl();
-        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR));
+        factory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, null));
         Templates templates = fac.getTemplates(ClassLoader.getSystemResourceAsStream(rules), factory);
         Assert.assertNotNull(templates);
 

--- a/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
+++ b/components/camel-schematron/src/test/resources/custom-resolver/title-rules.sch
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<sch:rule context="title" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <sch:assert test="string-length(.) >= 2">A title should be at least two characters</sch:assert>
+</sch:rule>

--- a/components/camel-schematron/src/test/resources/sch/schematron-3.sch
+++ b/components/camel-schematron/src/test/resources/sch/schematron-3.sch
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            queryBinding="xslt2">
+
+    <sch:title>Sample Schematron using XPath 2.0</sch:title>
+    <sch:ns prefix="p" uri="http://www.apache.org/camel/schematron"/>
+    <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+
+    <!-- Your constraints go here -->
+    <sch:pattern>
+        <sch:include href="title-rules.sch"/>
+        <sch:rule context="chapter">
+            <sch:let name="numOfTitles" value="count(title)"/>
+            <sch:assert test="title">A chapter should have a title</sch:assert>
+            <sch:report test="count(title) > 1">
+                        'chapter' element has more than one title present
+             </sch:report>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/components/camel-schematron/src/test/resources/xml/article-3.xml
+++ b/components/camel-schematron/src/test/resources/xml/article-3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<doc>
+    <chapter id="c1">
+        <title>chapter title</title>
+        <para>Chapter content</para>
+    </chapter>
+    <chapter id="c2">
+        <title>chapter 2 title</title>
+        <para>Content</para>
+    </chapter>
+    <chapter id="c3">
+        <title>T</title>
+        <para>Chapter 3 content</para>
+    </chapter>
+</doc>


### PR DESCRIPTION
Allows a user to supply a custom URIResolver to be used to resolve imports in his/her schematron rules files.

Fix now applied to master. But we would really need to have this back ported to the 2.16.x and 2.17.x branches if possible. 