### PR TITLE
CAMEL-9945 Upgrade to jetty 9.3

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceHttpClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceHttpClient.java
@@ -52,6 +52,8 @@ public class SalesforceHttpClient extends HttpClient {
 
     private final Method addSecuirtyHandlerMethod;
 
+    private final Method getProtocolHandlersMethod;
+
     public SalesforceHttpClient() {
         this(null);
     }
@@ -75,6 +77,8 @@ public class SalesforceHttpClient extends HttpClient {
             } else {
                 addSecuirtyHandlerMethod = getProtocolHandlersType.getMethod("put", ProtocolHandler.class);
             }
+
+            getProtocolHandlersMethod = HttpClient.class.getMethod("getProtocolHandlers");
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException("Found no method of adding SalesforceSecurityHandler as ProtocolHandler to Jetty HttpClient. You need Jetty 9.2 or newer on the classpath.");
         }
@@ -99,7 +103,7 @@ public class SalesforceHttpClient extends HttpClient {
         }
 
         // compensate for Jetty 9.2 vs 9.3 API change
-        final Object protocolHandlers = getProtocolHandlers();
+        final Object protocolHandlers = getProtocolHandlersMethod.invoke(this);
         addSecuirtyHandlerMethod.invoke(protocolHandlers, new SalesforceSecurityHandler(this));
 
         super.doStart();


### PR DESCRIPTION
Java compiler uses the actual return type of the method in the compiled
class and as the signature of
`org.eclipse.jetty.client.HttpClient::getProtocolHandlers` method
changed between Jetty 9.2 and 9.3 in return type it could be compiled
and run against both versions, but it could not be compiled with one
version and run against another.

This commit uses reflection when calling `getProtocolHandlers` method to
maintain compatibility with 9.2 and 9.3 versions of Jetty regardless of
compile time vs runtime version.