### PR TITLE
Support CamelHttpUri inside netty4-http Producer similar to http4 component

### DIFF
--- a/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
+++ b/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
@@ -218,6 +218,11 @@ request.
 |=======================================================================
 |Name |Type |Description
 
+|`CamelHttpUri` |`String` |(Since Camel 2.19.0) URI to call. Will override existing URI set directly on
+the endpoint.  This uri is the uri of the http server to call. Its not the same as the Camel endpoint uri,
+where you can configure endpoint options such as security etc. This header does not support that, its only
+the uri of the http server.
+
 |`CamelHttpMethod` |`String` |Allow to control what HTTP method to use such as GET, POST, TRACE etc.
 The type can also be a `io.netty.handler.codec.http.HttpMethod`
 instance.

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpHelper.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpHelper.java
@@ -186,6 +186,9 @@ public final class NettyHttpHelper {
     public static String createURL(Exchange exchange, NettyHttpEndpoint endpoint) throws URISyntaxException {
         // rest producer may provide an override url to be used which we should discard if using (hence the remove)
         String uri = (String) exchange.getIn().removeHeader(Exchange.REST_HTTP_URI);
+        if (uri == null && !(endpoint.getConfiguration().isBridgeEndpoint())) {
+            uri = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
+        }
         if (uri == null) {
             uri = endpoint.getEndpointUri();
         }

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpHelperTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpHelperTest.java
@@ -1,0 +1,75 @@
+package org.apache.camel.component.netty4.http;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class NettyHttpHelperTest {
+
+    @Test
+    public void createURLShouldReturnTheHeaderURIIfNotBridgeEndpoint() throws URISyntaxException {
+        String url = NettyHttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", null),
+                createNettyHttpEndpoint(false, "http://camel.apache.org"));
+
+        assertEquals("http://apache.org", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIIfBridgeEndpoint() throws URISyntaxException {
+        String url = NettyHttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", null),
+                createNettyHttpEndpoint(true, "http://camel.apache.org"));
+
+        assertEquals("http://camel.apache.org", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIWithHeaderHttpPathAndAddOneSlash() throws URISyntaxException {
+        String url = NettyHttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader(null, "search"),
+                createNettyHttpEndpoint(true, "http://www.google.com"));
+
+        assertEquals("http://www.google.com/search", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIWithHeaderHttpPathAndRemoveOneSlash() throws URISyntaxException {
+        String url = NettyHttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader(null, "/search"),
+                createNettyHttpEndpoint(true, "http://www.google.com/"));
+
+        assertEquals("http://www.google.com/search", url);
+    }
+
+    private Exchange createExchangeWithOptionalCamelHttpUriHeader(String endpointURI, String httpPath) throws URISyntaxException {
+        CamelContext context = new DefaultCamelContext();
+        DefaultExchange exchange = new DefaultExchange(context);
+        Message inMsg = exchange.getIn();
+        if (endpointURI != null) {
+            inMsg.setHeader(Exchange.HTTP_URI, endpointURI);
+        }
+        if (httpPath != null) {
+            inMsg.setHeader(Exchange.HTTP_PATH, httpPath);
+        }
+
+        return exchange;
+    }
+
+    private NettyHttpEndpoint createNettyHttpEndpoint(boolean bridgeEndpoint, String endpointURI) throws URISyntaxException {
+        NettyHttpConfiguration configuration = new NettyHttpConfiguration();
+        configuration.setBridgeEndpoint(bridgeEndpoint);
+        return new NettyHttpEndpoint(endpointURI, null, configuration);
+    }
+
+}


### PR DESCRIPTION
This allows you to override the endpoint location for the NettyHttpProducer.  Similar to how the http4 component works.