### PR TITLE
CAMEL-10240: Fix for thread pool sizes in CamelHttpClient

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/CamelHttpClient.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/CamelHttpClient.java
@@ -22,6 +22,7 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.camel.util.ObjectHelper;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
@@ -31,6 +32,10 @@ public abstract class CamelHttpClient extends HttpClient {
 
     public CamelHttpClient(SslContextFactory sslContextFactory) {
         super(sslContextFactory);
+    }
+
+    public CamelHttpClient(HttpClientTransport transport, SslContextFactory sslContextFactory) {
+        super(transport, sslContextFactory);
     }
 
     @Deprecated
@@ -45,10 +50,8 @@ public abstract class CamelHttpClient extends HttpClient {
     @Override
     protected void doStart() throws Exception {
         if (!hasThreadPool()) {
-            // if there is no thread pool then create a default thread pool using daemon threads
+            // if there is no thread pool then create a default thread pool using daemon threads with default size (200)
             QueuedThreadPool qtp = new QueuedThreadPool();
-            // 16 max threads is the default in the http client
-            qtp.setMaxThreads(16);
             qtp.setDaemon(true);
             // let the thread names indicate they are from the client
             qtp.setName("CamelJettyClient(" + ObjectHelper.getIdentityHashCode(this) + ")");

--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -67,6 +67,8 @@ import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.apache.camel.util.jsse.SSLContextParameters;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.AbstractConnector;
@@ -658,7 +660,8 @@ public abstract class JettyHttpComponent extends HttpCommonComponent implements 
      */
     public CamelHttpClient createHttpClient(JettyHttpEndpoint endpoint, Integer minThreads, Integer maxThreads, SSLContextParameters ssl) throws Exception {
         SslContextFactory sslContextFactory = createSslContextFactory(ssl);
-        CamelHttpClient httpClient = createCamelHttpClient(sslContextFactory);
+        HttpClientTransport transport = createHttpClientTransport(maxThreads);
+        CamelHttpClient httpClient = createCamelHttpClient(transport, sslContextFactory);
         
         CamelContext context = endpoint.getCamelContext();
 
@@ -708,7 +711,21 @@ public abstract class JettyHttpComponent extends HttpCommonComponent implements 
         return httpClient;
     }
 
-    protected abstract CamelHttpClient createCamelHttpClient(SslContextFactory sslContextFactory);
+    private HttpClientTransport createHttpClientTransport(Integer maxThreads) {
+        if (maxThreads == null) {
+            return new HttpClientTransportOverHTTP();
+        }
+
+        int selectors = Runtime.getRuntime().availableProcessors() / 2;
+
+        if (selectors >= maxThreads) {
+            selectors = maxThreads - 1;
+        }
+
+        return new HttpClientTransportOverHTTP(selectors);
+    }
+
+    protected abstract CamelHttpClient createCamelHttpClient(HttpClientTransport transport, SslContextFactory sslContextFactory);
 
     public Integer getHttpClientMinThreads() {
         return httpClientMinThreads;

--- a/components/camel-jetty9/src/main/java/org/apache/camel/component/jetty9/CamelHttpClient9.java
+++ b/components/camel-jetty9/src/main/java/org/apache/camel/component/jetty9/CamelHttpClient9.java
@@ -19,12 +19,17 @@ package org.apache.camel.component.jetty9;
 import java.util.concurrent.Executor;
 
 import org.apache.camel.component.jetty.CamelHttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class CamelHttpClient9 extends CamelHttpClient {
     
     public CamelHttpClient9(SslContextFactory sslContextFactory) {
         super(sslContextFactory);
+    }
+
+    public CamelHttpClient9(HttpClientTransport transport, SslContextFactory sslContextFactory) {
+        super(transport, sslContextFactory);
     }
 
     protected boolean hasThreadPool() {

--- a/components/camel-jetty9/src/main/java/org/apache/camel/component/jetty9/JettyHttpComponent9.java
+++ b/components/camel-jetty9/src/main/java/org/apache/camel/component/jetty9/JettyHttpComponent9.java
@@ -27,6 +27,7 @@ import org.apache.camel.component.jetty.JettyHttpComponent;
 import org.apache.camel.component.jetty.JettyHttpEndpoint;
 import org.apache.camel.util.IntrospectionSupport;
 import org.apache.camel.util.ObjectHelper;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
@@ -39,8 +40,8 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class JettyHttpComponent9 extends JettyHttpComponent {
 
-    protected CamelHttpClient createCamelHttpClient(SslContextFactory sslContextFactory) {
-        return new CamelHttpClient9(sslContextFactory);
+    protected CamelHttpClient createCamelHttpClient(HttpClientTransport transport, SslContextFactory sslContextFactory) {
+        return new CamelHttpClient9(transport, sslContextFactory);
     }
 
     protected JettyHttpEndpoint createEndpoint(URI endpointUri, URI httpUri) throws URISyntaxException {


### PR DESCRIPTION
Fixes CAMEL-10240.

Things I did:

- Removed setting the `QueuedThreadPool` size to 16 in `CamelHttpClient`. Now it relies on defaults in `QueuedThreadPool` class itself.

- Added a constructor in `CamelHttpClient` for setting `HttpClientTransport`.

- If the `httpClientMaxThreads` parameter is set, it is used for counting the selectors number for the `HttpClientTransport` instance (`httpClientMaxThreads / 2`). I'm not sure about this one but I thought it might be good to enable the possibility to configure this instead of having the dependency on `Runtime.getRuntime().availableProcessors()` for all cases. But maybe it would be better to create a new parameter for this?
