### PR TITLE
Fix: OutOfMemoryErrors due to not explicit closed Deflater

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/ZipDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ZipDataFormat.java
@@ -59,13 +59,22 @@ public class ZipDataFormat extends org.apache.camel.support.ServiceSupport imple
 
     public void marshal(final Exchange exchange, final Object graph, final OutputStream stream) throws Exception {
         // ask for a mandatory type conversion to avoid a possible NPE beforehand as we do copy from the InputStream
-        InputStream is = exchange.getContext().getTypeConverter().mandatoryConvertTo(InputStream.class, exchange, graph);
+        final InputStream is = exchange.getContext().getTypeConverter().mandatoryConvertTo(InputStream.class, exchange, graph);
 
-        DeflaterOutputStream zipOutput = new DeflaterOutputStream(stream, new Deflater(compressionLevel));
+        final Deflater deflater = new Deflater(compressionLevel);
+        final DeflaterOutputStream zipOutput = new DeflaterOutputStream(stream, new Deflater(compressionLevel));
         try {
             IOHelper.copy(is, zipOutput);
         } finally {
             IOHelper.close(is, zipOutput);
+            
+            /*
+            * As we create the Deflater our self and do not use the stream default
+            * (see {@link java.util.zip.DeflaterOutputStream#usesDefaultDeflater})
+            * we need to close the Deflater to not risk a OutOfMemoryException
+            * in native code parts (see {@link java.util.zip.Deflater#end})
+            */
+            deflater.end();
         }
     }
 


### PR DESCRIPTION
The Deflater usage in this class might cause OutOfMemoryErrors. These will arise in high-load + high-ram-jvm scenarios as the GC cannot monitor the Deflater's internal native buffer.

"""
Caused by: java.lang.OutOfMemoryError: null
                at java.util.zip.Deflater.init(Native Method)
                at java.util.zip.Deflater.<init>(Deflater.java:171)
                at java.util.zip.Deflater.<init>(Deflater.java:180)
                at org.apache.camel.impl.ZipDataFormat.marshal(ZipDataFormat.java:58)
                at org.apache.camel.processor.MarshalProcessor.process(MarshalProcessor.java:81)
                ... 33 common frames omitted
"""