### PR TITLE
BreadcrumbId and SoapHeader 

### DIFF
--- a/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
+++ b/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
@@ -93,7 +93,7 @@ The Spring WebService component has no options.
 
 
 // endpoint options: START
-The Spring WebService component supports 23 endpoint options which are listed below:
+The Spring WebService component supports 24 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -110,6 +110,7 @@ The Spring WebService component supports 23 endpoint options which are listed be
 | sslContextParameters | consumer |  | SSLContextParameters | To configure security using SSLContextParameters
 | exceptionHandler | consumer (advanced) |  | ExceptionHandler | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN/ERROR level and ignored.
 | exchangePattern | consumer (advanced) |  | ExchangePattern | Sets the exchange pattern when the consumer creates an exchange.
+| allowResponseHeaderOverride | producer | false | boolean | Option to override soap response header in in/out exchange with header info from the actual service layer. If the invoked service appends or rewrites the soap header this option when set to true allows the modified soap header to be overwritten in in/out message headers
 | faultAction | producer |  | URI | Signifies the value for the faultAction response WS-Addressing Fault Action header that is provided by the method.
 | faultTo | producer |  | URI | Signifies the value for the faultAction response WS-Addressing FaultTo header that is provided by the method.
 | messageFactory | producer |  | WebServiceMessageFactory | Option to provide a custom WebServiceMessageFactory. For example when you want Apache Axiom to handle web service messages instead of SAAJ.

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
@@ -70,6 +70,8 @@ public class SpringWebserviceConfiguration {
     private MessageIdStrategy messageIdStrategy;
     @UriParam(label = "producer")
     private int timeout = -1;
+    @UriParam(label = "producer")
+    private boolean allowResponseHeaderOverride;
 
     /* Consumer configuration */
     @UriParam(label = "consumer")
@@ -380,5 +382,24 @@ public class SpringWebserviceConfiguration {
     public void setMessageIdStrategy(MessageIdStrategy messageIdStrategy) {
         this.messageIdStrategy = messageIdStrategy;
     }
-    
+
+    /**
+     * @return boolean - true, will override header with spring-ws response message header
+     */
+    public boolean isAllowResponseHeaderOverride() {
+        return allowResponseHeaderOverride;
+    }
+
+    /**
+     * Option to override soap response header in in/out exchange with header info from the actual service layer.
+     * If the invoked service appends or rewrites the soap header this option when set to true, allows the modified
+     * soap header to be overwritten in in/out message headers
+     * 
+     * @param allowResponseHeaderOverride
+     *            - true, will override header with spring-ws response message header
+     */
+    public void setAllowResponseHeaderOverride(boolean allowResponseHeaderOverride) {
+        this.allowResponseHeaderOverride = allowResponseHeaderOverride;
+    }
+
 }

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/filter/impl/BasicMessageFilter.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/filter/impl/BasicMessageFilter.java
@@ -36,7 +36,6 @@ import org.springframework.ws.soap.SoapMessage;
  * instance.
  */
 public class BasicMessageFilter implements MessageFilter {
-    private static final String BREADCRUMB_ID = "BreadcrumbId";
 
     @Override
     public void filterProducer(Exchange exchange, WebServiceMessage response) {
@@ -103,8 +102,14 @@ public class BasicMessageFilter implements MessageFilter {
         headerKeySet.remove(SpringWebserviceConstants.SPRING_WS_ADDRESSING_PRODUCER_REPLY_TO);
         headerKeySet.remove(SpringWebserviceConstants.SPRING_WS_ADDRESSING_CONSUMER_FAULT_ACTION);
         headerKeySet.remove(SpringWebserviceConstants.SPRING_WS_ADDRESSING_CONSUMER_OUTPUT_ACTION);
+        // This gets repeated again in the below 'for loop' and gets added as attribute to soapenv:header. 
+        // This would have already been processed in SpringWebserviceProducer/Consumer instance.
+        headerKeySet.remove(SpringWebserviceConstants.SPRING_WS_SOAP_HEADER);
 
-        headerKeySet.remove(BREADCRUMB_ID);
+        // Replaced local constant 'BreadcrumbId' with the actual constant key in header 'breadcrumbId'
+        // from org.apache.camel.Exchange.BREADCRUMB_ID. Because of this case mismatch, this key never
+        // gets removed from header rather gets added to soapHeader all the time.
+        headerKeySet.remove(Exchange.BREADCRUMB_ID);
 
         for (String name : headerKeySet) {
             Object value = headers.get(name);

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/filter/impl/BasicMessageFilterTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/filter/impl/BasicMessageFilterTest.java
@@ -92,7 +92,7 @@ public class BasicMessageFilterTest extends ExchangeTestSupport {
         exchange.getOut().getHeaders().put(SpringWebserviceConstants.SPRING_WS_ADDRESSING_CONSUMER_OUTPUT_ACTION, "mustBeRemoved");
         exchange.getOut().getHeaders().put(SpringWebserviceConstants.SPRING_WS_ENDPOINT_URI, "mustBeRemoved");
 
-        exchange.getOut().getHeaders().put("BreadcrumbId", "mustBeRemoved");
+        exchange.getOut().getHeaders().put("breadcrumbId", "mustBeRemoved");
 
         filter.filterConsumer(exchange, message);
 


### PR DESCRIPTION
1. Case mismatch - BreadcrumbId - Replaced with the source from org.apache.camel.Exchange. Actual header constant is breadcrumbId whereas the one that is mentioned in this class is BreadcrumbId, so that it never gets removed from the header.

2. Though SpringWebserviceConstants.SPRING_WS_SOAP_HEADER gets processed in producer and consumer, it is again being processed in 'for loop' in BasicMessageFilter, so that this key and value goes as attributes in the soapHeader which is already constructed.

3. An option (allowResponseHeaderOverride) added to allow soap header to be overwritten in in/out message in ws-producer from the soapHeader of underlying spring web service. Currently there is no way to replace this header from spring web service. This option is added to give room for the header part to be overwritten when the actual spring web service appends or re-writes something in the soap header part.