### PR TITLE
CAMEL-10409: Prevent double release of request

### DIFF
--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpProducer.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpProducer.java
@@ -86,19 +86,6 @@ public class NettyHttpProducer extends NettyProducer {
             }
         }
 
-        // need to release the request when we are done
-        exchange.addOnCompletion(new SynchronizationAdapter() {
-            @Override
-            public void onDone(Exchange exchange) {
-                if (request instanceof ReferenceCounted) {
-                    if (((ReferenceCounted) request).refCnt() > 0) {
-                        log.debug("Releasing Netty HttpRequest ByteBuf");
-                        ReferenceCountUtil.release(request);
-                    }
-                }
-            }
-        });
-
         return request;
     }
 

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureAppender.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureAppender.java
@@ -1,0 +1,15 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2014, PostgreSQL Global Development Group
+* Copyright (c) 2004, Open Cloud Limited.
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.apache.camel.component.netty4.http;
+
+/**
+ * @author vit@tym.im
+ */
+public class LogCaptureAppender {
+}

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureAppender.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureAppender.java
@@ -1,15 +1,65 @@
-/*-------------------------------------------------------------------------
-*
-* Copyright (c) 2003-2014, PostgreSQL Global Development Group
-* Copyright (c) 2004, Open Cloud Limited.
-*
-*
-*-------------------------------------------------------------------------
-*/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.netty4.http;
 
+import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
 /**
- * @author vit@tym.im
  */
-public class LogCaptureAppender {
+@Plugin(name = "LogCaptureAppender", category = "Core", elementType = "appender", printObject = true)
+public class LogCaptureAppender extends AbstractAppender {
+    private static final Deque<LogEvent> LOG_EVENTS = new ArrayDeque<>();
+
+    public LogCaptureAppender(String name, Filter filter, Layout<? extends Serializable> layout) {
+        super(name, filter, layout);
+    }
+
+    public LogCaptureAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions) {
+        super(name, filter, layout, ignoreExceptions);
+    }
+
+    @PluginFactory
+    public static LogCaptureAppender createAppender(@PluginAttribute("name") final String name,
+                                                    @PluginElement("Filter") final Filter filter) {
+        return new LogCaptureAppender(name, filter, null);
+    }
+
+    @Override
+    public void append(LogEvent logEvent) {
+        LOG_EVENTS.add(logEvent);
+    }
+
+    public static void reset() {
+        LOG_EVENTS.clear();
+    }
+
+    public static Collection<LogEvent> getEvents() {
+        return LOG_EVENTS;
+    }
 }

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureTest.java
@@ -1,15 +1,35 @@
-/*-------------------------------------------------------------------------
-*
-* Copyright (c) 2003-2014, PostgreSQL Global Development Group
-* Copyright (c) 2004, Open Cloud Limited.
-*
-*
-*-------------------------------------------------------------------------
-*/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.netty4.http;
 
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
- * @author vit@tym.im
+ * This test ensures LogCaptureAppender is configured properly
  */
 public class LogCaptureTest {
+    @Test
+    public void testCapture() {
+        InternalLoggerFactory.getInstance(ResourceLeakDetector.class).error("testError");
+        Assert.assertFalse(LogCaptureAppender.getEvents().isEmpty());
+        LogCaptureAppender.reset();
+    }
 }

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/LogCaptureTest.java
@@ -1,0 +1,15 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2014, PostgreSQL Global Development Group
+* Copyright (c) 2004, Open Cloud Limited.
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.apache.camel.component.netty4.http;
+
+/**
+ * @author vit@tym.im
+ */
+public class LogCaptureTest {
+}

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyRequestManagementTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyRequestManagementTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests https://issues.apache.org/jira/browse/CAMEL-10409
+ */
+public class NettyRequestManagementTest extends BaseNettyTest {
+
+    @Test
+    public void testBufferManagement() {
+        Exchange exchange = template.send("direct:start", e -> e.getIn().setBody("World"));
+        Assert.assertEquals("Bye World", exchange.getIn().getBody(String.class));
+        exchange.getProperty("buffer", ByteBuf.class).release();
+    }
+
+    private static void requestBuffer(Exchange exchange) {
+        exchange.setProperty("buffer", PooledByteBufAllocator.DEFAULT.directBuffer());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("netty4-http:http://0.0.0.0:{{port}}/foo")
+                        .transform(body().prepend("Bye "));
+
+                from("direct:start")
+                        .to("netty4-http:http://localhost:{{port}}/foo?synchronous=true")
+                        .process(NettyRequestManagementTest::requestBuffer);
+            }
+        };
+    }
+}

--- a/components/camel-netty4-http/src/test/resources/log4j2.properties
+++ b/components/camel-netty4-http/src/test/resources/log4j2.properties
@@ -15,6 +15,7 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
+configuration.packages=org.apache.camel.component.netty4.http
 appender.file.type = File
 appender.file.name = file
 appender.file.fileName = target/camel-netty4-http-test.log
@@ -24,5 +25,11 @@ appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
 appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+appender.capture.type=LogCaptureAppender
+appender.capture.name=capture
+
+logger.leak.name = io.netty.util.ResourceLeakDetector
+logger.leak.appenderRef.capture.ref = capture
+
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = file


### PR DESCRIPTION
Please also merge into 2.18 as it's quite important problem that may lead to buffer corruption (buffer is being incorrectly reused) 