### PR TITLE
CAMEL-10745

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/Produce.java
+++ b/camel-core/src/main/java/org/apache/camel/Produce.java
@@ -43,4 +43,5 @@ public @interface Produce {
     String ref() default "";
     String property() default "";
     String context() default "";
+    boolean binding() default true;
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/CamelPostProcessorHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/CamelPostProcessorHelper.java
@@ -31,6 +31,7 @@ import org.apache.camel.IsSingleton;
 import org.apache.camel.NoSuchBeanException;
 import org.apache.camel.PollingConsumer;
 import org.apache.camel.Processor;
+import org.apache.camel.Produce;
 import org.apache.camel.Producer;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.ProxyInstantiationException;
@@ -50,14 +51,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A helper class for Camel based injector or post processing hooks which can be reused by
- * both the <a href="http://camel.apache.org/spring.html">Spring</a>,
+ * A helper class for Camel based injector or post processing hooks which can be
+ * reused by both the <a href="http://camel.apache.org/spring.html">Spring</a>,
  * <a href="http://camel.apache.org/guice.html">Guice</a> and
  * <a href="http://camel.apache.org/blueprint.html">Blueprint</a> support.
  *
- * @version 
+ * @version
  */
 public class CamelPostProcessorHelper implements CamelContextAware {
+
     private static final Logger LOG = LoggerFactory.getLogger(CamelPostProcessorHelper.class);
 
     @XmlTransient
@@ -146,7 +148,7 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     public Endpoint getEndpointInjection(Object bean, String uri, String name, String propertyName,
-                                         String injectionPointName, boolean mandatory) {
+            String injectionPointName, boolean mandatory) {
         if (ObjectHelper.isEmpty(uri) && ObjectHelper.isEmpty(name)) {
             // if no uri or ref, then fallback and try the endpoint property
             return doGetEndpointInjection(bean, propertyName, injectionPointName);
@@ -161,6 +163,7 @@ public class CamelPostProcessorHelper implements CamelContextAware {
 
     /**
      * Gets the injection endpoint from a bean property.
+     *
      * @param bean the bean
      * @param propertyName the property name on the bean
      */
@@ -199,10 +202,22 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Creates the object to be injected for an {@link org.apache.camel.EndpointInject} or {@link org.apache.camel.Produce} injection point
+     * Creates the object to be injected for an
+     * {@link org.apache.camel.EndpointInject} or
+     * {@link org.apache.camel.Produce} injection point
      */
     public Object getInjectionValue(Class<?> type, String endpointUri, String endpointRef, String endpointProperty,
-                                    String injectionPointName, Object bean, String beanName) {
+            String injectionPointName, Object bean, String beanName) {
+        return getInjectionValue(type, endpointUri, endpointRef, endpointProperty, injectionPointName, bean, beanName, true);
+    }
+    
+    /**
+     * Creates the object to be injected for an
+     * {@link org.apache.camel.EndpointInject} or
+     * {@link org.apache.camel.Produce} injection point
+     */
+    public Object getInjectionValue(Class<?> type, String endpointUri, String endpointRef, String endpointProperty,
+            String injectionPointName, Object bean, String beanName, boolean binding) {
         if (type.isAssignableFrom(ProducerTemplate.class)) {
             return createInjectionProducerTemplate(endpointUri, endpointRef, endpointProperty, injectionPointName, bean);
         } else if (type.isAssignableFrom(FluentProducerTemplate.class)) {
@@ -221,7 +236,7 @@ public class CamelPostProcessorHelper implements CamelContextAware {
                 } else if (type.isInterface()) {
                     // lets create a proxy
                     try {
-                        return ProxyHelper.createProxy(endpoint, type);
+                        return ProxyHelper.createProxy(endpoint, binding, type);
                     } catch (Exception e) {
                         throw createProxyInstantiationRuntimeException(type, endpoint, e);
                     }
@@ -235,7 +250,7 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     public Object getInjectionPropertyValue(Class<?> type, String propertyName, String propertyDefaultValue,
-                                            String injectionPointName, Object bean, String beanName) {
+            String injectionPointName, Object bean, String beanName) {
         try {
             // enforce a properties component to be created if none existed
             CamelContextHelper.lookupPropertiesComponent(getCamelContext(), true);
@@ -285,10 +300,11 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Factory method to create a {@link org.apache.camel.ProducerTemplate} to be injected into a POJO
+     * Factory method to create a {@link org.apache.camel.ProducerTemplate} to
+     * be injected into a POJO
      */
     protected ProducerTemplate createInjectionProducerTemplate(String endpointUri, String endpointRef, String endpointProperty,
-                                                               String injectionPointName, Object bean) {
+            String injectionPointName, Object bean) {
         // endpoint is optional for this injection point
         Endpoint endpoint = getEndpointInjection(bean, endpointUri, endpointRef, endpointProperty, injectionPointName, false);
         CamelContext context = endpoint != null ? endpoint.getCamelContext() : getCamelContext();
@@ -304,10 +320,12 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Factory method to create a {@link org.apache.camel.FluentProducerTemplate} to be injected into a POJO
+     * Factory method to create a
+     * {@link org.apache.camel.FluentProducerTemplate} to be injected into a
+     * POJO
      */
     protected FluentProducerTemplate createInjectionFluentProducerTemplate(String endpointUri, String endpointRef, String endpointProperty,
-                                                                           String injectionPointName, Object bean) {
+            String injectionPointName, Object bean) {
         // endpoint is optional for this injection point
         Endpoint endpoint = getEndpointInjection(bean, endpointUri, endpointRef, endpointProperty, injectionPointName, false);
         CamelContext context = endpoint != null ? endpoint.getCamelContext() : getCamelContext();
@@ -324,10 +342,11 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Factory method to create a {@link org.apache.camel.ConsumerTemplate} to be injected into a POJO
+     * Factory method to create a {@link org.apache.camel.ConsumerTemplate} to
+     * be injected into a POJO
      */
     protected ConsumerTemplate createInjectionConsumerTemplate(String endpointUri, String endpointRef, String endpointProperty,
-                                                               String injectionPointName) {
+            String injectionPointName) {
         ConsumerTemplate answer = new DefaultConsumerTemplate(getCamelContext());
         // start the template so its ready to use
         try {
@@ -339,7 +358,8 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Factory method to create a started {@link org.apache.camel.PollingConsumer} to be injected into a POJO
+     * Factory method to create a started
+     * {@link org.apache.camel.PollingConsumer} to be injected into a POJO
      */
     protected PollingConsumer createInjectionPollingConsumer(Endpoint endpoint, Object bean, String beanName) {
         try {
@@ -352,7 +372,8 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * A Factory method to create a started {@link org.apache.camel.Producer} to be injected into a POJO
+     * A Factory method to create a started {@link org.apache.camel.Producer} to
+     * be injected into a POJO
      */
     protected Producer createInjectionProducer(Endpoint endpoint, Object bean, String beanName) {
         try {
@@ -368,10 +389,12 @@ public class CamelPostProcessorHelper implements CamelContextAware {
     }
 
     /**
-     * Implementations can override this method to determine if the bean is singleton.
+     * Implementations can override this method to determine if the bean is
+     * singleton.
      *
      * @param bean the bean
-     * @return <tt>true</tt> if its singleton scoped, for prototype scoped <tt>false</tt> is returned.
+     * @return <tt>true</tt> if its singleton scoped, for prototype scoped
+     * <tt>false</tt> is returned.
      */
     protected boolean isSingleton(Object bean, String beanName) {
         if (bean instanceof IsSingleton) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelBeanPostProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelBeanPostProcessor.java
@@ -183,7 +183,7 @@ public class DefaultCamelBeanPostProcessor {
 
                 Produce produce = field.getAnnotation(Produce.class);
                 if (produce != null && getPostProcessorHelper().matchContext(produce.context())) {
-                    injectField(field, produce.uri(), produce.ref(), produce.property(), bean, beanName);
+                    injectField(field, produce.uri(), produce.ref(), produce.property(), bean, beanName, produce.binding());
                 }
             }
         });
@@ -191,9 +191,14 @@ public class DefaultCamelBeanPostProcessor {
 
     public void injectField(Field field, String endpointUri, String endpointRef, String endpointProperty,
                                Object bean, String beanName) {
+        injectField(field, endpointUri, endpointRef, endpointProperty, bean, beanName, true);
+    }
+    
+    public void injectField(Field field, String endpointUri, String endpointRef, String endpointProperty,
+                               Object bean, String beanName, boolean binding) {
         ReflectionHelper.setField(field, bean,
                 getPostProcessorHelper().getInjectionValue(field.getType(), endpointUri, endpointRef, endpointProperty,
-                        field.getName(), bean, beanName));
+                        field.getName(), bean, beanName, binding));
     }
 
     public void injectFieldBean(Field field, String name, Object bean, String beanName) {

--- a/components/camel-etcd/src/main/docs/etcd-component.adoc
+++ b/components/camel-etcd/src/main/docs/etcd-component.adoc
@@ -14,7 +14,7 @@
 
 
 // endpoint options: START
-The etcd component supports 31 endpoint options which are listed below:
+The etcd component supports 16 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -28,26 +28,11 @@ The etcd component supports 31 endpoint options which are listed below:
 | uris | common | http://localhost:2379,http://localhost:4001 | String | To set the URIs the client connects.
 | bridgeErrorHandler | consumer | false | boolean | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored.
 | sendEmptyExchangeOnTimeout | consumer | false | boolean | To send an empty message in case of timeout watching for a key.
-| sendEmptyMessageWhenIdle | consumer | false | boolean | If the polling consumer did not poll any files you can enable this option to send an empty message (no body) instead.
 | exceptionHandler | consumer (advanced) |  | ExceptionHandler | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored.
 | exchangePattern | consumer (advanced) |  | ExchangePattern | Sets the exchange pattern when the consumer creates an exchange.
 | fromIndex | consumer (advanced) | 0 | Long | The index to watch from
-| pollStrategy | consumer (advanced) |  | PollingConsumerPollStrategy | A pluggable org.apache.camel.PollingConsumerPollingStrategy allowing you to provide your custom implementation to control error handling usually occurred during the poll operation before an Exchange have been created and being routed in Camel.
 | timeToLive | producer |  | Integer | To set the lifespan of a key in milliseconds.
 | synchronous | advanced | false | boolean | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported).
-| backoffErrorThreshold | scheduler |  | int | The number of subsequent error polls (failed due some error) that should happen before the backoffMultipler should kick-in.
-| backoffIdleThreshold | scheduler |  | int | The number of subsequent idle polls that should happen before the backoffMultipler should kick-in.
-| backoffMultiplier | scheduler |  | int | To let the scheduled polling consumer backoff if there has been a number of subsequent idles/errors in a row. The multiplier is then the number of polls that will be skipped before the next actual attempt is happening again. When this option is in use then backoffIdleThreshold and/or backoffErrorThreshold must also be configured.
-| delay | scheduler | 500 | long | Milliseconds before the next poll. You can also specify time values using units such as 60s (60 seconds) 5m30s (5 minutes and 30 seconds) and 1h (1 hour).
-| greedy | scheduler | false | boolean | If greedy is enabled then the ScheduledPollConsumer will run immediately again if the previous run polled 1 or more messages.
-| initialDelay | scheduler | 1000 | long | Milliseconds before the first poll starts. You can also specify time values using units such as 60s (60 seconds) 5m30s (5 minutes and 30 seconds) and 1h (1 hour).
-| runLoggingLevel | scheduler | TRACE | LoggingLevel | The consumer logs a start/complete log line when it polls. This option allows you to configure the logging level for that.
-| scheduledExecutorService | scheduler |  | ScheduledExecutorService | Allows for configuring a custom/shared thread pool to use for the consumer. By default each consumer has its own single threaded thread pool.
-| scheduler | scheduler | none | ScheduledPollConsumerScheduler | To use a cron scheduler from either camel-spring or camel-quartz2 component
-| schedulerProperties | scheduler |  | Map | To configure additional properties when using a custom scheduler or any of the Quartz2 Spring based scheduler.
-| startScheduler | scheduler | true | boolean | Whether the scheduler should be auto started.
-| timeUnit | scheduler | MILLISECONDS | TimeUnit | Time unit for initialDelay and delay options.
-| useFixedDelay | scheduler | true | boolean | Controls if fixed delay or fixed rate is used. See ScheduledExecutorService in JDK for details.
 | password | security |  | String | The password to use for basic authentication.
 | sslContextParameters | security |  | SSLContextParameters | To configure security using SSLContextParameters.
 | userName | security |  | String | The user name to use for basic authentication.

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgument.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgument.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import org.apache.camel.Produce;
+
+public class MyMultiArgument {
+
+    @Produce(uri = "direct:myargs", binding = false)
+    MyMultiArgumentServiceInterface myMultiArgumentServiceInterface;
+
+    public void doSomethingMultiple() {
+        myMultiArgumentServiceInterface.doSomething("Hello World 1", "Hello World 2", new Long(3));
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentService.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentService.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import static junit.framework.TestCase.assertEquals;
+import org.apache.camel.Consume;
+
+public class MyMultiArgumentService implements MyMultiArgumentServiceInterface {
+
+    @Override
+    @Consume(uri = "direct:myargs")
+    public void doSomething(String arg1, String arg2, Long arg3) {
+        assertEquals("Hello World 1", arg1);
+        assertEquals("Hello World 2", arg2);
+        assertEquals(new Long(3), arg3);
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentServiceInterface.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentServiceInterface.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+public interface MyMultiArgumentServiceInterface {
+
+    public void doSomething(String arg1, String arg2, Long arg3);
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentSpringRemotingPojoDirectTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MyMultiArgumentSpringRemotingPojoDirectTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import org.apache.camel.spring.SpringTestSupport;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @version
+ */
+public class MyMultiArgumentSpringRemotingPojoDirectTest extends SpringTestSupport {
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/remoting/my-multi-argument-pojo-direct.xml");
+    }
+
+    public void testMultiArgumentPojo() throws Exception {
+        try {
+            // use the pojo directly to call the injected endpoint and have the
+            // original runtime exception thrown
+            MyMultiArgument myMultArgumentPojo = applicationContext.getBean("myMultiArgumentPojoDirect", MyMultiArgument.class);
+            myMultArgumentPojo.doSomethingMultiple();
+        } catch (RuntimeException e) {
+            fail(""
+                    + "\nShould not have failed with multiple arguments on POJO @Produce @Consume."
+                    + "\nValues are incorrect in the consume for doSomething(String arg1, String arg2, Long arg3)"
+                    + "\nProduce called with doSomething(\"Hello World 1\", \"Hello World 2\", new Long(\"3\"))."
+                    + "\nConsume got doSomething(Long(3), null, null)"
+                    + "\n");
+        }
+    }
+
+}

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/remoting/my-multi-argument-pojo-direct.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/remoting/my-multi-argument-pojo-direct.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+    http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <bean id="myMultiArgumentService" class="org.apache.camel.spring.remoting.MyMultiArgumentService"/>
+
+    <bean id="myMultiArgumentPojoDirect" class="org.apache.camel.spring.remoting.MyMultiArgument"/>
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        
+    </camelContext>
+
+</beans>


### PR DESCRIPTION
Fix to turn off binding using the POJO @Produce, when there are multiple arguments on the interface method for remoting.

1. Added binding to Produce annotation default is true.
2. Added binding passthrough in class CamelPostProcessorHelp for getInjectionValue, still kept old method without binding, but with default binding being true.
3. CamelPostProcessorHelp.getInjectionValue ProxyHelper to use binding parameter passed through.
4. Changed DefaultCamelBeanPostProcessor to pass binding option from Produce annotation into the injectField method.
5. Changed DefaultCamelBeanPostProcessor. injectField to pass the binding option to the PostProcessorHelper.
6. Added Test for Spring multiple argument POJO for @Product @Consume.
    When binding is set to false to will work, but when true it will fail.