### PR TITLE
added method to check for key existence

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
@@ -290,6 +290,15 @@ public class HazelcastAggregationRepository extends ServiceSupport
         return unmarshallExchange(camelContext, cache.get(key));
     }
     
+    /**
+     * Checks if the key in question is in the repository.
+     * 
+     * @param key Object - key in question
+     */
+    public boolean containsKey(Object key){
+        return cache.containsKey(key);
+    }
+    
     public boolean isAllowSerializedHeaders() {
         return allowSerializedHeaders;
     }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
@@ -296,7 +296,10 @@ public class HazelcastAggregationRepository extends ServiceSupport
      * @param key Object - key in question
      */
     public boolean containsKey(Object key){
+      if(cache != null)
         return cache.containsKey(key);
+      else
+        return false;
     }
     
     public boolean isAllowSerializedHeaders() {


### PR DESCRIPTION
Sometimes it is necessary to check for the existence but not fetching the value.

For example in a filefilter that uses the aggregationRepository to dtermine wheter a file should be consumed or not we don't need to fetch the actual DefaultExchangeHolder object and unmarshal it. 

So in this fileFilter we can use the containsKey method to delegate to the actual map and return the presence of the key.

If possible we'd like to have that change from camel 2.16.x 

Thanks,
Michael