### PR TITLE
Add allowEmpty endpoint option

### DIFF
--- a/components/camel-git/src/main/docs/git-component.adoc
+++ b/components/camel-git/src/main/docs/git-component.adoc
@@ -40,7 +40,7 @@ The Git component has no options.
 
 
 // endpoint options: START
-The Git component supports 13 endpoint options which are listed below:
+The Git component supports 14 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -57,6 +57,7 @@ The Git component supports 13 endpoint options which are listed below:
 | type | consumer |  | GitType | The consumer type
 | exceptionHandler | consumer (advanced) |  | ExceptionHandler | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN/ERROR level and ignored.
 | exchangePattern | consumer (advanced) |  | ExchangePattern | Sets the exchange pattern when the consumer creates an exchange.
+| allowEmpty | producer | true | boolean | The flag to manage empty git commits
 | operation | producer |  | String | The operation to do on the repository
 | synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
 |=======================================================================
@@ -85,6 +86,9 @@ Message Headers
 |CamelGitCommitEmail |`null` |String |Producer |The commit email in a commit operation
 
 |CamelGitCommitId |`null` |String |Producer |The commit id
+
+|CamelGitAlowEmpty |`null` |Boolean |Producer |The flag to manage empty git commits
+
 |=======================================================================
 
 [[Git-ProducerExample]]

--- a/components/camel-git/src/main/java/org/apache/camel/component/git/GitConstants.java
+++ b/components/camel-git/src/main/java/org/apache/camel/component/git/GitConstants.java
@@ -28,4 +28,6 @@ public interface GitConstants {
     String GIT_COMMIT_EMAIL = "CamelGitCommitEmail";
     
     String GIT_COMMIT_ID = "CamelGitCommitId";
+
+    String GIT_ALLOW_EMPTY = "CamelGitAllowEmpty";
 }

--- a/components/camel-git/src/main/java/org/apache/camel/component/git/GitEndpoint.java
+++ b/components/camel-git/src/main/java/org/apache/camel/component/git/GitEndpoint.java
@@ -61,6 +61,11 @@ public class GitEndpoint extends DefaultEndpoint {
     @UriParam
     private String remoteName;
 
+    @UriParam
+    // Set to true For backward compatibility , better to set to false (native git behavior)
+    @Metadata(defaultValue = "true", label = "producer")
+    private boolean allowEmpty = true;
+
     @UriParam(enums = "clone,init,add,remove,commit,commitAll,createBranch,deleteBranch,createTag,deleteTag,status,log,push,pull,showBranches,cherryPick", label = "producer")
     private String operation;
 
@@ -190,4 +195,14 @@ public class GitEndpoint extends DefaultEndpoint {
         this.remoteName = remoteName;
     }
 
+    /**
+     * The flag to manage empty git commits
+     */
+    public boolean isAllowEmpty() {
+        return allowEmpty;
+    }
+
+    public void setAllowEmpty(boolean allowEmpty) {
+        this.allowEmpty = allowEmpty;
+    }
 }

--- a/components/camel-git/src/main/java/org/apache/camel/component/git/producer/GitProducer.java
+++ b/components/camel-git/src/main/java/org/apache/camel/component/git/producer/GitProducer.java
@@ -83,7 +83,7 @@ public class GitProducer extends DefaultProducer {
         }
 
         switch (operation) {
-        
+
         case GitOperation.CLONE_OPERATION:
             doClone(exchange, operation);
             break;
@@ -99,7 +99,7 @@ public class GitProducer extends DefaultProducer {
         case GitOperation.CHERRYPICK_OPERATION:
             doCherryPick(exchange, operation);
             break;
-            
+
         case GitOperation.REMOVE_OPERATION:
             doRemove(exchange, operation);
             break;
@@ -143,11 +143,11 @@ public class GitProducer extends DefaultProducer {
         case GitOperation.DELETE_TAG_OPERATION:
             doDeleteTag(exchange, operation);
             break;
-            
+
         case GitOperation.SHOW_BRANCHES:
             doShowBranches(exchange, operation);
             break;
-                
+
         default:
             throw new IllegalArgumentException("Unsupported operation " + operation);
         }
@@ -242,19 +242,24 @@ public class GitProducer extends DefaultProducer {
         } else {
             throw new IllegalArgumentException("Commit message must be specified to execute " + operation);
         }
-        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME)) 
+        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME))
                 && ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_EMAIL))) {
             username = exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME, String.class);
             email = exchange.getIn().getHeader(GitConstants.GIT_COMMIT_EMAIL, String.class);
         }
+        boolean allowEmpty = endpoint.isAllowEmpty();
+        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_ALLOW_EMPTY))) {
+            allowEmpty = exchange.getIn().getHeader(GitConstants.GIT_ALLOW_EMPTY, Boolean.class);
+        }
+
         try {
             if (ObjectHelper.isNotEmpty(endpoint.getBranchName())) {
                 git.checkout().setCreateBranch(false).setName(endpoint.getBranchName()).call();
             }
             if (ObjectHelper.isNotEmpty(username) && ObjectHelper.isNotEmpty(email)) {
-                git.commit().setCommitter(username, email).setMessage(commitMessage).call();
+                git.commit().setAllowEmpty(allowEmpty).setCommitter(username, email).setMessage(commitMessage).call();
             } else {
-                git.commit().setMessage(commitMessage).call();
+                git.commit().setAllowEmpty(allowEmpty).setMessage(commitMessage).call();
             }
         } catch (Exception e) {
             LOG.error("There was an error in Git " + operation + " operation");
@@ -271,19 +276,24 @@ public class GitProducer extends DefaultProducer {
         } else {
             throw new IllegalArgumentException("Commit message must be specified to execute " + operation);
         }
-        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME)) 
+        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME))
                 && ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_COMMIT_EMAIL))) {
             username = exchange.getIn().getHeader(GitConstants.GIT_COMMIT_USERNAME, String.class);
             email = exchange.getIn().getHeader(GitConstants.GIT_COMMIT_EMAIL, String.class);
         }
+        boolean allowEmpty = endpoint.isAllowEmpty();
+        if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(GitConstants.GIT_ALLOW_EMPTY))) {
+            allowEmpty = exchange.getIn().getHeader(GitConstants.GIT_ALLOW_EMPTY, Boolean.class);
+        }
+
         try {
             if (ObjectHelper.isNotEmpty(endpoint.getBranchName())) {
                 git.checkout().setCreateBranch(false).setName(endpoint.getBranchName()).call();
             }
             if (ObjectHelper.isNotEmpty(username) && ObjectHelper.isNotEmpty(email)) {
-                git.commit().setAll(true).setCommitter(username, email).setMessage(commitMessage).call();
+                git.commit().setAllowEmpty(allowEmpty).setAll(true).setCommitter(username, email).setMessage(commitMessage).call();
             } else {
-                git.commit().setAll(true).setMessage(commitMessage).call();
+                git.commit().setAllowEmpty(allowEmpty).setAll(true).setMessage(commitMessage).call();
             }
         } catch (Exception e) {
             LOG.error("There was an error in Git " + operation + " operation");
@@ -410,7 +420,7 @@ public class GitProducer extends DefaultProducer {
             throw e;
         }
     }
-    
+
     protected void doShowBranches(Exchange exchange, String operation) throws Exception {
         List<Ref> result = null;
         try {
@@ -421,7 +431,7 @@ public class GitProducer extends DefaultProducer {
         }
         exchange.getOut().setBody(result);
     }
-    
+
     protected void doCherryPick(Exchange exchange, String operation) throws Exception {
         CherryPickResult result = null;
         String commitId = null;


### PR DESCRIPTION
Component "camel-git"
Just added a "allowEmpty" option to the endpoint to manage empty commits. I initilized this option to true for backward compatibility reason whether it sounds more natural to set it to false to match native git behaviour. I also create the corresponding header that take precedence on the property.

I tried to create an issue with this but at that time the site : http://issues.apache.org/jira/browse/CAMEL were Offline.