### PR TITLE
Camel 10086 - Moved Pattern.compile() usages into static variables

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/TimePatternConverter.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
 @Converter
 public final class TimePatternConverter {   
     private static final Logger LOG = LoggerFactory.getLogger(TimePatternConverter.class);
-    private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
-    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
-    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond)?(s)?)?";
+    private static final Pattern NUMBERS_ONLY_STRING_PATTERN = Pattern.compile("^[-]?(\\d)+$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern HOUR_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))h(our(s)?)?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern MINUTES_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))m(in(ute(s)?)?)?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SECONDS_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))s(ec(ond)?(s)?)?", Pattern.CASE_INSENSITIVE);
 
     /**
      * Utility classes should not have a public constructor.
@@ -124,8 +124,7 @@ public final class TimePatternConverter {
         }
     }
 
-    private static Matcher createMatcher(String regexPattern, String source) {
-        Pattern pattern = Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
+    private static Matcher createMatcher(Pattern pattern, String source) {
         return pattern.matcher(source);        
     }    
 }

--- a/components/camel-atmos/src/main/java/org/apache/camel/component/atmos/validator/AtmosConfigurationValidator.java
+++ b/components/camel-atmos/src/main/java/org/apache/camel/component/atmos/validator/AtmosConfigurationValidator.java
@@ -29,6 +29,8 @@ import static org.apache.camel.component.atmos.util.AtmosConstants.ATMOS_FILE_SE
 
 public final class AtmosConfigurationValidator {
 
+    private static final Pattern UNIX_PATH_PATTERN = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
+
     private AtmosConfigurationValidator() {
     }
 
@@ -118,8 +120,7 @@ public final class AtmosConfigurationValidator {
     }
 
     private static void validatePathInUnix(String path) throws AtmosException {
-        Pattern pattern = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
-        Matcher matcher = pattern.matcher(path);
+        Matcher matcher = UNIX_PATH_PATTERN.matcher(path);
         if (!matcher.matches()) {
             throw new AtmosException(path + " is not a valid path, must be in UNIX form!");
         }

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumerTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumerTest.java
@@ -173,7 +173,7 @@ public class DdbStreamConsumerTest {
 
         private final Map<String, String> shardIterators;
         private final Map<String, Collection<Record>> answers;
-        private final Pattern SHARD_ITERATOR_PATTERN = Pattern.compile("shard_iterator_d_0*(\\d+)");
+        private final Pattern shardIteratorPattern = Pattern.compile("shard_iterator_d_0*(\\d+)");
 
         GetRecordsAnswer(Map<String, String> shardIterators, Map<String, Collection<Record>> answers) {
             this.shardIterators = shardIterators;
@@ -187,7 +187,7 @@ public class DdbStreamConsumerTest {
             // A null 'nextShardIterator' indicates that the shard has finished
             // and we should move onto the next shard.
             String nextShardIterator = shardIterators.get(shardIterator);
-            Matcher m = SHARD_ITERATOR_PATTERN.matcher(shardIterator);
+            Matcher m = shardIteratorPattern.matcher(shardIterator);
             Collection<Record> ans = answers.get(shardIterator);
             if (nextShardIterator == null && m.matches()) { // last shard iterates forever.
                 Integer num = Integer.parseInt(m.group(1));

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumerTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/ddbstream/DdbStreamConsumerTest.java
@@ -173,6 +173,7 @@ public class DdbStreamConsumerTest {
 
         private final Map<String, String> shardIterators;
         private final Map<String, Collection<Record>> answers;
+        private final Pattern SHARD_ITERATOR_PATTERN = Pattern.compile("shard_iterator_d_0*(\\d+)");
 
         GetRecordsAnswer(Map<String, String> shardIterators, Map<String, Collection<Record>> answers) {
             this.shardIterators = shardIterators;
@@ -186,7 +187,7 @@ public class DdbStreamConsumerTest {
             // A null 'nextShardIterator' indicates that the shard has finished
             // and we should move onto the next shard.
             String nextShardIterator = shardIterators.get(shardIterator);
-            Matcher m = Pattern.compile("shard_iterator_d_0*(\\d+)").matcher(shardIterator);
+            Matcher m = SHARD_ITERATOR_PATTERN.matcher(shardIterator);
             Collection<Record> ans = answers.get(shardIterator);
             if (nextShardIterator == null && m.matches()) { // last shard iterates forever.
                 Integer num = Integer.parseInt(m.group(1));

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/validator/DropboxConfigurationValidator.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/validator/DropboxConfigurationValidator.java
@@ -28,7 +28,7 @@ import static org.apache.camel.component.dropbox.util.DropboxConstants.DROPBOX_F
 
 public final class DropboxConfigurationValidator {
 
-    private static final Pattern pattern = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
 
     private DropboxConfigurationValidator() { }
 
@@ -117,7 +117,7 @@ public final class DropboxConfigurationValidator {
     }
 
     private static void validatePathInUnix(String path) throws DropboxException {
-        Matcher matcher = pattern.matcher(path);
+        Matcher matcher = PATTERN.matcher(path);
         if (!matcher.matches()) {
             throw new DropboxException(path + " is not a valid path, must be in UNIX form!");
         }

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/validator/DropboxConfigurationValidator.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/validator/DropboxConfigurationValidator.java
@@ -28,6 +28,8 @@ import static org.apache.camel.component.dropbox.util.DropboxConstants.DROPBOX_F
 
 public final class DropboxConfigurationValidator {
 
+    private static final Pattern pattern = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
+
     private DropboxConfigurationValidator() { }
 
     /**
@@ -115,7 +117,6 @@ public final class DropboxConfigurationValidator {
     }
 
     private static void validatePathInUnix(String path) throws DropboxException {
-        Pattern pattern = Pattern.compile("/*?(\\S+)/*?", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(path);
         if (!matcher.matches()) {
             throw new DropboxException(path + " is not a valid path, must be in UNIX form!");

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/OsgiParserFactory.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/OsgiParserFactory.java
@@ -40,7 +40,7 @@ import org.apache.commons.net.ftp.parser.VMSVersioningFTPEntryParser;
  * OsgiParserFactory
  * 
  * commons-net DefaultFTPFileEntryParserFactory uses Class.forName, and fails
- * to load custom ParserFactories in OSGI.   This class is an alternative ParserFactory
+ * to load custom ParserFactories in OSGI. This class is an alternative ParserFactory
  * that can be used when Camel is used in an OSGI environment.
  */
 public class OsgiParserFactory extends DefaultFTPFileEntryParserFactory {

--- a/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
+++ b/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
@@ -39,7 +39,7 @@ public class JasyptPropertiesParser extends DefaultPropertiesParser {
     public static final String JASYPT_SUFFIX_TOKEN = ")";
 
     private static final String JASYPT_REGEX = JASYPT_PREFIX_TOKEN.replace("(", "\\(") + "(.+?)" + JASYPT_SUFFIX_TOKEN.replace(")", "\\)");
-    private static final Pattern pattern = Pattern.compile(JASYPT_REGEX);
+    private static final Pattern PATTERN = Pattern.compile(JASYPT_REGEX);
 
     private StringEncryptor encryptor;
     private String password;
@@ -53,7 +53,7 @@ public class JasyptPropertiesParser extends DefaultPropertiesParser {
         log.trace(format("Parsing property '%s=%s'", key, value));
         if (value != null) {
             initEncryptor();
-            Matcher matcher = pattern.matcher(value);
+            Matcher matcher = PATTERN.matcher(value);
             while (matcher.find()) {
                 log.trace(format("Decrypting part '%s'", matcher.group(0)));
                 String decrypted = encryptor.decrypt(matcher.group(1));

--- a/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
+++ b/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
@@ -31,22 +31,21 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
  * A {@link org.apache.camel.component.properties.PropertiesParser} which is using
  * &nbsp;<a href="http://www.jasypt.org/">Jasypt</a> to decrypt encrypted values.
  * <p/>
- * The parts of the values which should be decrpted must be enclosed in the prefix and suffix token.
+ * The parts of the values which should be decrypted must be enclosed in the prefix and suffix token.
  */
 public class JasyptPropertiesParser extends DefaultPropertiesParser {
 
     public static final String JASYPT_PREFIX_TOKEN = "ENC(";
     public static final String JASYPT_SUFFIX_TOKEN = ")";
 
+    private static final String JASYPT_REGEX = JASYPT_PREFIX_TOKEN.replace("(", "\\(") + "(.+?)" + JASYPT_SUFFIX_TOKEN.replace(")", "\\)");
+    private static final Pattern pattern = Pattern.compile(JASYPT_REGEX);
+
     private StringEncryptor encryptor;
     private String password;
     private String algorithm;
 
-    private Pattern pattern;
-
     public JasyptPropertiesParser() {
-        String regex = JASYPT_PREFIX_TOKEN.replace("(", "\\(") + "(.+?)" + JASYPT_SUFFIX_TOKEN.replace(")", "\\)");
-        pattern = Pattern.compile(regex);
     }
 
     @Override
@@ -73,7 +72,7 @@ public class JasyptPropertiesParser extends DefaultPropertiesParser {
                 pbeStringEncryptor.setAlgorithm(algorithm);
                 log.debug(format("Initialized encryptor using %s algorithm and provided password", algorithm));
             } else {
-                log.debug(format("Initialized encryptor using default algorithm and provided password"));
+                log.debug("Initialized encryptor using default algorithm and provided password");
             }
             encryptor = pbeStringEncryptor;
         }

--- a/components/camel-mllp/src/test/java/org/apache/camel/test/junit/rule/mllp/MllpServerResource.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/test/junit/rule/mllp/MllpServerResource.java
@@ -167,11 +167,11 @@ public class MllpServerResource extends ExternalResource {
     }
 
     public boolean sendApplicationRejectAcknowledgement(String hl7Message) {
-        return evaluatePatten(hl7Message, this.sendApplicationErrorAcknowledgementPattern);
+        return evaluatePattern(hl7Message, this.sendApplicationErrorAcknowledgementPattern);
     }
 
     public boolean sendApplicationErrorAcknowledgement(String hl7Message) {
-        return evaluatePatten(hl7Message, this.sendApplicationRejectAcknowledgementPattern);
+        return evaluatePattern(hl7Message, this.sendApplicationRejectAcknowledgementPattern);
     }
 
     public boolean sendApplicationRejectAcknowledgement(int messageCount) {
@@ -221,7 +221,7 @@ public class MllpServerResource extends ExternalResource {
         }
     }
 
-    private boolean evaluatePatten(String hl7Message, Pattern pattern) {
+    private boolean evaluatePattern(String hl7Message, Pattern pattern) {
         boolean retValue = false;
 
         if (null != pattern && pattern.matcher(hl7Message).matches()) {

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
@@ -91,6 +91,9 @@ public class CamelSalesforceMojo extends AbstractMojo {
     private static final String JAVA_EXT = ".java";
     private static final String PACKAGE_NAME_PATTERN = "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
 
+    private static final Pattern MATCH_EVERYTHING_PATTERN = Pattern.compile(".*");
+    private static final Pattern MATCH_NOTHING_PATTERN = Pattern.compile("^$");
+
     private static final String SOBJECT_POJO_VM = "/sobject-pojo.vm";
     private static final String SOBJECT_POJO_OPTIONAL_VM = "/sobject-pojo-optional.vm";
     private static final String SOBJECT_QUERY_RECORDS_VM = "/sobject-query-records.vm";
@@ -448,10 +451,10 @@ public class CamelSalesforceMojo extends AbstractMojo {
             incPattern = Pattern.compile(includePattern.trim());
         } else if (includedNames.isEmpty()) {
             // include everything by default if no include names are set
-            incPattern = Pattern.compile(".*");
+            incPattern = MATCH_EVERYTHING_PATTERN;
         } else {
             // include nothing by default if include names are set
-            incPattern = Pattern.compile("^$");
+            incPattern = MATCH_NOTHING_PATTERN;
         }
 
         // check whether a pattern is in effect
@@ -460,7 +463,7 @@ public class CamelSalesforceMojo extends AbstractMojo {
             excPattern = Pattern.compile(excludePattern.trim());
         } else {
             // exclude nothing by default
-            excPattern = Pattern.compile("^$");
+            excPattern = MATCH_NOTHING_PATTERN;
         }
 
         final Set<String> acceptedNames = new HashSet<String>();

--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
@@ -36,7 +36,7 @@ import org.apache.camel.util.URISupport;
 
 public class SparkComponent extends UriEndpointComponent implements RestConsumerFactory, RestApiConsumerFactory {
 
-    private final Pattern pattern = Pattern.compile("\\{(.*?)\\}");
+    private static final Pattern pattern = Pattern.compile("\\{(.*?)\\}");
 
     private int port = 4567;
     private String ipAddress;

--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
@@ -36,7 +36,7 @@ import org.apache.camel.util.URISupport;
 
 public class SparkComponent extends UriEndpointComponent implements RestConsumerFactory, RestApiConsumerFactory {
 
-    private static final Pattern pattern = Pattern.compile("\\{(.*?)\\}");
+    private static final Pattern PATTERN = Pattern.compile("\\{(.*?)\\}");
 
     private int port = 4567;
     private String ipAddress;
@@ -299,7 +299,7 @@ public class SparkComponent extends UriEndpointComponent implements RestConsumer
 
         if (ObjectHelper.isNotEmpty(path)) {
             // spark-rest uses :name syntax instead of {name} so we need to replace those
-            Matcher matcher = pattern.matcher(path);
+            Matcher matcher = PATTERN.matcher(path);
             path = matcher.replaceAll(":$1");
         }
 

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkEndpoint.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkEndpoint.java
@@ -38,6 +38,9 @@ import org.slf4j.LoggerFactory;
 public class SplunkEndpoint extends ScheduledPollEndpoint {
     private static final Logger LOG = LoggerFactory.getLogger(SplunkEndpoint.class);
 
+    private static final Pattern SPLUNK_SCHEMA_PATTERN = Pattern.compile("splunk:(//)*");
+    private static final Pattern SPLUNK_OPTIONS_PATTER = Pattern.compile("\\?.*");
+
     private Service service;
     @UriParam
     private SplunkConfiguration configuration;
@@ -91,11 +94,8 @@ public class SplunkEndpoint extends ScheduledPollEndpoint {
     }
 
     private static String[] splitUri(String uri) {
-        Pattern p1 = Pattern.compile("splunk:(//)*");
-        Pattern p2 = Pattern.compile("\\?.*");
-
-        uri = p1.matcher(uri).replaceAll("");
-        uri = p2.matcher(uri).replaceAll("");
+        uri = SPLUNK_SCHEMA_PATTERN.matcher(uri).replaceAll("");
+        uri = SPLUNK_OPTIONS_PATTER.matcher(uri).replaceAll("");
 
         return uri.split("/");
     }

--- a/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/TwitterHelper.java
+++ b/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/TwitterHelper.java
@@ -40,6 +40,9 @@ import org.apache.camel.component.twitter.producer.UserProducer;
 import twitter4j.User;
 
 public final class TwitterHelper {
+    private static final Pattern TWITTER_SCHEMA_PATTERN = Pattern.compile("twitter:(//)*");
+    private static final Pattern TWITTER_OPTIONS_PATTERN = Pattern.compile("\\?.*");
+
     private TwitterHelper() {
     }
 
@@ -151,11 +154,8 @@ public final class TwitterHelper {
     }
 
     private static String[] splitUri(String uri) {
-        Pattern p1 = Pattern.compile("twitter:(//)*");
-        Pattern p2 = Pattern.compile("\\?.*");
-
-        uri = p1.matcher(uri).replaceAll("");
-        uri = p2.matcher(uri).replaceAll("");
+        uri = TWITTER_SCHEMA_PATTERN.matcher(uri).replaceAll("");
+        uri = TWITTER_OPTIONS_PATTERN.matcher(uri).replaceAll("");
 
         return uri.split("/");
     }

--- a/components/camel-yammer/src/main/java/org/apache/camel/component/yammer/scribe/JsonTokenExtractor.java
+++ b/components/camel-yammer/src/main/java/org/apache/camel/component/yammer/scribe/JsonTokenExtractor.java
@@ -24,12 +24,12 @@ import org.scribe.extractors.AccessTokenExtractor;
 import org.scribe.model.Token;
 import org.scribe.utils.Preconditions;
 
-
 public class JsonTokenExtractor implements AccessTokenExtractor {
+    private static final Pattern DEFAULT_ACCESS_TOKEN_PATTERN = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
     private Pattern accessTokenPattern;
 
     public JsonTokenExtractor() {
-        accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
+        accessTokenPattern = DEFAULT_ACCESS_TOKEN_PATTERN;
     }
 
     public JsonTokenExtractor(String tokenRegex) {

--- a/components/camel-yammer/src/main/java/org/apache/camel/component/yammer/utils/YammerAccessCodeGenerator.java
+++ b/components/camel-yammer/src/main/java/org/apache/camel/component/yammer/utils/YammerAccessCodeGenerator.java
@@ -24,11 +24,9 @@ import org.scribe.model.Token;
 import org.scribe.model.Verifier;
 import org.scribe.oauth.OAuthService;
 
-
 /**
  * Use this to get an access token from yammer. You will need the 
  * consumer key and secret key for your app registered with yammer to do this.
- *
  */
 public final class YammerAccessCodeGenerator {
 

--- a/platforms/catalog/src/main/java/org/apache/camel/catalog/DefaultRuntimeProvider.java
+++ b/platforms/catalog/src/main/java/org/apache/camel/catalog/DefaultRuntimeProvider.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/platforms/catalog/src/main/java/org/apache/camel/catalog/RuntimeProvider.java
+++ b/platforms/catalog/src/main/java/org/apache/camel/catalog/RuntimeProvider.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
+++ b/platforms/catalog/src/main/java/org/apache/camel/catalog/TimePatternConverter.java
@@ -23,10 +23,10 @@ import java.util.regex.Pattern;
  * This class is a copy from camel-core so we can use it independent to validate uris with time patterns
  */
 public final class TimePatternConverter {
-    private static final String NUMBERS_ONLY_STRING_PATTERN = "^[-]?(\\d)+$";
-    private static final String HOUR_REGEX_PATTERN = "((\\d)*(\\d))h(our(s)?)?";
-    private static final String MINUTES_REGEX_PATTERN = "((\\d)*(\\d))m(in(ute(s)?)?)?";
-    private static final String SECONDS_REGEX_PATTERN = "((\\d)*(\\d))s(ec(ond)?(s)?)?";
+    private static final Pattern NUMBERS_ONLY_STRING_PATTERN = Pattern.compile("^[-]?(\\d)+$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern HOUR_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))h(our(s)?)?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern MINUTES_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))m(in(ute(s)?)?)?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SECONDS_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))s(ec(ond)?(s)?)?", Pattern.CASE_INSENSITIVE);
 
     /**
      * Utility classes should not have a public constructor.
@@ -114,8 +114,7 @@ public final class TimePatternConverter {
         }
     }
 
-    private static Matcher createMatcher(String regexPattern, String source) {
-        Pattern pattern = Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
+    private static Matcher createMatcher(Pattern pattern, String source) {
         return pattern.matcher(source);
     }
 }

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
@@ -91,6 +91,8 @@ public final class ArquillianPackager {
     private static final String LIB_FOLDER = "/BOOT-INF/lib";
     private static final String CLASSES_FOLDER = "BOOT-INF/classes";
 
+    private static final Pattern PROP_PATTERN = Pattern.compile("(\\$\\{[^}]*\\})");
+
     private ArquillianPackager() {
     }
 
@@ -469,8 +471,7 @@ public final class ArquillianPackager {
         pom = pom.replace("<!-- DEPENDENCIES -->", dependencies.toString());
 
         Map<String, String> resolvedProperties = new TreeMap<>();
-        Pattern propPattern = Pattern.compile("(\\$\\{[^}]*\\})");
-        Matcher m = propPattern.matcher(pom);
+        Matcher m = PROP_PATTERN.matcher(pom);
         while (m.find()) {
             String property = m.group();
             String resolved = DependencyResolver.resolveModuleOrParentProperty(new File(new File(config.getModuleBasePath()), "pom.xml"), property);


### PR DESCRIPTION
This PR covers a first set of changes for [CAMEL-10086](https://issues.apache.org/jira/browse/CAMEL-10086) which targets extracting some `Pattern.compile()` usages from within methods into static variables.

Couple of things to note:
- I did not pay attention and ended up with 3 commits. if this is a problem let me know and I'll close this PR, squash the commits on a new branch and re-raise
- This PR also has some typo fixes and some license fixes (I found those by chance and could not leave them as they were); I hope that's ok