### PR TITLE
CAMEL-10711: Added automatic source roots addition in api maven plugin

### DIFF
--- a/tooling/maven/camel-api-component-maven-plugin/src/it/all-it/pom.xml
+++ b/tooling/maven/camel-api-component-maven-plugin/src/it/all-it/pom.xml
@@ -126,6 +126,7 @@
               <goal>fromApis</goal>
             </goals>
             <configuration>
+              <addCompileSourceRoots>test</addCompileSourceRoots>
               <apis>
                 <api>
                   <apiName>test</apiName>
@@ -185,26 +186,6 @@
                   </aliases>
                 </api>
               </apis>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- add generated source and test source to build for test-compile -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>@build-helper-maven-plugin-version@</version>
-        <executions>
-          <execution>
-            <id>add-generated-test-sources</id>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-sources/camel-component</source>
-                <source>${project.build.directory}/generated-test-sources/camel-component</source>
-              </sources>
             </configuration>
           </execution>
         </executions>

--- a/tooling/maven/camel-api-component-maven-plugin/src/it/settings.xml
+++ b/tooling/maven/camel-api-component-maven-plugin/src/it/settings.xml
@@ -26,6 +26,10 @@ under the License.
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+      </properties>
       <repositories>
         <repository>
           <id>local.central</id>

--- a/tooling/maven/camel-api-component-maven-plugin/src/it/settings.xml
+++ b/tooling/maven/camel-api-component-maven-plugin/src/it/settings.xml
@@ -27,8 +27,8 @@ under the License.
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
       </properties>
       <repositories>
         <repository>

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractApiMethodGeneratorMojo.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractApiMethodGeneratorMojo.java
@@ -52,6 +52,8 @@ public abstract class AbstractApiMethodGeneratorMojo extends AbstractApiMethodBa
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
+        setCompileSourceRoots();
+
         // load proxy class and get enumeration file to generate
         final Class proxyType = getProxyType();
 

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSourceGeneratorMojo.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSourceGeneratorMojo.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.maven;
 
-import org.apache.maven.plugins.annotations.Parameter;
-
 import java.io.File;
+
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Base class for API based code generation MOJOs.
@@ -40,18 +40,19 @@ public abstract class AbstractSourceGeneratorMojo extends AbstractGeneratorMojo 
 
     protected void setCompileSourceRoots() {
         switch (addCompileSourceRoots) {
-            case source:
-                project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
-                project.addCompileSourceRoot(generatedTestDir.getAbsolutePath());
-                break;
-            case test:
-                project.addTestCompileSourceRoot(generatedSrcDir.getAbsolutePath());
-                project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
-                break;
-            case all:
-                project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
-                project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
-                break;
+        case source:
+            project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+            project.addCompileSourceRoot(generatedTestDir.getAbsolutePath());
+            break;
+        case test:
+            project.addTestCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+            project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
+            break;
+        case all:
+            project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+            project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
+            break;
+        default:
         }
     }
 

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSourceGeneratorMojo.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSourceGeneratorMojo.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.maven;
 
-import java.io.File;
-
 import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
 
 /**
  * Base class for API based code generation MOJOs.
@@ -30,4 +30,29 @@ public abstract class AbstractSourceGeneratorMojo extends AbstractGeneratorMojo 
 
     @Parameter(defaultValue = "${project.build.directory}/generated-test-sources/camel-component")
     protected File generatedTestDir;
+
+    enum CompileRoots {
+        source, test, all, none
+    }
+
+    @Parameter(defaultValue = "all", property = PREFIX + "addCompileSourceRoots")
+    protected CompileRoots addCompileSourceRoots = CompileRoots.all;
+
+    protected void setCompileSourceRoots() {
+        switch (addCompileSourceRoots) {
+            case source:
+                project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+                project.addCompileSourceRoot(generatedTestDir.getAbsolutePath());
+                break;
+            case test:
+                project.addTestCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+                project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
+                break;
+            case all:
+                project.addCompileSourceRoot(generatedSrcDir.getAbsolutePath());
+                project.addTestCompileSourceRoot(generatedTestDir.getAbsolutePath());
+                break;
+        }
+    }
+
 }

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/ApiComponentGeneratorMojo.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/ApiComponentGeneratorMojo.java
@@ -133,7 +133,7 @@ public class ApiComponentGeneratorMojo extends AbstractApiMethodBaseMojo {
             clearSharedProjectState();
         }
     }
-
+    
     private void configureMethodGenerator(AbstractApiMethodGeneratorMojo mojo, ApiProxy apiProxy) {
 
         // set AbstractGeneratorMojo properties
@@ -146,6 +146,7 @@ public class ApiComponentGeneratorMojo extends AbstractApiMethodBaseMojo {
         // set AbstractSourceGeneratorMojo properties
         mojo.generatedSrcDir = generatedSrcDir;
         mojo.generatedTestDir = generatedTestDir;
+        mojo.addCompileSourceRoots = addCompileSourceRoots;
 
         // set AbstractAPIMethodBaseMojo properties
         mojo.substitutions = apiProxy.getSubstitutions().length != 0

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/AbstractGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/AbstractGeneratorMojoTest.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,23 @@
  */
 package org.apache.camel.maven;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -91,4 +100,62 @@ public abstract class AbstractGeneratorMojoTest {
             }
         };
     }
+
+    protected AbstractSourceGeneratorMojo createGeneratorMojo() {
+        return null;
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldAddCompilationRootsByDefault() throws Exception {
+        AbstractSourceGeneratorMojo mojo = createGeneratorMojo();
+        Assume.assumeThat("Ignored because createGeneratorMojo is not implemented", mojo, notNullValue());
+        // Differentiate target folders to simplify assertion
+        mojo.generatedSrcDir = new File(OUT_DIR.replace("-test-", ""));
+        mojo.generatedTestDir = new File(OUT_DIR);
+        mojo.execute();
+
+        assertCompileSourceRoots(mojo.project::getCompileSourceRoots, mojo.generatedSrcDir);
+        assertCompileSourceRoots(mojo.project::getTestCompileSourceRoots, mojo.generatedTestDir);
+    }
+
+    @Test
+    public void shouldAddCompilationRootsByConfiguration() throws Exception {
+        File srcDir = new File(OUT_DIR.replace("-test-", ""));
+        File testDir = new File(OUT_DIR);
+        File[] empty = new File[0];
+        assertCompilationRootsByConfiguration(AbstractSourceGeneratorMojo.CompileRoots.source, srcDir, testDir,
+            new File[]{srcDir, testDir}, empty);
+        assertCompilationRootsByConfiguration(AbstractSourceGeneratorMojo.CompileRoots.test, srcDir, testDir,
+            empty, new File[]{srcDir, testDir});
+        assertCompilationRootsByConfiguration(AbstractSourceGeneratorMojo.CompileRoots.all, srcDir, testDir,
+            new File[]{srcDir}, new File[]{testDir});
+        assertCompilationRootsByConfiguration(AbstractSourceGeneratorMojo.CompileRoots.none, srcDir, testDir,
+            empty, empty);
+    }
+
+    private void assertCompilationRootsByConfiguration(AbstractSourceGeneratorMojo.CompileRoots compileRoots,
+                                                       File srcDir, File testDir,
+                                                       File[] expectedSource, File[] expectedTest) throws Exception {
+        AbstractSourceGeneratorMojo mojo = createGeneratorMojo();
+        Assume.assumeThat("Ignored because createGeneratorMojo is not implemented", mojo, notNullValue());
+        mojo.generatedSrcDir = srcDir;
+        mojo.generatedTestDir = testDir;
+        mojo.addCompileSourceRoots = compileRoots;
+        mojo.execute();
+
+        assertCompileSourceRoots(mojo.project::getCompileSourceRoots, expectedSource);
+        assertCompileSourceRoots(mojo.project::getTestCompileSourceRoots, expectedTest);
+    }
+
+    private void assertCompileSourceRoots(Supplier<List<String>> roots, File... expectedSources) {
+        List<String> compileSourceRoots = roots.get();
+        Assert.assertThat(compileSourceRoots.size(), is(expectedSources.length));
+        Assert.assertThat(compileSourceRoots, hasItems(
+            Stream.of(expectedSources).map(File::getAbsolutePath).toArray(String[]::new))
+        );
+
+    }
+
 }

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/AbstractGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/AbstractGeneratorMojoTest.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,12 @@
  */
 package org.apache.camel.maven;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
@@ -23,12 +29,6 @@ import org.apache.maven.project.MavenProject;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
-
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/ApiComponentGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/ApiComponentGeneratorMojoTest.java
@@ -21,8 +21,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.camel.component.test.TestProxy;
+import org.apache.camel.util.CastUtils;
 import org.apache.velocity.VelocityContext;
+import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 
 /**
  * Tests {@link ApiComponentGeneratorMojo}
@@ -37,6 +42,15 @@ public class ApiComponentGeneratorMojoTest extends AbstractGeneratorMojoTest {
         // delete target files to begin
         collectionFile.delete();
 
+        final ApiComponentGeneratorMojo mojo = createGeneratorMojo();
+
+        mojo.execute();
+
+        // check target file was generated
+        assertExists(collectionFile);
+    }
+
+    protected ApiComponentGeneratorMojo createGeneratorMojo() {
         final ApiComponentGeneratorMojo mojo = new ApiComponentGeneratorMojo();
         configureSourceGeneratorMojo(mojo);
 
@@ -72,10 +86,8 @@ public class ApiComponentGeneratorMojoTest extends AbstractGeneratorMojoTest {
         fromJavadoc.setExcludePackages(JavadocApiMethodGeneratorMojo.DEFAULT_EXCLUDE_PACKAGES);
         fromJavadoc.setExcludeMethods("clone|Current|internal|icache");
         mojo.apis[1].setFromJavadoc(fromJavadoc);
-
-        mojo.execute();
-
-        // check target file was generated
-        assertExists(collectionFile);
+        return mojo;
     }
+    
+
 }

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/FileApiMethodGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/FileApiMethodGeneratorMojoTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.maven;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.camel.component.test.TestProxy;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * Tests {@link FileApiMethodGeneratorMojo}
@@ -38,6 +38,14 @@ public class FileApiMethodGeneratorMojoTest extends AbstractGeneratorMojoTest {
             outFile.delete();
         }
 
+        final FileApiMethodGeneratorMojo mojo = createGeneratorMojo();
+        mojo.execute();
+
+        // check target file was generated
+        assertExists(outFile);
+    }
+
+    protected FileApiMethodGeneratorMojo createGeneratorMojo() {
         final FileApiMethodGeneratorMojo mojo = new FileApiMethodGeneratorMojo();
         mojo.substitutions = new Substitution[2];
         mojo.substitutions[0] = new Substitution(".+", "(.+)", "java.util.List", "$1List", false);
@@ -52,11 +60,7 @@ public class FileApiMethodGeneratorMojoTest extends AbstractGeneratorMojoTest {
         // exclude name2, and int times
         mojo.excludeConfigNames = "name2";
         mojo.excludeConfigTypes = "int";
-
-        mojo.execute();
-
-        // check target file was generated
-        assertExists(outFile);
+        return mojo;
     }
 
 }

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/FileApiMethodGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/FileApiMethodGeneratorMojoTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.maven;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.camel.component.test.TestProxy;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
 
 /**
  * Tests {@link FileApiMethodGeneratorMojo}

--- a/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/JavadocApiMethodGeneratorMojoTest.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/test/java/org/apache/camel/maven/JavadocApiMethodGeneratorMojoTest.java
@@ -38,6 +38,15 @@ public class JavadocApiMethodGeneratorMojoTest extends AbstractGeneratorMojoTest
             outFile.delete();
         }
 
+        final JavadocApiMethodGeneratorMojo mojo = createGeneratorMojo();
+        mojo.execute();
+
+        // check target file was generated
+        assertExists(outFile);
+    }
+
+    @Override
+    protected JavadocApiMethodGeneratorMojo createGeneratorMojo() {
         final JavadocApiMethodGeneratorMojo mojo = new JavadocApiMethodGeneratorMojo();
 
         configureSourceGeneratorMojo(mojo);
@@ -52,11 +61,6 @@ public class JavadocApiMethodGeneratorMojoTest extends AbstractGeneratorMojoTest
         mojo.excludePackages = JavadocApiMethodGeneratorMojo.DEFAULT_EXCLUDE_PACKAGES;
         mojo.includeMethods = ".+";
         mojo.excludeMethods = "clone|Current|internal|icache";
-
-        mojo.execute();
-
-        // check target file was generated
-        assertExists(outFile);
+        return mojo;
     }
-
 }


### PR DESCRIPTION
A property has been added: **addCompileSourceRoots** to automatically make generated source directory available in compilation phases.
Available values are:

* **source**: adds both _generatedSrcDir_ and _generatedTestDir_ as compile source roots
* **test**: adds both _generatedSrcDir_ and _generatedTestDir_ as test compile source roots
* **all**: adds _generatedSrcDir_ to compile source roots and _generatedTestDir_ as test compile source roots
* **none**: do not add generated directories at all

The default value is **all**.

The integration test *all-it* has been modified to remove *build-helper-maven-plugin* 