### PR TITLE
CAMEL-10507  Make TypeReference inline anonymous classes constant

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/TypeReferences.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/TypeReferences.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.salesforce.api;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.apache.camel.component.salesforce.api.dto.Limits.Operation;
+import org.apache.camel.component.salesforce.api.dto.Limits.Usage;
+import org.apache.camel.component.salesforce.api.dto.RestError;
+import org.apache.camel.component.salesforce.api.dto.SearchResult;
+import org.apache.camel.component.salesforce.api.dto.Version;
+import org.apache.camel.component.salesforce.api.dto.analytics.reports.RecentReport;
+import org.apache.camel.component.salesforce.api.dto.analytics.reports.ReportInstance;
+
+/**
+ * Class that holds {@link TypeReference} instances needed for Jackson mapper to support generics.
+ */
+public final class TypeReferences {
+
+    public static final TypeReference<Map<Operation, Usage>> USAGES_TYPE = new TypeReference<Map<Operation, Usage>>() {
+    };
+
+    public static final TypeReference<List<RestError>> REST_ERROR_LIST_TYPE = new TypeReference<List<RestError>>() {
+    };
+
+    public static final TypeReference<List<ReportInstance>> REPORT_INSTANCE_LIST_TYPE = new TypeReference<List<ReportInstance>>() {
+    };
+
+    public static final TypeReference<List<RecentReport>> RECENT_REPORT_LIST_TYPE = new TypeReference<List<RecentReport>>() {
+    };
+
+    public static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<List<String>>() {
+    };
+
+    public static final TypeReference<List<Version>> VERSION_LIST_TYPE = new TypeReference<List<Version>>() {
+    };
+
+    public static final TypeReference<List<SearchResult>> SEARCH_RESULT_TYPE = new TypeReference<List<SearchResult>>() {
+    };
+
+    private TypeReferences() {
+        // not meant for instantiation, only for TypeReference constants
+    }
+
+}

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/Limits.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/Limits.java
@@ -25,11 +25,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import org.apache.camel.component.salesforce.api.TypeReferences;
 import org.apache.camel.component.salesforce.api.dto.Limits.LimitsDeserializer;
 
 /**
@@ -43,14 +43,11 @@ public final class Limits implements Serializable {
 
     public static final class LimitsDeserializer extends JsonDeserializer {
 
-        private static final TypeReference<Map<Operation, Usage>> USAGES_TYPE = new TypeReference<Map<Operation, Usage>>() {
-        };
-
         @Override
         public Object deserialize(final JsonParser parser, final DeserializationContext context)
                 throws IOException, JsonProcessingException {
 
-            final Map<Operation, Usage> usages = parser.readValueAs(USAGES_TYPE);
+            final Map<Operation, Usage> usages = parser.readValueAs(TypeReferences.USAGES_TYPE);
 
             return new Limits(usages);
         }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultAnalyticsApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultAnalyticsApiClient.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
 import org.apache.camel.component.salesforce.api.SalesforceException;
+import org.apache.camel.component.salesforce.api.TypeReferences;
 import org.apache.camel.component.salesforce.api.dto.RestError;
 import org.apache.camel.component.salesforce.api.dto.analytics.reports.AsyncReportResults;
 import org.apache.camel.component.salesforce.api.dto.analytics.reports.RecentReport;
@@ -67,15 +68,11 @@ public class DefaultAnalyticsApiClient extends AbstractClientBase implements Ana
 
         doHttpRequest(request, new ClientResponseCallback() {
             @Override
-            @SuppressWarnings("unchecked")
             public void onResponse(InputStream response, SalesforceException ex) {
                 List<RecentReport> recentReports = null;
                 if (response != null) {
                     try {
-                        recentReports = unmarshalResponse(response, request,
-                                new TypeReference<List<RecentReport>>() {
-                                }
-                        );
+                        recentReports = unmarshalResponse(response, request, TypeReferences.RECENT_REPORT_LIST_TYPE);
                     } catch (SalesforceException e) {
                         ex = e;
                     }
@@ -180,15 +177,11 @@ public class DefaultAnalyticsApiClient extends AbstractClientBase implements Ana
 
         doHttpRequest(request, new ClientResponseCallback() {
             @Override
-            @SuppressWarnings("unchecked")
             public void onResponse(InputStream response, SalesforceException ex) {
                 List<ReportInstance> reportInstances = null;
                 if (response != null) {
                     try {
-                        reportInstances = unmarshalResponse(response, request,
-                                new TypeReference<List<ReportInstance>>() {
-                                }
-                        );
+                        reportInstances = unmarshalResponse(response, request, TypeReferences.REPORT_INSTANCE_LIST_TYPE);
                     } catch (SalesforceException e) {
                         ex = e;
                     }
@@ -261,9 +254,7 @@ public class DefaultAnalyticsApiClient extends AbstractClientBase implements Ana
         try {
             if (responseContent != null) {
                 // unmarshal RestError
-                final List<RestError> errors = objectMapper.readValue(responseContent,
-                        new TypeReference<List<RestError>>() {
-                        });
+                final List<RestError> errors = objectMapper.readValue(responseContent, TypeReferences.REST_ERROR_LIST_TYPE);
                 return new SalesforceException(errors, statusCode);
             }
         } catch (UnsupportedEncodingException e) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.XStream;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.SalesforceMultipleChoicesException;
+import org.apache.camel.component.salesforce.api.TypeReferences;
 import org.apache.camel.component.salesforce.api.dto.RestError;
 import org.apache.camel.component.salesforce.api.utils.JsonUtils;
 import org.apache.camel.component.salesforce.internal.PayloadFormat;
@@ -100,8 +101,7 @@ public class DefaultRestClient extends AbstractClientBase implements RestClient 
                 // return list of choices as error message for 300
                 if (statusCode == HttpStatus.MULTIPLE_CHOICES_300) {
                     if (PayloadFormat.JSON.equals(format)) {
-                        choices = objectMapper.readValue(responseContent, new TypeReference<List<String>>() {
-                        });
+                        choices = objectMapper.readValue(responseContent, TypeReferences.STRING_LIST_TYPE);
                     } else {
                         RestChoices restChoices = new RestChoices();
                         xStream.fromXML(responseContent, restChoices);
@@ -111,10 +111,7 @@ public class DefaultRestClient extends AbstractClientBase implements RestClient 
                 } else {
                     final List<RestError> restErrors;
                     if (PayloadFormat.JSON.equals(format)) {
-                        restErrors = objectMapper.readValue(
-                                responseContent, new TypeReference<List<RestError>>() {
-                                }
-                        );
+                        restErrors = objectMapper.readValue(responseContent, TypeReferences.REST_ERROR_LIST_TYPE);
                     } else {
                         RestErrors errors = new RestErrors();
                         xStream.fromXML(responseContent, errors);

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/JsonRestProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/JsonRestProcessor.java
@@ -30,6 +30,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.salesforce.SalesforceEndpoint;
 import org.apache.camel.component.salesforce.api.SalesforceException;
+import org.apache.camel.component.salesforce.api.TypeReferences;
 import org.apache.camel.component.salesforce.api.dto.AbstractDTOBase;
 import org.apache.camel.component.salesforce.api.dto.CreateSObjectResult;
 import org.apache.camel.component.salesforce.api.dto.GlobalObjects;
@@ -38,7 +39,6 @@ import org.apache.camel.component.salesforce.api.dto.RestResources;
 import org.apache.camel.component.salesforce.api.dto.SObjectBasicInfo;
 import org.apache.camel.component.salesforce.api.dto.SObjectDescription;
 import org.apache.camel.component.salesforce.api.dto.SearchResult;
-import org.apache.camel.component.salesforce.api.dto.Version;
 import org.apache.camel.component.salesforce.api.utils.JsonUtils;
 import org.eclipse.jetty.util.StringUtil;
 
@@ -65,8 +65,7 @@ public class JsonRestProcessor extends AbstractRestProcessor {
         switch (operationName) {
         case GET_VERSIONS:
             // handle in built response types
-            exchange.setProperty(RESPONSE_TYPE, new TypeReference<List<Version>>() {
-            });
+            exchange.setProperty(RESPONSE_TYPE, TypeReferences.VERSION_LIST_TYPE);
             break;
 
         case GET_RESOURCES:
@@ -101,8 +100,7 @@ public class JsonRestProcessor extends AbstractRestProcessor {
 
         case SEARCH:
             // handle known response type
-            exchange.setProperty(RESPONSE_TYPE, new TypeReference<List<SearchResult>>() {
-            });
+            exchange.setProperty(RESPONSE_TYPE, TypeReferences.SEARCH_RESULT_TYPE);
             break;
 
         case LIMITS:


### PR DESCRIPTION
Created a class (o.a.c.c.s.a.TypeReferences) to hold any TypeReferences
as constants and replaced all usage with the constant values.