### PR TITLE
CAMEL-10255 - Make it easy to configure property placeholder

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/main/Main.java
+++ b/camel-core/src/main/java/org/apache/camel/main/Main.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.camel.impl.CompositeRegistry;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
@@ -174,4 +175,13 @@ public class Main extends MainSupport {
         return new DefaultCamelContext();
     }
 
+    /**
+     * A list of locations to load properties. You can use comma to separate multiple locations.
+     * This option will override any default locations and only use the locations from this option.
+     */
+    protected void setPropertyPlaceholderLocations(String location) {
+        PropertiesComponent pc = new PropertiesComponent();
+        pc.setLocation(location);
+        bind("properties", pc);
+    }
 }

--- a/camel-core/src/test/java/org/apache/camel/main/MainExample.java
+++ b/camel-core/src/test/java/org/apache/camel/main/MainExample.java
@@ -44,7 +44,8 @@ public class MainExample {
         main.addRouteBuilder(new MyRouteBuilder());
         // add event listener
         main.addMainListener(new Events());
-
+        // set the properties from a file
+        main.setPropertyPlaceholderLocations("example.properties");
         // run until you terminate the JVM
         System.out.println("Starting Camel. Use ctrl + c to terminate the JVM.\n");
         main.run();
@@ -53,7 +54,7 @@ public class MainExample {
     private static class MyRouteBuilder extends RouteBuilder {
         @Override
         public void configure() throws Exception {
-            from("timer:foo?delay=2000")
+            from("timer:foo?delay={{millisecs}}")
                 .process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         System.out.println("Invoked timer at " + new Date());

--- a/camel-core/src/test/resources/example.properties
+++ b/camel-core/src/test/resources/example.properties
@@ -1,0 +1,1 @@
+millisecs=2000


### PR DESCRIPTION
I added a setPropertyPlaceholderLocations() method to Main, as suggested by the ticket: 
https://issues.apache.org/jira/browse/CAMEL-10255

I also made a change to the test class "MainExample" and added a test file example.properties.
Not sure if a test is worth having in this case, but added it, just in case.