### PR TITLE
Jetty9: fixed typos and documentation in X-Forwarded-For

### DIFF
--- a/components-starter/camel-jetty9-starter/src/main/java/org/apache/camel/component/jetty9/springboot/JettyHttpComponentConfiguration9.java
+++ b/components-starter/camel-jetty9-starter/src/main/java/org/apache/camel/component/jetty9/springboot/JettyHttpComponentConfiguration9.java
@@ -169,7 +169,7 @@ public class JettyHttpComponentConfiguration9 {
      */
     private Integer proxyPort;
     /**
-     * To use the X-Fowarded-For header in HttpServletRequest.getRemoteAddr.
+     * To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.
      */
     private Boolean useXForwardedForHeader;
     /**

--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -999,17 +999,17 @@ public abstract class JettyHttpComponent extends HttpCommonComponent implements 
     }
     
     /**
-     * To use the X-Fowarded-For header in HttpServletRequest.getRemoteAddr.
+     * To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.
      */
-    @Metadata(description = "To use the X-Fowarded-For header in HttpServletRequest.getRemoteAddr.")
+    @Metadata(description = "To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.")
     public boolean isUseXForwardedForHeader() {
         return useXForwardedForHeader;
     }
 
     /**
-     * To use a http proxy to configure the port number.
+     * To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.
      */
-    @Metadata(description = "To use the X-Fowarded-For header in HttpServletRequest.getRemoteAddr.")
+    @Metadata(description = "To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.")
     public void setUseXForwardedForHeader(boolean useXForwardedForHeader) {
         this.useXForwardedForHeader = useXForwardedForHeader;
     }

--- a/components/camel-jetty9/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty9/src/main/docs/jetty-component.adoc
@@ -89,7 +89,7 @@ The Jetty 9 component supports 31 options which are listed below.
 | responseHeaderSize | Integer | Allows to configure a custom value of the response header size on the Jetty connectors.
 | proxyHost | String | To use a http proxy to configure the hostname.
 | proxyPort | Integer | To use a http proxy to configure the port number.
-| useXForwardedForHeader | boolean | To use the X-Fowarded-For header in HttpServletRequest.getRemoteAddr.
+| useXForwardedForHeader | boolean | To use the X-Forwarded-For header in HttpServletRequest.getRemoteAddr.
 | sendServerVersion | boolean | If the option is true jetty server will send the date header to the client which sends the request. NOTE please make sure there is no any other camel-jetty endpoint is share the same port otherwise this option may not work as expected.
 | allowJavaSerializedObject | boolean | Whether to allow java serialization when a request uses context-type=application/x-java-serialized-object This is by default turned off. If you enable this then be aware that Java will deserialize the incoming data from the request to Java and that can be a potential security risk.
 | headerFilterStrategy | HeaderFilterStrategy | To use a custom HeaderFilterStrategy to filter header to and from Camel message.


### PR DESCRIPTION
I saw that I didn't correct a typo in the documentation.