### PR TITLE
CAMEL-10772: Convention over configuration

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/AbstractCamelInvocationHandler.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/AbstractCamelInvocationHandler.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.bean;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,7 +106,23 @@ public abstract class AbstractCamelInvocationHandler implements InvocationHandle
     protected Object invokeProxy(final Method method, final ExchangePattern pattern, Object[] args, boolean binding) throws Throwable {
         final Exchange exchange = new DefaultExchange(endpoint, pattern);
 
-        if (binding) {
+        //Need to check if there are mutiple arguments and the parameters have no annotations for binding,
+        //then use the original bean invocation.
+        
+        boolean canUseBinding = method.getParameterCount() == 1;
+
+        if (!canUseBinding) {
+            for (Parameter parameter : method.getParameters()) {
+                if (parameter.isAnnotationPresent(Header.class)
+                        || parameter.isAnnotationPresent(Headers.class)
+                        || parameter.isAnnotationPresent(ExchangeProperty.class)
+                        || parameter.isAnnotationPresent(Body.class)) {
+                    canUseBinding = true;
+                }
+            }
+        }
+
+        if (binding && canUseBinding) {
             // in binding mode we bind the passed in arguments (args) to the created exchange
             // using the existing Camel @Body, @Header, @Headers, @ExchangeProperty annotations
             // if no annotation then its bound as the message body
@@ -284,7 +301,7 @@ public abstract class AbstractCamelInvocationHandler implements InvocationHandle
      * <p/>
      * It looks in the exception hierarchy from the caused exception and matches
      * this against the declared exceptions being thrown on the method.
-     * 
+     *
      * @param cause the caused exception
      * @param method the method
      * @return the exception to throw, or <tt>null</tt> if not possible to find

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBinding.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBinding.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import java.util.Date;
+import org.apache.camel.Produce;
+
+public class MultiArgumentsWithDefaultBinding {
+
+    @Produce(uri = "direct:myargs")
+    MultiArgumentsWithDefaultBindingServiceInterface multiArgumentServiceInterface;
+
+    public void doSomethingMultiple() {
+        multiArgumentServiceInterface.doSomething("Hello World 1", "Hello World 2", new Date());
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingService.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingService.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import java.util.Date;
+import org.apache.camel.Consume;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
+
+public class MultiArgumentsWithDefaultBindingService implements MultiArgumentsWithDefaultBindingServiceInterface {
+
+    @Override
+    @Consume(uri = "direct:myargs")
+    public void doSomething(String arg1, String arg2, Date arg3) {
+        assertEquals("Hello World 1", arg1);
+        assertEquals("Hello World 2", arg2);
+        assertNotNull(arg3);
+        assertTrue(arg3 instanceof Date);
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingServiceInterface.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingServiceInterface.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import java.util.Date;
+
+public interface MultiArgumentsWithDefaultBindingServiceInterface {
+
+    void doSomething(String arg1, String arg2, Date arg3);
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingSpringRemotingPojoDirectTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/remoting/MultiArgumentsWithDefaultBindingSpringRemotingPojoDirectTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.remoting;
+
+import org.apache.camel.spring.SpringTestSupport;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @version
+ */
+public class MultiArgumentsWithDefaultBindingSpringRemotingPojoDirectTest extends SpringTestSupport {
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/remoting/multi-arguments-with-default-binding-pojo-direct.xml");
+    }
+
+    public void testMultiArgumentPojo() throws Exception {
+        try {
+            // use the pojo directly to call the injected endpoint and have the
+            // original runtime exception thrown
+            MultiArgumentsWithDefaultBinding myMultArgumentPojo = applicationContext.getBean("multiArgumentsPojoDirect", MultiArgumentsWithDefaultBinding.class);
+            myMultArgumentPojo.doSomethingMultiple();
+        } catch (RuntimeException e) {
+            fail(""
+                    + "\nShould not have failed with multiple arguments on POJO @Produce @Consume."
+                    + "\nValues are incorrect in the consume for doSomething(String arg1, String arg2, Date arg3)"
+                    + "\nProduce called with doSomething(\"Hello World 1\", \"Hello World 2\", new Date())."
+                    + "\nConsume got something else."
+                    + "\n" + e.getMessage()
+                    + "\n");
+        }
+    }
+
+}

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/remoting/multi-arguments-with-default-binding-pojo-direct.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/remoting/multi-arguments-with-default-binding-pojo-direct.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+    http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <bean id="multiArgumentsService" class="org.apache.camel.spring.remoting.MultiArgumentsWithDefaultBindingService"/>
+
+    <bean id="multiArgumentsPojoDirect" class="org.apache.camel.spring.remoting.MultiArgumentsWithDefaultBinding"/>
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        
+    </camelContext>
+
+</beans>


### PR DESCRIPTION
Improvement in AbstractCamelInvocationHandler.invokeProxy, to auto detect if the invocation is binding capable.

It is determined by checking the parameter count and annotation types on each parameter, and only use binding if it is capable. Otherwise fallback on to the old bean invocation way.