### PR TITLE
fixes for windows buid

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/pom.xml
+++ b/components/camel-olingo2/camel-olingo2-component/pom.xml
@@ -38,6 +38,7 @@
 
     <camel.osgi.export.pkg>${componentPackage}</camel.osgi.export.pkg>
     <camel.osgi.private.pkg>${outPackage}</camel.osgi.private.pkg>
+    <maven.exe.file.extension></maven.exe.file.extension>
   </properties>
 
   <dependencies>
@@ -277,6 +278,17 @@
 
   <profiles>
     <profile>
+      <id>Windows</id>
+      <activation>
+        <os>
+          <family>Windows</family>
+        </os>
+      </activation>
+      <properties>
+        <maven.exe.file.extension>.cmd</maven.exe.file.extension>
+      </properties>
+    </profile>
+    <profile>
       <!-- REVISIT as of now, the olingo odata2 sample service that is used in the tests 
            is not available in nexus and needs to be generated and built using its architype plugin.
            If the sample service jar becomes available, we can use it directly -->
@@ -310,7 +322,7 @@
               </execution>
             </executions>
             <configuration>
-              <executable>mvn</executable>
+              <executable>mvn${maven.exe.file.extension}</executable>
               <workingDirectory>${basedir}/target</workingDirectory>
               <arguments>
                 <argument>archetype:generate</argument>

--- a/examples/camel-example-swagger-xml/pom.xml
+++ b/examples/camel-example-swagger-xml/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <swagger-ui.version>2.1.5</swagger-ui.version>
     <logback-version>1.1.7</logback-version>
-    <swagger.url>http://github.com/swagger-api/swagger-ui/archive</swagger.url>
+    <swagger.url>https://github.com/swagger-api/swagger-ui/archive</swagger.url>
     <destDir>target/swagger-ui</destDir>
   </properties>
 

--- a/examples/camel-example-swagger-xml/pom.xml
+++ b/examples/camel-example-swagger-xml/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <swagger-ui.version>2.1.5</swagger-ui.version>
     <logback-version>1.1.7</logback-version>
-    <swagger.url>https://github.com/swagger-api/swagger-ui/archive</swagger.url>
+    <swagger.url>http://github.com/swagger-api/swagger-ui/archive</swagger.url>
     <destDir>target/swagger-ui</destDir>
   </properties>
 


### PR DESCRIPTION
These fixes make it possible to do a full build on windows.

This fix just appends .cmd to the maven command called from "exec-maven-plugin" if you are building on windows.
