### PR TITLE
CAMEL-10394: Resolve components from Camel Context

### DIFF
--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/handler/CamelNamespaceHandler.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/handler/CamelNamespaceHandler.java
@@ -1050,7 +1050,11 @@ public class CamelNamespaceHandler implements NamespaceHandler {
             // because the factory has already been instantiated
             try {
                 for (String component : components) {
-                    getComponentResolverReference(context, component);
+                    if (camelContext.getComponent(component) == null) {
+                        getComponentResolverReference(context, component);
+                    } else {
+                        LOG.debug("Not creating a service reference for component {} because a component already exists in the Camel Context", component);
+                    }
                 }
                 for (String language : languages) {
                     getLanguageResolverReference(context, language);

--- a/tests/camel-blueprint-test/pom.xml
+++ b/tests/camel-blueprint-test/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>tests</artifactId>
+    <version>2.19.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-blueprint-test</artifactId>
+  <name>Camel :: Integration Tests :: Blueprint </name>
+  <description>Tests the camel-blueprint features</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-blueprint</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-blueprint</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/tests/camel-blueprint-test/src/test/java/org/apache/camel/blueprint/BlueprintResolveComponentFromCamelContextTest.java
+++ b/tests/camel-blueprint-test/src/test/java/org/apache/camel/blueprint/BlueprintResolveComponentFromCamelContextTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.blueprint;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.junit.Test;
+
+
+public class BlueprintResolveComponentFromCamelContextTest extends CamelBlueprintTestSupport {
+
+    @EndpointInject(uri = "mock://result")
+    MockEndpoint result;
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "OSGI-INF/blueprint/test-resolve-component-from-camel-context.xml";
+    }
+
+    @Test
+    public void testResolveComponentFromCamelContext() throws Exception {
+        result.expectedMinimumMessageCount(1);
+
+        // The route is driven by a timer, so we should receive at least one message within 5 seconds
+        assertMockEndpointsSatisfied(5, TimeUnit.SECONDS);
+    }
+}

--- a/tests/camel-blueprint-test/src/test/java/org/apache/camel/blueprint/test/builder/AddComponentInConfigureBuilder.java
+++ b/tests/camel-blueprint-test/src/test/java/org/apache/camel/blueprint/test/builder/AddComponentInConfigureBuilder.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.blueprint.test.builder;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.timer.TimerComponent;
+import org.apache.camel.model.ModelCamelContext;
+
+public class AddComponentInConfigureBuilder extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        ModelCamelContext context = getContext();
+        TimerComponent timerComponent = new TimerComponent();
+
+        getContext().addComponent("my-timer", timerComponent);
+
+        from("my-timer://test-timer?period=1000")
+                .to("mock://result");
+    }
+}

--- a/tests/camel-blueprint-test/src/test/resources/OSGI-INF/blueprint/test-resolve-component-from-camel-context.xml
+++ b/tests/camel-blueprint-test/src/test/resources/OSGI-INF/blueprint/test-resolve-component-from-camel-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="test-builder" class="org.apache.camel.blueprint.test.builder.AddComponentInConfigureBuilder"/>
+
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+        <routeBuilder ref="test-builder"/>
+    </camelContext>
+
+</blueprint>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -41,6 +41,7 @@
     <module>camel-itest</module>
     <module>camel-itest-cdi</module>
     <module>camel-blueprint-cxf-test</module>
+    <module>camel-blueprint-test</module>
     <module>camel-partial-classpath-test</module>
     <module>camel-typeconverterscan-test</module>
   </modules>


### PR DESCRIPTION
Check the camel context for a component registered under the given name before creating a service reference.