### PR TITLE
New Operation DELETE_INDEX

### DIFF
--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConfiguration.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConfiguration.java
@@ -34,7 +34,7 @@ public class ElasticsearchConfiguration {
 
     @UriPath @Metadata(required = "true")
     private String clusterName;
-    @UriParam(enums = "INDEX,UPDATE,BULK,BULK_INDEX,GET_BY_ID,MULTIGET,DELETE,EXISTS,SEARCH,MULTISEARCH")
+    @UriParam(enums = "INDEX,UPDATE,BULK,BULK_INDEX,GET_BY_ID,MULTIGET,DELETE,EXISTS,SEARCH,MULTISEARCH,DELETE_INDEX")
     private String operation;
     @UriParam
     private String indexName;

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConstants.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchConstants.java
@@ -29,6 +29,7 @@ public interface ElasticsearchConstants {
     String OPERATION_GET_BY_ID = "GET_BY_ID";
     String OPERATION_MULTIGET = "MULTIGET";
     String OPERATION_DELETE = "DELETE";
+    String OPERATION_DELETE_INDEX = "DELETE_INDEX";
     String OPERATION_SEARCH = "SEARCH";
     String OPERATION_MULTISEARCH = "MULTISEARCH";
     String OPERATION_EXISTS = "EXISTS";

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultProducer;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -82,6 +83,8 @@ public class ElasticsearchProducer extends DefaultProducer {
             return ElasticsearchConstants.OPERATION_SEARCH;
         } else if (request instanceof MultiSearchRequest) {
             return ElasticsearchConstants.OPERATION_MULTISEARCH;
+        } else if (request instanceof DeleteIndexRequest) {
+            return ElasticsearchConstants.OPERATION_DELETE_INDEX;
         }
 
         String operationConfig = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_OPERATION, String.class);
@@ -166,6 +169,9 @@ public class ElasticsearchProducer extends DefaultProducer {
         } else if (ElasticsearchConstants.OPERATION_MULTISEARCH.equals(operation)) {
             MultiSearchRequest multiSearchRequest = message.getBody(MultiSearchRequest.class);
             message.setBody(client.multiSearch(multiSearchRequest));
+        } else if (ElasticsearchConstants.OPERATION_DELETE_INDEX.equals(operation)) {
+        	DeleteIndexRequest deleteIndexRequest = message.getBody(DeleteIndexRequest.class);
+            message.setBody(client.admin().indices().delete(deleteIndexRequest).actionGet());
         } else {
             throw new IllegalArgumentException(ElasticsearchConstants.PARAM_OPERATION + " value '" + operation + "' is not supported");
         }

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -24,6 +24,7 @@ import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.elasticsearch.ElasticsearchConstants;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.exists.ExistsRequest;
@@ -164,6 +165,14 @@ public final class ElasticsearchActionRequestConverter {
                 .type(exchange.getIn().getHeader(
                         ElasticsearchConstants.PARAM_INDEX_TYPE,
                         String.class)).id(id);
+    }
+    
+    @Converter
+    public static DeleteIndexRequest toDeleteIndexRequest(String id, Exchange exchange) {
+        return new DeleteIndexRequest()
+                .indices(exchange.getIn().getHeader(
+                        ElasticsearchConstants.PARAM_INDEX_NAME,
+                        String.class));
     }
 
     @Converter


### PR DESCRIPTION
The purpose of this change is to add a new feature. Allow delete the index as a whole at one time