### PR TITLE
CAMEL-10679

### DIFF
--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
@@ -72,7 +72,9 @@ public class SpringWebserviceConfiguration {
     private int timeout = -1;
     @UriParam(label = "producer")
     private boolean allowResponseHeaderOverride;
-
+    @UriParam(label = "producer")
+    private boolean allowResponseAttachmentOverride;
+    
     /* Consumer configuration */
     @UriParam(label = "consumer")
     private EndpointMappingKey endpointMappingKey;
@@ -401,5 +403,22 @@ public class SpringWebserviceConfiguration {
     public void setAllowResponseHeaderOverride(boolean allowResponseHeaderOverride) {
         this.allowResponseHeaderOverride = allowResponseHeaderOverride;
     }
+    /**
+     * @return boolean - true, will override attachments with spring-ws response message attachments
+     */
+    public boolean isAllowResponseAttachmentOverride() {
+        return allowResponseAttachmentOverride;
+    }
 
+    /**
+     * Option to override soap response attachments in in/out exchange with attachments info the actual service layer.
+     * If the invoked service appends or rewrites the soap attachments this option when set to true, allows the modified
+     * soap attachments to be overwritten in in/out message attachments
+     * 
+     * @param allowResponseAttachmentOverride
+     *            - true, will override attachments with spring-ws response message attachments
+     */
+    public void setAllowResponseAttachmentOverride(boolean allowResponseAttachmentOverride) {
+        this.allowResponseAttachmentOverride = allowResponseAttachmentOverride;
+    }
 }

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapAttachmentResponseProcessor.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapAttachmentResponseProcessor.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import javax.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * Returns the request as the response so it can be analysed (eg. for presence
+ * of SOAP Headers). 
+ * Also adds 2 attachments to the out message, which could be returned in a soap message by a ws request.
+ */
+public class SoapAttachmentResponseProcessor implements Processor {
+
+    public void process(Exchange exchange) throws Exception {
+        exchange.setOut(exchange.getIn());
+        exchange.getOut().addAttachment("responseAttachment1.txt", new DataHandler("responseAttachment1", "text/plain"));
+        exchange.getOut().addAttachment("responseAttachment2.xml", new DataHandler("<responseAttachment2/>", "application/xml"));
+    }
+
+}

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration
+public class SoapResponseAttachmentTest extends AbstractJUnit4SpringContextTests {
+
+    private final String xmlRequestForGoogleStockQuote = "<GetQuote xmlns=\"http://www.webserviceX.NET/\"><symbol>GOOG</symbol></GetQuote>";
+    private final String soapHeader = "<h:Header xmlns:h=\"http://www.webserviceX.NET/\"><h:MessageID>1234567890</h:MessageID><h:Nested><h:NestedID>1111</h:NestedID></h:Nested></h:Header>";
+
+    @Produce
+    private ProducerTemplate template;
+
+    /**
+     * This tests if attachments, returned by a spring-ws request, are populated into the exchange. 
+     * The SOAP attachments are populated by the SoapAttachmentResponseProcessor. 
+     * Which adds 2 response attachments.
+     * Note: 'allowResponseAttachmentOverride=true' must be set!
+     *
+     * @throws Exception
+     */
+    @Test()
+    public void consumeStockQuoteWebserviceWithSoapHeader() throws Exception {
+        Exchange result = template.request("direct:stockQuoteWebservice", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setBody(xmlRequestForGoogleStockQuote);
+                exchange.getIn().setHeader(SpringWebserviceConstants.SPRING_WS_SOAP_HEADER, soapHeader);
+                exchange.getIn().addAttachment("requestAttachment1.txt", new DataHandler("hello attachment!", "text/plain"));
+            }
+        });
+        assertNotNull(result);
+        assertNotNull(result.getOut().getAttachment("requestAttachment1.txt"));
+        assertNotNull(result.getOut().getAttachment("responseAttachment1.txt"));
+        assertNotNull(result.getOut().getAttachment("responseAttachment2.xml"));
+    }
+}

--- a/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest-context.xml
+++ b/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest-context.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <!-- producer routes (web service clients) -->
+        <route>
+            <from uri="direct:stockQuoteWebservice"/>
+            <to uri="spring-ws:http://localhost?webServiceTemplate=#webServiceTemplate&amp;soapAction=http://www.stockquotes.edu/GetQuote&amp;allowResponseAttachmentOverride=true"/>
+        </route>
+
+        <!-- consumer route (providing the actual web service) that responds with the request so we can see SOAP headers -->
+        <route>
+            <from uri="spring-ws:soapaction:http://www.stockquotes.edu/GetQuote?endpointMapping=#endpointMapping"/>
+            <to uri="responseProcessor"/>
+        </route>
+    </camelContext>
+
+    <bean id="messageFactory" class="org.springframework.ws.soap.saaj.SaajSoapMessageFactory"/>
+
+    <bean id="endpointMapping"
+          class="org.apache.camel.component.spring.ws.bean.CamelEndpointMapping"/>
+
+    <bean id="responseProcessor"
+          class="org.apache.camel.component.spring.ws.SoapAttachmentResponseProcessor"/>
+
+    <bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate">
+        <property name="defaultUri" value="http://localhost"/>
+        <property name="messageSender">
+            <bean class="net.javacrumbs.springws.test.helper.InMemoryWebServiceMessageSender"/>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
Producer does not populate attachments from response.

I would think of refactoring the whole part of the response handling.
In my opinion it would be best to handle this the same way as the BasicMessageFilter does this for the request message.
This way anyone could implement custom behaviour if neccessary.
I would have done it, but i didnt want to break anybodys code, so i just implemented it the same way the headers are populated.
Feel free to contact me about the change.