### PR TITLE
SmppNLSTSplitter for sending messages using National Language Shift Table

### DIFF
--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConstants.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConstants.java
@@ -27,6 +27,7 @@ public interface SmppConstants {
     String COMMAND_ID = "CamelSmppCommandId";
     String COMMAND_STATUS = "CamelSmppCommandStatus";
     String DATA_CODING = "CamelSmppDataCoding";
+    String DATA_SPLITTER = "CamelSmppSplitter";
     String DELIVERED = "CamelSmppDelivered";
     String DEST_ADDR = "CamelSmppDestAddr";
     String DEST_ADDR_NPI = "CamelSmppDestAddrNpi";
@@ -34,6 +35,7 @@ public interface SmppConstants {
     String DONE_DATE = "CamelSmppDoneDate";
     String ENCODING = "CamelSmppEncoding";
     String ERROR = "CamelSmppError";
+    String ESM_CLASS = "CamelSmppClass";
     String ESME_ADDR = "CamelSmppEsmeAddr";
     String ESME_ADDR_NPI = "CamelSmppEsmeAddrNpi";
     String ESME_ADDR_TON = "CamelSmppEsmeAddrTon";

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppNLSTSplitter.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppNLSTSplitter.java
@@ -1,0 +1,100 @@
+package org.apache.camel.component.smpp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by engin on 30/11/2016.
+ */
+class SmppNLSTSplitter extends SmppSplitter{
+
+    protected static final int UDHIE_NLI_SINGLE_MSG_HEADER_LENGTH = 0x03; // header length for single message
+    protected static final int UDHIE_NLI_SINGLE_MSG_HEADER_REAL_LENGTH = UDHIE_NLI_SINGLE_MSG_HEADER_LENGTH + 1;
+
+    protected static final int UDHIE_NLI_MULTI_MSG_HEADER_LENGTH = 0x08; // header length for multi message
+    protected static final int UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH = UDHIE_NLI_MULTI_MSG_HEADER_LENGTH + 1;
+
+
+    protected static final int UDHIE_SAR_REF_NUM_LENGTH = 1;
+//        protected static final byte UDHIE_IDENTIFIER_SAR = 0x00;
+//        protected static final byte UDHIE_SAR_LENGTH = 0x03;
+//        protected static final int MAX_SEG_COUNT = 255;
+
+    protected static final int UDHIE_NLI_IDENTIFIER = 0x25;
+    protected static final int UDHIE_NLI_HEADER_LENGTH = 0x01;
+
+    public static final int MAX_MSG_CHAR_SIZE = (MAX_MSG_BYTE_LENGTH * 8 / 7) - (UDHIE_NLI_SINGLE_MSG_HEADER_REAL_LENGTH + 1); // 155 for NLST
+    public static final int MAX_SEG_BYTE_SIZE = (MAX_MSG_BYTE_LENGTH - UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH) * 8 / 7;
+
+    private byte languageIdentifier;
+    private final Logger logger = LoggerFactory.getLogger(SmppNLSTSplitter.class);
+
+    SmppNLSTSplitter(int currentLength, byte languageIdentifier) {
+        super(MAX_MSG_CHAR_SIZE, MAX_SEG_BYTE_SIZE, currentLength);
+        this.languageIdentifier = languageIdentifier;
+    }
+
+    public byte[][] split(byte[] message) {
+        if (!isSplitRequired()) {
+            byte[] nli_message = new byte[UDHIE_NLI_SINGLE_MSG_HEADER_REAL_LENGTH + message.length];
+            nli_message[0] = (byte) UDHIE_NLI_SINGLE_MSG_HEADER_LENGTH;
+            nli_message[1] = (byte) UDHIE_NLI_IDENTIFIER;
+            nli_message[2] = (byte) UDHIE_NLI_HEADER_LENGTH;
+            nli_message[3] = this.languageIdentifier;
+            System.arraycopy(message, 0, nli_message, 4, message.length);
+            return new byte[][]{nli_message};
+        }
+
+        int segmentLength = getSegmentLength();
+
+        // determine how many messages
+        int segmentNum = message.length / segmentLength;
+        int messageLength = message.length;
+        if (segmentNum > MAX_SEG_COUNT) {
+            // this is too long, can't fit, so chop
+            segmentNum = MAX_SEG_COUNT;
+            messageLength = segmentNum * segmentLength;
+        }
+        if ((messageLength % segmentLength) > 0) {
+            segmentNum++;
+        }
+
+        byte[][] segments = new byte[segmentNum][];
+
+        int lengthOfData;
+        byte refNum = getReferenceNumber();
+        for (int i = 0; i < segmentNum; i++) {
+            logger.info("segment number = {}", i);
+            if (segmentNum - i == 1) {
+                lengthOfData = messageLength - i * segmentLength;
+            } else {
+                lengthOfData = segmentLength;
+            }
+            logger.info("Length of data = {}", lengthOfData);
+
+            segments[i] = new byte[UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH + lengthOfData];
+            logger.info("segments[{}].length = {}", i, segments[i].length);
+
+            segments[i][0] = UDHIE_NLI_MULTI_MSG_HEADER_LENGTH; // doesn't include itself, is header length
+            // SAR identifier
+            segments[i][1] = UDHIE_IDENTIFIER_SAR;
+            // SAR length
+            segments[i][2] = UDHIE_SAR_LENGTH;
+            // DATAGRAM REFERENCE NUMBER
+            segments[i][3] = refNum;
+            // total number of segments
+            segments[i][4] = (byte) segmentNum;
+            // segment #
+            segments[i][5] = (byte) (i + 1);
+
+            // language stuff
+            segments[i][6] = (byte) UDHIE_NLI_IDENTIFIER;
+            segments[i][7] = (byte) UDHIE_NLI_HEADER_LENGTH;
+            segments[i][8] = this.languageIdentifier;
+
+            // now copy the data
+            System.arraycopy(message, i * segmentLength, segments[i], UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH, lengthOfData);
+        }
+        return segments;
+    }
+}

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
@@ -75,16 +75,16 @@ public abstract class SmppSmCommand extends AbstractSmppCommand {
         return config.getSplittingPolicy();
     }
 
-    protected SmppSplitter createSplitter(Message message) {
+    protected SmppSplitter createSplitter(Message message) throws SmppException {
 
         SmppSplitter splitter;
         // use the splitter if provided via header
-        if (message.getHeaders().containsKey(SmppConstants.DATA_SPLITTER)){
+        if (message.getHeaders().containsKey(SmppConstants.DATA_SPLITTER)) {
             splitter = message.getHeader(SmppConstants.DATA_SPLITTER, SmppSplitter.class);
-            if (null != splitter){
+            if (null != splitter) {
                 return splitter;
             }
-            logger.warn("Invalid splitter given. Must be instance of SmppSplitter");
+            throw new SmppException("Invalid splitter given. Must be instance of SmppSplitter");
         }
         Alphabet alphabet = determineAlphabet(message);
         String body = message.getBody(String.class);
@@ -96,7 +96,6 @@ public abstract class SmppSmCommand extends AbstractSmppCommand {
         } else {
             splitter = new SmppDefaultSplitter(body.length());
         }
-
         return splitter;
     }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSmCommand.java
@@ -76,11 +76,19 @@ public abstract class SmppSmCommand extends AbstractSmppCommand {
     }
 
     protected SmppSplitter createSplitter(Message message) {
-        Alphabet alphabet = determineAlphabet(message);
-
-        String body = message.getBody(String.class);
 
         SmppSplitter splitter;
+        // use the splitter if provided via header
+        if (message.getHeaders().containsKey(SmppConstants.DATA_SPLITTER)){
+            splitter = message.getHeader(SmppConstants.DATA_SPLITTER, SmppSplitter.class);
+            if (null != splitter){
+                return splitter;
+            }
+            logger.warn("Invalid splitter given. Must be instance of SmppSplitter");
+        }
+        Alphabet alphabet = determineAlphabet(message);
+        String body = message.getBody(String.class);
+
         if (SmppUtils.is8Bit(alphabet)) {
             splitter = new Smpp8BitSplitter(body.length());
         } else if (alphabet == Alphabet.ALPHA_UCS2) {

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
@@ -99,7 +99,7 @@ public class SmppSubmitSmCommand extends SmppSmCommand {
         if (null != esmClass) {
             template.setEsmClass(esmClass.value());
             // multipart message
-        }else if (segments.length > 1) {
+        } else if (segments.length > 1) {
             template.setEsmClass(new ESMClass(MessageMode.DEFAULT, MessageType.DEFAULT, GSMSpecificFeature.UDHI).value());
         }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
@@ -95,8 +95,11 @@ public class SmppSubmitSmCommand extends SmppSmCommand {
         SubmitSm template = createSubmitSmTemplate(exchange);
         byte[][] segments = splitBody(exchange.getIn());
 
-        // multipart message
-        if (segments.length > 1) {
+        ESMClass esmClass = exchange.getIn().getHeader(SmppConstants.ESM_CLASS, ESMClass.class);
+        if (null != esmClass) {
+            template.setEsmClass(esmClass.value());
+            // multipart message
+        }else if (segments.length > 1) {
             template.setEsmClass(new ESMClass(MessageMode.DEFAULT, MessageType.DEFAULT, GSMSpecificFeature.UDHI).value());
         }
 

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppNLSTSplitterTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppNLSTSplitterTest.java
@@ -1,0 +1,63 @@
+package org.apache.camel.component.smpp;
+
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by engin on 30/11/2016.
+ */
+public class SmppNLSTSplitterTest {
+
+    @Test
+    public void splitTurkishShortMessageWith155Character() {
+        String message = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+                + "123456789012345678901234567890123456789012345678901234567890123456789012345"; // 155 single message
+
+        byte turkishLanguageIdentifier = 0x01;
+        SmppSplitter splitter = new SmppNLSTSplitter(message.length(), turkishLanguageIdentifier);
+        SmppSplitter.resetCurrentReferenceNumber();
+        byte[][] result = splitter.split(message.getBytes());
+
+        assertEquals(1, result.length);
+        assertArrayEquals(new byte[]{SmppNLSTSplitter.UDHIE_NLI_SINGLE_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
+                54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53}, result[0]);
+    }
+
+    @Test
+    public void splitShortMessageWith156Character() {
+        String message = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" + // first part 149
+                "0123456"; // second part 7
+
+        byte turkishLanguageIdentifier = 0x01;
+        SmppSplitter splitter = new SmppNLSTSplitter(message.length(), turkishLanguageIdentifier);
+        SmppSplitter.resetCurrentReferenceNumber();
+        byte[][] result = splitter.split(message.getBytes());
+
+        assertEquals(2, result.length);
+        assertArrayEquals(new byte[]{
+                SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 1,
+                SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
+                54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57}, result[0]);
+
+        assertArrayEquals(new byte[]{
+                SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 2,
+                SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
+                48, 49, 50, 51, 52, 53, 54}, result[1]);
+
+        String firstShortMessage = new String(result[0], SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH, result[0].length - SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH);
+        String secondShortMessage = new String(result[1], SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH, result[1].length - SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH);
+        assertEquals(message, firstShortMessage + secondShortMessage);
+    }
+}

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppNLSTSplitterTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppNLSTSplitterTest.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.smpp;
 
 import java.nio.charset.Charset;
@@ -9,9 +25,6 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-/**
- * Created by engin on 30/11/2016.
- */
 public class SmppNLSTSplitterTest {
 
     @Test
@@ -26,10 +39,10 @@ public class SmppNLSTSplitterTest {
 
         assertEquals(1, result.length);
         assertArrayEquals(new byte[]{SmppNLSTSplitter.UDHIE_NLI_SINGLE_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
-                54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53}, result[0]);
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
+            54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53}, result[0]);
     }
 
     @Test
@@ -44,17 +57,17 @@ public class SmppNLSTSplitterTest {
 
         assertEquals(2, result.length);
         assertArrayEquals(new byte[]{
-                SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 1,
-                SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
-                54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
-                49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57}, result[0]);
+            SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 1,
+            SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53,
+            54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+            49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57}, result[0]);
 
         assertArrayEquals(new byte[]{
-                SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 2,
-                SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
-                48, 49, 50, 51, 52, 53, 54}, result[1]);
+            SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_LENGTH, SmppNLSTSplitter.UDHIE_IDENTIFIER_SAR, SmppNLSTSplitter.UDHIE_SAR_LENGTH, 1, 2, 2,
+            SmppNLSTSplitter.UDHIE_NLI_IDENTIFIER, SmppNLSTSplitter.UDHIE_NLI_HEADER_LENGTH, turkishLanguageIdentifier,
+            48, 49, 50, 51, 52, 53, 54}, result[1]);
 
         String firstShortMessage = new String(result[0], SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH, result[0].length - SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH);
         String secondShortMessage = new String(result[1], SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH, result[1].length - SmppNLSTSplitter.UDHIE_NLI_MULTI_MSG_HEADER_REAL_LENGTH);


### PR DESCRIPTION
to support sending messages with [National Language Shift Tables](https://en.wikipedia.org/wiki/GSM_03.38#National_language_shift_tables), there are two thing needs to be taken care of:
even if the short message is only one part, we need to set UDHI; we are using esm_class.
splitting messages for locking tables:
155 characters allowed when submitting single short message
149 characters allowed when submitting multipart short messages

i've added test cases for splitting
