### PR TITLE
Added 'preferredAuthentications' option to camel-jsch

### DIFF
--- a/components/camel-jsch/src/main/docs/scp-component.adoc
+++ b/components/camel-jsch/src/main/docs/scp-component.adoc
@@ -89,6 +89,7 @@ The SCP component supports 21 endpoint options which are listed below:
 | timeout | advanced | 30000 | int | Sets the data timeout for waiting for reply Used only by FTPClient
 | knownHostsFile | security |  | String | Sets the known_hosts file so that the jsch endpoint can do host key verification.
 | password | security |  | String | Password to use for login
+| preferredAuthentications | security |  | String | Set the authentication methods that JSch will be allowed to use, e.g. gssapi-with-mic,publickey,keyboard-interactive,password
 | privateKeyFile | security |  | String | Set the private key file to that the SFTP endpoint can do private key verification.
 | privateKeyFilePassphrase | security |  | String | Set the private key file passphrase to that the SFTP endpoint can do private key verification.
 | username | security |  | String | Username to use for login

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpConfiguration.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpConfiguration.java
@@ -46,6 +46,8 @@ public class ScpConfiguration extends RemoteFileConfiguration {
     // null means default jsch list will be used
     @UriParam(label = "security,advanced")
     private String ciphers;
+    @UriParam(label = "security", secret = true)
+    private String preferredAuthentications;
 
     public ScpConfiguration() {
         setProtocol("scp");
@@ -150,4 +152,17 @@ public class ScpConfiguration extends RemoteFileConfiguration {
         return ciphers;
     }
 
+    /**
+     * Set a comma separated list of authentications that will be used in order of preference.
+	 * Possible authentication methods are defined by JCraft JSCH. Some examples include: gssapi-with-mic,publickey,keyboard-interactive,password
+     * If not specified the JSCH and/or system defaults will be used.
+     */
+    public void setPreferredAuthentications(final String preferredAuthentications) {
+      this.preferredAuthentications = preferredAuthentications;
+    }
+
+    public String getPreferredAuthentications() {
+      return preferredAuthentications;
+    }
+	
 }

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
@@ -245,6 +245,11 @@ public class ScpOperations implements RemoteFileOperations<ScpFile> {
                 session.setConfig("StrictHostKeyChecking", config.getStrictHostKeyChecking());
             }
 
+            if (ObjectHelper.isNotEmpty(config.getPreferredAuthentications())) {
+                LOG.trace("Using preferredAuthentications: {}", config.getPreferredAuthentications());
+                session.setConfig("PreferredAuthentications", config.getPreferredAuthentications());
+            }
+			
             int timeout = config.getConnectTimeout();
             LOG.debug("Connecting to {} with {} timeout...", config.remoteServerInformation(),
                 timeout > 0 ? (Integer.toString(timeout) + " ms") : "no");


### PR DESCRIPTION
This is a simple change to pass a new config option through to JSch. We need to set the 'preferredAuthentications' option to override the default order on our servers, specifically to prevent a kerberos password prompt being shown.

More details here...
http://stackoverflow.com/questions/29669459/skipping-kerberos-authentication-prompts-with-jsch

Regards,
James