### PR TITLE
CAMEL-10679

### DIFF
--- a/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
+++ b/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
@@ -93,7 +93,7 @@ The Spring WebService component has no options.
 
 
 // endpoint options: START
-The Spring WebService component supports 24 endpoint options which are listed below:
+The Spring WebService component supports 21 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -103,12 +103,10 @@ The Spring WebService component supports 24 endpoint options which are listed be
 | lookupKey | consumer |  | String | Endpoint mapping key if endpoint mapping is used
 | webServiceEndpointUri | producer |  | String | The default Web Service endpoint uri to use for the producer.
 | messageFilter | common |  | MessageFilter | Option to provide a custom MessageFilter. For example when you want to process your headers or attachments by your own.
-| bridgeErrorHandler | consumer | false | boolean | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored.
 | endpointDispatcher | consumer |  | CamelEndpointDispatcher | Spring org.springframework.ws.server.endpoint.MessageEndpoint for dispatching messages received by Spring-WS to a Camel endpoint to integrate with existing (legacy) endpoint mappings like PayloadRootQNameEndpointMapping SoapActionEndpointMapping etc.
 | endpointMapping | consumer |  | CamelSpringWSEndpointMapping | Reference to an instance of org.apache.camel.component.spring.ws.bean.CamelEndpointMapping in the Registry/ApplicationContext. Only one bean is required in the registry to serve all Camel/Spring-WS endpoints. This bean is auto-discovered by the MessageDispatcher and used to map requests to Camel endpoints based on characteristics specified on the endpoint (like root QName SOAP action etc)
 | expression | consumer |  | String | The XPath expression to use when option type=xpathresult. Then this option is required to be configured.
-| exceptionHandler | consumer (advanced) |  | ExceptionHandler | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored.
-| exchangePattern | consumer (advanced) |  | ExchangePattern | Sets the exchange pattern when the consumer creates an exchange.
+| allowResponseAttachmentOverride | producer | false | boolean | Option to override soap response attachments in in/out exchange with attachments from the actual service layer. If the invoked service appends or rewrites the soap attachments this option when set to true allows the modified soap attachments to be overwritten in in/out message attachments
 | allowResponseHeaderOverride | producer | false | boolean | Option to override soap response header in in/out exchange with header info from the actual service layer. If the invoked service appends or rewrites the soap header this option when set to true allows the modified soap header to be overwritten in in/out message headers
 | faultAction | producer |  | URI | Signifies the value for the faultAction response WS-Addressing Fault Action header that is provided by the method.
 | faultTo | producer |  | URI | Signifies the value for the faultAction response WS-Addressing FaultTo header that is provided by the method.
@@ -121,7 +119,6 @@ The Spring WebService component supports 24 endpoint options which are listed be
 | timeout | producer |  | int | Sets the socket read timeout (in milliseconds) while invoking a webservice using the producer see URLConnection.setReadTimeout() and CommonsHttpMessageSender.setReadTimeout(). This option works when using the built-in message sender implementations: CommonsHttpMessageSender and HttpUrlConnectionMessageSender. One of these implementations will be used by default for HTTP based services unless you customize the Spring WS configuration options supplied to the component. If you are using a non-standard sender it is assumed that you will handle your own timeout configuration. The built-in message sender HttpComponentsMessageSender is considered instead of CommonsHttpMessageSender which has been deprecated see HttpComponentsMessageSender.setReadTimeout().
 | webServiceTemplate | producer |  | WebServiceTemplate | Option to provide a custom WebServiceTemplate. This allows for full control over client-side web services handling; like adding a custom interceptor or specifying a fault resolver message sender or message factory.
 | wsAddressingAction | producer |  | URI | WS-Addressing 1.0 action header to include when accessing web services. The To header is set to the address of the web service as specified in the endpoint URI (default Spring-WS behavior).
-| synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
 | sslContextParameters | security |  | SSLContextParameters | To configure security using SSLContextParameters
 |=======================================================================
 {% endraw %}

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
@@ -385,9 +385,6 @@ public class SpringWebserviceConfiguration {
         this.messageIdStrategy = messageIdStrategy;
     }
 
-    /**
-     * @return boolean - true, will override header with spring-ws response message header
-     */
     public boolean isAllowResponseHeaderOverride() {
         return allowResponseHeaderOverride;
     }
@@ -397,15 +394,12 @@ public class SpringWebserviceConfiguration {
      * If the invoked service appends or rewrites the soap header this option when set to true, allows the modified
      * soap header to be overwritten in in/out message headers
      * 
-     * @param allowResponseHeaderOverride
-     *            - true, will override header with spring-ws response message header
+     * @param allowResponseHeaderOverride - true, will override header with spring-ws response message header
      */
     public void setAllowResponseHeaderOverride(boolean allowResponseHeaderOverride) {
         this.allowResponseHeaderOverride = allowResponseHeaderOverride;
     }
-    /**
-     * @return boolean - true, will override attachments with spring-ws response message attachments
-     */
+
     public boolean isAllowResponseAttachmentOverride() {
         return allowResponseAttachmentOverride;
     }
@@ -415,8 +409,7 @@ public class SpringWebserviceConfiguration {
      * If the invoked service appends or rewrites the soap attachments this option when set to true, allows the modified
      * soap attachments to be overwritten in in/out message attachments
      * 
-     * @param allowResponseAttachmentOverride
-     *            - true, will override attachments with spring-ws response message attachments
+     * @param allowResponseAttachmentOverride - true, will override attachments with spring-ws response message attachments
      */
     public void setAllowResponseAttachmentOverride(boolean allowResponseAttachmentOverride) {
         this.allowResponseAttachmentOverride = allowResponseAttachmentOverride;

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConfiguration.java
@@ -74,7 +74,9 @@ public class SpringWebserviceConfiguration {
     private int timeout = -1;
     @UriParam(label = "producer")
     private boolean allowResponseHeaderOverride;
-
+    @UriParam(label = "producer")
+    private boolean allowResponseAttachmentOverride;
+    
     /* Consumer configuration */
     @UriParam(label = "consumer")
     private EndpointMappingKey endpointMappingKey;
@@ -401,5 +403,22 @@ public class SpringWebserviceConfiguration {
     public void setAllowResponseHeaderOverride(boolean allowResponseHeaderOverride) {
         this.allowResponseHeaderOverride = allowResponseHeaderOverride;
     }
+    /**
+     * @return boolean - true, will override attachments with spring-ws response message attachments
+     */
+    public boolean isAllowResponseAttachmentOverride() {
+        return allowResponseAttachmentOverride;
+    }
 
+    /**
+     * Option to override soap response attachments in in/out exchange with attachments from the actual service layer.
+     * If the invoked service appends or rewrites the soap attachments this option when set to true, allows the modified
+     * soap attachments to be overwritten in in/out message attachments
+     * 
+     * @param allowResponseAttachmentOverride
+     *            - true, will override attachments with spring-ws response message attachments
+     */
+    public void setAllowResponseAttachmentOverride(boolean allowResponseAttachmentOverride) {
+        this.allowResponseAttachmentOverride = allowResponseAttachmentOverride;
+    }
 }

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceProducer.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceProducer.java
@@ -109,18 +109,22 @@ public class SpringWebserviceProducer extends DefaultProducer {
             }
         });
     }
+ 
     /**
      * Populates soap message headers and attachments from soap response
-     * @param inOrOut {@link Message}
-     * @param soapMessage {@link SoapMessage}
+     * 
+     * @param inOrOut
+     *            {@link Message}
+     * @param soapMessage
+     *            {@link SoapMessage}
      */
     private void populateHeaderAndAttachmentsFromResponse(Message inOrOut, SoapMessage soapMessage) {
-    	 if (soapMessage.getSoapHeader() != null && getEndpoint().getConfiguration().isAllowResponseHeaderOverride()) { 
-    		 populateMessageHeaderFromResponse(inOrOut, soapMessage.getSoapHeader());
-    	 }
-    	 if (soapMessage.getAttachments() != null && getEndpoint().getConfiguration().isAllowResponseAttachmentOverride()) {
-    		 populateMessageAttachmentsFromResponse(inOrOut, soapMessage.getAttachments());
-    	 }
+        if (soapMessage.getSoapHeader() != null && getEndpoint().getConfiguration().isAllowResponseHeaderOverride()) {
+            populateMessageHeaderFromResponse(inOrOut, soapMessage.getSoapHeader());
+        }
+        if (soapMessage.getAttachments() != null && getEndpoint().getConfiguration().isAllowResponseAttachmentOverride()) {
+            populateMessageAttachmentsFromResponse(inOrOut, soapMessage.getAttachments());
+        }
     }
 
     /**
@@ -155,10 +159,10 @@ public class SpringWebserviceProducer extends DefaultProducer {
      * @param soapMessage {@link SoapMessage}
      */
     private void populateMessageAttachmentsFromResponse(Message inOrOut, Iterator<Attachment> attachments) {
-    	while (attachments.hasNext()) {
-    		Attachment attachment = attachments.next();
-    		inOrOut.getAttachments().put(attachment.getContentId(), attachment.getDataHandler());
-    	}
+        while (attachments.hasNext()) {
+            Attachment attachment = attachments.next();
+            inOrOut.getAttachments().put(attachment.getContentId(), attachment.getDataHandler());
+        }
     }    
     
     private void prepareMessageSenders(SpringWebserviceConfiguration configuration) {

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceProducer.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceProducer.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.client.core.WebServiceTemplate;
+import org.springframework.ws.mime.Attachment;
 import org.springframework.ws.soap.SoapHeader;
 import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
@@ -98,19 +99,28 @@ public class SpringWebserviceProducer extends DefaultProducer {
             public void doWithMessage(WebServiceMessage responseMessage) throws IOException, TransformerException {
                 SoapMessage soapMessage = (SoapMessage) responseMessage;
                 if (ExchangeHelper.isOutCapable(exchange)) {
-                    exchange.getOut().copyFromWithNewBody(exchange.getIn(), responseMessage.getPayloadSource());
-                    if (soapMessage.getSoapHeader() != null && getEndpoint().getConfiguration().isAllowResponseHeaderOverride()) {
-                        populateMessageHeaderFromResponse(exchange.getOut(), soapMessage.getSoapHeader());
-                    }
+                    exchange.getOut().copyFromWithNewBody(exchange.getIn(), soapMessage.getPayloadSource());
+                    populateHeaderAndAttachmentsFromResponse(exchange.getOut(), soapMessage);
                 } else {
-                    exchange.getIn().setBody(responseMessage.getPayloadSource());
-                    if (soapMessage.getSoapHeader() != null && getEndpoint().getConfiguration().isAllowResponseHeaderOverride()) {
-                        populateMessageHeaderFromResponse(exchange.getIn(), soapMessage.getSoapHeader());
-                    }
+                    exchange.getIn().setBody(soapMessage.getPayloadSource());
+                    populateHeaderAndAttachmentsFromResponse(exchange.getIn(), soapMessage);
                 }
 
             }
         });
+    }
+    /**
+     * Populates soap message headers and attachments from soap response
+     * @param inOrOut {@link Message}
+     * @param soapMessage {@link SoapMessage}
+     */
+    private void populateHeaderAndAttachmentsFromResponse(Message inOrOut, SoapMessage soapMessage) {
+    	 if (soapMessage.getSoapHeader() != null && getEndpoint().getConfiguration().isAllowResponseHeaderOverride()) { 
+    		 populateMessageHeaderFromResponse(inOrOut, soapMessage.getSoapHeader());
+    	 }
+    	 if (soapMessage.getAttachments() != null && getEndpoint().getConfiguration().isAllowResponseAttachmentOverride()) {
+    		 populateMessageAttachmentsFromResponse(inOrOut, soapMessage.getAttachments());
+    	 }
     }
 
     /**
@@ -139,7 +149,18 @@ public class SpringWebserviceProducer extends DefaultProducer {
 
         }
     }
-
+    /**
+     * Populates message attachments from soap response attachments 
+     * @param inOrOut {@link Message}
+     * @param soapMessage {@link SoapMessage}
+     */
+    private void populateMessageAttachmentsFromResponse(Message inOrOut, Iterator<Attachment> attachments) {
+    	while (attachments.hasNext()) {
+    		Attachment attachment = attachments.next();
+    		inOrOut.getAttachments().put(attachment.getContentId(), attachment.getDataHandler());
+    	}
+    }    
+    
     private void prepareMessageSenders(SpringWebserviceConfiguration configuration) {
         // Skip this whole thing if none of the relevant config options are set.
         if (!(configuration.getTimeout() > -1) && configuration.getSslContextParameters() == null) {

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapAttachmentResponseProcessor.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapAttachmentResponseProcessor.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import javax.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * Returns the request as the response so it can be analysed (eg. for presence
+ * of SOAP Headers). 
+ * Also adds 2 attachments to the out message, which could be returned in a soap message by a ws request.
+ */
+public class SoapAttachmentResponseProcessor implements Processor {
+
+    public void process(Exchange exchange) throws Exception {
+        exchange.setOut(exchange.getIn());
+        exchange.getOut().addAttachment("responseAttachment1.txt", new DataHandler("responseAttachment1", "text/plain"));
+        exchange.getOut().addAttachment("responseAttachment2.xml", new DataHandler("<responseAttachment2/>", "application/xml"));
+    }
+
+}

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration
+public class SoapResponseAttachmentTest extends AbstractJUnit4SpringContextTests {
+
+    private final String xmlRequestForGoogleStockQuote = "<GetQuote xmlns=\"http://www.webserviceX.NET/\"><symbol>GOOG</symbol></GetQuote>";
+    private final String soapHeader = "<h:Header xmlns:h=\"http://www.webserviceX.NET/\"><h:MessageID>1234567890</h:MessageID><h:Nested><h:NestedID>1111</h:NestedID></h:Nested></h:Header>";
+
+    @Produce
+    private ProducerTemplate template;
+
+    /**
+     * This tests if attachments, returned by a spring-ws request, are populated into the exchange. 
+     * The SOAP attachments are populated by the SoapAttachmentResponseProcessor. 
+     * Which adds 2 response attachments.
+     * Note: 'allowResponseAttachmentOverride=true' must be set!
+     *
+     * @throws Exception
+     */
+    @Test()
+    public void consumeStockQuoteWebserviceWithSoapHeader() throws Exception {
+        Exchange result = template.request("direct:stockQuoteWebservice", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setBody(xmlRequestForGoogleStockQuote);
+                exchange.getIn().setHeader(SpringWebserviceConstants.SPRING_WS_SOAP_HEADER, soapHeader);
+                exchange.getIn().addAttachment("requestAttachment1.txt", new DataHandler("hello attachment!", "text/plain"));
+            }
+        });
+        assertNotNull(result);
+        assertNotNull(result.getOut().getAttachment("requestAttachment1.txt"));
+        assertNotNull(result.getOut().getAttachment("responseAttachment1.txt"));
+        assertNotNull(result.getOut().getAttachment("responseAttachment2.xml"));
+    }
+}

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
@@ -46,7 +46,7 @@ public class SoapResponseAttachmentTest extends AbstractJUnit4SpringContextTests
      * @throws Exception
      */
     @Test()
-    public void consumeStockQuoteWebserviceWithSoapHeader() throws Exception {
+    public void consumeStockQuoteWebserviceWithSoapResponseAttachment() throws Exception {
         Exchange result = template.request("direct:stockQuoteWebservice", new Processor() {
 
             @Override

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest.java
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 package org.apache.camel.component.spring.ws;
-
-import static org.junit.Assert.assertNotNull;
-
 import javax.activation.DataHandler;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+import static org.junit.Assert.assertNotNull;
 
 @ContextConfiguration
 public class SoapResponseAttachmentTest extends AbstractJUnit4SpringContextTests {

--- a/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest-context.xml
+++ b/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/SoapResponseAttachmentTest-context.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <!-- producer routes (web service clients) -->
+        <route>
+            <from uri="direct:stockQuoteWebservice"/>
+            <to uri="spring-ws:http://localhost?webServiceTemplate=#webServiceTemplate&amp;soapAction=http://www.stockquotes.edu/GetQuote&amp;allowResponseAttachmentOverride=true"/>
+        </route>
+
+        <!-- consumer route (providing the actual web service) that responds with the request so we can see SOAP headers -->
+        <route>
+            <from uri="spring-ws:soapaction:http://www.stockquotes.edu/GetQuote?endpointMapping=#endpointMapping"/>
+            <to uri="responseProcessor"/>
+        </route>
+    </camelContext>
+
+    <bean id="messageFactory" class="org.springframework.ws.soap.saaj.SaajSoapMessageFactory"/>
+
+    <bean id="endpointMapping"
+          class="org.apache.camel.component.spring.ws.bean.CamelEndpointMapping"/>
+
+    <bean id="responseProcessor"
+          class="org.apache.camel.component.spring.ws.SoapAttachmentResponseProcessor"/>
+
+    <bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate">
+        <property name="defaultUri" value="http://localhost"/>
+        <property name="messageSender">
+            <bean class="net.javacrumbs.springws.test.helper.InMemoryWebServiceMessageSender"/>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
Producer does not populate attachments from response.

I would think of refactoring the whole part of the response handling.
In my opinion it would be best to handle this the same way as the
BasicMessageFilter does this for the request message.
This way anyone could implement custom behaviour if neccessary.
I would have done it, but i didnt want to break anybodys code, so i just
implemented it the same way the headers are populated.
Feel free to contact me about the change.