### PR TITLE
CAMEL-10759 RabbitMQ Component binding args

### DIFF
--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -45,7 +45,7 @@ The RabbitMQ component has no options.
 
 
 // endpoint options: START
-The RabbitMQ component supports 56 endpoint options which are listed below:
+The RabbitMQ component supports 59 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -90,10 +90,13 @@ The RabbitMQ component supports 56 endpoint options which are listed below:
 | publisherAcknowledgementsTimeout | producer |  | long | The amount of time in milliseconds to wait for a basic.ack response from RabbitMQ server
 | addresses | advanced |  | Address[] | If this option is set camel-rabbitmq will try to create connection based on the setting of option addresses. The addresses value is a string which looks like server1:12345 server2:12345
 | automaticRecoveryEnabled | advanced |  | Boolean | Enables connection automatic recovery (uses connection implementation that performs automatic recovery when connection shutdown is not initiated by the application)
+| bindingArgs | advanced |  | Map | Key/value args for configuring the queue binding parameters when declare=true
 | clientProperties | advanced |  | Map | Connection client properties (client info used in negotiating with the server)
 | connectionFactory | advanced |  | ConnectionFactory | To use a custom RabbitMQ connection factory. When this option is set all connection options (connectionTimeout requestedChannelMax...) set on URI are not used
+| exchangeArgs | advanced |  | Map | Key/value args for configuring the exchange parameters when declare=true
 | exchangeArgsConfigurer | advanced |  | ArgsConfigurer | Set the configurer for setting the exchange args in Channel.exchangeDeclare
 | networkRecoveryInterval | advanced |  | Integer | Network recovery interval in milliseconds (interval used when recovering from network failure)
+| queueArgs | advanced |  | Map | Key/value args for configuring the queue parameters when declare=true
 | queueArgsConfigurer | advanced |  | ArgsConfigurer | Set the configurer for setting the queue args in Channel.queueDeclare
 | requestedChannelMax | advanced | 0 | int | Connection requested channel max (max number of channels offered)
 | requestedFrameMax | advanced | 0 | int | Connection requested frame max (max size of frame offered)
@@ -235,6 +238,25 @@ To send messages to an exchange called C
 -------------------------------
 ...to("rabbitmq://localhost/B")
 -------------------------------
+
+Declaring a headers exchange and queue
+
+[source,java]
+---------------------------------------------------------------------------------
+from("rabbitmq://localhost/ex?exchangeType=headers&queue=q&bindingArgs=bindArgs")
+---------------------------------------------------------------------------------
+
+and place corresponding Map<String, Object> with the id of "bindArgs" in the Registry.
+
+For example declaring a method in spring
+
+[source,java]
+---------------------------------------------------------------------------------
+@Bean(name="bindArgs")
+public Map<String, Object> bindArgsBuilder() {
+    return Collections.singletonMap("foo", "bar");
+}
+---------------------------------------------------------------------------------
 
 ### See Also
 

--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -243,7 +243,7 @@ Declaring a headers exchange and queue
 
 [source,java]
 ---------------------------------------------------------------------------------
-from("rabbitmq://localhost/ex?exchangeType=headers&queue=q&bindingArgs=bindArgs")
+from("rabbitmq://localhost/ex?exchangeType=headers&queue=q&bindingArgs=#bindArgs")
 ---------------------------------------------------------------------------------
 
 and place corresponding Map<String, Object> with the id of "bindArgs" in the Registry.

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.rabbitmq;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -141,6 +142,12 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     private boolean mandatory;
     @UriParam(label = "producer")
     private boolean immediate;
+    @UriParam(label = "advanced")
+    private Map<String, Object> exchangeArgs = new HashMap<>();
+    @UriParam(label = "advanced")
+    private Map<String, Object> queueArgs = new HashMap<>();
+    @UriParam(label = "advanced")
+    private Map<String, Object> bindingArgs = new HashMap<>();
     @UriParam(label = "advanced")
     private ArgsConfigurer queueArgsConfigurer;
     @UriParam(label = "advanced")
@@ -752,6 +759,39 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
      */
     public void setImmediate(boolean immediate) {
         this.immediate = immediate;
+    }
+
+    /**
+     * Key/value args for configuring the exchange parameters when declare=true
+     */
+    public void setExchangeArgs(Map<String, Object> exchangeArgs) {
+        this.exchangeArgs = exchangeArgs;
+    }
+
+    public Map<String, Object> getExchangeArgs() {
+        return exchangeArgs;
+    }
+
+    /**
+     * Key/value args for configuring the queue parameters when declare=true
+     */
+    public void setQueueArgs(Map<String, Object> queueArgs) {
+        this.queueArgs = queueArgs;
+    }
+
+    public Map<String, Object> getQueueArgs() {
+        return queueArgs;
+    }
+
+    /**
+     * Key/value args for configuring the queue binding parameters when declare=true
+     */
+    public void setBindingArgs(Map<String, Object> bindingArgs) {
+        this.bindingArgs = bindingArgs;
+    }
+
+    public Map<String, Object> getBindingArgs() {
+        return bindingArgs;
     }
 
     public ArgsConfigurer getQueueArgsConfigurer() {

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/AbstractRabbitMQIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/AbstractRabbitMQIntTest.java
@@ -16,25 +16,28 @@
  */
 package org.apache.camel.component.rabbitmq;
 
-import java.util.Map;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.apache.camel.test.junit4.CamelTestSupport;
 
-/**
- * @deprecated The endpoint uri properties
- * <ul>
- *     <li>{@link RabbitMQEndpoint#setExchangeArgs(Map)}</li>
- *     <li>{@link RabbitMQEndpoint#setQueueArgs(Map)}</li>
- *     <li>{@link RabbitMQEndpoint#setBindingArgs(Map)}</li>
- * </ul>
- *
- * are favoured over their configurer counterparts.
- */
-@Deprecated
-public interface ArgsConfigurer {
-    
+public abstract class AbstractRabbitMQIntTest extends CamelTestSupport {
+
     /**
-     * Configure the args maps for RabbitMQ to use
-     * @param args the map need to be configured
+     * Helper method for creating a rabbitmq connection to the test instance of the
+     * rabbitmq server.
+     * @return
+     * @throws IOException
+     * @throws TimeoutException
      */
-    void configurArgs(Map<String, Object> args);
-
+    protected Connection connection() throws IOException, TimeoutException {
+        ConnectionFactory factory = new ConnectionFactory();
+        factory.setHost("localhost");
+        factory.setPort(5672);
+        factory.setUsername("cameltest");
+        factory.setPassword("cameltest");
+        factory.setVirtualHost("/");
+        return factory.newConnection();
+    }
 }

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -51,8 +51,14 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
             public void configurArgs(Map<String, Object> args) {
                 // do nothing here
             }
-            
+
         });
+
+        HashMap<String, Object> args = new HashMap<>();
+        args.put("foo", "bar");
+        registry.bind("args", args);
+
+
         return registry;
     }
 
@@ -159,10 +165,39 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
     }
 
     @Test
-    public void testArgConfigurer() throws Exception {
+    public void testQueueArgsConfigurer() throws Exception {
         RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?queueArgsConfigurer=#argsConfigurer", RabbitMQEndpoint.class);
         assertNotNull("We should get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
         assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
+        assertTrue("We should not get the bindingArgsConfigurer here.", endpoint.getBindingArgs().isEmpty());
+    }
+
+    @Test
+    public void testBindingArgs() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?bindingArgs=#args", RabbitMQEndpoint.class);
+        assertEquals("We should get the bindingArgsConfigurer here.", 1, endpoint.getBindingArgs().size());
+        assertNull("We should not get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
+        assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
+    }
+
+    @Test
+    public void testQueueArgs() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?queueArgs=#args", RabbitMQEndpoint.class);
+        assertEquals("We should get the queueArgs here.", 1, endpoint.getQueueArgs().size());
+        assertTrue("We should not get the binding args here.", endpoint.getBindingArgs().isEmpty());
+        assertTrue("We should not get the exchange args here.", endpoint.getExchangeArgs().isEmpty());
+        assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
+        assertNull("We should not get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
+    }
+
+    @Test
+    public void testExchangeArgs() throws Exception {
+        RabbitMQEndpoint endpoint = context.getEndpoint("rabbitmq:localhost/exchange?exchangeArgs=#args", RabbitMQEndpoint.class);
+        assertEquals("We should get the exchangeArgs here.", 1, endpoint.getExchangeArgs().size());
+        assertTrue("We should not get the binding args here.", endpoint.getBindingArgs().isEmpty());
+        assertTrue("We should not get the queue args here.", endpoint.getQueueArgs().isEmpty());
+        assertNull("We should not get the exchangeArgsConfigurer here.", endpoint.getExchangeArgsConfigurer());
+        assertNull("We should not get the queueArgsConfigurer here.", endpoint.getQueueArgsConfigurer());
     }
 
     @Test

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQInOutIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQInOutIntTest.java
@@ -64,7 +64,7 @@ public class RabbitMQInOutIntTest extends CamelTestSupport {
     @EndpointInject(uri = "rabbitmq:localhost:5672/" + EXCHANGE_NO_ACK + "?threadPoolSize=1&exchangeType=direct&username=cameltest&password=cameltest"
             + "&autoAck=false&autoDelete=false&durable=false&queue=q5&routingKey=" + ROUTING_KEY
             + "&transferException=true&requestTimeout=" + TIMEOUT_MS
-            + "&queueArgsConfigurer=#queueArgs")
+            + "&queueArgs=#queueArgs")
     private Endpoint noAutoAckEndpoint;
 
     @EndpointInject(uri = "mock:result")
@@ -74,12 +74,8 @@ public class RabbitMQInOutIntTest extends CamelTestSupport {
     protected JndiRegistry createRegistry() throws Exception {
         JndiRegistry jndi = super.createRegistry();
 
-        ArgsConfigurer queueArgs = new ArgsConfigurer() {
-            @Override
-            public void configurArgs(Map<String, Object> args) {
-                args.put("x-expires", 60000);
-            }
-        };
+        HashMap<String, Object> queueArgs = new HashMap<>();
+        queueArgs.put("x-expires", 60000);
         jndi.bind("queueArgs", queueArgs);
 
         return jndi;

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerIntTest.java
@@ -36,7 +36,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RabbitMQProducerIntTest extends CamelTestSupport {
+public class RabbitMQProducerIntTest extends AbstractRabbitMQIntTest {
     private static final String EXCHANGE = "ex1";
     private static final String ROUTE = "route1";
     private static final String BASIC_URI_FORMAT = "rabbitmq:localhost:5672/%s?routingKey=%s&username=cameltest&password=cameltest&skipQueueDeclare=true";
@@ -86,7 +86,7 @@ public class RabbitMQProducerIntTest extends CamelTestSupport {
 
     @Before
     public void setUpRabbitMQ() throws Exception {
-        connection = createTestConnection();
+        connection = connection();
         channel = connection.createChannel();
         channel.queueDeclare("sammyq", false, false, true, null);
         channel.queueBind("sammyq", EXCHANGE, ROUTE);
@@ -160,16 +160,6 @@ public class RabbitMQProducerIntTest extends CamelTestSupport {
         templateWithGuranteedDeliveryBadRouteButNotMandatory.sendBodyAndHeader("publisher ack message", RabbitMQConstants.EXCHANGE_NAME, "ex1");
 
         assertThatBodiesReceivedIn(received);
-    }
-
-    private Connection createTestConnection() throws IOException, TimeoutException {
-        ConnectionFactory factory = new ConnectionFactory();
-        factory.setHost("localhost");
-        factory.setPort(5672);
-        factory.setUsername("cameltest");
-        factory.setPassword("cameltest");
-        factory.setVirtualHost("/");
-        return factory.newConnection();
     }
 
     private class ArrayPopulatingConsumer extends DefaultConsumer {


### PR DESCRIPTION
Introduced 3 new Endpoint URI properties 
- exchangeArgs
- queueArgs
- bindingArgs

As an easier way to specifiy rabbitmq properties at declare time.
Meanwhile deprecated the ArgsConfigurer class whilst maintaining backwards compatibility. It's actually possible to use both styles of arg declaration because the Maps are combined. 

Introduced a new integration test for the bindingArgs which tests a headers exchange correctly routing to a queue. Updated the previous integration test RabbitMQInOutIntTest to use the new style of arg when setting the "x-expires" property on the queue.

Finally added a small example of how to declare a headers exchange using new feature.