### PR TITLE
Added support for oplog tracking and support for different tracking strategies

### DIFF
--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -83,6 +83,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <scope>test</scope>

--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -66,7 +66,7 @@ The MongoDB component has no options.
 
 
 // endpoint options: START
-The MongoDB component supports 22 endpoint options which are listed below:
+The MongoDB component supports 24 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -85,15 +85,17 @@ The MongoDB component supports 22 endpoint options which are listed below:
 | exchangePattern | consumer (advanced) |  | ExchangePattern | Sets the exchange pattern when the consumer creates an exchange.
 | cursorRegenerationDelay | advanced | 1000 | long | MongoDB tailable cursors will block until new data arrives. If no new data is inserted after some time the cursor will be automatically freed and closed by the MongoDB server. The client is expected to regenerate the cursor if needed. This value specifies the time to wait before attempting to fetch a new cursor and if the attempt fails how long before the next attempt is made. Default value is 1000ms.
 | dynamicity | advanced | false | boolean | Sets whether this endpoint will attempt to dynamically resolve the target database and collection from the incoming Exchange properties. Can be used to override at runtime the database and collection specified on the otherwise static endpoint URI. It is disabled by default to boost performance. Enabling it will take a minimal performance hit.
-| readPreference | advanced |  | ReadPreference | Sets a MongoDB ReadPreference on the Mongo connection. Read preferences set directly on the connection will be overridden by this setting. The link com.mongodb.ReadPreferencevalueOf(String) utility method is used to resolve the passed readPreference value. Some examples for the possible values are nearest primary or secondary etc.
+| readPreference | advanced |  | ReadPreference | Sets a MongoDB ReadPreference on the Mongo connection. Read preferences set directly on the connection will be overridden by this setting. The link ReadPreferencevalueOf(String) utility method is used to resolve the passed readPreference value. Some examples for the possible values are nearest primary or secondary etc.
 | synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
 | writeResultAsHeader | advanced | false | boolean | In write operations it determines whether instead of returning WriteResult as the body of the OUT message we transfer the IN message to the OUT and attach the WriteResult as a header.
 | persistentId | tail |  | String | One tail tracking collection can host many trackers for several tailable consumers. To keep them separate each tracker should have its own unique persistentId.
 | persistentTailTracking | tail | false | boolean | Enable persistent tail tracking which is a mechanism to keep track of the last consumed message across system restarts. The next time the system is up the endpoint will recover the cursor from the point where it last stopped slurping records.
+| persistRecords | tail | -1 | int | Sets the number of tailed records after which the tail tracking data is persisted to MongoDB.
 | tailTrackCollection | tail |  | String | Collection where tail tracking information will be persisted. If not specified link MongoDbTailTrackingConfigDEFAULT_COLLECTION will be used by default.
 | tailTrackDb | tail |  | String | Indicates what database the tail tracking mechanism will persist to. If not specified the current database will be picked by default. Dynamicity will not be taken into account even if enabled i.e. the tail tracking database will not vary past endpoint initialisation.
 | tailTrackField | tail |  | String | Field where the last tracked value will be placed. If not specified link MongoDbTailTrackingConfigDEFAULT_FIELD will be used by default.
 | tailTrackIncreasingField | tail |  | String | Correlation field in the incoming record which is of increasing nature and will be used to position the tailing cursor every time it is generated. The cursor will be (re)created with a query of type: tailTrackIncreasingField lastValue (possibly recovered from persistent tail tracking). Can be of type Integer Date String etc. NOTE: No support for dot notation at the current time so the field should be at the top level of the document.
+| tailTrackingStrategy | tail | LITERAL | MongoDBTailTrackingEnum | Sets the strategy used to extract the increasing field value and to create the query to position the tail cursor.
 |=======================================================================
 {% endraw %}
 // endpoint options: END
@@ -811,6 +813,122 @@ from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasing
     .autoStartup(false)
     .to("mock:test");
 -----------------------------------------------------------------------------------------------------------------------------------
+
+[[MongoDB-TailtrackingOnOplog]]
+Oplog Tail Tracking
+^^^^^^^^^^^^^^^^^^^
+
+The *oplog* collection tracking feature allows to implement trigger like functionality in MongoDB.
+In order to activate this collection you will have first to activate a replica set. For more
+information on this topic please check https://docs.mongodb.com/manual/tutorial/deploy-replica-set/ .
+
+Below you can find an example of a Java DSL based route demonstrating how you can use the component to track the *oplog*
+collection. In this specific case we are filtering the events which affect a collection *customers* in
+database *optlog_test*. Note that the `tailTrackIncreasingField` is a timestamp field ('ts') which implies
+that you have to use the `tailTrackingStrategy` parameter with the *TIMESTAMP* value.
+
+[source,java]
+-----------------------------------------------------------------------------------------------------------------------------------
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mongodb.MongoDBTailTrackingEnum;
+import org.apache.camel.main.Main;
+
+import java.io.InputStream;
+
+/**
+ * For this to work you need to turn on the replica set
+ * <p>
+ * Commands to create a replica set:
+ * <p>
+ * rs.initiate( {
+ * _id : "rs0",
+ * members: [ { _id : 0, host : "localhost:27017" } ]
+ * })
+ */
+public class MongoDbTracker {
+
+    private final String database;
+
+    private final String collection;
+
+    private final String increasingField;
+
+    private MongoDBTailTrackingEnum trackingStrategy;
+
+    private int persistRecords = -1;
+
+    private boolean persistenTailTracking;
+
+    public MongoDbTracker(String database, String collection, String increasingField) {
+        this.database = database;
+        this.collection = collection;
+        this.increasingField = increasingField;
+    }
+
+    public static void main(String[] args) throws Exception {
+        final MongoDbTracker mongoDbTracker = new MongoDbTracker("local", "oplog.rs", "ts");
+        mongoDbTracker.setTrackingStrategy(MongoDBTailTrackingEnum.TIMESTAMP);
+        mongoDbTracker.setPersistRecords(5);
+        mongoDbTracker.setPersistenTailTracking(true);
+        mongoDbTracker.startRouter();
+        // run until you terminate the JVM
+        System.out.println("Starting Camel. Use ctrl + c to terminate the JVM.\n");
+
+    }
+
+    public void setTrackingStrategy(MongoDBTailTrackingEnum trackingStrategy) {
+        this.trackingStrategy = trackingStrategy;
+    }
+
+    public void setPersistRecords(int persistRecords) {
+        this.persistRecords = persistRecords;
+    }
+
+    public void setPersistenTailTracking(boolean persistenTailTracking) {
+        this.persistenTailTracking = persistenTailTracking;
+    }
+
+    void startRouter() throws Exception {
+        // create a Main instance
+        Main main = new Main();
+        main.bind(MongoConstants.CONN_NAME, new MongoClient("localhost", 27017));
+        main.addRouteBuilder(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                getContext().getTypeConverterRegistry().addTypeConverter(InputStream.class, BasicDBObject.class,
+                        new MongoToInputStreamConverter());
+                from("mongodb://" + MongoConstants.CONN_NAME + "?database=" + database
+                        + "&collection=" + collection
+                        + "&persistentTailTracking=" + persistenTailTracking
+                        + "&persistentId=trackerName" + "&tailTrackDb=local"
+                        + "&tailTrackCollection=talendTailTracking"
+                        + "&tailTrackField=lastTrackingValue"
+                        + "&tailTrackIncreasingField=" + increasingField
+                        + "&tailTrackingStrategy=" + trackingStrategy.toString()
+                        + "&persistRecords=" + persistRecords
+                        + "&cursorRegenerationDelay=1000")
+                        .filter().jsonpath("$[?(@.ns=='optlog_test.customers')]")
+                        .id("logger")
+                        .to("log:logger?level=WARN")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                Message message = exchange.getIn();
+                                System.out.println(message.getBody().toString());
+                                exchange.getOut().setBody(message.getBody().toString());
+                            }
+                        });
+            }
+        });
+        main.run();
+    }
+}
+-----------------------------------------------------------------------------------------------------------------------------------
+
 
 [[MongoDB-Typeconversions]]
 Type conversions

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDBTailTrackingEnum.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDBTailTrackingEnum.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mongodb;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.bson.types.BSONTimestamp;
+
+/**
+ * Contains the concrete MongoDB tail tracking strategies.
+ */
+public enum MongoDBTailTrackingEnum implements MongoDBTailTrackingStrategy {
+
+    TIMESTAMP {
+
+        @Override
+        public Object extractLastVal(DBObject o, String increasingField) {
+            Object temp = o.get(increasingField);
+            return ((BSONTimestamp) temp).getTime();
+        }
+
+        @Override
+        public BasicDBObject createQuery(Object lastVal, String increasingField) {
+            return new BasicDBObject(increasingField, new BasicDBObject("$gt", new BSONTimestamp((Integer)lastVal, 1)));
+        }
+    }, LITERAL {
+
+        @Override
+        public Object extractLastVal(DBObject o, String increasingField) {
+            return o.get(increasingField);
+        }
+
+        @Override
+        public BasicDBObject createQuery(Object lastVal, String increasingField) {
+            return new BasicDBObject(increasingField, new BasicDBObject("$gt", lastVal));
+        }
+    };
+}

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDBTailTrackingStrategy.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDBTailTrackingStrategy.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mongodb;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * This class contains different methods for extracting and saving tail tracking information.
+ */
+public interface MongoDBTailTrackingStrategy {
+
+    /**
+     * Extracts the last tracking value using the field name or an expression.
+     * @param o The object retrieved by the trailing process.
+     * @param increasingField The field name or an expression used to extract the last value.
+     * @return an object representing the last tracking value in a MongoDB collection.
+     */
+    Object extractLastVal(DBObject o, String increasingField);
+
+    /**
+     * Creates an object to be used in a query using the last tracking value.
+     * @param lastVal The last tracking value.
+     * @param increasingField The field name or an expression used to extract the last value.
+     * @return the object to be used in a MongoDB query.
+     */
+    BasicDBObject createQuery(Object lastVal, String increasingField);
+}

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -663,6 +663,9 @@ public class MongoDbEndpoint extends DefaultEndpoint {
     }
 
     public MongoDBTailTrackingEnum getTailTrackingStrategy() {
+        if(tailTrackingStrategy == null) {
+            tailTrackingStrategy = MongoDBTailTrackingEnum.LITERAL;
+        }
         return tailTrackingStrategy;
     }
 

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -188,9 +188,6 @@ public class MongoDbEndpoint extends DefaultEndpoint {
                 if (persistentTailTracking && (ObjectHelper.isEmpty(persistentId))) {
                     throw new IllegalArgumentException("persistentId is compulsory for persistent tail tracking");
                 }
-                if (persistentTailTracking && (ObjectHelper.isEmpty(persistentId))) {
-                    throw new IllegalArgumentException("persistentId is compulsory for persistent tail tracking");
-                }
             }
 
         } else {

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailTrackingConfig.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailTrackingConfig.java
@@ -18,17 +18,9 @@ package org.apache.camel.component.mongodb;
 
 public class MongoDbTailTrackingConfig {
     
-    public static final String DEFAULT_COLLECTION = "camelTailTracking";
-    public static final String DEFAULT_FIELD = "lastTrackingValue";
-    
-    /**
-     * See {@link MongoDbEndpoint#setTailTrackIncreasingField(String)}
-     */
-    public final String increasingField;
-    /**
-     * See {@link MongoDbEndpoint#setPersistentTailTracking(boolean)}
-     */
-    public final boolean persistent;
+    static final String DEFAULT_COLLECTION = "camelTailTracking";
+    static final String DEFAULT_FIELD = "lastTrackingValue";
+
     /**
      * See {@link MongoDbEndpoint#setTailTrackDb(String)}
      */
@@ -38,21 +30,35 @@ public class MongoDbTailTrackingConfig {
      */
     public final String collection;
     /**
+     * See {@link MongoDbEndpoint#setTailTrackIncreasingField(String)}
+     */
+    final String increasingField;
+    /**
+     * See {@link MongoDbEndpoint#setPersistentTailTracking(boolean)}
+     */
+    final boolean persistent;
+    /**
      * See {@link MongoDbEndpoint#setTailTrackField(String)}
      */
-    public final String field;
+    final String field;
     /**
      * See {@link MongoDbEndpoint#setPersistentId(String)}
      */
-    public final String persistentId;
+    final String persistentId;
+
+    /**
+     * See {@link MongoDbEndpoint#setTailTrackingStrategy(MongoDBTailTrackingEnum)}
+     */
+    final MongoDBTailTrackingEnum mongoDBTailTrackingStrategy;
     
     public MongoDbTailTrackingConfig(boolean persistentTailTracking, String tailTrackIncreasingField, String tailTrackDb,
-            String tailTrackCollection, String tailTrackField, String persistentId) {
+            String tailTrackCollection, String tailTrackField, String persistentId, MongoDBTailTrackingEnum mongoDBTailTrackingStrategy) {
         this.increasingField = tailTrackIncreasingField;
         this.persistent = persistentTailTracking;
         this.db = tailTrackDb;
         this.persistentId = persistentId;
         this.collection = tailTrackCollection == null ? MongoDbTailTrackingConfig.DEFAULT_COLLECTION : tailTrackCollection;
         this.field = tailTrackField == null ? MongoDbTailTrackingConfig.DEFAULT_FIELD : tailTrackField;
+        this.mongoDBTailTrackingStrategy = mongoDBTailTrackingStrategy == null ? MongoDBTailTrackingEnum.LITERAL : mongoDBTailTrackingStrategy;
     }
 }

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailTrackingManager.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailTrackingManager.java
@@ -20,31 +20,29 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
-
+import org.bson.types.BSONTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MongoDbTailTrackingManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbTailTrackingManager.class);
-    
     public Object lastVal;
-
     private final MongoClient connection;
     private final MongoDbTailTrackingConfig config;
     private MongoCollection<BasicDBObject> dbCol;
     private BasicDBObject trackingObj;
-    
+
     public MongoDbTailTrackingManager(MongoClient connection, MongoDbTailTrackingConfig config) {
         this.connection = connection;
         this.config = config;
     }
-    
+
     public void initialize() throws Exception {
         if (!config.persistent) {
             return;
         }
-        
+
         dbCol = connection.getDatabase(config.db).getCollection(config.collection, BasicDBObject.class);
         BasicDBObject filter = new BasicDBObject("persistentId", config.persistentId);
         trackingObj = dbCol.find(filter).first();
@@ -55,43 +53,42 @@ public class MongoDbTailTrackingManager {
         // keep only the _id, the rest is useless and causes more overhead during update
         trackingObj = new BasicDBObject("_id", trackingObj.get("_id"));
     }
-    
+
     public synchronized void persistToStore() {
         if (!config.persistent || lastVal == null) {
             return;
         }
-        
+
         if (LOG.isDebugEnabled()) {
             LOG.debug("Persisting lastVal={} to store, collection: {}", lastVal, config.collection);
         }
-        
+
         BasicDBObject updateObj = new BasicDBObject().append("$set", new BasicDBObject(config.field, lastVal));
         dbCol.updateOne(trackingObj, updateObj);
         trackingObj = dbCol.find().first();
     }
-    
+
     public synchronized Object recoverFromStore() {
         if (!config.persistent) {
             return null;
         }
-        
+
         lastVal = dbCol.find(trackingObj).first().get(config.field);
-        
+
         if (LOG.isDebugEnabled()) {
             LOG.debug("Recovered lastVal={} from store, collection: {}", lastVal, config.collection);
         }
-        
+
         return lastVal;
     }
-    
+
     public void setLastVal(DBObject o) {
         if (config.increasingField == null) {
             return;
         }
-        
-        lastVal = o.get(config.increasingField);
+        lastVal = config.mongoDBTailTrackingStrategy.extractLastVal(o, config.increasingField);
     }
-    
+
     public String getIncreasingFieldName() {
         return config.increasingField;
     }

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDBTailTrackingStrategyTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDBTailTrackingStrategyTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mongodb;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.bson.types.BSONTimestamp;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MongoDBTailTrackingStrategyTest {
+
+    private static final String INCREASING_FIELD_NAME = "ts";
+
+    @Test
+    public void testExtractLastValForLiterals() throws Exception {
+        int expected = 1483701465;
+        DBObject o = mock(DBObject.class);
+        when(o.get(INCREASING_FIELD_NAME)).thenReturn(expected);
+        Object lastVal = MongoDBTailTrackingEnum.LITERAL.extractLastVal(o, INCREASING_FIELD_NAME);
+        assertThat(lastVal, is(expected));
+    }
+
+    @Test
+    public void testCreateQueryForLiterals() {
+        Integer lastVal = 1483701465;
+        BasicDBObject basicDBObject = MongoDBTailTrackingEnum.LITERAL.createQuery(lastVal, INCREASING_FIELD_NAME);
+        final Object actual = basicDBObject.get(INCREASING_FIELD_NAME);
+        assertThat(actual, is(notNullValue()));
+        assertThat(actual instanceof BasicDBObject, is(true));
+        assertThat(((BasicDBObject)actual).get("$gt"), is(lastVal));
+    }
+
+    @Test
+    public void testExtractLastValForTimestamp() throws Exception {
+        DBObject o = mock(DBObject.class);
+        final int lastVal = 1483701465;
+        when(o.get(INCREASING_FIELD_NAME)).thenReturn(new BSONTimestamp(lastVal, 1));
+        Object res = MongoDBTailTrackingEnum.TIMESTAMP.extractLastVal(o, INCREASING_FIELD_NAME);
+        assertThat(res, is(lastVal));
+    }
+
+    @Test
+    public void testExtracCreateQueryForTimestamp() throws Exception {
+        final int lastVal = 1483701465;
+        BasicDBObject basicDBObject = MongoDBTailTrackingEnum.TIMESTAMP.createQuery(lastVal, INCREASING_FIELD_NAME);
+        final Object actual = basicDBObject.get(INCREASING_FIELD_NAME);
+        assertThat(actual, is(notNullValue()));
+        assertThat(actual instanceof BasicDBObject, is(true));
+        assertThat(((BasicDBObject)actual).get("$gt") instanceof BSONTimestamp, is(true));
+        BSONTimestamp bsonTimestamp = (BSONTimestamp) ((BasicDBObject)actual).get("$gt");
+        assertThat(bsonTimestamp.getTime(), is(lastVal));
+    }
+
+
+}


### PR DESCRIPTION
This pull request adds an MongoDBTailTrackingStrategy interface which allows to flexibly extend the way the tracking field data is extracted.
We introduced this change so that we can perform oplog tracking which uses as id a MongoDB Timestamp object. The current implementation did not allow to track using this specific data type. The oplog table can be used to implement database like triggers in MongoDB.
With this patch you can track the oplog table and implement routes that act as triggers on MongoDB tables.
I am a beginner with little experience in Mongo and Camel, so it might well be that I did something wrong. Please let me know your thoughts on this implementation.

We have used this component in order to create a Talend ESB component which listens to oplog events.

![tail_tracking_component](https://cloud.githubusercontent.com/assets/442931/21730160/595543a6-d446-11e6-8719-eaf2fa9a1440.png)
