### PR TITLE
CAMEL-10328 : Support for attachments in Slack incoming web hooks

### DIFF
--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
@@ -16,12 +16,16 @@
  */
 package org.apache.camel.component.slack;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.slack.helper.SlackMessage;
+import org.apache.camel.component.slack.helper.SlackMessage.Attachment;
+import org.apache.camel.component.slack.helper.SlackMessage.Attachment.Field;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.camel.util.IOHelper;
 import org.apache.http.HttpResponse;
@@ -48,8 +52,14 @@ public class SlackProducer extends DefaultProducer {
         HttpPost httpPost = new HttpPost(slackEndpoint.getWebhookUrl());
 
         // Build Helper object
-        SlackMessage slackMessage = new SlackMessage();
-        slackMessage.setText(exchange.getIn().getBody(String.class));
+        SlackMessage slackMessage;
+        Object payload = exchange.getIn().getBody();
+        if(payload instanceof SlackMessage) {
+            slackMessage = (SlackMessage) payload;
+        } else { 
+            slackMessage = new SlackMessage();
+            slackMessage.setText(exchange.getIn().getBody(String.class));
+        }
         slackMessage.setChannel(slackEndpoint.getChannel());
         slackMessage.setUsername(slackEndpoint.getUsername());
         slackMessage.setIconUrl(slackEndpoint.getIconUrl());
@@ -79,7 +89,7 @@ public class SlackProducer extends DefaultProducer {
      * @return JSON string
      */
     public String asJson(SlackMessage message) {
-        Map<String, String> jsonMap = new HashMap<String, String>();
+        Map<String, Object> jsonMap = new HashMap<>();
 
         // Put the values in a map
         jsonMap.put("text", message.getText());
@@ -88,6 +98,11 @@ public class SlackProducer extends DefaultProducer {
         jsonMap.put("icon_url", message.getIconUrl());
         jsonMap.put("icon_emoji", message.getIconEmoji());
 
+        List<SlackMessage.Attachment> attachments = message.getAttachments();
+        if (attachments != null && !attachments.isEmpty()) {
+            buildAttachmentJson(jsonMap, attachments);
+        }
+
         // Generate a JSONObject
         JSONObject jsonObject = new JSONObject(jsonMap);
 
@@ -95,4 +110,42 @@ public class SlackProducer extends DefaultProducer {
         return JSONObject.toJSONString(jsonObject);
     }
 
+    private void buildAttachmentJson(Map<String, Object> jsonMap, List<SlackMessage.Attachment> attachments) {
+        List<Map<String, Object>> attachmentsJson = new ArrayList<>(attachments.size());
+        attachments.forEach(attachment -> {
+            Map<String, Object> attachmentJson = new HashMap<>();
+            attachmentJson.put("fallback", attachment.getFallback());
+            attachmentJson.put("color", attachment.getColor());
+            attachmentJson.put("pretext", attachment.getPretext());
+            attachmentJson.put("author_name", attachment.getAuthorName());
+            attachmentJson.put("author_link", attachment.getAuthorLink());
+            attachmentJson.put("author_icon", attachment.getAuthorIcon());
+            attachmentJson.put("title", attachment.getTitle());
+            attachmentJson.put("title_link", attachment.getTitleLink());
+            attachmentJson.put("text", attachment.getText());
+            attachmentJson.put("image_url", attachment.getImageUrl());
+            attachmentJson.put("footer", attachment.getFooter());
+            attachmentJson.put("footer_icon", attachment.getFooterIcon());
+            attachmentJson.put("ts", attachment.getTs());
+
+            List<SlackMessage.Attachment.Field> fields = attachment.getFields();
+            if (fields != null && !fields.isEmpty()) {
+                buildAttachmentFieldJson(attachmentJson, fields);
+            }
+            attachmentsJson.add(attachmentJson);
+        });
+        jsonMap.put("attachments", attachmentsJson);
+    }
+
+    private void buildAttachmentFieldJson(Map<String, Object> attachmentJson, List<SlackMessage.Attachment.Field> fields) {
+        List<Map<String, Object>> fieldsJson = new ArrayList<>(fields.size());
+        fields.forEach(field -> {
+            Map<String, Object> fieldJson = new HashMap<>();
+            fieldJson.put("title", field.getTitle());
+            fieldJson.put("value", field.getValue());
+            fieldJson.put("short", field.isShortValue());
+            fieldsJson.add(fieldJson);
+        });
+        attachmentJson.put("fields", fieldsJson);
+    }
 }

--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/helper/SlackMessage.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/helper/SlackMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.slack.helper;
 
+import java.util.List;
+
 public class SlackMessage {
 
     private String text;
@@ -23,6 +25,7 @@ public class SlackMessage {
     private String username;
     private String iconUrl;
     private String iconEmoji;
+    private List<Attachment> attachments;
 
     public String getText() {
         return text;
@@ -62,6 +65,179 @@ public class SlackMessage {
 
     public void setIconEmoji(String iconEmoji) {
         this.iconEmoji = iconEmoji;
+    }
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(List<Attachment> attachments) {
+        this.attachments = attachments;
+    }
+
+    public class Attachment {
+
+        private String fallback;
+        private String color;
+        private String pretext;
+        private String authorName;
+        private String authorLink;
+        private String authorIcon;
+        private String title;
+        private String titleLink;
+        private String text;
+        private String imageUrl;
+        private String thumbUrl;
+        private String footer;
+        private String footerIcon;
+        private Long ts;
+        private List<Field> fields;
+
+        public String getFallback() {
+            return fallback;
+        }
+
+        public void setFallback(String fallback) {
+            this.fallback = fallback;
+        }
+
+        public String getColor() {
+            return color;
+        }
+
+        public void setColor(String color) {
+            this.color = color;
+        }
+
+        public String getPretext() {
+            return pretext;
+        }
+
+        public void setPretext(String pretext) {
+            this.pretext = pretext;
+        }
+
+        public String getAuthorName() {
+            return authorName;
+        }
+
+        public void setAuthorName(String authorName) {
+            this.authorName = authorName;
+        }
+
+        public String getAuthorLink() {
+            return authorLink;
+        }
+
+        public void setAuthorLink(String authorLink) {
+            this.authorLink = authorLink;
+        }
+
+        public String getAuthorIcon() {
+            return authorIcon;
+        }
+
+        public void setAuthorIcon(String authorIcon) {
+            this.authorIcon = authorIcon;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getTitleLink() {
+            return titleLink;
+        }
+
+        public void setTitleLink(String titleLink) {
+            this.titleLink = titleLink;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
+
+        public void setImageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+        }
+
+        public String getThumbUrl() {
+            return thumbUrl;
+        }
+
+        public void setThumbUrl(String thumbUrl) {
+            this.thumbUrl = thumbUrl;
+        }
+
+        public String getFooter() {
+            return footer;
+        }
+
+        public void setFooter(String footer) {
+            this.footer = footer;
+        }
+
+        public String getFooterIcon() {
+            return footerIcon;
+        }
+
+        public void setFooterIcon(String footerIcon) {
+            this.footerIcon = footerIcon;
+        }
+
+        public Long getTs() {
+            return ts;
+        }
+
+        public void setTs(Long ts) {
+            this.ts = ts;
+        }
+
+        public List<Field> getFields() {
+            return fields;
+        }
+
+        public void setFields(List<Field> fields) {
+            this.fields = fields;
+        }
+
+        public class Field {
+
+            private String title;
+            private String value;
+            private Boolean shortValue;
+
+            public String getTitle() {
+                return title;
+            }
+            public void setTitle(String title) {
+                this.title = title;
+            }
+            public String getValue() {
+                return value;
+            }
+            public void setValue(String value) {
+                this.value = value;
+            }
+            public Boolean isShortValue() {
+                return shortValue;
+            }
+            public void setShortValue(Boolean shortValue) {
+                this.shortValue = shortValue;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Added support for sending attachments as part of incoming webhooks to Slack. 

Reference : https://api.slack.com/docs/message-attachments

@davsclaus  I couldn't find camel-slack category in JIRA component field and hence haven't tagged the JIRA ticket