### PR TITLE
Fix typos in camel-cxf jax-rs xml comments

### DIFF
--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/jaxrs/CxfRsSpringRouter.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/jaxrs/CxfRsSpringRouter.xml
@@ -51,7 +51,7 @@
     </cxf:providers>
   </cxf:rsServer>
 
-  <!-- Defined the client endpoint to create the cxf-rs consumer -->
+  <!-- Defined the client endpoint to create the cxf-rs producer -->
   <cxf:rsClient id="rsClient" address="http://localhost:${CXFTestSupport.port2}/CxfRsRouterTest/rest"
     serviceClass="org.apache.camel.component.cxf.jaxrs.testbean.CustomerService"
     loggingFeatureEnabled="true" skipFaultLogging="true">

--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/jaxrs/JettyCxfRsSpringRouter.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/jaxrs/JettyCxfRsSpringRouter.xml
@@ -42,7 +42,7 @@
 
   <bean id="customerService" class="org.apache.camel.component.cxf.jaxrs.testbean.CustomerService" />
   
-  <!-- Defined the client endpoint to create the cxf-rs consumer -->
+  <!-- Defined the client endpoint to create the cxf-rs producer -->
   <cxf:rsClient id="rsClient" address="http://localhost:${CXFTestSupport.port2}/JettyCxfRsRouterTest/rest"
     serviceClass="org.apache.camel.component.cxf.jaxrs.testbean.CustomerService"
     loggingFeatureEnabled="true" skipFaultLogging="true"/>


### PR DESCRIPTION
`<cxf:rsClient>` should really be "producer", not "consumer". I just skipped filing a JIRA for it as it's such a trivial doc typo fix :-)