### PR TITLE
CAMEL-10546: Continued the deprecation of CamelContext.getProperties()

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/CamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/CamelContext.java
@@ -1303,7 +1303,7 @@ public interface CamelContext extends SuspendableService, RuntimeConfiguration {
     /**
      * @deprecated use {@link #getGlobalOption(String)} instead.
      */
-    String getProperty(String name);
+    String getProperty(String key);
 
     /**
      * Gets the global option value that can be referenced in the camel context
@@ -1315,7 +1315,7 @@ public interface CamelContext extends SuspendableService, RuntimeConfiguration {
      *
      * @return the string value of the global option
      */
-    String getGlobalOption(String name);
+    String getGlobalOption(String key);
 
     /**
      * Gets the default FactoryFinder which will be used for the loading the factory class from META-INF

--- a/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
+++ b/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
@@ -49,8 +49,12 @@ public interface ManagedCamelContextMBean extends ManagedPerformanceCounterMBean
     @ManagedAttribute(description = "Camel Management StatisticsLevel")
     String getManagementStatisticsLevel();
 
+    @Deprecated
     @ManagedAttribute(description = "Camel Properties")
     Map<String, String> getProperties();
+
+    @ManagedAttribute(description = "Camel Global Options")
+    Map<String, String> getGlobalOptions();
 
     @ManagedAttribute(description = "ClassResolver class name")
     String getClassResolver();
@@ -61,26 +65,34 @@ public interface ManagedCamelContextMBean extends ManagedPerformanceCounterMBean
     @ManagedAttribute(description = "ApplicationContext class name")
     String getApplicationContextClassName();
 
+    @Deprecated
+    @ManagedOperation(description = "Gets the value of a Camel global option")
+    String getProperty(String key) throws Exception;
+
     /**
-     * Gets the value of a CamelContext property name
+     * Gets the value of a CamelContext global option
      *
-     * @param name the name of the property
-     * @return String the value of the property
-     * @throws Exception is thrown if error occurred
+     * @param key the global option key
+     * @return the global option value
+     * @throws Exception when an error occurred
      */
-    @ManagedOperation(description = "Get the value of a Camel property")
-    String getProperty(String name) throws Exception;
-    
+    @ManagedOperation(description = "Gets the value of a Camel global option")
+    String getGlobalOption(String key) throws Exception;
+
+    @Deprecated
+    @ManagedOperation(description = "Sets the value of a Camel global option")
+    void setProperty(String key, String value) throws Exception;
+
     /**
      * Sets the value of a CamelContext property name
      *
-     * @param name the name of the property
-     * @param value the new value of the property
-     * @throws Exception is thrown if error occurred
+     * @param key the global option key
+     * @param value the global option value
+     * @throws Exception when an error occurred
      */
-    @ManagedOperation(description = "Set the value of a Camel property")
-    void setProperty(String name, String value) throws Exception;
-    
+    @ManagedOperation(description = "Sets the value of a Camel global option")
+    void setGlobalOption(String key, String value) throws Exception;
+
     @ManagedAttribute(description = "Tracing")
     Boolean getTracing();
 

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -4282,18 +4282,18 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
 
     @Deprecated
     @Override
-    public String getProperty(String name) {
-        return getGlobalOption(name);
+    public String getProperty(String key) {
+        return getGlobalOption(key);
     }
 
     @Override
-    public String getGlobalOption(String name) {
-        String value = getGlobalOptions().get(name);
+    public String getGlobalOption(String key) {
+        String value = getGlobalOptions().get(key);
         if (ObjectHelper.isNotEmpty(value)) {
             try {
                 value = resolvePropertyPlaceholders(value);
             } catch (Exception e) {
-                throw new RuntimeCamelException("Error getting global option: " + name, e);
+                throw new RuntimeCamelException("Error getting global option: " + key, e);
             }
         }
         return value;

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -143,19 +143,37 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
         }
     }
 
+    @Deprecated
     public Map<String, String> getProperties() {
+        return getGlobalOptions();
+    }
+
+    @Override
+    public Map<String, String> getGlobalOptions() {
         if (context.getGlobalOptions().isEmpty()) {
             return null;
         }
         return context.getGlobalOptions();
     }
 
-    public String getProperty(String name) throws Exception {
-        return context.getGlobalOption(name);
+    @Deprecated
+    public String getProperty(String key) throws Exception {
+        return getGlobalOption(key);
     }
 
-    public void setProperty(String name, String value) throws Exception {
-        context.getGlobalOptions().put(name, value);
+    @Override
+    public String getGlobalOption(String key) throws Exception {
+        return context.getGlobalOption(key);
+    }
+
+    @Deprecated
+    public void setProperty(String key, String value) throws Exception {
+        setGlobalOption(key, value);
+    }
+
+    @Override
+    public void setGlobalOption(String key, String value) throws Exception {
+        context.getGlobalOptions().put(key, value);
     }
 
     public Boolean getTracing() {

--- a/camel-core/src/main/java/org/apache/camel/model/GlobalOptionDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/GlobalOptionDefinition.java
@@ -21,13 +21,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Exchange;
 import org.apache.camel.spi.Metadata;
 
 /**
- * Models a string key/value pair for configuring some global options on
- * {@link CamelContext} such as {@link Exchange#LOG_DEBUG_BODY_MAX_CHARS}.
+ * Models a string key/value pair for configuring some global options on a Camel
+ * context such as max debug log length.
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "globalOption")

--- a/camel-core/src/main/java/org/apache/camel/model/GlobalOptionDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/GlobalOptionDefinition.java
@@ -16,49 +16,44 @@
  */
 package org.apache.camel.model;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.spi.Metadata;
 
 /**
- * A series of key value pair
- *
- * @deprecated Use {@link GlobalOptionsDefinition} instead.
+ * Models a string key/value pair for configuring some global options on
+ * {@link CamelContext} such as {@link Exchange#LOG_DEBUG_BODY_MAX_CHARS}.
  */
 @Metadata(label = "configuration")
-@XmlRootElement(name = "properties")
+@XmlRootElement(name = "globalOption")
 @XmlAccessorType(XmlAccessType.FIELD)
-@Deprecated
-public class PropertiesDefinition {
-    @XmlElement(name = "property")
-    private List<PropertyDefinition> properties;
-    
-    public PropertiesDefinition() {
+public class GlobalOptionDefinition {
+    @XmlAttribute(required = true)
+    String key;
+    @XmlAttribute(required = true)
+    String value;
+
+    public GlobalOptionDefinition() {
     }
 
-    /**
-     * A series of properties as key value pairs
-     */
-    public void setProperties(List<PropertyDefinition> properties) {
-        this.properties = properties;
-    }
-    
-    public List<PropertyDefinition> getProperties() {
-        return properties;
-    }
-    
-    public Map<String, String> asMap() {
-        Map<String, String> propertiesAsMap = new HashMap<String, String>();
-        for (PropertyDefinition propertyType : getProperties()) {
-            propertiesAsMap.put(propertyType.getKey(), propertyType.getValue());
-        }
-        return propertiesAsMap;
+    public void setKey(String key) {
+        this.key = key;
     }
 
+    public String getKey() {
+        return key;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
@@ -19,46 +19,44 @@ package org.apache.camel.model;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.spi.Metadata;
 
 /**
- * A series of key value pair
- *
- * @deprecated Use {@link GlobalOptionsDefinition} instead.
+ * Models a series of string key/value pairs for configuring some global options
+ * on {@link CamelContext} such as {@link Exchange#LOG_DEBUG_BODY_MAX_CHARS}.
  */
 @Metadata(label = "configuration")
-@XmlRootElement(name = "properties")
+@XmlRootElement(name = "globalOptions")
 @XmlAccessorType(XmlAccessType.FIELD)
-@Deprecated
-public class PropertiesDefinition {
-    @XmlElement(name = "property")
-    private List<PropertyDefinition> properties;
-    
-    public PropertiesDefinition() {
+public class GlobalOptionsDefinition {
+    @XmlElement(name = "globalOption")
+    private List<GlobalOptionDefinition> globalOptions;
+
+    public GlobalOptionsDefinition() {
     }
 
-    /**
-     * A series of properties as key value pairs
-     */
-    public void setProperties(List<PropertyDefinition> properties) {
-        this.properties = properties;
+    public void setGlobalOptions(List<GlobalOptionDefinition> globalOptions) {
+        this.globalOptions = globalOptions;
     }
-    
-    public List<PropertyDefinition> getProperties() {
-        return properties;
+
+    public List<GlobalOptionDefinition> getGlobalOptions() {
+        return globalOptions;
     }
-    
+
     public Map<String, String> asMap() {
-        Map<String, String> propertiesAsMap = new HashMap<String, String>();
-        for (PropertyDefinition propertyType : getProperties()) {
-            propertiesAsMap.put(propertyType.getKey(), propertyType.getValue());
+        Map<String, String> globalOptionsAsMap = new HashMap<>();
+        for (GlobalOptionDefinition globalOption : getGlobalOptions()) {
+            globalOptionsAsMap.put(globalOption.getKey(), globalOption.getValue());
         }
-        return propertiesAsMap;
+        return globalOptionsAsMap;
     }
 
 }

--- a/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.model;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -50,11 +50,7 @@ public class GlobalOptionsDefinition {
     }
 
     public Map<String, String> asMap() {
-        Map<String, String> globalOptionsAsMap = new HashMap<>();
-        for (GlobalOptionDefinition globalOption : getGlobalOptions()) {
-            globalOptionsAsMap.put(globalOption.getKey(), globalOption.getValue());
-        }
-        return globalOptionsAsMap;
+        return getGlobalOptions().stream().collect(Collectors.toMap(o -> o.getKey(), o -> o.getValue(), (o1, o2) -> o2));
     }
 
 }

--- a/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/GlobalOptionsDefinition.java
@@ -25,13 +25,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Exchange;
 import org.apache.camel.spi.Metadata;
 
 /**
  * Models a series of string key/value pairs for configuring some global options
- * on {@link CamelContext} such as {@link Exchange#LOG_DEBUG_BODY_MAX_CHARS}.
+ * on a Camel context such as max debug log length.
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "globalOptions")

--- a/camel-core/src/main/java/org/apache/camel/model/PropertyDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/PropertyDefinition.java
@@ -25,13 +25,10 @@ import org.apache.camel.spi.Metadata;
 
 /**
  * A key value pair
- *
- * @deprecated Use {@link GlobalOptionDefinition} instead.
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "property")
 @XmlAccessorType(XmlAccessType.FIELD)
-@Deprecated
 public class PropertyDefinition {
     @XmlAttribute(required = true)
     String key;

--- a/camel-core/src/main/java/org/apache/camel/model/PropertyDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/PropertyDefinition.java
@@ -25,10 +25,13 @@ import org.apache.camel.spi.Metadata;
 
 /**
  * A key value pair
+ *
+ * @deprecated Use {@link GlobalOptionDefinition} instead.
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "property")
 @XmlAccessorType(XmlAccessType.FIELD)
+@Deprecated
 public class PropertyDefinition {
     @XmlAttribute(required = true)
     String key;

--- a/camel-core/src/main/resources/org/apache/camel/model/jaxb.index
+++ b/camel-core/src/main/resources/org/apache/camel/model/jaxb.index
@@ -30,6 +30,8 @@ ExpressionSubElementDefinition
 FilterDefinition
 FinallyDefinition
 FromDefinition
+GlobalOptionsDefinition
+GlobalOptionDefinition
 HystrixDefinition
 HystrixConfigurationDefinition
 IdempotentConsumerDefinition

--- a/camel-core/src/test/java/org/apache/camel/model/GlobalOptionsDefinitionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/model/GlobalOptionsDefinitionTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GlobalOptionsDefinitionTest {
+
+    private static final String LOG_DEBUG_BODY_MAX_CHARS_VALUE = "500";
+
+    private GlobalOptionsDefinition instance;
+
+    @Before
+    public void setup() {
+        GlobalOptionDefinition globalOption = new GlobalOptionDefinition();
+        globalOption.setKey(Exchange.LOG_DEBUG_BODY_MAX_CHARS);
+        globalOption.setValue(LOG_DEBUG_BODY_MAX_CHARS_VALUE);
+        List<GlobalOptionDefinition> globalOptions = new ArrayList<>();
+        globalOptions.add(globalOption);
+        instance = new GlobalOptionsDefinition();
+        instance.setGlobalOptions(globalOptions);
+    }
+
+    @Test
+    public void asMapShouldCarryOnLogDebugMaxChars() {
+        Map<String, String> map = instance.asMap();
+        Assert.assertNotNull(map);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(LOG_DEBUG_BODY_MAX_CHARS_VALUE, map.get(Exchange.LOG_DEBUG_BODY_MAX_CHARS));
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/model/GlobalOptionsDefinitionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/model/GlobalOptionsDefinitionTest.java
@@ -28,16 +28,25 @@ import org.junit.Test;
 public class GlobalOptionsDefinitionTest {
 
     private static final String LOG_DEBUG_BODY_MAX_CHARS_VALUE = "500";
+    private static final String LOG_DEBUG_BODY_MAX_CHARS_DUP_VALUE = "400";
 
     private GlobalOptionsDefinition instance;
+    private List<GlobalOptionDefinition> globalOptions;
+    private GlobalOptionDefinition nominalOption;
+    private GlobalOptionDefinition duplicateOption;
 
     @Before
     public void setup() {
-        GlobalOptionDefinition globalOption = new GlobalOptionDefinition();
-        globalOption.setKey(Exchange.LOG_DEBUG_BODY_MAX_CHARS);
-        globalOption.setValue(LOG_DEBUG_BODY_MAX_CHARS_VALUE);
-        List<GlobalOptionDefinition> globalOptions = new ArrayList<>();
-        globalOptions.add(globalOption);
+        nominalOption = new GlobalOptionDefinition();
+        nominalOption.setKey(Exchange.LOG_DEBUG_BODY_MAX_CHARS);
+        nominalOption.setValue(LOG_DEBUG_BODY_MAX_CHARS_VALUE);
+
+        duplicateOption = new GlobalOptionDefinition();
+        duplicateOption.setKey(Exchange.LOG_DEBUG_BODY_MAX_CHARS);
+        duplicateOption.setValue(LOG_DEBUG_BODY_MAX_CHARS_DUP_VALUE);
+
+        globalOptions = new ArrayList<>();
+        globalOptions.add(nominalOption);
         instance = new GlobalOptionsDefinition();
         instance.setGlobalOptions(globalOptions);
     }
@@ -48,6 +57,38 @@ public class GlobalOptionsDefinitionTest {
         Assert.assertNotNull(map);
         Assert.assertEquals(1, map.size());
         Assert.assertEquals(LOG_DEBUG_BODY_MAX_CHARS_VALUE, map.get(Exchange.LOG_DEBUG_BODY_MAX_CHARS));
+    }
+
+    @Test
+    public void asMapWithDuplicateKeyShouldOverride() {
+        globalOptions.add(duplicateOption);
+        Map<String, String> map = instance.asMap();
+        Assert.assertNotNull(map);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(LOG_DEBUG_BODY_MAX_CHARS_DUP_VALUE, map.get(Exchange.LOG_DEBUG_BODY_MAX_CHARS));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void asMapWithNullGlobalOptionsShouldThrowNullPointerException() {
+        instance.setGlobalOptions(null);
+        instance.asMap();
+    }
+
+    @Test
+    public void asMapWithEmptyGlobalOptionsShouldReturnEmptyMap() {
+        globalOptions.clear();
+        Map<String, String> map = instance.asMap();
+        Assert.assertNotNull(map);
+        Assert.assertEquals(0, map.size());
+    }
+
+    @Test
+    public void asMapWithNullKeyShouldReturnEmptyMap() {
+        nominalOption.setKey(null);
+        Map<String, String> map = instance.asMap();
+        Assert.assertNotNull(map);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(LOG_DEBUG_BODY_MAX_CHARS_VALUE, map.get(null));
     }
 
 }

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
@@ -45,6 +45,7 @@ import org.apache.camel.core.xml.CamelPropertyPlaceholderDefinition;
 import org.apache.camel.core.xml.CamelServiceExporterDefinition;
 import org.apache.camel.core.xml.CamelStreamCachingStrategyDefinition;
 import org.apache.camel.model.ContextScanDefinition;
+import org.apache.camel.model.GlobalOptionsDefinition;
 import org.apache.camel.model.HystrixConfigurationDefinition;
 import org.apache.camel.model.InterceptDefinition;
 import org.apache.camel.model.InterceptFromDefinition;
@@ -129,8 +130,11 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
     private TypeConverterExists typeConverterExists;
     @XmlAttribute
     private LoggingLevel typeConverterExistsLoggingLevel;
+    @Deprecated
     @XmlElement(name = "properties")
     private PropertiesDefinition properties;
+    @XmlElement(name = "globalOptions")
+    private GlobalOptionsDefinition globalOptions;
     @XmlElement(name = "propertyPlaceholder", type = CamelPropertyPlaceholderDefinition.class)
     private CamelPropertyPlaceholderDefinition camelPropertyPlaceholder;
     @XmlElement(name = "package")
@@ -563,12 +567,23 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
         this.errorHandlerRef = errorHandlerRef;
     }
 
+    @Deprecated
     public PropertiesDefinition getProperties() {
         return properties;
     }
 
+    @Override
+    public GlobalOptionsDefinition getGlobalOptions() {
+        return globalOptions;
+    }
+
+    @Deprecated
     public void setProperties(PropertiesDefinition properties) {
         this.properties = properties;
+    }
+
+    public void setGlobalOptions(GlobalOptionsDefinition globalOptions) {
+        this.globalOptions = globalOptions;
     }
 
     public String[] getPackages() {

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -175,6 +175,7 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
         if (getGlobalOptions() != null) {
             mergedOptions.putAll(getGlobalOptions().asMap());
         }
+
         getContext().setGlobalOptions(mergedOptions);
 
         // and enable lazy loading of type converters if applicable

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -17,6 +17,7 @@
 package org.apache.camel.core.xml;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.apache.camel.management.DefaultManagementStrategy;
 import org.apache.camel.management.ManagedManagementStrategy;
 import org.apache.camel.model.ContextScanDefinition;
 import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.GlobalOptionsDefinition;
 import org.apache.camel.model.IdentifiedType;
 import org.apache.camel.model.InterceptDefinition;
 import org.apache.camel.model.InterceptFromDefinition;
@@ -166,9 +168,15 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
         }
 
         // then set custom properties
+        Map<String, String> mergedOptions = new HashMap<>();
         if (getProperties() != null) {
-            getContext().setGlobalOptions(getProperties().asMap());
+            mergedOptions.putAll(getProperties().asMap());
         }
+        if (getGlobalOptions() != null) {
+            mergedOptions.putAll(getGlobalOptions().asMap());
+        }
+        getContext().setGlobalOptions(mergedOptions);
+
         // and enable lazy loading of type converters if applicable
         initLazyLoadTypeConverters();
 
@@ -696,7 +704,9 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
 
     public abstract List<InterceptSendToEndpointDefinition> getInterceptSendToEndpoints();
 
+    @Deprecated
     public abstract PropertiesDefinition getProperties();
+    public abstract GlobalOptionsDefinition getGlobalOptions();
 
     public abstract String[] getPackages();
 

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -113,7 +113,7 @@ public class CamelAutoConfiguration {
         camelContext.getShutdownStrategy().setLogInflightExchangesOnTimeout(config.isShutdownLogInflightExchangesOnTimeout());
 
         if (config.getLogDebugMaxChars() > 0) {
-            camelContext.getProperties().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "" + config.getLogDebugMaxChars());
+            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "" + config.getLogDebugMaxChars());
         }
 
         // stream caching

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
@@ -44,6 +44,7 @@ import org.apache.camel.core.xml.CamelProxyFactoryDefinition;
 import org.apache.camel.core.xml.CamelServiceExporterDefinition;
 import org.apache.camel.core.xml.CamelStreamCachingStrategyDefinition;
 import org.apache.camel.model.ContextScanDefinition;
+import org.apache.camel.model.GlobalOptionsDefinition;
 import org.apache.camel.model.HystrixConfigurationDefinition;
 import org.apache.camel.model.InterceptDefinition;
 import org.apache.camel.model.InterceptFromDefinition;
@@ -138,8 +139,11 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
     private TypeConverterExists typeConverterExists;
     @XmlAttribute @Metadata(defaultValue = "WARN")
     private LoggingLevel typeConverterExistsLoggingLevel;
+    @Deprecated
     @XmlElement(name = "properties")
     private PropertiesDefinition properties;
+    @XmlElement(name = "globalOptions")
+    private GlobalOptionsDefinition globalOptions;
     @XmlElement(name = "propertyPlaceholder", type = CamelPropertyPlaceholderDefinition.class)
     private CamelPropertyPlaceholderDefinition camelPropertyPlaceholder;
     @XmlElement(name = "package")
@@ -493,15 +497,29 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
         this.interceptSendToEndpoints = interceptSendToEndpoints;
     }
 
+    @Deprecated
     public PropertiesDefinition getProperties() {
         return properties;
     }
 
+    @Override
+    public GlobalOptionsDefinition getGlobalOptions() {
+        return globalOptions;
+    }
+
     /**
-     * Configuration of CamelContext properties such as limit of debug logging and other general options.
+     * Configuration of CamelContext properties such as limit of debug logging
+     * and other general options.
+     * 
+     * @deprecated Use {@link GlobalOptionsDefinition} instead.
      */
+    @Deprecated
     public void setProperties(PropertiesDefinition properties) {
         this.properties = properties;
+    }
+
+    public void setGlobalOptions(GlobalOptionsDefinition globalOptions) {
+        this.globalOptions = globalOptions;
     }
 
     public String[] getPackages() {

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/handler/CamelNamespaceHandler.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/handler/CamelNamespaceHandler.java
@@ -390,6 +390,7 @@ public class CamelNamespaceHandler extends NamespaceHandlerSupport {
                 builder.addPropertyValue("routeRefs", factoryBean.getRouteRefs());
                 builder.addPropertyValue("restRefs", factoryBean.getRestRefs());
                 builder.addPropertyValue("properties", factoryBean.getProperties());
+                builder.addPropertyValue("globalOptions", factoryBean.getGlobalOptions());
                 builder.addPropertyValue("packageScan", factoryBean.getPackageScan());
                 builder.addPropertyValue("contextScan", factoryBean.getContextScan());
                 if (factoryBean.getPackages().length > 0) {

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/CamelContextAwareTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/CamelContextAwareTest.java
@@ -33,8 +33,8 @@ public class CamelContextAwareTest extends SpringTestSupport {
     public void testInjectionPoints() throws Exception {
         assertNotNull("No CamelContext injected!", bean1.getCamelContext());
         Map<String, String> globalOptions  = bean1.getCamelContext().getGlobalOptions();
-        assertNotNull("the properties should not been null", globalOptions);
-        assertEquals("No properties injected", globalOptions.size(), 1);
+        assertNotNull("The global options reference should not be null", globalOptions);
+        assertEquals("No global options injected", globalOptions.size(), 1);
         assertEquals("Should get the value of org.apache.camel.test", globalOptions.get("org.apache.camel.test"), "this is a test first");
     }
     

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/CamelGlobalOptionsTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/CamelGlobalOptionsTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class CamelGlobalOptionsTest extends SpringTestSupport {
+
+    public void testGlobalOptionsOverrideProperties() {
+        assertEquals(3, context.getGlobalOptions().size());
+        assertEquals("VALUE_1", context.getGlobalOptions().get("KEY_1"));
+        assertEquals("VALUE_2_OVERIDDEN", context.getGlobalOptions().get("KEY_2"));
+        assertEquals("VALUE_3", context.getGlobalOptions().get("KEY_3"));
+    }
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/camelGlobalOptions.xml");
+    }
+
+}

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/camelGlobalOptions.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/camelGlobalOptions.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+    license agreements. See the NOTICE file distributed with this work for additional 
+    information regarding copyright ownership. The ASF licenses this file to 
+    You under the Apache License, Version 2.0 (the "License"); you may not use 
+    this file except in compliance with the License. You may obtain a copy of 
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+  <camelContext xmlns="http://camel.apache.org/schema/spring">
+    <properties>
+      <property key="KEY_1" value="VALUE_1" />
+      <property key="KEY_2" value="VALUE_2" />
+    </properties>
+
+    <globalOptions>
+      <globalOption key="KEY_2" value="VALUE_2_OVERIDDEN" />
+      <globalOption key="KEY_3" value="VALUE_3" />
+    </globalOptions>
+
+    <route>
+      <from uri="direct:start" />
+      <to uri="log:TEST" />
+    </route>
+
+  </camelContext>
+</beans>


### PR DESCRIPTION
+ properties and globalOptions coexist in schemas
+ globalOptions override existing properties
+ I first deprecated PropertyDefinition but rolled this back in the **third** commit when I realized it is duly used for endpoint level properties
+ I couldn't help with re-writing GlobalOptionsDefinition.asMap()
+ I didn't completed camel-spring-boot as it looks like the functionality behind "properties" would be implemented in CamelConfigurationProperties with spring boot. Not sure about that however, guidance is welcome if need be.