### PR TITLE
New configuration parameter added : allowSerializedHeaders

### DIFF
--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyConfiguration.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyConfiguration.java
@@ -74,6 +74,8 @@ public class NettyConfiguration extends NettyServerBootstrapConfiguration implem
     private boolean lazyChannelCreation = true;
     @UriParam(label = "advanced")
     private boolean transferExchange;
+    @UriParam(label = "advanced", defaultValue = "false")
+    private boolean allowSerializedHeaders;
     @UriParam(label = "consumer,advanced", defaultValue = "true")
     private boolean disconnectOnNoReply = true;
     @UriParam(label = "consumer,advanced", defaultValue = "WARN")
@@ -426,6 +428,19 @@ public class NettyConfiguration extends NettyServerBootstrapConfiguration implem
         this.transferExchange = transferExchange;
     }
 
+    public boolean isAllowSerializedHeaders() {
+    	return allowSerializedHeaders;
+    }
+    
+    /**
+     * Only used for TCP when transferExchange is true. When set to true, serializable objects in headers and properties
+     * will be added to the exchange. Otherwise Camel will exclude any non-serializable objects and log it at WARN
+     * level.
+     */
+    public void setAllowSerializedHeaders(final boolean allowSerializedHeaders) {
+        this.allowSerializedHeaders = allowSerializedHeaders;
+    }
+    
     public boolean isDisconnectOnNoReply() {
         return disconnectOnNoReply;
     }

--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyPayloadHelper.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyPayloadHelper.java
@@ -41,7 +41,7 @@ public final class NettyPayloadHelper {
     public static Object getIn(NettyEndpoint endpoint, Exchange exchange) {
         if (endpoint.getConfiguration().isTransferExchange()) {
             // we should transfer the entire exchange over the wire (includes in/out)
-            return DefaultExchangeHolder.marshal(exchange);
+        	return DefaultExchangeHolder.marshal(exchange, true, endpoint.getConfiguration().isAllowSerializedHeaders());
         } else {
             if (endpoint.getConfiguration().isUseByteBuf()) {
                 // Just leverage the type converter 


### PR DESCRIPTION
Only used for TCP when transferExchange is true. When set to true, serializable objects in headers and properties will be added to the exchange.

see issue https://issues.apache.org/jira/browse/CAMEL-10343