### PR TITLE
The interface SpringApplicationConfiguration is deprecated

### DIFF
--- a/examples/camel-example-spring-boot/src/test/java/org/apache/camel/example/spring/boot/MySpringBootRouterTest.java
+++ b/examples/camel-example-spring-boot/src/test/java/org/apache/camel/example/spring/boot/MySpringBootRouterTest.java
@@ -25,12 +25,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = MySpringBootRouter.class)
-@WebIntegrationTest(randomPort = true)
+@SpringBootTest(classes = MySpringBootRouter.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class MySpringBootRouterTest extends Assert {
 
     @Autowired

--- a/examples/camel-example-spring-boot/src/test/java/org/apache/camel/example/spring/boot/MySpringBootRouterTest.java
+++ b/examples/camel-example-spring-boot/src/test/java/org/apache/camel/example/spring/boot/MySpringBootRouterTest.java
@@ -24,12 +24,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = MySpringBootRouter.class)
+@SpringBootTest(classes = MySpringBootRouter.class)
 @WebIntegrationTest(randomPort = true)
 public class MySpringBootRouterTest extends Assert {
 


### PR DESCRIPTION
From @SpringApplicationConfiguration(classes=MyConfig.class) to @SpringBootTest(classes=MyConfig.class)
Note: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.4.0-M2-Release-Notes