### PR TITLE
Fix qpid versions in camel-amqp feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -96,7 +96,7 @@
     <bundle dependency='true'>mvn:commons-collections/commons-collections/${commons-collections-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mina/${mina-bundle-version}</bundle>
     <bundle dependency='true'>wrap:mvn:org.apache.qpid/qpid-jms-client/${qpid-jms-client-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.apache.qpid/proton-j/0.10</bundle>
+    <bundle dependency='true'>wrap:mvn:org.apache.qpid/proton-j/0.12.0</bundle>
     <bundle dependency='true'>wrap:mvn:io.netty/netty-all/4.0.17.Final</bundle>
     <bundle>mvn:org.apache.camel/camel-amqp/${project.version}</bundle>
   </feature>


### PR DESCRIPTION
qpid-jms-client 0.8.0 is incompatible with proton-j 0.10 so we need to
bump up the proton-j to compatible 0.12.0.

more details: https://issues.apache.org/jira/browse/CAMEL-10278