### PR TITLE
CAMEL-10427 - CXFRS client gets "Response timeout" exception when used with Camel transport

### DIFF
--- a/components/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
+++ b/components/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
@@ -70,9 +70,10 @@ public final class CxfHeaderHelper {
                     message.put(Message.CONTENT_TYPE, entry.getValue());
                 }
                 if (Client.REQUEST_CONTEXT.equals(entry.getKey())
-                    || Client.RESPONSE_CONTEXT.equals(entry.getKey())
-                    || Message.RESPONSE_CODE.equals(entry.getKey())) {
+                    || Client.RESPONSE_CONTEXT.equals(entry.getKey())) {
                     message.put(entry.getKey(), entry.getValue());
+                } else if (Exchange.HTTP_RESPONSE_CODE.equals(entry.getKey())) {
+                    message.put(Message.RESPONSE_CODE, entry.getValue());
                 } else {
                     Object values = entry.getValue();
                     if (values instanceof List<?>) {

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelperTest.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelperTest.java
@@ -45,10 +45,11 @@ public class CxfHeaderHelperTest extends Assert {
     @Test
     public void testPropagateCamelToCxf() {
         Exchange exchange = new DefaultExchange(context);
-        
+
         exchange.getIn().setHeader("soapAction", "urn:hello:world");
         exchange.getIn().setHeader("MyFruitHeader", "peach");
         exchange.getIn().setHeader("MyBrewHeader", Arrays.asList("cappuccino", "espresso"));
+        exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, "200");
         org.apache.cxf.message.Message cxfMessage = new org.apache.cxf.message.MessageImpl();
         
         CxfHeaderHelper.propagateCamelToCxf(new DefaultHeaderFilterStrategy(), 
@@ -59,7 +60,7 @@ public class CxfHeaderHelperTest extends Assert {
             CastUtils.cast((Map<?, ?>)cxfMessage.get(org.apache.cxf.message.Message.PROTOCOL_HEADERS));
         assertNotNull(cxfHeaders);
         assertTrue(cxfHeaders.size() == 3);
-        
+
         verifyHeader(cxfHeaders, "soapaction", "urn:hello:world");
         verifyHeader(cxfHeaders, "SoapAction", "urn:hello:world");
         verifyHeader(cxfHeaders, "SOAPAction", "urn:hello:world");
@@ -67,6 +68,7 @@ public class CxfHeaderHelperTest extends Assert {
         verifyHeader(cxfHeaders, "myFruitHeader", "peach");
         verifyHeader(cxfHeaders, "MYFRUITHEADER", "peach");
         verifyHeader(cxfHeaders, "MyBrewHeader", Arrays.asList("cappuccino", "espresso"));
+        assertEquals("200", cxfMessage.get(Message.RESPONSE_CODE));
     } 
 
     @Test
@@ -79,6 +81,7 @@ public class CxfHeaderHelperTest extends Assert {
         cxfHeaders.put("myfruitheader", Arrays.asList("peach"));
         cxfHeaders.put("mybrewheader", Arrays.asList("cappuccino", "espresso"));
         cxfMessage.put(org.apache.cxf.message.Message.PROTOCOL_HEADERS, cxfHeaders);
+        cxfMessage.put(Message.RESPONSE_CODE, "200");
         
         Map<String, Object> camelHeaders = exchange.getIn().getHeaders();
         CxfHeaderHelper.propagateCxfToCamel(new DefaultHeaderFilterStrategy(), 
@@ -89,6 +92,7 @@ public class CxfHeaderHelperTest extends Assert {
         assertEquals("241", camelHeaders.get("content-length"));
         assertEquals("peach", camelHeaders.get("MyFruitHeader"));
         assertEquals(Arrays.asList("cappuccino", "espresso"), camelHeaders.get("MyBrewHeader"));
+        assertEquals("200", camelHeaders.get(Exchange.HTTP_RESPONSE_CODE));
     } 
 
     @Test

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/transport/CxfRsCamelTransportTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/transport/CxfRsCamelTransportTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cxf.transport;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+public class CxfRsCamelTransportTest extends CamelSpringTestSupport {
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("/org/apache/camel/component/cxf/transport/CxfRsCamelTransport.xml");
+    }
+
+    @Test
+    public void testCamelTransport() throws Exception {
+        MockEndpoint result = getMockEndpoint("mock:result");
+        result.expectedBodiesReceived("Hello, Test!");
+
+        template.sendBody("direct:input", "Test");
+        assertMockEndpointsSatisfied();
+    }
+
+    @Path("/greeting")
+    public interface GreetingResource {
+        @GET
+        @Path("/hello/{name}")
+        @Consumes("text/plain")
+        @Produces("text/plain")
+        String hello(@PathParam("name") String name);
+    }
+
+    @Path("/greeting")
+    public static class GreetingResourceBean implements GreetingResource {
+        @GET
+        @Path("/hello/{name}")
+        @Consumes("text/plain")
+        @Produces("text/plain")
+        public String hello(@PathParam("name") String name) {
+            return String.format("Hello, %s!", name);
+        }
+    }
+
+}

--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/transport/CxfRsCamelTransport.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/transport/CxfRsCamelTransport.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cxf="http://camel.apache.org/schema/cxf"
+       xmlns:camel="http://cxf.apache.org/transports/camel"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://cxf.apache.org/transports/camel http://cxf.apache.org/transports/camel.xsd
+       http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+       http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd
+    ">
+
+    <jaxrs:server id="rsServer" address="camel://direct:cxf.out">
+        <jaxrs:serviceBeans>
+            <bean class="org.apache.camel.component.cxf.transport.CxfRsCamelTransportTest.GreetingResourceBean" />
+        </jaxrs:serviceBeans>
+    </jaxrs:server>
+    <cxf:rsClient id="rsClient" address="camel://direct:cxf.in"
+                  serviceClass="org.apache.camel.component.cxf.transport.CxfRsCamelTransportTest.GreetingResource"
+                  loggingFeatureEnabled="true" />
+
+    <camel:conduit name="*.camel-conduit" camelContextId="cxfrs-camel-transport" />
+    <camel:destination name="*.camel-destination" camelContextId="cxfrs-camel-transport" />
+
+    <camelContext id="cxfrs-camel-transport" xmlns="http://camel.apache.org/schema/spring">
+        <!-- CXFRS producer -->
+        <route>
+            <from uri="direct:input" />
+            <!-- using HttpClientAPI -->
+            <setHeader headerName="CamelHttpMethod">
+                <constant>GET</constant>
+            </setHeader>
+            <setHeader headerName="Content-Type">
+                <constant>text/plain</constant>
+            </setHeader>
+            <setHeader headerName="CamelHttpUri">
+                <simple>/greeting/hello/${body}</simple>
+            </setHeader>
+            <!-- doesn't work for Camel tranport
+            <setHeader headerName="CamelHttpPath">
+                <simple>/greeting/hello/${body}</simple>
+            </setHeader>
+            -->
+            <setHeader headerName="CamelHttpMethod">
+                <constant>GET</constant>
+            </setHeader>
+            <inOut uri="cxfrs:bean:rsClient" />
+            <to uri="mock:result" />
+        </route>
+        <!-- CXFRS consumer -->
+        <route>
+            <from uri="direct:cxf.in" />
+            <to uri="direct:cxf.out" />
+        </route>
+    </camelContext>
+
+</beans>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-10427
https://issues.jboss.org/browse/ENTESB-6028

Made `CxfHeaderHelper` aware of mapping between Camel `Exchange.HTTP_RESPONSE_CODE` <-> CXF `Message.RESPONSE_CODE`.