### PR TITLE
[CAMEL-10557] Fix Salesforce BulkAPI getRequest() URL

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultBulkApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultBulkApiClient.java
@@ -259,7 +259,7 @@ public class DefaultBulkApiClient extends AbstractClientBase implements BulkApiC
 
     @Override
     public void getRequest(String jobId, String batchId, final StreamResponseCallback callback) {
-        final Request get = getRequest(HttpMethod.GET, batchUrl(jobId, batchId));
+        final Request get = getRequest(HttpMethod.GET, batchRequestUrl(jobId, batchId, null));
 
         // make the call and parse the result
         doHttpRequest(get, new ClientResponseCallback() {
@@ -470,6 +470,14 @@ public class DefaultBulkApiClient extends AbstractClientBase implements BulkApiC
             return batchUrl(jobId, batchId) + "/result/" + resultId;
         } else {
             return batchUrl(jobId, batchId) + "/result";
+        }
+    }
+
+    private String batchRequestUrl(String jobId, String batchId, String requestId) {
+        if (requestId != null) {
+            return batchUrl(jobId, batchId) + "/request/" + requestId;
+        } else {
+            return batchUrl(jobId, batchId) + "/request";
         }
     }
 }


### PR DESCRIPTION
This commit fixes the URL returned by `getRequest()`. It used to return the same URL as `getBatch()`, while the documentation states that `/request` should be appended: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_batches_get_request.htm#asynch_api_batch_get_request

While there is currently no use of the third parameter (`String requestId`) to the introduced private method `batchRequestUrl()`, it has been included for symmetry with the private method `batchResultUrl()`, which, like `batchRequestUrl()`, provides for requesting a path that the API does not explicitly define (i.e. providing a request/result ID after `/request`/`/result`), but may still be accessible.

We'd very much like this to be back-ported to the 2.17.x branch.