### PR TITLE
CAMEL-10245 JPA detached entity fix

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
@@ -124,8 +124,10 @@ public class JpaProducer extends DefaultProducer {
                  */
                 private Object remove(final Object entity) {
                     LOG.debug("remove: {}", entity);
-                    entityManager.remove(entity);
-                    return entity;
+
+                    Object managedEntity = entityManager.contains(entity) ? entity : entityManager.merge(entity);
+                    entityManager.remove(managedEntity);
+                    return managedEntity;
                 }
             });
         }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
@@ -125,7 +125,16 @@ public class JpaProducer extends DefaultProducer {
                 private Object remove(final Object entity) {
                     LOG.debug("remove: {}", entity);
 
-                    Object managedEntity = entityManager.contains(entity) ? entity : entityManager.merge(entity);
+                    Object managedEntity;
+
+                    // First check if entity is attached to the persistence context
+                    if (entityManager.contains(entity)) {
+                        managedEntity = entity;
+                    } else {
+                        // If not, merge entity state into context before removing it
+                        managedEntity = entityManager.merge(entity);
+                    }
+
                     entityManager.remove(managedEntity);
                     return managedEntity;
                 }

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaProducerRemoveTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaProducerRemoveTest.java
@@ -51,7 +51,7 @@ public class JpaProducerRemoveTest extends AbstractJpaTest {
         mock.reset();
 
         entityManager = emf.createEntityManager();
-        template.sendBody("direct:remove", new SendEmail("foo@beer.org"));
+        template.sendBody("direct:remove", persistedEntity);
         exchange = mock.getReceivedExchanges().get(0);
         persistedEntity = exchange.getIn().getBody(SendEmail.class);
         emfindEntity = entityManager.find(SendEmail.class, persistedEntity.getId());


### PR DESCRIPTION
Fixed JpaProducer when removing an entity that is not attached to current persistence context