### PR TITLE
CAMEL-10344: RouteIdFactory for rest routes

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -772,7 +772,13 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                     route.setId(id);
                 }
             }
-            String routeId = route.idOrCreate(camelContext.getNodeIdFactory());
+
+            String routeId = verb.idOrCreate(camelContext.getNodeIdFactory());
+
+            if (!verb.getUsedForGeneratingNodeId()) {
+                routeId = route.idOrCreate(camelContext.getNodeIdFactory());
+            }
+
             verb.setRouteId(routeId);
             options.put("routeId", routeId);
             if (component != null && !component.isEmpty()) {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -101,6 +101,9 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     @XmlAttribute
     private Boolean apiDocs;
 
+    @XmlTransient
+    private Boolean usedForGeneratingNodeId = Boolean.FALSE;
+
     @Override
     public String getLabel() {
         if (method != null) {
@@ -406,6 +409,11 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
         }
     }
 
+    public Boolean getUsedForGeneratingNodeId() {
+        return usedForGeneratingNodeId;
+    }
 
-
+    public void setUsedForGeneratingNodeId(Boolean usedForGeneratingNodeId) {
+        this.usedForGeneratingNodeId = usedForGeneratingNodeId;
+    }
 }

--- a/camel-core/src/test/java/org/apache/camel/impl/RouteIdFactoryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/RouteIdFactoryTest.java
@@ -39,6 +39,9 @@ public class RouteIdFactoryTest extends ContextTestSupport {
                 context.setNodeIdFactory(new RouteIdFactory());
                 from("direct:start1?timeout=30000").to("mock:result");
                 from("direct:start2").to("mock:result");
+                rest("/say/hello").get("/bar").to("mock:result");
+                rest("/say/hello").get().to("mock:result");
+                rest().get("/hello").to("mock:result");
             }
         };
     }
@@ -49,6 +52,18 @@ public class RouteIdFactoryTest extends ContextTestSupport {
 
     public void testDirectRouteId() {
         assertEquals("start2", context.getRouteDefinitions().get(1).getId());
+    }
+
+    public void testRestRouteIdWithVerbUri() {
+        assertEquals("get-say-hello-bar", context.getRouteDefinitions().get(2).getId());
+    }
+
+    public void testRestRouteIdWithoutVerbUri() {
+        assertEquals("get-say-hello", context.getRouteDefinitions().get(3).getId());
+    }
+
+    public void testRestRouteIdWithoutPathUri() {
+        assertEquals("get-hello", context.getRouteDefinitions().get(4).getId());
     }
 
 }


### PR DESCRIPTION
This PR extends the functionality introduced in #1242 by better handling rest routes. The implementation was written following the suggestions made in #1242 by @davsclaus 