### PR TITLE
Add publishedEndpointUrl capability to rsServer

### DIFF
--- a/components/camel-cxf/src/main/docs/cxfrs-component.adoc
+++ b/components/camel-cxf/src/main/docs/cxfrs-component.adoc
@@ -116,6 +116,7 @@ The CXF-RS component supports 29 endpoint options which are listed below:
 | performInvocation | advanced | false | boolean | When the option is true Camel will perform the invocation of the resource class instance and put the response object into the exchange for further processing.
 | propagateContexts | advanced | false | boolean | When the option is true JAXRS UriInfo HttpHeaders Request and SecurityContext contexts will be available to custom CXFRS processors as typed Camel exchange properties. These contexts can be used to analyze the current requests using JAX-RS API.
 | synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
+| publishedEndpointUrl | producer |  | String | This option can override the endpointUrl that published from the WADL which can be accessed with resource address url plus ?_wadl
 |=======================================================================
 {% endraw %}
 // endpoint options: END

--- a/components/camel-cxf/src/main/resources/schema/blueprint/camel-cxf.xsd
+++ b/components/camel-cxf/src/main/resources/schema/blueprint/camel-cxf.xsd
@@ -98,6 +98,7 @@
           <xsd:attribute name="staticSubresourceResolution" type="xsd:boolean"/>
           <xsd:attribute name="loggingFeatureEnabled" type="xsd:boolean"/>
           <xsd:attribute name="loggingSizeLimit" type="xsd:integer" />
+          <xsd:attribute name="publishedEndpointUrl" type="xsd:string" />
         </xsd:extension>
       </xsd:complexContent>
     </xsd:complexType>

--- a/components/camel-cxf/src/main/resources/schema/cxfEndpoint.xsd
+++ b/components/camel-cxf/src/main/resources/schema/cxfEndpoint.xsd
@@ -98,6 +98,7 @@
           <xsd:attribute name="loggingFeatureEnabled" type="xsd:boolean"/>
           <xsd:attribute name="loggingSizeLimit" type="xsd:integer" />
           <xsd:attribute name="skipFaultLogging" type="xsd:boolean" />
+          <xsd:attribute name="publishedEndpointUrl" type="xsd:string" />
         </xsd:extension>
       </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
Endpoint definition allows to specify publishedEndpointUrl, but this attribute is not available in rsServer element. This attribute (publishedEndpointUrl) is used by WadlGenerator to compose baseUri resource in the WADL. If you are deploying a REST service in an internal net but exposed to internet (through reverse proxy, for example) , WADL should inform such publishing address (in a similar way that you can do it with WSDL in camel-cxf).

Actually, since no publishedEndpointUrl can be used in rsServer definition, baseUri is built with HTTP request information. That means internal network information could be leaked in a reverse proxy scenario.