### PR TITLE
CAMEL-10298: Remove readLockTimeout check from readLockMinAge (2.17.x)

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -1311,12 +1311,6 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
     protected void doStart() throws Exception {
         // validate that the read lock options is valid for the process strategy
         if (!"none".equals(readLock) && !"off".equals(readLock)) {
-            if (readLockTimeout > 0 && readLockMinAge > 0 && readLockTimeout <= readLockCheckInterval + readLockMinAge) {
-                throw new IllegalArgumentException("The option readLockTimeout must be higher than readLockCheckInterval + readLockMinAge"
-                    + ", was readLockTimeout=" + readLockTimeout + ", readLockCheckInterval+readLockMinAge=" + (readLockCheckInterval + readLockMinAge)
-                    + ". A good practice is to let the readLockTimeout be at least readLockMinAge + 2 times the readLockCheckInterval"
-                    + " to ensure that the read lock procedure has enough time to acquire the lock.");
-            }
             if (readLockTimeout > 0 && readLockTimeout <= readLockCheckInterval) {
                 throw new IllegalArgumentException("The option readLockTimeout must be higher than readLockCheckInterval"
                         + ", was readLockTimeout=" + readLockTimeout + ", readLockCheckInterval=" + readLockCheckInterval

--- a/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockMinAgeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockMinAgeTest.java
@@ -79,7 +79,7 @@ public class FileChangedReadLockMinAgeTest extends ContextTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("file:target/changed/in?readLock=changed&readLockMinAge=3000")
+                from("file:target/changed/in?readLock=changed&readLockMinAge=3000&readLockTimeout=1500")
                         .to("file:target/changed/out", "mock:result");
             }
         };


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-10298