### PR TITLE
add prefix when initialize the s3endpoint and bucket check. 

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Endpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Endpoint.java
@@ -113,8 +113,10 @@ public class S3Endpoint extends ScheduledPollEndpoint {
         String bucketName = getConfiguration().getBucketName();
         LOG.trace("Querying whether bucket [{}] already exists...", bucketName);
 
+        String prefix = getConfiguration().getPrefix();
+
         try {
-            s3Client.listObjects(new ListObjectsRequest(bucketName, null, null, null, 0));
+            s3Client.listObjects(new ListObjectsRequest(bucketName, prefix, null, null, 0));
             LOG.trace("Bucket [{}] already exists", bucketName);
             return;
         } catch (AmazonServiceException ase) {


### PR DESCRIPTION
Use Case:
When AWS access key only has permission to specific path under bucket, the bucket check will fail.