### PR TITLE
CAMEL-9570:  Blueprint service proxies aren't used

### DIFF
--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintCamelContext.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintCamelContext.java
@@ -179,7 +179,7 @@ public class BlueprintCamelContext extends DefaultCamelContext implements Servic
         if (!event.isReplay() && this.getBundleContext().getBundle().getBundleId() == event.getBundle().getBundleId()) {
             if (event.getType() == BlueprintEvent.CREATED) {
                 try {
-                    this.start();
+                    this.maybeStart();
                 } catch (Exception startEx) {
                     LOG.error("Error occurred starting Camel: " + this, startEx);
                 }

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
@@ -272,7 +272,7 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
             if (pc.getLocations() == null) {
                 String[] ids = parser.lookupPropertyPlaceholderIds();
                 for (int i = 0; i < ids.length; i++) {
-                    if (!ids[i].startsWith( "blueprint:")) {
+                    if (!ids[i].startsWith("blueprint:")) {
                         ids[i] = "blueprint:" + ids[i];
                     }
                 }


### PR DESCRIPTION
This PR has two main pieces.  First, the CamelDependenciesFinder was removed from the CamelNamespaceHandler.  This code caused the issue described in CAMEL-9570 as well as CAMEL-10394.  The net effect of removing this class is the CamelContext may attempt to start when a service isn't available because the reference hasn't been specified in the XML.  This is better than what happens today which is service references sometimes get registered for services that don't exist - therefore, starting Blueprint Context times-out waiting for service references.  This one actually bit me 18-mo ago with a customer - I'm just didn't know at the time what was causing it.

The second piece of the PR is changing the BlueprintCamelContext so it starts after the BlueprintContainer is created (on the BlueprintEvent.CREATED).  This fixes some startup issues.  Basically what was happening is if the serviceChanged method (which previously was used to start the camel context) threw a RuntimeException, the Karaf container would spin until a stack overflow occurred.  I didn't see this behavior when the context is started after the BlueprintContainer is fully initialized.

The only thing I changed in the CamelContextFactoryBean was removing a space that caused a Checkstyle error.

