### PR TITLE
CAMEL-10562: camel-core - Switched to List#sort

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
@@ -1677,7 +1677,7 @@ public final class ExpressionBuilder {
         return new ExpressionAdapter() {
             public Object evaluate(Exchange exchange) {
                 List<?> list = expression.evaluate(exchange, List.class);
-                Collections.sort(list, comparator);
+                list.sort(comparator);
                 return list;
             }
 

--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -1206,7 +1206,7 @@ public class BeanInfo {
         }
 
         // sort the methods by name A..Z
-        Collections.sort(methods, new Comparator<MethodInfo>() {
+        methods.sort(new Comparator<MethodInfo>() {
             public int compare(MethodInfo o1, MethodInfo o2) {
                 return o1.getMethod().getName().compareTo(o2.getMethod().getName());
             }

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
@@ -141,7 +141,7 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
 
         // sort files using file comparator if provided
         if (endpoint.getSorter() != null) {
-            Collections.sort(files, endpoint.getSorter());
+            files.sort(endpoint.getSorter());
         }
 
         // sort using build in sorters so we can use expressions
@@ -155,7 +155,7 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
         }
         // sort files using exchange comparator if provided
         if (endpoint.getSortBy() != null) {
-            Collections.sort(exchanges, endpoint.getSortBy());
+            exchanges.sort(endpoint.getSortBy());
         }
         if (endpoint.isShuffle()) {
             Collections.shuffle(exchanges);

--- a/camel-core/src/main/java/org/apache/camel/impl/ComponentConfigurationSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ComponentConfigurationSupport.java
@@ -123,7 +123,7 @@ public abstract class ComponentConfigurationSupport implements ComponentConfigur
                 queryParams.add(key + "=" + UnsafeUriCharactersEncoder.encode(value.toString()));
             }
         }
-        Collections.sort(queryParams);
+        queryParams.sort(null);
         StringBuilder builder = new StringBuilder();
         String base = getBaseUri();
         if (base != null) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -3540,7 +3540,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         doWarmUpRoutes(inputs, startConsumer);
 
         // sort the startup listeners so they are started in the right order
-        Collections.sort(startupListeners, new OrderedComparator());
+        startupListeners.sort(new OrderedComparator());
         // now call the startup listeners where the routes has been warmed up
         // (only the actual route consumer has not yet been started)
         for (StartupListener startup : startupListeners) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -3564,7 +3564,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         }
 
         // sort the startup listeners so they are started in the right order
-        Collections.sort(startupListeners, new OrderedComparator());
+        startupListeners.sort(new OrderedComparator());
         // now the consumers that was just started may also add new StartupListeners (such as timer)
         // so we need to ensure they get started as well
         for (StartupListener startup : startupListeners) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
@@ -123,7 +123,7 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
         }
 
         if (sortByLongestDuration) {
-            Collections.sort(values, new Comparator<Exchange>() {
+            values.sort(new Comparator<Exchange>() {
                 @Override
                 public int compare(Exchange e1, Exchange e2) {
                     long d1 = getExchangeDuration(e1);
@@ -133,7 +133,7 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
             });
         } else {
             // else sort by exchange id
-            Collections.sort(values, new Comparator<Exchange>() {
+            values.sort(new Comparator<Exchange>() {
                 @Override
                 public int compare(Exchange e1, Exchange e2) {
                     return e1.getExchangeId().compareTo(e2.getExchangeId());

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultShutdownStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultShutdownStrategy.java
@@ -180,7 +180,7 @@ public class DefaultShutdownStrategy extends ServiceSupport implements ShutdownS
 
         // at first sort according to route startup order
         List<RouteStartupOrder> routesOrdered = new ArrayList<RouteStartupOrder>(routes);
-        Collections.sort(routesOrdered, new Comparator<RouteStartupOrder>() {
+        routesOrdered.sort(new Comparator<RouteStartupOrder>() {
             public int compare(RouteStartupOrder o1, RouteStartupOrder o2) {
                 return o1.getStartupOrder() - o2.getStartupOrder();
             }

--- a/camel-core/src/main/java/org/apache/camel/impl/MappedEndpointConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MappedEndpointConfiguration.java
@@ -129,7 +129,7 @@ public final class MappedEndpointConfiguration extends DefaultEndpointConfigurat
             }
         }
 
-        Collections.sort(queryParams);
+        queryParams.sort(null);
         String q = "";
         for (String entry : queryParams) {
             q += q.length() == 0 ? "" : "&";

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -499,7 +499,7 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
                     processors.add(processor);
                 }
             }
-            Collections.sort(processors, new OrderProcessorMBeans());
+            processors.sort(new OrderProcessorMBeans());
 
             // loop the routes, and append the processor stats if needed
             sb.append("  <routeStats>\n");

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
@@ -366,7 +366,7 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
                         mps.add(processor);
                     }
                 }
-                Collections.sort(mps, new OrderProcessorMBeans());
+                mps.sort(new OrderProcessorMBeans());
 
                 // walk the processors in reverse order, and calculate the accumulated total time
                 Map<String, Long> accumulatedTimes = new HashMap<String, Long>();

--- a/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
@@ -104,7 +104,7 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor {
     public void addAdvice(CamelInternalProcessorAdvice advice) {
         advices.add(advice);
         // ensure advices are sorted so they are in the order we want
-        Collections.sort(advices, new OrderedComparator());
+        advices.sort(new OrderedComparator());
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/processor/SortProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/SortProcessor.java
@@ -54,7 +54,7 @@ public class SortProcessor<T> extends ServiceSupport implements AsyncProcessor, 
 
             @SuppressWarnings("unchecked")
             List<T> list = expression.evaluate(exchange, List.class);
-            Collections.sort(list, comparator);
+            list.sort(comparator);
 
             if (exchange.getPattern().isOutCapable()) {
                 Message out = exchange.getOut();

--- a/camel-core/src/main/java/org/apache/camel/processor/interceptor/DefaultChannel.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/interceptor/DefaultChannel.java
@@ -260,7 +260,7 @@ public class DefaultChannel extends CamelInternalProcessor implements ModelChann
         }
 
         // sort interceptors according to ordered
-        Collections.sort(interceptors, new OrderedComparator());
+        interceptors.sort(new OrderedComparator());
         // then reverse list so the first will be wrapped last, as it would then be first being invoked
         Collections.reverse(interceptors);
         // wrap the output with the configured interceptors

--- a/camel-core/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
+++ b/camel-core/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
@@ -211,7 +211,7 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
             // if we found any expired then we need to sort, onEviction and remove
             if (!expired.isEmpty()) {
                 // sort according to the expired time so we got the first expired first
-                Collections.sort(expired, new Comparator<TimeoutMapEntry<K, V>>() {
+                expired.sort(new Comparator<TimeoutMapEntry<K, V>>() {
                     public int compare(TimeoutMapEntry<K, V> a, TimeoutMapEntry<K, V> b) {
                         long diff = a.getExpireTime() - b.getExpireTime();
                         if (diff == 0) {

--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -583,7 +583,7 @@ public final class URISupport {
         } else {
             // reorder parameters a..z
             List<String> keys = new ArrayList<String>(parameters.keySet());
-            Collections.sort(keys);
+            keys.sort(null);
 
             Map<String, Object> sorted = new LinkedHashMap<String, Object>(parameters.size());
             for (String key : keys) {

--- a/camel-core/src/main/java/org/apache/camel/util/UnitOfWorkHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/UnitOfWorkHelper.java
@@ -91,7 +91,7 @@ public final class UnitOfWorkHelper {
             // reverse so we invoke it FILO style instead of FIFO
             Collections.reverse(copy);
             // and honor if any was ordered by sorting it accordingly
-            Collections.sort(copy, new OrderedComparator());
+            copy.sort(new OrderedComparator());
 
             // invoke synchronization callbacks
             for (Synchronization synchronization : copy) {
@@ -119,7 +119,7 @@ public final class UnitOfWorkHelper {
             // reverse so we invoke it FILO style instead of FIFO
             Collections.reverse(copy);
             // and honor if any was ordered by sorting it accordingly
-            Collections.sort(copy, new OrderedComparator());
+            copy.sort(new OrderedComparator());
 
             // invoke synchronization callbacks
             for (Synchronization synchronization : copy) {
@@ -144,7 +144,7 @@ public final class UnitOfWorkHelper {
             // reverse so we invoke it FILO style instead of FIFO
             Collections.reverse(copy);
             // and honor if any was ordered by sorting it accordingly
-            Collections.sort(copy, new OrderedComparator());
+            copy.sort(new OrderedComparator());
 
             // invoke synchronization callbacks
             for (Synchronization synchronization : copy) {

--- a/camel-core/src/main/java/org/apache/camel/util/component/ApiMethodParser.java
+++ b/camel-core/src/main/java/org/apache/camel/util/component/ApiMethodParser.java
@@ -170,7 +170,7 @@ public abstract class ApiMethodParser<T> {
         }
         allArguments.clear();
 
-        Collections.sort(result, new Comparator<ApiMethodModel>() {
+        result.sort(new Comparator<ApiMethodModel>() {
             @Override
             public int compare(ApiMethodModel model1, ApiMethodModel model2) {
                 final int nameCompare = model1.name.compareTo(model2.name);

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanConcurrentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanConcurrentTest.java
@@ -50,7 +50,7 @@ public class BeanConcurrentTest extends ContextTestSupport {
             String body = mock.getReceivedExchanges().get(i).getIn().getBody(String.class);
             list.add(body);
         }
-        Collections.sort(list);
+        list.sort(null);
 
         // and they should be unique and no lost messages
         assertEquals(1000, list.size());

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanExpressionConcurrentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanExpressionConcurrentTest.java
@@ -50,7 +50,7 @@ public class BeanExpressionConcurrentTest extends ContextTestSupport {
             String body = mock.getReceivedExchanges().get(i).getIn().getBody(String.class);
             list.add(body);
         }
-        Collections.sort(list);
+        list.sort(null);
 
         // and they should be unique and no lost messages
         assertEquals(1000, list.size());

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerDirectoryFilterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerDirectoryFilterTest.java
@@ -69,7 +69,7 @@ public class FileConsumerDirectoryFilterTest extends ContextTestSupport {
         assertEquals(4, names.size());
         // copy to list so its easier to index
         List<String> list = new ArrayList<String>(names);
-        Collections.sort(list);
+        list.sort(null);
 
         assertEquals("okDir", list.get(0));
         // windows or unix paths

--- a/camel-core/src/test/java/org/apache/camel/util/OrderedComparatorTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/OrderedComparatorTest.java
@@ -37,7 +37,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(5));
         answer.add(new MyOrder(4));
 
-        Collections.sort(answer, new OrderedComparator());
+        answer.sort(new OrderedComparator());
 
         assertEquals(0, answer.get(0).getOrder());
         assertEquals(1, answer.get(1).getOrder());
@@ -54,7 +54,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(5));
         answer.add(new MyOrder(4));
 
-        Collections.sort(answer, new OrderedComparator(true));
+        answer.sort(new OrderedComparator(true));
 
         assertEquals(5, answer.get(0).getOrder());
         assertEquals(4, answer.get(1).getOrder());
@@ -72,7 +72,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(Ordered.HIGHEST));
         answer.add(new MyOrder(4));
 
-        Collections.sort(answer, new OrderedComparator());
+        answer.sort(new OrderedComparator());
 
         assertEquals(Ordered.HIGHEST, answer.get(0).getOrder());
         assertEquals(0, answer.get(1).getOrder());
@@ -91,7 +91,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(Ordered.HIGHEST));
         answer.add(new MyOrder(4));
 
-        Collections.sort(answer, new OrderedComparator(true));
+        answer.sort(new OrderedComparator(true));
 
         assertEquals(200, answer.get(0).getOrder());
         assertEquals(50, answer.get(1).getOrder());
@@ -110,7 +110,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(Ordered.LOWEST));
         answer.add(new MyOrder(-4));
 
-        Collections.sort(answer, new OrderedComparator());
+        answer.sort(new OrderedComparator());
 
         assertEquals(-4, answer.get(0).getOrder());
         assertEquals(-2, answer.get(1).getOrder());
@@ -129,7 +129,7 @@ public class OrderedComparatorTest extends TestCase {
         answer.add(new MyOrder(Ordered.LOWEST));
         answer.add(new MyOrder(-4));
 
-        Collections.sort(answer, new OrderedComparator(true));
+        answer.sort(new OrderedComparator(true));
 
         assertEquals(Ordered.LOWEST, answer.get(0).getOrder());
         assertEquals(200, answer.get(1).getOrder());


### PR DESCRIPTION
Usage of Collections.sort(CopyOnWriteArrayList, Comparator) causes an UnsupportedOperationException on Oracle Java 1.8.0 up to fixpack 20 due to the documented restriction of this method to require an implemented ListIterator#set(...) operation on the given list.

For details have a look at [CAMEL-10562](https://issues.apache.org/jira/browse/CAMEL-10562).