### PR TITLE
Followup to CAMEL-8072

### DIFF
--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
@@ -110,7 +110,8 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
             response.headers().set("Allow", s);
             response.headers().set(Exchange.CONTENT_TYPE, "text/plain");
             response.headers().set(Exchange.CONTENT_LENGTH, 0);
-            messageEvent.getChannel().write(response);
+            messageEvent.getChannel().write(response).syncUninterruptibly();
+            messageEvent.getChannel().close();
             return;
         }
         if (consumer.getEndpoint().getHttpMethodRestrict() != null


### PR DESCRIPTION
This is a small followup to CAMEL-8072, which was fixed in e9dded769bff8e060c64e62c962cd552d24d4c70.

Yoshiki, Shinpei, Hideaki, and Mei