### PR TITLE
CAMEL-10534-Update StreamProducer to handle streaming using URLConnection

### DIFF
--- a/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
+++ b/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
@@ -90,6 +90,7 @@ public class StreamProducer extends DefaultProducer {
 
         URL url = new URL(u);
         URLConnection c = url.openConnection();
+        c.setDoOutput(true);
         return c.getOutputStream();
     }
 


### PR DESCRIPTION
Set `doOutput` flag to true to handle streaming using URLConnection.