### PR TITLE
CAMEL-10291: support java.util.date for timestamps in rabbitmq messages

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQMessageConverter.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQMessageConverter.java
@@ -152,7 +152,7 @@ public class RabbitMQMessageConverter {
 
         final Object timestamp = msg.removeHeader(RabbitMQConstants.TIMESTAMP);
         if (timestamp != null) {
-            properties.timestamp(new Date(Long.parseLong(timestamp.toString())));
+            properties.timestamp(convertTimestamp(timestamp));
         }
 
         final Map<String, Object> headers = msg.getHeaders();
@@ -177,6 +177,13 @@ public class RabbitMQMessageConverter {
         properties.headers(filteredHeaders);
 
         return properties;
+    }
+
+    private Date convertTimestamp(Object timestamp) {
+        if(timestamp instanceof Date){
+            return (Date)timestamp;
+        }
+        return new Date(Long.parseLong(timestamp.toString()));
     }
 
     /**

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
@@ -152,11 +152,20 @@ public class RabbitMQProducerTest {
     }
 
     @Test
-    public void testPropertiesUsesTimestampHeader() throws IOException {
+    public void testPropertiesUsesTimestampHeaderAsLongValue() throws IOException {
         RabbitMQProducer producer = new RabbitMQProducer(endpoint);
         message.setHeader(RabbitMQConstants.TIMESTAMP, "12345123");
         AMQP.BasicProperties props = producer.buildProperties(exchange).build();
         assertEquals(12345123, props.getTimestamp().getTime());
+    }
+
+    @Test
+    public void testPropertiesUsesTimestampHeaderAsDateValue() throws IOException {
+        Date timestamp = new Date();
+        RabbitMQProducer producer = new RabbitMQProducer(endpoint);
+        message.setHeader(RabbitMQConstants.TIMESTAMP, timestamp);
+        AMQP.BasicProperties props = producer.buildProperties(exchange).build();
+        assertEquals(timestamp, props.getTimestamp());
     }
 
     @Test


### PR DESCRIPTION
See bug report https://issues.apache.org/jira/browse/CAMEL-10291