### PR TITLE
CAMEL-10483 Introduce property bindingArgsConfigurer

### DIFF
--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -45,7 +45,7 @@ The RabbitMQ component has no options.
 
 
 // endpoint options: START
-The RabbitMQ component supports 56 endpoint options which are listed below:
+The RabbitMQ component supports 57 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -90,6 +90,7 @@ The RabbitMQ component supports 56 endpoint options which are listed below:
 | publisherAcknowledgementsTimeout | producer |  | long | The amount of time in milliseconds to wait for a basic.ack response from RabbitMQ server
 | addresses | advanced |  | Address[] | If this option is set camel-rabbitmq will try to create connection based on the setting of option addresses. The addresses value is a string which looks like server1:12345 server2:12345
 | automaticRecoveryEnabled | advanced |  | Boolean | Enables connection automatic recovery (uses connection implementation that performs automatic recovery when connection shutdown is not initiated by the application)
+| bindingArgsConfigurer | advanced |  | ArgsConfigurer | Set the configurer for setting the queue binding parameters in Channel.queueBind
 | clientProperties | advanced |  | Map | Connection client properties (client info used in negotiating with the server)
 | connectionFactory | advanced |  | ConnectionFactory | To use a custom RabbitMQ connection factory. When this option is set all connection options (connectionTimeout requestedChannelMax...) set on URI are not used
 | exchangeArgsConfigurer | advanced |  | ArgsConfigurer | Set the configurer for setting the exchange args in Channel.exchangeDeclare

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -40,7 +40,7 @@ public class RabbitMQDeclareSupport {
         if (endpoint.getDeadLetterExchange() != null) {
             // TODO Do we need to setup the args for the DeadLetter?
             declareExchange(channel, endpoint.getDeadLetterExchange(), endpoint.getDeadLetterExchangeType(), Collections.<String, Object>emptyMap());
-            declareAndBindQueue(channel, endpoint.getDeadLetterQueue(), endpoint.getDeadLetterExchange(), endpoint.getDeadLetterRoutingKey(), null);
+            declareAndBindQueue(channel, endpoint.getDeadLetterQueue(), endpoint.getDeadLetterExchange(), endpoint.getDeadLetterRoutingKey(), null, null);
         }
     }
 
@@ -51,7 +51,7 @@ public class RabbitMQDeclareSupport {
 
         if (shouldDeclareQueue()) {
             // need to make sure the queueDeclare is same with the exchange declare
-            declareAndBindQueue(channel, endpoint.getQueue(), endpoint.getExchangeName(), endpoint.getRoutingKey(), resolvedQueueArguments());
+            declareAndBindQueue(channel, endpoint.getQueue(), endpoint.getExchangeName(), endpoint.getRoutingKey(), resolvedQueueArguments(), resolvedBindingArguments());
         }
     }
 
@@ -79,6 +79,14 @@ public class RabbitMQDeclareSupport {
         return exchangeArgs;
     }
 
+    private Map<String, Object> resolvedBindingArguments() {
+        Map<String, Object> exchangeArgs = new HashMap<>();
+        if (endpoint.getBindingArgsConfigurer() != null) {
+            endpoint.getBindingArgsConfigurer().configurArgs(exchangeArgs);
+        }
+        return exchangeArgs;
+    }
+
     private boolean shouldDeclareQueue() {
         return !endpoint.isSkipQueueDeclare() && endpoint.getQueue() != null;
     }
@@ -101,11 +109,16 @@ public class RabbitMQDeclareSupport {
         channel.exchangeDeclare(exchange, exchangeType, endpoint.isDurable(), endpoint.isAutoDelete(), exchangeArgs);
     }
 
-    private void declareAndBindQueue(final Channel channel, final String queue, final String exchange, final String routingKey, final Map<String, Object> arguments)
+    private void declareAndBindQueue(final Channel channel,
+                                     final String queue,
+                                     final String exchange,
+                                     final String routingKey,
+                                     final Map<String, Object> queueArgs,
+                                     final Map<String, Object> bindingArgs)
             throws IOException {
-        channel.queueDeclare(queue, endpoint.isDurable(), endpoint.isExclusive(), endpoint.isAutoDelete(), arguments);
+        channel.queueDeclare(queue, endpoint.isDurable(), endpoint.isExclusive(), endpoint.isAutoDelete(), queueArgs);
         if (shouldBindQueue()) {
-            channel.queueBind(queue, exchange, emptyIfNull(routingKey));
+            channel.queueBind(queue, exchange, emptyIfNull(routingKey), bindingArgs);
         }
     }
 

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -146,6 +146,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     @UriParam(label = "advanced")
     private ArgsConfigurer exchangeArgsConfigurer;
     @UriParam(label = "advanced")
+    private ArgsConfigurer bindingArgsConfigurer;
+    @UriParam(label = "advanced")
     private long requestTimeout = 20000;
     @UriParam(label = "advanced")
     private long requestTimeoutCheckerInterval = 1000;
@@ -774,6 +776,18 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
      */
     public void setExchangeArgsConfigurer(ArgsConfigurer exchangeArgsConfigurer) {
         this.exchangeArgsConfigurer = exchangeArgsConfigurer;
+    }
+
+    /**
+     * Set the configurer for setting the queue binding parameters in Channel.queueBind
+     * @return
+     */
+    public void setBindingArgsConfigurer(ArgsConfigurer bindingArgsConfigurer) {
+        this.bindingArgsConfigurer = bindingArgsConfigurer;
+    }
+
+    public ArgsConfigurer getBindingArgsConfigurer() {
+        return bindingArgsConfigurer;
     }
 
     /**

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQConsumerIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQConsumerIntTest.java
@@ -18,7 +18,9 @@ package org.apache.camel.component.rabbitmq;
 
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import com.rabbitmq.client.AMQP;
@@ -30,18 +32,27 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.JndiRegistry;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
 public class RabbitMQConsumerIntTest extends CamelTestSupport {
 
     private static final String EXCHANGE = "ex1";
+    private static final String HEADERS_EXCHANGE = "ex2";
+    private static final String QUEUE = "q1";
+    private static final String HEADER_KEY = "foo";
+    private static final String HEADER_VALUE = "bar";
+    private static final String MSG = "hello world";
 
     @EndpointInject(uri = "rabbitmq:localhost:5672/" + EXCHANGE + "?username=cameltest&password=cameltest")
     private Endpoint from;
 
     @EndpointInject(uri = "mock:result")
     private MockEndpoint to;
+
+    @EndpointInject(uri = "rabbitmq:localhost:5672/" + HEADERS_EXCHANGE + "?username=cameltest&password=cameltest&exchangeType=headers&queue=" + QUEUE + "&bindingArgsConfigurer=#bindArgs")
+    private Endpoint headersExchangeWithQueue;
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
@@ -50,8 +61,24 @@ public class RabbitMQConsumerIntTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from(from).to(to);
+                from(headersExchangeWithQueue).to(to);
             }
         };
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+
+        ArgsConfigurer queueArgs = new ArgsConfigurer() {
+            @Override
+            public void configurArgs(Map<String, Object> args) {
+                args.put(HEADER_KEY, HEADER_VALUE);
+            }
+        };
+        jndi.bind("bindArgs", queueArgs);
+
+        return jndi;
     }
 
     @Test
@@ -60,19 +87,11 @@ public class RabbitMQConsumerIntTest extends CamelTestSupport {
         to.expectedMessageCount(1);
         to.expectedHeaderReceived(RabbitMQConstants.REPLY_TO, "myReply");
 
-        ConnectionFactory factory = new ConnectionFactory();
-        factory.setHost("localhost");
-        factory.setPort(5672);
-        factory.setUsername("cameltest");
-        factory.setPassword("cameltest");
-        factory.setVirtualHost("/");
-        Connection conn = factory.newConnection();
-
         AMQP.BasicProperties.Builder properties = new AMQP.BasicProperties.Builder();
         properties.replyTo("myReply");
 
-        Channel channel = conn.createChannel();
-        channel.basicPublish(EXCHANGE, "", properties.build(), "hello world".getBytes());
+        Channel channel = connection().createChannel();
+        channel.basicPublish(EXCHANGE, "", properties.build(), MSG.getBytes());
 
         to.assertIsSatisfied();
     }
@@ -84,21 +103,49 @@ public class RabbitMQConsumerIntTest extends CamelTestSupport {
         to.expectedMessageCount(1);
         to.expectedHeaderReceived(RabbitMQConstants.TIMESTAMP, timestamp);
 
+
+        AMQP.BasicProperties.Builder properties = new AMQP.BasicProperties.Builder();
+        properties.timestamp(timestamp);
+
+        Channel channel = connection().createChannel();
+        channel.basicPublish(EXCHANGE, "", properties.build(), MSG.getBytes());
+
+        to.assertIsSatisfied();
+    }
+
+    /**
+     * Tests the proper rabbit binding arguments are in place when the headersExchangeWithQueue is created.
+     * Should only receive messages with the header [foo=bar]
+     */
+    @Test
+    public void sentMessageIsReceivedWithHeadersRouting() throws InterruptedException, IOException, TimeoutException {
+        //should only be one message that makes it through because only
+        //one has the correct header set
+        to.expectedMessageCount(1);
+
+        AMQP.BasicProperties.Builder properties = new AMQP.BasicProperties.Builder();
+        properties.headers(Collections.singletonMap(HEADER_KEY, HEADER_VALUE));
+
+        AMQP.BasicProperties.Builder nonMatchingProperties = new AMQP.BasicProperties.Builder();
+        nonMatchingProperties.headers(Collections.singletonMap(HEADER_KEY, "wrong-value"));
+
+
+        Channel channel = connection().createChannel();
+        channel.basicPublish(HEADERS_EXCHANGE, "", properties.build(), MSG.getBytes());
+        channel.basicPublish(HEADERS_EXCHANGE, "", null, MSG.getBytes());
+        channel.basicPublish(HEADERS_EXCHANGE, "", nonMatchingProperties.build(), MSG.getBytes());
+
+        to.assertIsSatisfied();
+    }
+
+    private Connection connection() throws IOException, TimeoutException {
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost("localhost");
         factory.setPort(5672);
         factory.setUsername("cameltest");
         factory.setPassword("cameltest");
         factory.setVirtualHost("/");
-        Connection conn = factory.newConnection();
-
-        AMQP.BasicProperties.Builder properties = new AMQP.BasicProperties.Builder();
-        properties.timestamp(timestamp);
-
-        Channel channel = conn.createChannel();
-        channel.basicPublish(EXCHANGE, "", properties.build(), "hello world".getBytes());
-
-        to.assertIsSatisfied();
+        return factory.newConnection();
     }
 
     private Date currentTimestampWithoutMillis() {

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -163,6 +163,15 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?queueArgsConfigurer=#argsConfigurer", RabbitMQEndpoint.class);
         assertNotNull("We should get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
         assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
+        assertNull("We should not get the bindingArgsConfigurer here.", endpoint.getBindingArgsConfigurer());
+    }
+
+    @Test
+    public void testBindingArgsConfigurer() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?bindingArgsConfigurer=#argsConfigurer", RabbitMQEndpoint.class);
+        assertNotNull("We should get the bindingArgsConfigurer here.", endpoint.getBindingArgsConfigurer());
+        assertNull("We should not get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
+        assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
     }
 
     @Test


### PR DESCRIPTION
Without the ability to specify binding properties, a headers exchange cannot be auto declared using the rabbitmq endpoint. Autodeclare is a key feature of rabbit and routing via headers is an important usecase. 

Introduced new optional property which reuses the ArgsConfigurer interface to achieve much the same thing as both the exchangeArgs and queueArgs.