### PR TITLE
Added array support for input body paremeter

### DIFF
--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -297,7 +297,9 @@ public class RestSwaggerReader {
 
                         if (verb.getType() != null) {
                             if(verb.getType().endsWith("[]")){
-                                Property prop = modelTypeAsProperty(verb.getType(), swagger);
+                                String typeName = verb.getType();
+                                typeName = typeName.substring(0, typeName.length() - 2);
+                                Property prop = modelTypeAsProperty(typeName, swagger);
                                 if (prop != null) {
                                     ArrayModel arrayModel = new ArrayModel();
                                     arrayModel.setItems(prop);

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -296,9 +296,19 @@ public class RestSwaggerReader {
                         BodyParameter bp = (BodyParameter) parameter;
 
                         if (verb.getType() != null) {
-                            String ref = modelTypeAsRef(verb.getType(), swagger);
-                            if (ref != null) {
-                                bp.setSchema(new RefModel(ref));
+                            if(verb.getType().endsWith("[]")){
+                                Property prop = modelTypeAsProperty(verb.getType(), swagger);
+                                if (prop != null) {
+                                    ArrayModel arrayModel = new ArrayModel();
+                                    arrayModel.setItems(prop);
+                                    bp.setSchema(arrayModel);
+                                }
+                            }
+                            else {
+                                String ref = modelTypeAsRef(verb.getType(), swagger);
+                                if (ref != null) {
+                                    bp.setSchema(new RefModel(ref));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Camel-swagger-java didnt support array of input objects. To check it, you can modify "/put root" in RestSwaggerReaderModelTest.java (.put().description("Updates or create a user").type**List**(User.class)) and check that final json file won't contain <"type" : "array"> defenition for input object. 
This solution is not  perfect, but it just show that problem exist and can be fixed very fast.