### PR TITLE
CAMEL-10358: do not clear the registry too early

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
@@ -274,12 +274,6 @@ public class UndertowComponent extends UriEndpointComponent implements RestConsu
         }
     }
 
-    @Override
-    protected void doStop() throws Exception {
-        super.doStop();
-        serversRegistry.clear();
-    }
-
     public void registerConsumer(UndertowConsumer consumer) {
         int port = consumer.getEndpoint().getHttpURI().getPort();
         if (serversRegistry.containsKey(port)) {


### PR DESCRIPTION
When running on Spring, the `doStop` is called by the spring framework before the default strategy unregisters the consumers, so the registry is cleared and the undertow servers remain bound to their port when the context is closed.

We should not clear the registry (change added in https://github.com/apache/camel/commit/cdd64e10a6c761ccfba4b6d605c53df1250bb9eb) because it is automatically cleared when the last consumer is unregistered.

This issue prevent using livereload with undertow (port already used). I'm working on a feature for dynamically changing the configuration on Kubernetes that is also be impacted.