### PR TITLE
CAMEL-10420: Allow custom changes to the pom.xml files

### DIFF
--- a/components-starter/camel-ahc-starter/pom.xml
+++ b/components-starter/camel-ahc-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ahc</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
@@ -50,5 +51,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ahc-ws-starter/pom.xml
+++ b/components-starter/camel-ahc-ws-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ahc-ws</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
@@ -50,5 +51,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-amqp-starter/pom.xml
+++ b/components-starter/camel-amqp-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-amqp</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-apns-starter/pom.xml
+++ b/components-starter/camel-apns-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-apns</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-asterisk-starter/pom.xml
+++ b/components-starter/camel-asterisk-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-asterisk</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-atmos-starter/pom.xml
+++ b/components-starter/camel-atmos-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-atmos</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-atmosphere-websocket-starter/pom.xml
+++ b/components-starter/camel-atmosphere-websocket-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-atmosphere-websocket</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-atom-starter/pom.xml
+++ b/components-starter/camel-atom-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-atom</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-avro-starter/pom.xml
+++ b/components-starter/camel-avro-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-avro</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-aws-starter/pom.xml
+++ b/components-starter/camel-aws-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-aws</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-bam-starter/pom.xml
+++ b/components-starter/camel-bam-starter/pom.xml
@@ -36,6 +36,7 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-bam</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -46,7 +47,9 @@
           <artifactId>geronimo-jpa_2.0_spec</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -63,5 +66,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-barcode-starter/pom.xml
+++ b/components-starter/camel-barcode-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-barcode</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-base64-starter/pom.xml
+++ b/components-starter/camel-base64-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-base64</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-bean-validator-starter/pom.xml
+++ b/components-starter/camel-bean-validator-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-bean-validator</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-beanio-starter/pom.xml
+++ b/components-starter/camel-beanio-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-beanio</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-beanstalk-starter/pom.xml
+++ b/components-starter/camel-beanstalk-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-beanstalk</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-bindy-starter/pom.xml
+++ b/components-starter/camel-bindy-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-bindy</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-bonita-starter/pom.xml
+++ b/components-starter/camel-bonita-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-bonita</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-boon-starter/pom.xml
+++ b/components-starter/camel-boon-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-boon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-box-starter/pom.xml
+++ b/components-starter/camel-box-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-box</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-braintree-starter/pom.xml
+++ b/components-starter/camel-braintree-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-braintree</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cache-starter/pom.xml
+++ b/components-starter/camel-cache-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-cache</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cassandraql-starter/pom.xml
+++ b/components-starter/camel-cassandraql-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-cassandraql</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -50,5 +51,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-castor-starter/pom.xml
+++ b/components-starter/camel-castor-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-castor</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-chronicle-starter/pom.xml
+++ b/components-starter/camel-chronicle-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-chronicle</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-chunk-starter/pom.xml
+++ b/components-starter/camel-chunk-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-chunk</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cm-sms-starter/pom.xml
+++ b/components-starter/camel-cm-sms-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cm-sms</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cmis-starter/pom.xml
+++ b/components-starter/camel-cmis-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-cmis</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-coap-starter/pom.xml
+++ b/components-starter/camel-coap-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-coap</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cometd-starter/pom.xml
+++ b/components-starter/camel-cometd-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-cometd</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-consul-starter/pom.xml
+++ b/components-starter/camel-consul-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-consul</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-context-starter/pom.xml
+++ b/components-starter/camel-context-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-context</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-core-xml-starter/pom.xml
+++ b/components-starter/camel-core-xml-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-core-xml</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-couchdb-starter/pom.xml
+++ b/components-starter/camel-couchdb-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-couchdb</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-crypto-starter/pom.xml
+++ b/components-starter/camel-crypto-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-crypto</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-csv-starter/pom.xml
+++ b/components-starter/camel-csv-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-csv</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cxf-starter/pom.xml
+++ b/components-starter/camel-cxf-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cxf</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-cxf-transport-starter/pom.xml
+++ b/components-starter/camel-cxf-transport-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cxf-transport</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-disruptor-starter/pom.xml
+++ b/components-starter/camel-disruptor-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-disruptor</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-dns-starter/pom.xml
+++ b/components-starter/camel-dns-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-docker-starter/pom.xml
+++ b/components-starter/camel-docker-starter/pom.xml
@@ -36,6 +36,7 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-docker</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -46,7 +47,9 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,5 +58,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-dozer-starter/pom.xml
+++ b/components-starter/camel-dozer-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-dozer</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-drill-starter/pom.xml
+++ b/components-starter/camel-drill-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-drill</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-dropbox-starter/pom.xml
+++ b/components-starter/camel-dropbox-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-dropbox</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-eclipse-starter/pom.xml
+++ b/components-starter/camel-eclipse-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-eclipse</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ehcache-starter/pom.xml
+++ b/components-starter/camel-ehcache-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ehcache</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-elasticsearch-starter/pom.xml
+++ b/components-starter/camel-elasticsearch-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-elasticsearch</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-elsql-starter/pom.xml
+++ b/components-starter/camel-elsql-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-elsql</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-etcd-starter/pom.xml
+++ b/components-starter/camel-etcd-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-etcd</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-exec-starter/pom.xml
+++ b/components-starter/camel-exec-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-exec</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-facebook-starter/pom.xml
+++ b/components-starter/camel-facebook-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-facebook</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-flatpack-starter/pom.xml
+++ b/components-starter/camel-flatpack-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-flatpack</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-flink-starter/pom.xml
+++ b/components-starter/camel-flink-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-flink</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-fop-starter/pom.xml
+++ b/components-starter/camel-fop-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-fop</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-freemarker-starter/pom.xml
+++ b/components-starter/camel-freemarker-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-freemarker</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ftp-starter/pom.xml
+++ b/components-starter/camel-ftp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ftp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ganglia-starter/pom.xml
+++ b/components-starter/camel-ganglia-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ganglia</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-geocoder-starter/pom.xml
+++ b/components-starter/camel-geocoder-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-geocoder</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-git-starter/pom.xml
+++ b/components-starter/camel-git-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-git</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-github-starter/pom.xml
+++ b/components-starter/camel-github-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-github</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -50,5 +51,6 @@
       <artifactId>org.eclipse.egit.github.core</artifactId>
       <version>${egit-github-core-version}</version>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-google-calendar-starter/pom.xml
+++ b/components-starter/camel-google-calendar-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-google-calendar</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-google-drive-starter/pom.xml
+++ b/components-starter/camel-google-drive-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-google-drive</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-google-mail-starter/pom.xml
+++ b/components-starter/camel-google-mail-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-google-mail</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-gora-starter/pom.xml
+++ b/components-starter/camel-gora-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-gora</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-grape-starter/pom.xml
+++ b/components-starter/camel-grape-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-grape</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-groovy-starter/pom.xml
+++ b/components-starter/camel-groovy-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-groovy</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-gson-starter/pom.xml
+++ b/components-starter/camel-gson-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-gson</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-guava-eventbus-starter/pom.xml
+++ b/components-starter/camel-guava-eventbus-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-guava-eventbus</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -50,5 +51,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-guice-starter/pom.xml
+++ b/components-starter/camel-guice-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-guice</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hawtdb-starter/pom.xml
+++ b/components-starter/camel-hawtdb-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hawtdb</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hazelcast-starter/pom.xml
+++ b/components-starter/camel-hazelcast-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-hazelcast</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hbase-starter/pom.xml
+++ b/components-starter/camel-hbase-starter/pom.xml
@@ -36,6 +36,7 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hbase</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -46,7 +47,9 @@
           <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,5 +58,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hdfs-starter/pom.xml
+++ b/components-starter/camel-hdfs-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hdfs</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hdfs2-starter/pom.xml
+++ b/components-starter/camel-hdfs2-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hdfs2</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hessian-starter/pom.xml
+++ b/components-starter/camel-hessian-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-hessian</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hipchat-starter/pom.xml
+++ b/components-starter/camel-hipchat-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hipchat</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hl7-starter/pom.xml
+++ b/components-starter/camel-hl7-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-hl7</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -50,5 +51,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-http-common-starter/pom.xml
+++ b/components-starter/camel-http-common-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-http-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-http-starter/pom.xml
+++ b/components-starter/camel-http-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-http</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-http4-starter/pom.xml
+++ b/components-starter/camel-http4-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-http4</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-hystrix-starter/pom.xml
+++ b/components-starter/camel-hystrix-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-hystrix</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ical-starter/pom.xml
+++ b/components-starter/camel-ical-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-ical</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ignite-starter/pom.xml
+++ b/components-starter/camel-ignite-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ignite</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-infinispan-starter/pom.xml
+++ b/components-starter/camel-infinispan-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-infinispan</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-influxdb-starter/pom.xml
+++ b/components-starter/camel-influxdb-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-influxdb</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-irc-starter/pom.xml
+++ b/components-starter/camel-irc-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-irc</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ironmq-starter/pom.xml
+++ b/components-starter/camel-ironmq-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ironmq</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jackson-starter/pom.xml
+++ b/components-starter/camel-jackson-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jacksonxml-starter/pom.xml
+++ b/components-starter/camel-jacksonxml-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jacksonxml</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jasypt-starter/pom.xml
+++ b/components-starter/camel-jasypt-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jasypt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-javaspace-starter/pom.xml
+++ b/components-starter/camel-javaspace-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-javaspace</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jaxb-starter/pom.xml
+++ b/components-starter/camel-jaxb-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jaxb</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jbpm-starter/pom.xml
+++ b/components-starter/camel-jbpm-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jbpm</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jcache-starter/pom.xml
+++ b/components-starter/camel-jcache-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jcache</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jcr-starter/pom.xml
+++ b/components-starter/camel-jcr-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jcr</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -50,5 +51,6 @@
       <artifactId>lucene-core</artifactId>
       <version>${lucene3-version}</version>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jdbc-starter/pom.xml
+++ b/components-starter/camel-jdbc-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jdbc</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jetty-common-starter/pom.xml
+++ b/components-starter/camel-jetty-common-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jetty-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jetty-starter/pom.xml
+++ b/components-starter/camel-jetty-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jetty</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jetty9-starter/pom.xml
+++ b/components-starter/camel-jetty9-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jetty9</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>apt</artifactId>
@@ -54,5 +55,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jgroups-starter/pom.xml
+++ b/components-starter/camel-jgroups-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jgroups</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jibx-starter/pom.xml
+++ b/components-starter/camel-jibx-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jibx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jing-starter/pom.xml
+++ b/components-starter/camel-jing-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jing</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jira-starter/pom.xml
+++ b/components-starter/camel-jira-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jira</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>com.atlassian.jira</groupId>
       <artifactId>jira-rest-java-client</artifactId>
@@ -49,11 +50,14 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
+  <!--START OF GENERATED CODE-->
   <repositories>
     <repository>
       <id>atlassian-public</id>
       <url>https://maven.atlassian.com/repository/public</url>
     </repository>
   </repositories>
+  <!--END OF GENERATED CODE-->
 </project>

--- a/components-starter/camel-jms-starter/pom.xml
+++ b/components-starter/camel-jms-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-jms</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,5 +58,6 @@
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jmx-starter/pom.xml
+++ b/components-starter/camel-jmx-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jmx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-johnzon-starter/pom.xml
+++ b/components-starter/camel-johnzon-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-johnzon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jolt-starter/pom.xml
+++ b/components-starter/camel-jolt-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jolt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-josql-starter/pom.xml
+++ b/components-starter/camel-josql-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-josql</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jpa-starter/pom.xml
+++ b/components-starter/camel-jpa-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-jpa</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,5 +58,6 @@
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jpa_2.0_spec</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jsch-starter/pom.xml
+++ b/components-starter/camel-jsch-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jsch</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jsonpath-starter/pom.xml
+++ b/components-starter/camel-jsonpath-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jsonpath</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jt400-starter/pom.xml
+++ b/components-starter/camel-jt400-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jt400</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-juel-starter/pom.xml
+++ b/components-starter/camel-juel-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-juel</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-jxpath-starter/pom.xml
+++ b/components-starter/camel-jxpath-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-jxpath</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-kafka-starter/pom.xml
+++ b/components-starter/camel-kafka-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-kafka</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-kestrel-starter/pom.xml
+++ b/components-starter/camel-kestrel-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-kestrel</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-krati-starter/pom.xml
+++ b/components-starter/camel-krati-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-krati</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-kubernetes-starter/pom.xml
+++ b/components-starter/camel-kubernetes-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-kubernetes</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-kura-starter/pom.xml
+++ b/components-starter/camel-kura-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-kura</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ldap-starter/pom.xml
+++ b/components-starter/camel-ldap-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ldap</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-leveldb-starter/pom.xml
+++ b/components-starter/camel-leveldb-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-leveldb</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-linkedin-starter/pom.xml
+++ b/components-starter/camel-linkedin-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-linkedin</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-lucene-starter/pom.xml
+++ b/components-starter/camel-lucene-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-lucene</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-lumberjack-starter/pom.xml
+++ b/components-starter/camel-lumberjack-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-lumberjack</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-lzf-starter/pom.xml
+++ b/components-starter/camel-lzf-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-lzf</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mail-starter/pom.xml
+++ b/components-starter/camel-mail-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mail</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-metrics-starter/pom.xml
+++ b/components-starter/camel-metrics-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-metrics</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mina2-starter/pom.xml
+++ b/components-starter/camel-mina2-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mina2</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mllp-starter/pom.xml
+++ b/components-starter/camel-mllp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mllp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mongodb-gridfs-starter/pom.xml
+++ b/components-starter/camel-mongodb-gridfs-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mongodb-gridfs</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mongodb-starter/pom.xml
+++ b/components-starter/camel-mongodb-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mongodb</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mqtt-starter/pom.xml
+++ b/components-starter/camel-mqtt-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mqtt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-msv-starter/pom.xml
+++ b/components-starter/camel-msv-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-msv</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mustache-starter/pom.xml
+++ b/components-starter/camel-mustache-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mustache</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mvel-starter/pom.xml
+++ b/components-starter/camel-mvel-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mvel</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-mybatis-starter/pom.xml
+++ b/components-starter/camel-mybatis-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-mybatis</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-nagios-starter/pom.xml
+++ b/components-starter/camel-nagios-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-nagios</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,7 +46,9 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
+  <!--START OF GENERATED CODE-->
   <repositories>
     <repository>
       <id>jboss.fs</id>
@@ -59,4 +62,5 @@
       </releases>
     </repository>
   </repositories>
+  <!--END OF GENERATED CODE-->
 </project>

--- a/components-starter/camel-nats-starter/pom.xml
+++ b/components-starter/camel-nats-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-nats</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-netty-http-starter/pom.xml
+++ b/components-starter/camel-netty-http-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-netty-http</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-netty-starter/pom.xml
+++ b/components-starter/camel-netty-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-netty</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-netty4-http-starter/pom.xml
+++ b/components-starter/camel-netty4-http-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-netty4-http</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-netty4-starter/pom.xml
+++ b/components-starter/camel-netty4-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-netty4</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ognl-starter/pom.xml
+++ b/components-starter/camel-ognl-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ognl</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-olingo2-starter/pom.xml
+++ b/components-starter/camel-olingo2-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-olingo2</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-openshift-starter/pom.xml
+++ b/components-starter/camel-openshift-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-openshift</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-optaplanner-starter/pom.xml
+++ b/components-starter/camel-optaplanner-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-optaplanner</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-paho-starter/pom.xml
+++ b/components-starter/camel-paho-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-paho</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,7 +46,9 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
+  <!--START OF GENERATED CODE-->
   <repositories>
     <repository>
       <id>eclipse-paho</id>
@@ -55,4 +58,5 @@
       </snapshots>
     </repository>
   </repositories>
+  <!--END OF GENERATED CODE-->
 </project>

--- a/components-starter/camel-pdf-starter/pom.xml
+++ b/components-starter/camel-pdf-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-pdf</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-pgevent-starter/pom.xml
+++ b/components-starter/camel-pgevent-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-pgevent</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-printer-starter/pom.xml
+++ b/components-starter/camel-printer-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-printer</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-protobuf-starter/pom.xml
+++ b/components-starter/camel-protobuf-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-protobuf</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-quartz2-starter/pom.xml
+++ b/components-starter/camel-quartz2-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-quartz2</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-quickfix-starter/pom.xml
+++ b/components-starter/camel-quickfix-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-quickfix</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-rabbitmq-starter/pom.xml
+++ b/components-starter/camel-rabbitmq-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-rabbitmq</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-restlet-starter/pom.xml
+++ b/components-starter/camel-restlet-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-restlet</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,7 +58,9 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
+  <!--START OF GENERATED CODE-->
   <repositories>
     <repository>
       <id>maven-restlet</id>
@@ -63,4 +68,5 @@
       <url>http://maven.restlet.org</url>
     </repository>
   </repositories>
+  <!--END OF GENERATED CODE-->
 </project>

--- a/components-starter/camel-ribbon-starter/pom.xml
+++ b/components-starter/camel-ribbon-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-ribbon</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-rmi-starter/pom.xml
+++ b/components-starter/camel-rmi-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-rmi</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-routebox-starter/pom.xml
+++ b/components-starter/camel-routebox-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-routebox</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-rss-starter/pom.xml
+++ b/components-starter/camel-rss-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-rss</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ruby-starter/pom.xml
+++ b/components-starter/camel-ruby-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ruby</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-rx-starter/pom.xml
+++ b/components-starter/camel-rx-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-rx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-salesforce-starter/pom.xml
+++ b/components-starter/camel-salesforce-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-salesforce</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -61,5 +62,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util-ajax</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-sap-netweaver-starter/pom.xml
+++ b/components-starter/camel-sap-netweaver-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-sap-netweaver</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-saxon-starter/pom.xml
+++ b/components-starter/camel-saxon-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-saxon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-scala-starter/pom.xml
+++ b/components-starter/camel-scala-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-scala</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -55,5 +56,6 @@
       <artifactId>scala-library</artifactId>
       <version>${scala-version}</version>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-schematron-starter/pom.xml
+++ b/components-starter/camel-schematron-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-schematron</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-scr-starter/pom.xml
+++ b/components-starter/camel-scr-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-scr</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-script-starter/pom.xml
+++ b/components-starter/camel-script-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-script</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,7 +46,9 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
+  <!--START OF GENERATED CODE-->
   <repositories>
     <repository>
       <id>servicemix</id>
@@ -53,4 +56,5 @@
       <url>http://svn.apache.org/repos/asf/servicemix/m2-repo</url>
     </repository>
   </repositories>
+  <!--END OF GENERATED CODE-->
 </project>

--- a/components-starter/camel-servicenow-starter/pom.xml
+++ b/components-starter/camel-servicenow-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-servicenow</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-servlet-starter/pom.xml
+++ b/components-starter/camel-servlet-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-servlet</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-servletlistener-starter/pom.xml
+++ b/components-starter/camel-servletlistener-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-servletlistener</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-shiro-starter/pom.xml
+++ b/components-starter/camel-shiro-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-shiro</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-sip-starter/pom.xml
+++ b/components-starter/camel-sip-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-sip</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-sjms-starter/pom.xml
+++ b/components-starter/camel-sjms-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-sjms</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-slack-starter/pom.xml
+++ b/components-starter/camel-slack-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-slack</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-smpp-starter/pom.xml
+++ b/components-starter/camel-smpp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-smpp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-snakeyaml-starter/pom.xml
+++ b/components-starter/camel-snakeyaml-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-snakeyaml</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-snmp-starter/pom.xml
+++ b/components-starter/camel-snmp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-snmp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-soap-starter/pom.xml
+++ b/components-starter/camel-soap-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-soap</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-solr-starter/pom.xml
+++ b/components-starter/camel-solr-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-solr</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spark-starter/pom.xml
+++ b/components-starter/camel-spark-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spark</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-splunk-starter/pom.xml
+++ b/components-starter/camel-splunk-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-splunk</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-batch-starter/pom.xml
+++ b/components-starter/camel-spring-batch-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-batch</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-boot-starter/pom.xml
+++ b/components-starter/camel-spring-boot-starter/pom.xml
@@ -36,6 +36,7 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>
@@ -46,10 +47,13 @@
           <artifactId>logback-core</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-dm-starter/pom.xml
+++ b/components-starter/camel-spring-dm-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-spring-dm</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-integration-starter/pom.xml
+++ b/components-starter/camel-spring-integration-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-integration</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-javaconfig-starter/pom.xml
+++ b/components-starter/camel-spring-javaconfig-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-javaconfig</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-ldap-starter/pom.xml
+++ b/components-starter/camel-spring-ldap-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-ldap</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-redis-starter/pom.xml
+++ b/components-starter/camel-spring-redis-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-redis</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-security-starter/pom.xml
+++ b/components-starter/camel-spring-security-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-security</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-starter/pom.xml
+++ b/components-starter/camel-spring-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-spring-ws-starter/pom.xml
+++ b/components-starter/camel-spring-ws-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-ws</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -56,5 +59,6 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${spring-boot-version}</version>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-sql-starter/pom.xml
+++ b/components-starter/camel-sql-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-sql</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-ssh-starter/pom.xml
+++ b/components-starter/camel-ssh-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-ssh</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-stax-starter/pom.xml
+++ b/components-starter/camel-stax-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-stax</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-stomp-starter/pom.xml
+++ b/components-starter/camel-stomp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-stomp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-stream-starter/pom.xml
+++ b/components-starter/camel-stream-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-stream</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-stringtemplate-starter/pom.xml
+++ b/components-starter/camel-stringtemplate-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-stringtemplate</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-swagger-java-starter/pom.xml
+++ b/components-starter/camel-swagger-java-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-swagger-java</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-syslog-starter/pom.xml
+++ b/components-starter/camel-syslog-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-syslog</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-tagsoup-starter/pom.xml
+++ b/components-starter/camel-tagsoup-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-tagsoup</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-tarfile-starter/pom.xml
+++ b/components-starter/camel-tarfile-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-tarfile</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-telegram-starter/pom.xml
+++ b/components-starter/camel-telegram-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-telegram</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-twitter-starter/pom.xml
+++ b/components-starter/camel-twitter-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-twitter</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-undertow-starter/pom.xml
+++ b/components-starter/camel-undertow-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-undertow</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -49,5 +50,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-univocity-parsers-starter/pom.xml
+++ b/components-starter/camel-univocity-parsers-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-univocity-parsers</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-urlrewrite-starter/pom.xml
+++ b/components-starter/camel-urlrewrite-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-urlrewrite</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-velocity-starter/pom.xml
+++ b/components-starter/camel-velocity-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-velocity</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-vertx-starter/pom.xml
+++ b/components-starter/camel-vertx-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-vertx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-weather-starter/pom.xml
+++ b/components-starter/camel-weather-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-weather</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-websocket-starter/pom.xml
+++ b/components-starter/camel-websocket-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-websocket</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xmlbeans-starter/pom.xml
+++ b/components-starter/camel-xmlbeans-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-xmlbeans</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xmljson-starter/pom.xml
+++ b/components-starter/camel-xmljson-starter/pom.xml
@@ -36,13 +36,16 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-xmljson</artifactId>
       <version>${project.version}</version>
+      <!--START OF GENERATED CODE-->
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -51,5 +54,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xmlrpc-starter/pom.xml
+++ b/components-starter/camel-xmlrpc-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-xmlrpc</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xmlsecurity-starter/pom.xml
+++ b/components-starter/camel-xmlsecurity-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-xmlsecurity</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xmpp-starter/pom.xml
+++ b/components-starter/camel-xmpp-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-xmpp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-xstream-starter/pom.xml
+++ b/components-starter/camel-xstream-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-xstream</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-yammer-starter/pom.xml
+++ b/components-starter/camel-yammer-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-yammer</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-zipfile-starter/pom.xml
+++ b/components-starter/camel-zipfile-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-zipfile</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components-starter/camel-zookeeper-starter/pom.xml
+++ b/components-starter/camel-zookeeper-starter/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>camel-zookeeper</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core-starter</artifactId>
@@ -45,5 +46,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
+    <!--END OF GENERATED CODE-->
   </dependencies>
 </project>

--- a/components/camel-jsch/src/main/docs/scp-component.adoc
+++ b/components/camel-jsch/src/main/docs/scp-component.adoc
@@ -67,7 +67,7 @@ The SCP component supports 1 options which are listed below.
 
 
 // endpoint options: START
-The SCP component supports 21 endpoint options which are listed below:
+The SCP component supports 22 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -89,7 +89,7 @@ The SCP component supports 21 endpoint options which are listed below:
 | timeout | advanced | 30000 | int | Sets the data timeout for waiting for reply Used only by FTPClient
 | knownHostsFile | security |  | String | Sets the known_hosts file so that the jsch endpoint can do host key verification.
 | password | security |  | String | Password to use for login
-| preferredAuthentications | security |  | String | Set the authentication methods that JSch will be allowed to use, e.g. gssapi-with-mic,publickey,keyboard-interactive,password
+| preferredAuthentications | security |  | String | Set a comma separated list of authentications that will be used in order of preference. Possible authentication methods are defined by JCraft JSCH. Some examples include: gssapi-with-micpublickeykeyboard-interactivepassword If not specified the JSCH and/or system defaults will be used.
 | privateKeyFile | security |  | String | Set the private key file to that the SFTP endpoint can do private key verification.
 | privateKeyFilePassphrase | security |  | String | Set the private key file passphrase to that the SFTP endpoint can do private key verification.
 | username | security |  | String | Username to use for login


### PR DESCRIPTION
Looking for a review because it's a bit ugly.

The aim is not to get the pom.xml of the starters overwritten at each build, and so be able to define eg. test dependencies and other stuff.

To do so, I changed the generator to add a *start* and a *end* markers before writing anything to the pom. Whenever a pom.xml is already present in the starter, the plugin now loads it and remove anything between the markers, in order to get a clean base pom. The plugin then redoes the work on top of it.

This way, custom changes are not erased. But maybe there is a cleaner solution to this. Thoughts?