### PR TITLE
fix moduleClassNames attribute wiring in JSonDataFormat

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
@@ -371,7 +371,7 @@ public class JsonDataFormat extends DataFormatDefinition {
             setProperty(camelContext, dataFormat, "enableJaxbAnnotationModule", enableJaxbAnnotationModule);
         }
         if (moduleClassNames != null) {
-            setProperty(camelContext, dataFormat, "modulesClassNames", moduleClassNames);
+            setProperty(camelContext, dataFormat, "moduleClassNames", moduleClassNames);
         }
         if (moduleRefs != null) {
             setProperty(camelContext, dataFormat, "moduleRefs", moduleRefs);


### PR DESCRIPTION
`moduleClassNames` is not taken into account in `<dataFormats><json moduleClassNames = "..."></dataFormats>`

This commit fix this.

Please can you backport to 2.17 too ? thanks