### PR TITLE
Remove deprecated method in CamelHttpClient

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/CamelHttpClient.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/CamelHttpClient.java
@@ -38,15 +38,6 @@ public abstract class CamelHttpClient extends HttpClient {
         super(transport, sslContextFactory);
     }
 
-    @Deprecated
-    /**
-     * It does nothing here, please setup SslContextFactory directly, it will be removed in Camel 2.16.0
-     * @param context
-     */
-    public void setSSLContext(SSLContext context) {
-        // do nothing here, please setup SslContextFactory directly.
-    }
-    
     @Override
     protected void doStart() throws Exception {
         if (!hasThreadPool()) {


### PR DESCRIPTION
I noticed that in CamelHttpClient there's a deprecated method present which apparently should've been deleted sooner.