### PR TITLE
CAMEL-10739: camel-bindy: Unmarshall CSV fields with crlf characters

### DIFF
--- a/components/camel-bindy/pom.xml
+++ b/components/camel-bindy/pom.xml
@@ -45,6 +45,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons-csv-version}</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
@@ -66,6 +66,7 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
     private boolean messageOrdered;
     private String quote;
     private boolean quoting;
+    private boolean multiLine;
     private boolean autospanLine;
 
     public BindyCsvFactory(Class<?> type) throws Exception {
@@ -397,7 +398,7 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
                 if (obj != null) {
 
                     // Retrieve the format, pattern and precision associated to the type
-                    Class<?> type = field.getType();
+//                    Class<?> type = field.getType(); // unused
 
                     // Create format
                     FormattingOptions formattingOptions = ConverterUtils.convert(datafield,
@@ -568,6 +569,9 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
                     quoting = record.quoting();
                     LOG.debug("CSV will be quoted: {}", quoting);
 
+                    multiLine = record.multiLine();
+                    LOG.debug("Multi Line: {}", multiLine);
+
                     autospanLine = record.autospanLine();
                     LOG.debug("Autospan line in last record: {}", autospanLine);
                 }
@@ -647,6 +651,10 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
 
     public String getQuote() {
         return quote;
+    }
+
+    public boolean isMultiLine() {
+        return multiLine;
     }
 
     public int getMaxpos() {

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
@@ -85,4 +85,9 @@ public @interface CsvRecord {
      */
     boolean autospanLine() default false;
 
+    /**
+     * Indicate if any of the fields contain new line character(s)
+     * (optional)
+     */
+    boolean multiLine() default false;
 }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -36,6 +36,9 @@ import org.apache.camel.dataformat.bindy.util.ConverterUtils;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,6 +109,26 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
         }
     }
 
+    private void bindAndLink(final List<Map<String, Object>> models, final List<String> result, final int count) 
+            throws Exception {
+
+        final BindyCsvFactory factory = (BindyCsvFactory) getFactory();
+
+        // Pojos of the model
+        final Map<String, Object> model = factory.factory();
+
+        // Bind data from CSV record with model classes
+        factory.bind(result, model, count);
+
+        // Link objects together
+        factory.link(model);
+
+        LOG.debug("Graph of objects created: {}", model);
+
+        // Add objects graph to the list
+        models.add(model);
+    }
+
     public Object unmarshal(Exchange exchange, InputStream inputStream) throws Exception {
         BindyCsvFactory factory = (BindyCsvFactory)getFactory();
         ObjectHelper.notNull(factory, "not instantiated");
@@ -113,86 +136,77 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
         // List of Pojos
         List<Map<String, Object>> models = new ArrayList<Map<String, Object>>();
 
-        // Pojos of the model
-        Map<String, Object> model;
+        try (InputStreamReader in = new InputStreamReader(inputStream, IOHelper.getCharsetName(exchange))) {
+            int count = 0;
 
-        InputStreamReader in = new InputStreamReader(inputStream, IOHelper.getCharsetName(exchange));
+            if (factory.isMultiLine()) {
+                try (final CSVParser parser = new CSVParser(in, CSVFormat.RFC4180)) {
+                    final Iterator<CSVRecord> csvRecords = parser.iterator();
+                    while (csvRecords.hasNext()) {
+                        final CSVRecord csvRecord = csvRecords.next();
+                        final Iterator<String> iterator = csvRecord.iterator();
+                        final List<String> result = new ArrayList<String>();
+                        iterator.forEachRemaining(result::add);
 
-        // Scanner is used to read big file
-        Scanner scanner = new Scanner(in);
-
-        // Retrieve the separator defined to split the record
-        String separator = factory.getSeparator();
-        String quote = factory .getQuote();
-        ObjectHelper.notNull(separator, "The separator has not been defined in the annotation @CsvRecord or not instantiated during initModel.");
-
-        int count = 0;
-        try {
-            // If the first line of the CSV file contains columns name, then we
-            // skip this line
-            if (factory.getSkipFirstLine()) {
-                // Check if scanner is empty
-                if (scanner.hasNextLine()) {
-                    scanner.nextLine();
-                }
-            }
-
-            while (scanner.hasNextLine()) {
-
-                // Read the line
-                String line = scanner.nextLine().trim();
-
-                if (ObjectHelper.isEmpty(line)) {
-                    // skip if line is empty
-                    continue;
+                        bindAndLink(models, result, ++count);
+                    }
                 }
 
-                // Increment counter
-                count++;
+            } else {
+                // Scanner is used to read big file
+                try (Scanner scanner = new Scanner(in)) {
+                    // Retrieve the separator defined to split the record
+                    String separator = factory.getSeparator();
+                    String quote = factory .getQuote();
+                    ObjectHelper.notNull(separator, "The separator has not been defined in the annotation @CsvRecord or not instantiated during initModel.");
 
-                // Create POJO where CSV data will be stored
-                model = factory.factory();
-
-                // Split the CSV record according to the separator defined in
-                // annotated class @CSVRecord
-                String[] tokens = line.split(separator, factory.getAutospanLine() ? factory.getMaxpos() : -1);
-                List<String> result = Arrays.asList(tokens);
-                // must unquote tokens before use
-                result = unquoteTokens(result, separator, quote);
-
-                if (result.size() == 0 || result.isEmpty()) {
-                    throw new java.lang.IllegalArgumentException("No records have been defined in the CSV");
-                } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Size of the record splitted : {}", result.size());
+                    if (factory.getSkipFirstLine()) {
+                        // Check if scanner is empty
+                        if (scanner.hasNextLine()) {
+                            scanner.nextLine();
+                        }
                     }
 
-                    // Bind data from CSV record with model classes
-                    factory.bind(result, model, count);
+                    while (scanner.hasNextLine()) {
+                        // Read the line
+                        String line = scanner.nextLine().trim();
 
-                    // Link objects together
-                    factory.link(model);
+                        if (ObjectHelper.isEmpty(line)) {
+                            // skip if line is empty
+                            continue;
+                        }
 
-                    // Add objects graph to the list
-                    models.add(model);
+                        // Increment counter
+                        count++;
 
-                    LOG.debug("Graph of objects created: {}", model);
+                        // Split the CSV record according to the separator defined in
+                        // annotated class @CSVRecord
+                        String[] tokens = line.split(separator, factory.getAutospanLine() ? factory.getMaxpos() : -1);
+                        List<String> result = Arrays.asList(tokens);
+                        // must unquote tokens before use
+                        result = unquoteTokens(result, separator, quote);
+
+                        if (result.size() == 0 || result.isEmpty()) {
+                            throw new java.lang.IllegalArgumentException("No records have been defined in the CSV");
+                        } else {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Size of the record splitted : {}", result.size());
+                            }
+
+                            bindAndLink(models, result, count);
+                        }
+                    }
                 }
             }
-
-            // BigIntegerFormatFactory if models list is empty or not
-            // If this is the case (correspond to an empty stream, ...)
-            if (models.size() == 0) {
-                throw new java.lang.IllegalArgumentException("No records have been defined in the CSV");
-            } else {
-                return extractUnmarshalResult(models);
-            }
-
-        } finally {
-            scanner.close();
-            IOHelper.close(in, "in", LOG);
         }
 
+        // BigIntegerFormatFactory if models list is empty or not
+        // If this is the case (correspond to an empty stream, ...)
+        if (models.size() == 0) {
+            throw new java.lang.IllegalArgumentException("No records have been defined in the CSV");
+        } else {
+            return extractUnmarshalResult(models);
+        }
     }
 
     /**

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -140,7 +140,9 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
             int count = 0;
 
             if (factory.isMultiLine()) {
-                try (final CSVParser parser = new CSVParser(in, CSVFormat.RFC4180)) {
+                try (final CSVParser parser = new CSVParser(in, factory.getSkipFirstLine() ? CSVFormat.RFC4180.withFirstRecordAsHeader()
+                                                                                           : CSVFormat.RFC4180)) {
+
                     final Iterator<CSVRecord> csvRecords = parser.iterator();
                     while (csvRecords.hasNext()) {
                         final CSVRecord csvRecord = csvRecords.next();

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest.java
@@ -51,7 +51,8 @@ public class BindyMultilineCsvUnmarshallTest extends AbstractJUnit4SpringContext
     @DirtiesContext
     public void testMultilineCsvUnmarshall() throws Exception {
 
-        expected = "ACDT,\"Australian Central Daylight Savings Time\r\nUTC+10:30\",,A,\"1000\",1000,1.000,\"1.000\",\r\n" 
+        expected = "name,description,comment,char,number1,number2,number3,number4,number5\r\n" 
+                 + "ACDT,\"Australian Central Daylight Savings Time\r\nUTC+10:30\",,A,\"1000\",1000,1.000,\"1.000\",\r\n" 
                  + "\"BST\",\"British Summer Time\r\nUTC+01\",\"a.k.a British Standard Time \"\"from Feb, 1968 to Oct, 1971\"\"\",B,2000,\"2000\",\"2.000\",2.000,\"20.02\"\r\n" 
                  + "\"CDT\",\"Central Daylight Time\r\nUTC-05\",\"North America\",\"C\",,3000,,\"3.000\",\"30.03\"\r\n" 
                  + "\"AEST\",\"\"\"Australia\"\" Eastern Summer Time\r\nUTC+10\",E.g. Brisbane,,\"4000\",4000,4.000,\"4.000\",\"40.04\"\r\n" 
@@ -130,7 +131,7 @@ public class BindyMultilineCsvUnmarshallTest extends AbstractJUnit4SpringContext
 
     }
 
-    @CsvRecord(separator = ",", multiLine = true)
+    @CsvRecord(separator = ",", skipFirstLine = true, multiLine = true)
     public static class MultiLineModel {
 
         @DataField(pos = 1)

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.csv;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.annotation.CsvRecord;
+import org.apache.camel.dataformat.bindy.annotation.DataField;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration
+public class BindyMultilineCsvUnmarshallTest extends AbstractJUnit4SpringContextTests {
+
+    private static final String URI_MOCK_RESULT = "mock:result";
+    private static final String URI_DIRECT_START = "direct:start";
+
+    @Produce(uri = URI_DIRECT_START)
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = URI_MOCK_RESULT)
+    private MockEndpoint result;
+
+    private String expected;
+
+    @Test
+    @DirtiesContext
+    public void testMultilineCsvUnmarshall() throws Exception {
+
+        expected = "ACDT,\"Australian Central Daylight Savings Time\r\nUTC+10:30\",,A,\"1000\",1000,1.000,\"1.000\",\r\n" 
+                 + "\"BST\",\"British Summer Time\r\nUTC+01\",\"a.k.a British Standard Time \"\"from Feb, 1968 to Oct, 1971\"\"\",B,2000,\"2000\",\"2.000\",2.000,\"20.02\"\r\n" 
+                 + "\"CDT\",\"Central Daylight Time\r\nUTC-05\",\"North America\",\"C\",,3000,,\"3.000\",\"30.03\"\r\n" 
+                 + "\"AEST\",\"\"\"Australia\"\" Eastern Summer Time\r\nUTC+10\",E.g. Brisbane,,\"4000\",4000,4.000,\"4.000\",\"40.04\"\r\n" 
+                 + "\"GMT\",\"Greenwich Mean Time\r\nGMT\",\"See also \"\"AZOST\"\", \"\"EGST\"\", \"\"UTC\"\" & \"\"WET\"\"\",E,\"5000\",,5.000,\"\",\"50.05\"\r\n";
+
+        template.sendBody(expected);
+
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+
+        final List<?> models = result.getReceivedExchanges().get(0).getIn().getBody(List.class);
+        TestCase.assertEquals(5, models.size());
+
+        final MultiLineModel acdt = (MultiLineModel) models.get(0);
+        TestCase.assertEquals("ACDT", acdt.getName());
+        TestCase.assertEquals("Australian Central Daylight Savings Time\r\nUTC+10:30", acdt.getDescription());
+        TestCase.assertEquals(null, acdt.getComment());
+        TestCase.assertEquals('A', acdt.getCharacter());
+        TestCase.assertEquals(1000, acdt.getNumber1());
+        TestCase.assertEquals(1000L, acdt.getNumber2());
+        TestCase.assertEquals(1.000f, acdt.getNumber3());
+        TestCase.assertEquals(1.000, acdt.getNumber4());
+        TestCase.assertEquals(null, acdt.getNumber5());
+
+        final MultiLineModel bst = (MultiLineModel) models.get(1);
+        TestCase.assertEquals("BST", bst.getName());
+        TestCase.assertEquals("British Summer Time\r\nUTC+01", bst.getDescription());
+        TestCase.assertEquals("a.k.a British Standard Time \"from Feb, 1968 to Oct, 1971\"", bst.getComment());
+        TestCase.assertEquals('B', bst.getCharacter());
+        TestCase.assertEquals(2000, bst.getNumber1());
+        TestCase.assertEquals(2000L, bst.getNumber2());
+        TestCase.assertEquals(2.000f, bst.getNumber3());
+        TestCase.assertEquals(2.000, bst.getNumber4());
+        TestCase.assertEquals(new BigDecimal("20.02"), bst.getNumber5());
+
+        final MultiLineModel cdt = (MultiLineModel) models.get(2);
+        TestCase.assertEquals("CDT", cdt.getName());
+        TestCase.assertEquals("Central Daylight Time\r\nUTC-05", cdt.getDescription());
+        TestCase.assertEquals("North America", cdt.getComment());
+        TestCase.assertEquals('C', cdt.getCharacter());
+        TestCase.assertEquals(Integer.MIN_VALUE, cdt.getNumber1());
+        TestCase.assertEquals(3000L, cdt.getNumber2());
+        TestCase.assertEquals(Float.MIN_VALUE, cdt.getNumber3());
+        TestCase.assertEquals(3.000, cdt.getNumber4());
+        TestCase.assertEquals(new BigDecimal("30.03"), cdt.getNumber5());
+
+        final MultiLineModel aest = (MultiLineModel) models.get(3);
+        TestCase.assertEquals("AEST", aest.getName());
+        TestCase.assertEquals("\"Australia\" Eastern Summer Time\r\nUTC+10", aest.getDescription());
+        TestCase.assertEquals("E.g. Brisbane", aest.getComment());
+        TestCase.assertEquals('\0', aest.getCharacter());
+        TestCase.assertEquals(4000, aest.getNumber1());
+        TestCase.assertEquals(4000L, aest.getNumber2());
+        TestCase.assertEquals(4.000f, aest.getNumber3());
+        TestCase.assertEquals(4.000, aest.getNumber4());
+        TestCase.assertEquals(new BigDecimal("40.04"), aest.getNumber5());
+
+        final MultiLineModel gmt = (MultiLineModel) models.get(4);
+        TestCase.assertEquals("GMT", gmt.getName());
+        TestCase.assertEquals("Greenwich Mean Time\r\nGMT", gmt.getDescription());
+        TestCase.assertEquals("See also \"AZOST\", \"EGST\", \"UTC\" & \"WET\"", gmt.getComment());
+        TestCase.assertEquals('E', gmt.getCharacter());
+        TestCase.assertEquals(5000, gmt.getNumber1());
+        TestCase.assertEquals(Long.MIN_VALUE, gmt.getNumber2());
+        TestCase.assertEquals(5.000f, gmt.getNumber3());
+        TestCase.assertEquals(Double.MIN_VALUE, gmt.getNumber4());
+        TestCase.assertEquals(new BigDecimal("50.05"), gmt.getNumber5());
+    }
+
+    public static class ContextConfig extends RouteBuilder {
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(MultiLineModel.class);
+
+        public void configure() {
+            from(URI_DIRECT_START).unmarshal(camelDataFormat).to(URI_MOCK_RESULT);
+        }
+
+    }
+
+    @CsvRecord(separator = ",", multiLine = true)
+    public static class MultiLineModel {
+
+        @DataField(pos = 1)
+        private String name;
+
+        @DataField(pos = 2)
+        private String description;
+
+        @DataField(pos = 3)
+        private String comment;
+
+        @DataField(pos = 4)
+        private char character;
+
+        @DataField(pos = 5)
+        private int number1;
+
+        @DataField(pos = 6)
+        private long number2;
+
+        @DataField(pos = 7)
+        private float number3;
+
+        @DataField(pos = 8)
+        private double number4;
+
+        @DataField(pos = 9, precision = 2)
+        private BigDecimal number5;
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getComment() {
+            return comment;
+        }
+
+        public char getCharacter() {
+            return character;
+        }
+
+        public int getNumber1() {
+            return number1;
+        }
+
+        public long getNumber2() {
+            return number2;
+        }
+
+        public float getNumber3() {
+            return number3;
+        }
+
+        public double getNumber4() {
+            return number4;
+        }
+
+        public BigDecimal getNumber5() {
+            return number5;
+        }
+
+        @Override
+        public String toString() {
+            return "name=" + this.name + ",description=" + this.description + ",comment=" + this.comment
+                    + ",character=" + character + ",number1=" + number1 + ",number2=" + number2
+                    + ",number3=" + number3 + ",number4=" + number4 + ",number5=" + number5;
+        }
+    }
+
+}

--- a/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest-context.xml
+++ b/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyMultilineCsvUnmarshallTest-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+                           http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <routeBuilder ref="myBuilder" />
+    </camelContext>
+
+    <bean id="myBuilder" class="org.apache.camel.dataformat.bindy.csv.BindyMultilineCsvUnmarshallTest$ContextConfig" />
+</beans>


### PR DESCRIPTION
Bindy CSV currently performs line by line scan, and split with provided delimiter ("comma by default"), thus unable to recognize if CSV fields might contain crlf characters.

Suggestion, add "multiLine" in @CsvRecord, which BindyCsvDataFormat will parse CSV with commons-csv library if multi line is true.