### PR TITLE
Added a test class to ensure CAMEL-10322 non-regression

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/processor/interceptor/AdviceWithWeaveByStringOnChoiceTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/interceptor/AdviceWithWeaveByStringOnChoiceTest.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.interceptor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * This test ensures non-regression for bug CAMEL-10322.
+ */
+public class AdviceWithWeaveByStringOnChoiceTest extends ContextTestSupport {
+
+    public void testWeaveByToStringShoultNotThrowUnsupportedOperationException() throws Exception {
+        context.getRouteDefinitions().get(0).adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveByToString(".*mock:foo.*").replace().to("mock:bar");
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:foo").expectedMessageCount(0);
+        getMockEndpoint("mock:bar").expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").choice().when(simple("true")).to("mock:foo");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Hi,

  In the context of [CAMEL-10322](https://issues.apache.org/jira/browse/CAMEL-10322), I have implemented a test reproducing the issue on 2.16.3 and demonstrating the issue correction at least in 2.19.0-SNAPSHOT.

  On my machine, I could run commands above against camel-core:
  mvn clean compile -P sourcecheck => ok
  mvn install => ok

  I could manage the JIRA issue but I don't have permission yet. Could someone bring me in ?

Many thanks