### PR TITLE
CAMEL-10131 added support for exclusive queues

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -99,7 +99,7 @@ public class RabbitMQDeclareSupport {
 
     private void declareAndBindQueue(final Channel channel, final String queue, final String exchange, final String routingKey, final Map<String, Object> arguments)
             throws IOException {
-        channel.queueDeclare(queue, endpoint.isDurable(), false, endpoint.isAutoDelete(), arguments);
+        channel.queueDeclare(queue, endpoint.isDurable(), endpoint.isExclusive(), endpoint.isAutoDelete(), arguments);
         channel.queueBind(queue, exchange, emptyIfNull(routingKey));
     }
 

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -69,6 +69,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
     private boolean autoDelete = true;
     @UriParam(defaultValue = "true")
     private boolean durable = true;
+    @UriParam(label = "common", defaultValue = "false")
+    private boolean exclusive = false;
     @UriParam(label = "producer")
     private boolean bridgeEndpoint;
     @UriParam
@@ -828,6 +830,17 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
      */
     public String getReplyTo() {
         return replyTo;
+    }
+
+    public boolean isExclusive() {
+        return exclusive;
+    }
+
+    /**
+     * Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.
+     */
+    public void setExclusive(boolean exclusive) {
+        this.exclusive = exclusive;
     }
 
 }

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -260,4 +260,10 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?skipExchangeDeclare=true", RabbitMQEndpoint.class);
         assertTrue(endpoint.isSkipExchangeDeclare());
     }
+
+    @Test
+    public void createEndpointWithExclusiveEnabled() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?exclusive=true", RabbitMQEndpoint.class);
+        assertTrue(endpoint.isExclusive());
+    }
 }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-10131

Exclusive queues are used by only one connection and the queue will be deleted when that connection closes. This is an important feature to have, especially when using fanout exchanges, since the generated queues will not autodelete when the client disconnects, leaving queues with no consumers behind, which require manual/scripted intervention.
