### PR TITLE
Throttling on Exceptions (RoutePolicy)

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/ThrottingExceptionHalfOpenHandler.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ThrottingExceptionHalfOpenHandler.java
@@ -1,0 +1,5 @@
+package org.apache.camel.impl;
+
+public interface ThrottingExceptionHalfOpenHandler {
+    boolean isReadyToBeClosed();
+}

--- a/camel-core/src/main/java/org/apache/camel/impl/ThrottingExceptionHalfOpenHandler.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ThrottingExceptionHalfOpenHandler.java
@@ -1,5 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.impl;
 
+/**
+ * used by the {@link ThrottlingExceptionRoutePolicy} to allow custom code
+ * to handle the half open circuit state and how to determine if a route
+ * should be closed
+ *
+ */
 public interface ThrottingExceptionHalfOpenHandler {
+    /**
+     * check the state of the Camel route
+     * @return true to close the route and false to leave open
+     */
     boolean isReadyToBeClosed();
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/ThrottlingExceptionRoutePolicy.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ThrottlingExceptionRoutePolicy.java
@@ -1,15 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.impl;
-
-import org.apache.camel.CamelContext;
-import org.apache.camel.CamelContextAware;
-import org.apache.camel.Exchange;
-import org.apache.camel.Route;
-import org.apache.camel.impl.ThrottlingInflightRoutePolicy;
-import org.apache.camel.processor.loadbalancer.CircuitBreakerLoadBalancer;
-import org.apache.camel.spi.RoutePolicy;
-import org.apache.camel.support.RoutePolicySupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Timer;
@@ -17,6 +22,16 @@ import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.processor.loadbalancer.CircuitBreakerLoadBalancer;
+import org.apache.camel.spi.RoutePolicy;
+import org.apache.camel.support.RoutePolicySupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * modeled after the {@link CircuitBreakerLoadBalancer} and {@link ThrottlingInflightRoutePolicy}
@@ -53,7 +68,7 @@ public class ThrottlingExceptionRoutePolicy extends RoutePolicySupport implement
     // handler for half open circuit
     // can be used instead of resuming route
     // to check on resources
-    ThrottingExceptionHalfOpenHandler halfOpenHandler;
+    private ThrottingExceptionHalfOpenHandler halfOpenHandler;
 
     // stateful information
     private Timer halfOpenTimer;
@@ -266,7 +281,8 @@ public class ThrottlingExceptionRoutePolicy extends RoutePolicySupport implement
     
     class HalfOpenTask extends TimerTask {
         private final Route route;
-        public HalfOpenTask(Route route) {
+        
+        HalfOpenTask(Route route) {
             this.route = route;
         }
         

--- a/camel-core/src/main/java/org/apache/camel/impl/ThrottlingExceptionRoutePolicy.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ThrottlingExceptionRoutePolicy.java
@@ -1,0 +1,288 @@
+package org.apache.camel.impl;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.impl.ThrottlingInflightRoutePolicy;
+import org.apache.camel.processor.loadbalancer.CircuitBreakerLoadBalancer;
+import org.apache.camel.spi.RoutePolicy;
+import org.apache.camel.support.RoutePolicySupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * modeled after the {@link CircuitBreakerLoadBalancer} and {@link ThrottlingInflightRoutePolicy}
+ * this {@link RoutePolicy} will stop consuming from an endpoint based on the type of exceptions that are
+ * thrown and the threshold setting. 
+ * 
+ * the scenario: if a route cannot process data from an endpoint due to problems with resources used by the route
+ * (ie database down) then it will stop consuming new messages from the endpoint by stopping the consumer. 
+ * The implementation is comparable to the Circuit Breaker pattern. After a set amount of time, it will move 
+ * to a half open state and attempt to determine if the consumer can be started.
+ * There are two ways to determine if a route can be closed after being opened
+ * (1) start the consumer and check the failure threshold
+ * (2) call the {@link ThrottlingExceptionHalfOpenHandler} 
+ * The second option allows a custom check to be performed without having to take on the possibiliy of 
+ * multiple messages from the endpoint. The idea is that a handler could run a simple test (ie select 1 from dual)
+ * to determine if the processes that cause the route to be open are now available  
+ */
+public class ThrottlingExceptionRoutePolicy extends RoutePolicySupport implements CamelContextAware {
+    private static Logger log = LoggerFactory.getLogger(ThrottlingExceptionRoutePolicy.class);
+    
+    private static final int STATE_CLOSED = 0;
+    private static final int STATE_HALF_OPEN = 1;
+    private static final int STATE_OPEN = 2;
+    
+    private CamelContext camelContext;
+    private final Lock lock = new ReentrantLock();
+    
+    // configuration
+    private int failureThreshold;
+    private long failureWindow;
+    private long halfOpenAfter;
+    private final List<Class<?>> throttledExceptions;
+    
+    // handler for half open circuit
+    // can be used instead of resuming route
+    // to check on resources
+    ThrottingExceptionHalfOpenHandler halfOpenHandler;
+
+    // stateful information
+    private Timer halfOpenTimer;
+    private AtomicInteger failures = new AtomicInteger();
+    private AtomicInteger state = new AtomicInteger(STATE_CLOSED);
+    private long lastFailure;
+    private long openedAt;
+    
+    public ThrottlingExceptionRoutePolicy(int threshold, long failureWindow, long halfOpenAfter, List<Class<?>> handledExceptions) {
+        this.throttledExceptions = handledExceptions;
+        this.failureWindow = failureWindow;
+        this.halfOpenAfter = halfOpenAfter;
+        this.failureThreshold = threshold;
+    }
+    
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    @Override
+    public void onInit(Route route) {
+        log.debug("initializing ThrottlingExceptionRoutePolicy route policy...");
+        logState();
+    }
+    
+    @Override
+    public void onExchangeDone(Route route, Exchange exchange) {
+        if (hasFailed(exchange)) {
+            // record the failure
+            failures.incrementAndGet();
+            lastFailure = System.currentTimeMillis();
+        } 
+        
+        // check for state change
+        calculateState(route);
+    }
+    
+    /**
+     * uses similar approach as {@link CircuitBreakerLoadBalancer}
+     * if the exchange has an exception that we are watching 
+     * then we count that as a failure otherwise we ignore it
+     * @param exchange
+     * @return
+     */
+    private boolean hasFailed(Exchange exchange) {
+        if (exchange == null) {
+            return false;
+        }
+
+        boolean answer = false;
+
+        if (exchange.getException() != null) {
+            log.debug("exception occured on route: checking to see if I handle that");
+            if (throttledExceptions == null || throttledExceptions.isEmpty()) {
+                // if no exceptions defined then always fail 
+                // (ie) assume we throttle on all exceptions
+                answer = true;
+            } else {
+                for (Class<?> exception : throttledExceptions) {
+                    // will look in exception hierarchy
+                    if (exchange.getException(exception) != null) {
+                        answer = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            String exceptionName = exchange.getException() == null ? "none" : exchange.getException().getClass().getSimpleName();
+            log.debug("hasFailed ({}) with Throttled Exception: {} for exchangeId: {}", answer, exceptionName, exchange.getExchangeId());
+        }
+        return answer;
+    }
+
+    private void calculateState(Route route) {
+        
+        // have we reached the failure limit?
+        boolean failureLimitReached = isThresholdExceeded();
+        
+        if (state.get() == STATE_CLOSED) {
+            if (failureLimitReached) {
+                log.debug("opening circuit...");
+                openCircuit(route);
+            }
+        } else if (state.get() == STATE_HALF_OPEN) {
+            if (failureLimitReached) {
+                log.debug("opening circuit...");
+                openCircuit(route);
+            } else {
+                log.debug("closing circuit...");
+                closeCircuit(route);
+            }
+        } else if (state.get() == STATE_OPEN) {
+            long elapsedTimeSinceOpened = System.currentTimeMillis() - openedAt;
+            if (halfOpenAfter <= elapsedTimeSinceOpened) {
+                log.debug("checking an open circuit...");
+                if (halfOpenHandler != null) {
+                    if (halfOpenHandler.isReadyToBeClosed()) {
+                        log.debug("closing circuit...");
+                        closeCircuit(route);
+                    } else {
+                        log.debug("opening circuit...");
+                        openCircuit(route);
+                    }
+                } else {
+                    log.debug("half opening circuit...");
+                    halfOpenCircuit(route);                    
+                }
+            } 
+        }
+        
+    }
+    
+    protected boolean isThresholdExceeded() {
+        boolean output = false;
+        logState();
+        // failures exceed the threshold 
+        // AND the last of those failures occurred within window
+        if ((failures.get() >= failureThreshold) && (lastFailure >= System.currentTimeMillis() - failureWindow)) {
+            output = true;
+        }
+        
+        return output;
+    }
+        
+    protected void openCircuit(Route route) {
+        try {
+            lock.lock();
+            stopConsumer(route.getConsumer());
+            state.set(STATE_OPEN);
+            openedAt = System.currentTimeMillis();
+            halfOpenTimer = new Timer();
+            halfOpenTimer.schedule(new HalfOpenTask(route), halfOpenAfter);
+            logState();
+        } catch (Exception e) {
+            handleException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    protected void halfOpenCircuit(Route route) {
+        try {
+            lock.lock();
+            startConsumer(route.getConsumer());
+            state.set(STATE_HALF_OPEN);
+            logState();
+        } catch (Exception e) {
+            handleException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    protected void closeCircuit(Route route) {
+        try {
+            lock.lock();
+            startConsumer(route.getConsumer());
+            this.reset();
+            logState();
+        } catch (Exception e) {
+            handleException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /**
+     * reset the route 
+     */
+    private void reset() {
+        failures.set(0);
+        lastFailure = 0;
+        openedAt = 0;
+        state.set(STATE_CLOSED);
+    }
+    
+    private void logState() {
+        if (log.isDebugEnabled()) {
+            log.debug(dumpState());
+        }
+    }
+    
+    public String dumpState() {
+        int num = state.get();
+        String state = stateAsString(num);
+        if (failures.get() > 0) {
+            return String.format("*** State %s, failures %d, last failure %d ms ago", state, failures.get(), System.currentTimeMillis() - lastFailure);
+        } else {
+            return String.format("*** State %s, failures %d", state, failures.get());
+        }
+    }
+    
+    private static String stateAsString(int num) {
+        if (num == STATE_CLOSED) {
+            return "closed";
+        } else if (num == STATE_HALF_OPEN) {
+            return "half opened";
+        } else {
+            return "opened";
+        }
+    }
+    
+    class HalfOpenTask extends TimerTask {
+        private final Route route;
+        public HalfOpenTask(Route route) {
+            this.route = route;
+        }
+        
+        @Override
+        public void run() {
+            calculateState(route);
+            halfOpenTimer.cancel();
+        }
+    }
+    
+    public ThrottingExceptionHalfOpenHandler getHalfOpenHandler() {
+        return halfOpenHandler;
+    }
+
+    public void setHalfOpenHandler(ThrottingExceptionHalfOpenHandler halfOpenHandler) {
+        this.halfOpenHandler = halfOpenHandler;
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
@@ -1,4 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.processor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -11,9 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest extends ContextTestSupport {
     private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.class);

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
@@ -1,0 +1,117 @@
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.ThrottingExceptionHalfOpenHandler;
+import org.apache.camel.impl.ThrottlingExceptionRoutePolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest extends ContextTestSupport {
+    private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenHandlerSedaTest.class);
+    
+    private String url = "seda:foo?concurrentConsumers=20";
+    private MockEndpoint result;
+    
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+        
+        context.getShutdownStrategy().setTimeout(1);
+    }
+    
+    @Test
+    public void testHalfOpenCircuit() throws Exception {
+        result.expectedMessageCount(2);
+        List<String> bodies = Arrays.asList(new String[]{"Message One", "Message Two"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        result.whenAnyExchangeReceived(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                String msg = exchange.getIn().getBody(String.class);
+                exchange.setException(new ThrottleException(msg));
+            }
+        });
+        
+        // send two messages which will fail
+        sendMessage("Message One");
+        sendMessage("Message Two");
+        
+        // wait long enough to 
+        // have the route shutdown
+        Thread.sleep(3000);
+        
+        // send more messages 
+        // but should get there (yet)
+        // due to open circuit
+        // SEDA will queue it up
+        log.debug("sending message three");
+        sendMessage("Message Three");
+
+        assertMockEndpointsSatisfied();
+        
+        result.reset();
+        result.expectedMessageCount(2);
+        bodies = Arrays.asList(new String[]{"Message Three", "Message Four"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        // wait long enough for
+        // half open attempt
+        Thread.sleep(4000);
+        
+        // send message
+        // should get through
+        log.debug("sending message four");
+        sendMessage("Message Four");
+        
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 5000;
+                ThrottlingExceptionRoutePolicy policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null);
+                policy.setHalfOpenHandler(new AlwaysCloseHandler());
+                
+                from(url)
+                    .routePolicy(policy)
+                    .log("${body}")
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+    
+    public class AlwaysCloseHandler implements ThrottingExceptionHalfOpenHandler {
+
+        @Override
+        public boolean isReadyToBeClosed() {
+            return true;
+        }
+        
+    }
+    
+    protected void sendMessage(String bodyText) {
+        try {
+            template.sendBody(url, bodyText);
+        } catch (Exception e) {
+            log.debug("Error sending:" + e.getCause().getMessage());
+        }
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerTest.java
@@ -1,4 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.processor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -11,9 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class ThrottingExceptionRoutePolicyHalfOpenHandlerTest extends ContextTestSupport {
     private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenHandlerTest.class);

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenHandlerTest.java
@@ -1,0 +1,116 @@
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.ThrottingExceptionHalfOpenHandler;
+import org.apache.camel.impl.ThrottlingExceptionRoutePolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ThrottingExceptionRoutePolicyHalfOpenHandlerTest extends ContextTestSupport {
+    private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenHandlerTest.class);
+    
+    private String url = "direct:start";
+    private MockEndpoint result;
+    
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+        
+        context.getShutdownStrategy().setTimeout(1);
+    }
+    
+    @Test
+    public void testHalfOpenCircuit() throws Exception {
+        result.expectedMessageCount(2);
+        List<String> bodies = Arrays.asList(new String[]{"Message One", "Message Two"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        result.whenAnyExchangeReceived(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                String msg = exchange.getIn().getBody(String.class);
+                exchange.setException(new ThrottleException(msg));
+            }
+        });
+        
+        // send two messages which will fail
+        sendMessage("Message One");
+        sendMessage("Message Two");
+        
+        // wait long enough to 
+        // have the route shutdown
+        Thread.sleep(3000);
+        
+        // send more messages 
+        // but never should get there
+        // due to open circuit
+        log.debug("sending message three");
+        sendMessage("Message Three");
+
+        assertMockEndpointsSatisfied();
+        
+        result.reset();
+        result.expectedMessageCount(1);
+        bodies = Arrays.asList(new String[]{"Message Four"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        // wait long enough for
+        // half open attempt
+        Thread.sleep(4000);
+        
+        // send message
+        // should get through
+        log.debug("sending message four");
+        sendMessage("Message Four");
+        
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 5000;
+                ThrottlingExceptionRoutePolicy policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null);
+                policy.setHalfOpenHandler(new AlwaysCloseHandler());
+                
+                from(url)
+                    .routePolicy(policy)
+                    .log("${body}")
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+    
+    public class AlwaysCloseHandler implements ThrottingExceptionHalfOpenHandler {
+
+        @Override
+        public boolean isReadyToBeClosed() {
+            return true;
+        }
+        
+    }
+    
+    protected void sendMessage(String bodyText) {
+        try {
+            template.sendBody(url, bodyText);
+        } catch (Exception e) {
+            log.debug("Error sending:" + e.getCause().getMessage());
+        }
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenTest.java
@@ -1,4 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.processor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -10,9 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class ThrottingExceptionRoutePolicyHalfOpenTest extends ContextTestSupport {
     private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenTest.class);

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottingExceptionRoutePolicyHalfOpenTest.java
@@ -1,0 +1,105 @@
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.ThrottlingExceptionRoutePolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ThrottingExceptionRoutePolicyHalfOpenTest extends ContextTestSupport {
+    private static Logger log = LoggerFactory.getLogger(ThrottingExceptionRoutePolicyHalfOpenTest.class);
+    
+    private String url = "direct:start";
+    private MockEndpoint result;
+    
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+        
+        context.getShutdownStrategy().setTimeout(1);
+    }
+    
+    @Test
+    public void testHalfOpenCircuit() throws Exception {
+        result.reset();
+        result.expectedMessageCount(2);
+        List<String> bodies = Arrays.asList(new String[]{"Message One", "Message Two"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        result.whenAnyExchangeReceived(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                String msg = exchange.getIn().getBody(String.class);
+                exchange.setException(new ThrottleException(msg));
+            }
+        });
+        
+        // send two messages which will fail
+        sendMessage("Message One");
+        sendMessage("Message Two");
+        
+        // wait long enough to 
+        // have the route shutdown
+        Thread.sleep(3000);
+        
+        // send more messages 
+        // but never should get there
+        // due to open circuit
+        log.debug("sending message three");
+        sendMessage("Message Three");
+        
+        assertMockEndpointsSatisfied();
+        
+        result.reset();
+        result.expectedMessageCount(1);
+        bodies = Arrays.asList(new String[]{"Message Four"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        // wait long enough for
+        // half open attempt
+        Thread.sleep(4000);
+        
+        // send message
+        // should get through
+        log.debug("sending message four");
+        sendMessage("Message Four");
+        
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 5000;
+                ThrottlingExceptionRoutePolicy policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null);
+                
+                from(url)
+                    .routePolicy(policy)
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+    
+    protected void sendMessage(String bodyText) {
+        try {
+            template.sendBody(url, bodyText);
+        } catch (Exception e) {
+            log.debug("Error sending:" + e.getCause().getMessage());
+        }
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottleException.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottleException.java
@@ -1,0 +1,22 @@
+package org.apache.camel.processor;
+
+public class ThrottleException extends RuntimeException {
+
+    private static final long serialVersionUID = 1993185881371058773L;
+
+    public ThrottleException() {
+        super();
+    }
+
+    public ThrottleException(String message) {
+        super(message);
+    }
+
+    public ThrottleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ThrottleException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottleException.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottleException.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.processor;
 
 public class ThrottleException extends RuntimeException {

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottlingExceptionRoutePolicyTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottlingExceptionRoutePolicyTest.java
@@ -1,0 +1,110 @@
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.ThrottingExceptionHalfOpenHandler;
+import org.apache.camel.impl.ThrottlingExceptionRoutePolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ThrottlingExceptionRoutePolicyTest extends ContextTestSupport {
+    private static Logger log = LoggerFactory.getLogger(ThrottlingExceptionRoutePolicyTest.class);
+    
+    private String url = "seda:foo?concurrentConsumers=20";
+    private MockEndpoint result;
+    private int size = 100;
+    
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+        
+        context.getShutdownStrategy().setTimeout(1);
+    }
+
+    
+    @Test
+    public void testThrottlingRoutePolicyClosed() throws Exception {
+        result.expectedMinimumMessageCount(size);
+
+        for (int i = 0; i < size; i++) {
+            template.sendBody(url, "Message " + i);
+            Thread.sleep(3);
+        }
+
+        assertMockEndpointsSatisfied();
+    }
+
+    
+    @Test
+    public void testOpenCircuitToPreventMessageThree() throws Exception {
+        result.reset();
+        result.expectedMessageCount(2);
+        List<String> bodies = Arrays.asList(new String[]{"Message One", "Message Two"}); 
+        result.expectedBodiesReceivedInAnyOrder(bodies);
+        
+        result.whenAnyExchangeReceived(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                String msg = exchange.getIn().getBody(String.class);
+                exchange.setException(new ThrottleException(msg));
+            }
+        });
+        
+        // send two messages which will fail
+        template.sendBody(url, "Message One");
+        template.sendBody(url, "Message Two");
+        
+        // wait long enough to 
+        // have the route shutdown
+        Thread.sleep(3000);
+        
+        // send more messages 
+        // but never should get there
+        // due to open circuit
+        log.debug("sending message three");
+        template.sendBody(url, "Message Three");
+        
+        Thread.sleep(2000);
+        
+        assertMockEndpointsSatisfied();
+    }
+    
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 5000;
+                ThrottlingExceptionRoutePolicy policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null);
+                policy.setHalfOpenHandler(new NeverCloseHandler());
+                
+                from(url)
+                    .routePolicy(policy)
+                    .log("${body}")
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+    
+    public class NeverCloseHandler implements ThrottingExceptionHalfOpenHandler {
+
+        @Override
+        public boolean isReadyToBeClosed() {
+            return false;
+        }
+        
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/ThrottlingExceptionRoutePolicyTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThrottlingExceptionRoutePolicyTest.java
@@ -1,4 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.processor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -11,9 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class ThrottlingExceptionRoutePolicyTest extends ContextTestSupport {
     private static Logger log = LoggerFactory.getLogger(ThrottlingExceptionRoutePolicyTest.class);


### PR DESCRIPTION
Our project recently needed a circuit breaker that stop consuming messages from the from endpoint. I noticed that the Camel circuit breakers consumed from the endpoint even in the open mode and controlled access to the to endpoints on the route. 

Based on this Stack Overflow [answer](http://stackoverflow.com/questions/9078621/controlling-start-up-and-shutdown-of-camel-routes), I created a circuit breaker that will stop consuming from the starting endpoint based on exceptions being thrown. It is using a [RoutePolicy](http://camel.apache.org/routepolicy.html) and imitates the existing [ThrottlingInflightRoutePolicy](http://camel.apache.org/route-throttling-example.html) as well as the [CircuitBreakingLoadBalancer](http://camel.apache.org/load-balancer.html).

Not sure if there is any interest in adding it to Camel.
Thanks