### PR TITLE
Fix restlet producer to use maxConnection properties

### DIFF
--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletProducer.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletProducer.java
@@ -51,6 +51,10 @@ public class RestletProducer extends DefaultAsyncProducer {
         client.setContext(new Context());
         client.getContext().getParameters().add("socketTimeout", String.valueOf(endpoint.getSocketTimeout()));
         client.getContext().getParameters().add("socketConnectTimeoutMs", String.valueOf(endpoint.getSocketTimeout()));
+        RestletComponent component = (RestletComponent)endpoint.getComponent();
+        client.getContext().getParameters().add("maxConnectionsPerHost", String.valueOf(component.getMaxConnectionsPerHost()));
+        client.getContext().getParameters().add("maxTotalConnections", String.valueOf(component.getMaxTotalConnections()));
+    
     }
 
     @Override

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletProducer.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletProducer.java
@@ -52,8 +52,12 @@ public class RestletProducer extends DefaultAsyncProducer {
         client.getContext().getParameters().add("socketTimeout", String.valueOf(endpoint.getSocketTimeout()));
         client.getContext().getParameters().add("socketConnectTimeoutMs", String.valueOf(endpoint.getSocketTimeout()));
         RestletComponent component = (RestletComponent)endpoint.getComponent();
-        client.getContext().getParameters().add("maxConnectionsPerHost", String.valueOf(component.getMaxConnectionsPerHost()));
-        client.getContext().getParameters().add("maxTotalConnections", String.valueOf(component.getMaxTotalConnections()));
+        if(component.getMaxConnectionsPerHost() != null && component.getMaxConnectionsPerHost() > 0) {
+            client.getContext().getParameters().add("maxConnectionsPerHost", String.valueOf(component.getMaxConnectionsPerHost()));
+        }
+        if(component.getMaxTotalConnections() != null && component.getMaxTotalConnections() > 0) {
+            client.getContext().getParameters().add("maxTotalConnections", String.valueOf(component.getMaxTotalConnections()));
+        }
     
     }
 


### PR DESCRIPTION
Currently Restlet client does not use the maxConnectionsPerHost or maxTotalConnections properties that can be set at the component level.  This fix should pass those properties into the context parameters to be used by httpclient.