### PR TITLE
CAMEL-10515 - Fix test on Windows

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/component/dataset/FileDataSetProducerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/dataset/FileDataSetProducerTest.java
@@ -16,19 +16,29 @@
  */
 package org.apache.camel.component.dataset;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import javax.naming.Context;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @version 
  */
 public class FileDataSetProducerTest extends ContextTestSupport {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
     protected FileDataSet dataSet;
 
-    final String testDataFileName = "src/test/data/file-dataset-test.txt";
     final String testPayload = String.format("Line 1%nLine 2%nLine 3%nLine 4%nLine 5%nLine 6%nLine 7%nLine 8%nLine 9%nLine 10%n");
 
     final String sourceUri = "direct://source";
@@ -56,9 +66,17 @@ public class FileDataSetProducerTest extends ContextTestSupport {
 
     @Override
     public void setUp() throws Exception {
-        dataSet = new FileDataSet(testDataFileName);
+        File fileDataset = createFileDatasetWithSystemEndOfLine();
+        dataSet = new FileDataSet(fileDataset);
         assertEquals("Unexpected DataSet size", 1, dataSet.getSize());
         super.setUp();
+    }
+
+    private File createFileDatasetWithSystemEndOfLine() throws IOException {
+        tempFolder.create();
+        File fileDataset = tempFolder.newFile("file-dataset-test.txt");
+        Files.copy(new ByteArrayInputStream(testPayload.getBytes()), fileDataset.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return fileDataset;
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/component/dataset/FileDataSetProducerWithSplitTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/dataset/FileDataSetProducerWithSplitTest.java
@@ -16,16 +16,27 @@
  */
 package org.apache.camel.component.dataset;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import javax.naming.Context;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @version 
  */
 public class FileDataSetProducerWithSplitTest extends ContextTestSupport {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
     protected FileDataSet dataSet;
 
     final String testDataFileName = "src/test/data/file-dataset-test.txt";
@@ -58,9 +69,18 @@ public class FileDataSetProducerWithSplitTest extends ContextTestSupport {
 
     @Override
     public void setUp() throws Exception {
-        dataSet = new FileDataSet(testDataFileName, System.lineSeparator());
+        File fileDataset = createFileDatasetWithSystemEndOfLine();
+        dataSet = new FileDataSet(fileDataset, System.lineSeparator());
         assertEquals("Unexpected DataSet size", testDataFileRecordCount, dataSet.getSize());
         super.setUp();
+    }
+
+    private File createFileDatasetWithSystemEndOfLine() throws IOException {
+        tempFolder.create();
+        File fileDataset = tempFolder.newFile("file-dataset-test.txt");
+        ByteArrayInputStream content = new ByteArrayInputStream(String.format("Line 1%nLine 2%nLine 3%nLine 4%nLine 5%nLine 6%nLine 7%nLine 8%nLine 9%nLine 10%n").getBytes());
+        Files.copy(content, fileDataset.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return fileDataset;
     }
 
     @Override


### PR DESCRIPTION
- depending on Git strategy, line endings can be converted to CRLF (the
default windows EOL) or kept to LF (the default Linux EOL and how files
are stored on the git repository for Camel project)
- test changed to create files in the test in order to use the system
EOL and don't make assumptions on the git strategy