### PR TITLE
CAMEL-10542: DataFormat from registry is used for every dataformat operation (marshal/unmarshal)

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/CamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/CamelContext.java
@@ -1206,6 +1206,14 @@ public interface CamelContext extends SuspendableService, RuntimeConfiguration {
     DataFormat resolveDataFormat(String name);
 
     /**
+     * Creates the given data format given its name.
+     *
+     * @param name the data format name or a reference to a data format factory in the {@link Registry}
+     * @return the resolved data format, or <tt>null</tt> if not found
+     */
+    DataFormat createDataFormat(String name);
+
+    /**
      * Resolve a data format definition given its name
      *
      * @param name the data format definition name or a reference to it in the {@link Registry}

--- a/camel-core/src/main/java/org/apache/camel/component/dataformat/DataFormatComponent.java
+++ b/camel-core/src/main/java/org/apache/camel/component/dataformat/DataFormatComponent.java
@@ -38,7 +38,13 @@ public class DataFormatComponent extends UriEndpointComponent {
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         String name = ObjectHelper.before(remaining, ":");
+
+        // try to lookup data format in the registry or create it from resource
         DataFormat df = getCamelContext().resolveDataFormat(name);
+        if (df == null) {
+            // if not, try to find a factory in the registry
+            df = getCamelContext().createDataFormat(name);
+        }
         if (df == null) {
             throw new IllegalArgumentException("Cannot find data format with name: " + name);
         }

--- a/camel-core/src/main/java/org/apache/camel/component/dataformat/DataFormatEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/dataformat/DataFormatEndpoint.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.dataformat;
 
 import org.apache.camel.AsyncCallback;
+import org.apache.camel.AsyncProcessor;
 import org.apache.camel.Component;
 import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
@@ -39,8 +40,7 @@ import org.apache.camel.util.ServiceHelper;
         label = "core,transformation", lenientProperties = true)
 public class DataFormatEndpoint extends DefaultEndpoint {
 
-    private MarshalProcessor marshal;
-    private UnmarshalProcessor unmarshal;
+    private AsyncProcessor processor;
     private DataFormat dataFormat;
 
     @UriPath(description = "Name of data format") @Metadata(required = "true")
@@ -88,11 +88,7 @@ public class DataFormatEndpoint extends DefaultEndpoint {
         return new DefaultAsyncProducer(this) {
             @Override
             public boolean process(Exchange exchange, AsyncCallback callback) {
-                if (marshal != null) {
-                    return marshal.process(exchange, callback);
-                } else {
-                    return unmarshal.process(exchange, callback);
-                }
+                return processor.process(exchange, callback);
             }
 
             @Override
@@ -123,20 +119,24 @@ public class DataFormatEndpoint extends DefaultEndpoint {
             dataFormat = getCamelContext().resolveDataFormat(name);
         }
         if (operation.equals("marshal")) {
-            marshal = new MarshalProcessor(dataFormat);
+            MarshalProcessor marshal = new MarshalProcessor(dataFormat);
             marshal.setCamelContext(getCamelContext());
+
+            processor = marshal;
         } else {
-            unmarshal = new UnmarshalProcessor(dataFormat);
+            UnmarshalProcessor unmarshal = new UnmarshalProcessor(dataFormat);
             unmarshal.setCamelContext(getCamelContext());
+
+            processor = unmarshal;
         }
 
-        ServiceHelper.startServices(dataFormat, marshal, unmarshal);
+        ServiceHelper.startServices(dataFormat, processor);
         super.doStart();
     }
 
     @Override
     protected void doStop() throws Exception {
-        ServiceHelper.stopServices(marshal, unmarshal, dataFormat);
+        ServiceHelper.stopServices(processor, dataFormat);
         super.doStop();
     }
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -4156,6 +4156,17 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         return answer;
     }
 
+    public DataFormat createDataFormat(String name) {
+        DataFormat answer = dataFormatResolver.createDataFormat(name, this);
+
+        // inject CamelContext if aware
+        if (answer != null && answer instanceof CamelContextAware) {
+            ((CamelContextAware) answer).setCamelContext(this);
+        }
+
+        return answer;
+    }
+
     public DataFormatDefinition resolveDataFormatDefinition(String name) {
         // lookup type and create the data format from it
         DataFormatDefinition type = lookup(this, name, DataFormatDefinition.class);

--- a/camel-core/src/main/java/org/apache/camel/impl/osgi/Activator.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/osgi/Activator.java
@@ -345,7 +345,18 @@ public class Activator implements BundleActivator, BundleTrackerCustomizer {
             this.dataformats = dataformats;
         }
 
+        @Override
         public DataFormat resolveDataFormat(String name, CamelContext context) {
+            DataFormat dataFormat = createInstance(name, dataformats.get(name), context);
+            if (dataFormat == null) {
+                dataFormat = createDataFormat(name, context);
+            }
+
+            return dataFormat;
+        }
+
+        @Override
+        public DataFormat createDataFormat(String name, CamelContext context) {
             return createInstance(name, dataformats.get(name), context);
         }
 
@@ -353,6 +364,7 @@ public class Activator implements BundleActivator, BundleTrackerCustomizer {
             return null;
         }
 
+        @Override
         public void register() {
             doRegister(DataFormatResolver.class, "dataformat", dataformats.keySet());
         }

--- a/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
@@ -133,7 +133,7 @@ public class DataFormatDefinition extends IdentifiedType implements OtherAttribu
     protected DataFormat createDataFormat(RouteContext routeContext) {
         // must use getDataFormatName() as we need special logic in json dataformat
         if (getDataFormatName() != null) {
-            return routeContext.getCamelContext().resolveDataFormat(getDataFormatName());
+            return routeContext.getCamelContext().createDataFormat(getDataFormatName());
         }
         return null;
     }

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/HessianDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/HessianDataFormat.java
@@ -26,7 +26,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Hessian data format
  */
-@Metadata(label = "dataformat,transformation", title = "Hessian")
+@Metadata(firstVersion = "2.17.0", label = "dataformat,transformation", title = "Hessian")
 @XmlRootElement(name = "hessian")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class HessianDataFormat extends DataFormatDefinition {

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/LZFDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/LZFDataFormat.java
@@ -29,7 +29,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * LZF compression data format
  */
-@Metadata(label = "dataformat,transformation", title = "LZF Deflate Compression")
+@Metadata(firstVersion = "2.17.0", label = "dataformat,transformation", title = "LZF Deflate Compression")
 @XmlRootElement(name = "lzf")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LZFDataFormat extends DataFormatDefinition {

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/MimeMultipartDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/MimeMultipartDataFormat.java
@@ -29,7 +29,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * MIME Multipart data format
  */
-@Metadata(label = "dataformat,transformation", title = "MIME Multipart")
+@Metadata(firstVersion = "2.17.0", label = "dataformat,transformation", title = "MIME Multipart")
 @XmlRootElement(name = "mime-multipart")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class MimeMultipartDataFormat extends DataFormatDefinition {

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
@@ -37,7 +37,7 @@ import org.apache.camel.util.ObjectHelper;
  *
  * @version 
  */
-@Metadata(label = "dataformat,transformation,yaml", title = "YAML")
+@Metadata(firstVersion = "2.17.0", label = "dataformat,transformation,yaml", title = "YAML")
 @XmlRootElement(name = "yaml")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class YAMLDataFormat extends DataFormatDefinition {

--- a/camel-core/src/main/java/org/apache/camel/model/language/TerserExpression.java
+++ b/camel-core/src/main/java/org/apache/camel/model/language/TerserExpression.java
@@ -27,7 +27,7 @@ import org.apache.camel.spi.Metadata;
  *
  * @version 
  */
-@Metadata(label = "language,hl7", title = "HL7 Terser")
+@Metadata(firstVersion = "2.11.0", label = "language,hl7", title = "HL7 Terser")
 @XmlRootElement(name = "terser")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TerserExpression extends ExpressionDefinition {

--- a/camel-core/src/main/java/org/apache/camel/model/language/XMLTokenizerExpression.java
+++ b/camel-core/src/main/java/org/apache/camel/model/language/XMLTokenizerExpression.java
@@ -32,7 +32,7 @@ import org.apache.camel.spi.Metadata;
  *
  * @see XMLTokenizeLanguage
  */
-@Metadata(label = "language,core,xml", title = "XML Tokenize")
+@Metadata(firstVersion = "2.14.0", label = "language,core,xml", title = "XML Tokenize")
 @XmlRootElement(name = "xtokenize")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XMLTokenizerExpression extends NamespaceAwareExpression {

--- a/camel-core/src/main/java/org/apache/camel/spi/DataFormatFactory.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/DataFormatFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.spi;
+
+/**
+ * A factory to create {@link org.apache.camel.spi.DataFormat}.
+ */
+@FunctionalInterface
+public interface DataFormatFactory {
+    /**
+     * Creates a new DataFormat instance.
+     *
+     * @return the instance
+     */
+    DataFormat newInstance();
+}

--- a/camel-core/src/main/java/org/apache/camel/spi/DataFormatResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/DataFormatResolver.java
@@ -24,7 +24,6 @@ import org.apache.camel.CamelContext;
  * @version 
  */
 public interface DataFormatResolver {
-
     /**
      * Resolves the given data format given its name.
      *
@@ -34,4 +33,12 @@ public interface DataFormatResolver {
      */
     DataFormat resolveDataFormat(String name, CamelContext context);
 
+    /**
+     * Creates the given data format given its name.
+     *
+     * @param name the name of the data format factory to lookup in {@link org.apache.camel.spi.Registry} or create
+     * @param context the camel context
+     * @return the data format or <tt>null</tt> if not possible to resolve
+     */
+    DataFormat createDataFormat(String name, CamelContext context);
 }

--- a/camel-core/src/main/java/org/apache/camel/util/ResolverHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ResolverHelper.java
@@ -19,6 +19,7 @@ package org.apache.camel.util;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.spi.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,8 @@ public final class ResolverHelper {
     public static final String COMPONENT_FALLBACK_SUFFIX = "-component";
 
     public static final String DATA_FORMAT_FALLBACK_SUFFIX = "-dataformat";
+
+    public static final String DATA_FORMAT_FACTORY_FALLBACK_SUFFIX = "-dataformat-factory";
 
     public static final String LANGUAGE_FALLBACK_SUFFIX = "-language";
 
@@ -83,6 +86,22 @@ public final class ResolverHelper {
 
         if (bean != null) {
             LOG.debug("Found DataFormat with incompatible class: {}", bean.getClass().getName());
+        }
+        return null;
+    }
+
+    public static DataFormatFactory lookupDataFormatFactoryInRegistryWithFallback(CamelContext context, String name) {
+        return lookupDataFormatFactoryInRegistryWithFallback(context, name, EXCEPTION_HANDLER);
+    }
+
+    public static DataFormatFactory lookupDataFormatFactoryInRegistryWithFallback(CamelContext context, String name, LookupExceptionHandler exceptionHandler) {
+        Object bean = lookupInRegistry(context, DataFormatFactory.class, false, exceptionHandler, name, name + DATA_FORMAT_FACTORY_FALLBACK_SUFFIX);
+        if (bean instanceof DataFormatFactory) {
+            return (DataFormatFactory) bean;
+        }
+
+        if (bean != null) {
+            LOG.debug("Found DataFormatFactory with incompatible class: {}", bean.getClass().getName());
         }
         return null;
     }

--- a/camel-core/src/test/java/org/apache/camel/processor/DataFormatFactoryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/DataFormatFactoryTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.impl.SerializationDataFormat;
+import org.apache.camel.impl.StringDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
+
+public class DataFormatFactoryTest extends ContextTestSupport {
+    private static final DataFormat STRING_DF = new StringDataFormat("US-ASCII");
+    private static final DataFormatFactory STRING_DFF = () -> new StringDataFormat("UTF-8");
+    private static final DataFormat SERIALIZATION_DF = new SerializationDataFormat();
+
+    public void testDataFormatResolveOrCreate() throws Exception {
+        assertSame(STRING_DF, context.resolveDataFormat("string"));
+        assertNotSame(STRING_DF, context.createDataFormat("string"));
+        assertNotSame(context.createDataFormat("string"), context.createDataFormat("string"));
+        
+        assertSame(SERIALIZATION_DF, context.resolveDataFormat("serialization"));
+        assertNotSame(SERIALIZATION_DF, context.createDataFormat("serialization"));
+        assertNotSame(context.createDataFormat("serialization"), context.createDataFormat("serialization"));
+
+        assertEquals("US-ASCII", ((StringDataFormat)context.resolveDataFormat("string")).getCharset());
+        assertEquals("UTF-8", ((StringDataFormat)context.createDataFormat("string")).getCharset());
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry registry = super.createRegistry();
+        registry.bind("string-dataformat", STRING_DF);
+        registry.bind("string-dataformat-factory", STRING_DFF);
+        registry.bind("serialization", SERIALIZATION_DF);
+
+        return registry;
+    }
+}

--- a/components/camel-bonita/src/main/java/org/apache/camel/component/bonita/BonitaEndpoint.java
+++ b/components/camel-bonita/src/main/java/org/apache/camel/component/bonita/BonitaEndpoint.java
@@ -26,7 +26,7 @@ import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 
-@UriEndpoint(scheme = "bonita", title = "Bonita", syntax = "bonita:operation", consumerOnly = true, label = "process")
+@UriEndpoint(firstVersion = "2.19.0", scheme = "bonita", title = "Bonita", syntax = "bonita:operation", consumerOnly = true, label = "process")
 public class BonitaEndpoint extends DefaultEndpoint {
 
     @UriParam

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomFactoryTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomFactoryTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dataformat.csv;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class CsvDataFormatCustomFactoryTest extends CamelSpringTestSupport {
+    @Test
+    public void marshalTest() throws InterruptedException {
+        MockEndpoint mock = getMockEndpoint("mock:marshaled");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:marshal", getData());
+
+        mock.assertIsSatisfied();
+
+        String body = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        String[] lines = body.split("\r\n");
+
+        Assert.assertEquals(2, lines.length);
+        Assert.assertEquals("A1:B1:C1", lines[0].trim());
+        Assert.assertEquals("A2:B2:C2", lines[1].trim());
+    }
+
+    private List<List<String>> getData() {
+        return Arrays.asList(
+            Arrays.asList("A1", "B1", "C1"),
+            Arrays.asList("A2", "B2", "C2")
+        );
+    }
+
+    @Override
+    protected ClassPathXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/dataformat/csv/CsvDataFormatCustomFactoryTest-context.xml");
+    }
+}

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatResourceFactoryTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatResourceFactoryTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.csv;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class CsvDataFormatResourceFactoryTest extends CamelSpringTestSupport {
+    @Test
+    public void marshalTest() throws InterruptedException {
+        MockEndpoint mock = getMockEndpoint("mock:marshaled");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:marshal", getData());
+
+        mock.assertIsSatisfied();
+
+        String body = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        String[] lines = body.split("\r\n");
+
+        Assert.assertEquals(2, lines.length);
+        Assert.assertEquals("A1,B1,C1", lines[0].trim());
+        Assert.assertEquals("A2,B2,C2", lines[1].trim());
+    }
+
+    private List<List<String>> getData() {
+        return Arrays.asList(
+            Arrays.asList("A1", "B1", "C1"),
+            Arrays.asList("A2", "B2", "C2")
+        );
+    }
+
+    @Override
+    protected ClassPathXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/dataformat/csv/CsvDataFormatResourceFactoryTest-context.xml");
+    }
+}

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/MyCsvDataFormatFactory.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/MyCsvDataFormatFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dataformat.csv;
+
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
+
+public class MyCsvDataFormatFactory implements DataFormatFactory {
+    private final char delimiter;
+
+    public MyCsvDataFormatFactory(char delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public DataFormat newInstance() {
+        CsvDataFormat dataFormat = new CsvDataFormat();
+        dataFormat.setDelimiter(delimiter);
+
+        return dataFormat;
+    }
+}

--- a/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatCustomFactoryTest-context.xml
+++ b/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatCustomFactoryTest-context.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <bean id="csv-dataformat-factory" class="org.apache.camel.dataformat.csv.MyCsvDataFormatFactory">
+    <constructor-arg value=":"/>
+  </bean>
+
+  <camelContext id="csvCamelContext" xmlns="http://camel.apache.org/schema/spring">
+    <route>
+      <from uri="direct:marshal"/>
+      <marshal>
+        <csv headerDisabled="true" quoteDisabled="true"/>
+      </marshal>
+      <convertBodyTo type="java.lang.String"/>
+      <to uri="mock:marshaled"/>
+    </route>
+    <route>
+      <from uri="direct:unmarshal"/>
+      <unmarshal>
+        <csv delimiter=";" headerDisabled="true"/>
+      </unmarshal>
+      <to uri="mock:unmarshaled"/>
+    </route>
+  </camelContext>
+
+</beans>

--- a/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatResourceFactoryTest-context.xml
+++ b/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatResourceFactoryTest-context.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <bean id="csv-dataformat" class="org.apache.camel.dataformat.csv.CsvDataFormat"/>
+
+  <camelContext id="csvCamelContext" xmlns="http://camel.apache.org/schema/spring">
+    <route>
+      <from uri="direct:marshal"/>
+      <marshal>
+        <csv headerDisabled="true" quoteDisabled="true"/>
+      </marshal>
+      <convertBodyTo type="java.lang.String"/>
+      <to uri="mock:marshaled"/>
+    </route>
+    <route>
+      <from uri="direct:unmarshal"/>
+      <unmarshal>
+        <csv delimiter=";" headerDisabled="true"/>
+      </unmarshal>
+      <to uri="mock:unmarshaled"/>
+    </route>
+  </camelContext>
+
+</beans>

--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * Built on top of the Service API libraries (v1).
  */
-@UriEndpoint(scheme = "google-pubsub", title = "Google Pubsub",
+@UriEndpoint(firstVersion = "2.19.0", scheme = "google-pubsub", title = "Google Pubsub",
         syntax = "google-pubsub:projectId:destinationName", label = "messaging")
 public class GooglePubsubEndpoint extends DefaultEndpoint {
 

--- a/components/camel-mongodb3/src/main/java/org/apache/camel/component/mongodb3/MongoDbEndpoint.java
+++ b/components/camel-mongodb3/src/main/java/org/apache/camel/component/mongodb3/MongoDbEndpoint.java
@@ -59,7 +59,8 @@ import static org.apache.camel.component.mongodb3.MongoDbOutputType.MongoIterabl
 /**
  * Component for working with documents stored in MongoDB database.
  */
-@UriEndpoint(scheme = "mongodb3", title = "MongoDB", syntax = "mongodb3:connectionBean", consumerClass = MongoDbTailableCursorConsumer.class, label = "database,nosql")
+@UriEndpoint(firstVersion = "2.19.0", scheme = "mongodb3", title = "MongoDB", syntax = "mongodb3:connectionBean",
+    consumerClass = MongoDbTailableCursorConsumer.class, label = "database,nosql")
 public class MongoDbEndpoint extends DefaultEndpoint {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbEndpoint.class);

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/cinder/CinderEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/cinder/CinderEndpoint.java
@@ -29,7 +29,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-cinder component allows messages to be sent to an OpenStack block storage services.
  */
-@UriEndpoint(scheme = "openstack-cinder", title = "OpenStack Cinder", syntax = "openstack-cinder:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-cinder", title = "OpenStack Cinder", syntax = "openstack-cinder:host", label = "cloud,paas", producerOnly = true)
 public class CinderEndpoint extends AbstractOpenstackEndpoint {
 
     @UriParam(enums = "snapshots,volumes")

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/glance/GlanceEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/glance/GlanceEndpoint.java
@@ -27,7 +27,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-glance component allows messages to be sent to an OpenStack image services.
  */
-@UriEndpoint(scheme = "openstack-glance", title = "OpenStack Glance", syntax = "openstack-glance:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-glance", title = "OpenStack Glance", syntax = "openstack-glance:host", label = "cloud,paas", producerOnly = true)
 public class GlanceEndpoint extends AbstractOpenstackEndpoint {
 
     @UriPath

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/keystone/KeystoneEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/keystone/KeystoneEndpoint.java
@@ -32,7 +32,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-keystone component allows messages to be sent to an OpenStack identity services.
  */
-@UriEndpoint(scheme = "openstack-keystone", title = "OpenStack Keystone", syntax = "openstack-keystone:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-keystone", title = "OpenStack Keystone", syntax = "openstack-keystone:host", label = "cloud,paas", producerOnly = true)
 public class KeystoneEndpoint extends AbstractOpenstackEndpoint {
 
     @UriParam(enums = "regions,domains,projects,users,groups")

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/neutron/NeutronEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/neutron/NeutronEndpoint.java
@@ -31,7 +31,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-neutron component allows messages to be sent to an OpenStack network services.
  */
-@UriEndpoint(scheme = "openstack-neutron", title = "OpenStack Neutron", syntax = "openstack-neutron:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-neutron", title = "OpenStack Neutron", syntax = "openstack-neutron:host", label = "cloud,paas", producerOnly = true)
 public class NeutronEndpoint extends AbstractOpenstackEndpoint {
 
     @UriParam(enums = "networks,subnets,ports,routers")

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/nova/NovaEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/nova/NovaEndpoint.java
@@ -30,7 +30,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-nova component allows messages to be sent to an OpenStack compute services.
  */
-@UriEndpoint(scheme = "openstack-nova", title = "OpenStack Nova", syntax = "openstack-nova:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-nova", title = "OpenStack Nova", syntax = "openstack-nova:host", label = "cloud,paas", producerOnly = true)
 public class NovaEndpoint extends AbstractOpenstackEndpoint {
 
     @UriParam(enums = "flavors,servers,keypairs")

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/SwiftEndpoint.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/SwiftEndpoint.java
@@ -29,7 +29,7 @@ import org.openstack4j.core.transport.Config;
 /**
  * The openstack-swift component allows messages to be sent to an OpenStack object storage services.
  */
-@UriEndpoint(scheme = "openstack-swift", title = "OpenStack Swift", syntax = "openstack-swift:host", label = "cloud,paas", producerOnly = true)
+@UriEndpoint(firstVersion = "2.19.0", scheme = "openstack-swift", title = "OpenStack Swift", syntax = "openstack-swift:host", label = "cloud,paas", producerOnly = true)
 public class SwiftEndpoint extends AbstractOpenstackEndpoint {
 
     @UriParam(enums = "objects,containers")

--- a/components/camel-tika/src/main/java/org/apache/camel/component/tika/TikaEndpoint.java
+++ b/components/camel-tika/src/main/java/org/apache/camel/component/tika/TikaEndpoint.java
@@ -24,7 +24,7 @@ import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 
-@UriEndpoint(scheme = "tika", title = "Tika", syntax = "tika:operation", producerOnly = true, label = "transformation")
+@UriEndpoint(firstVersion = "2.19.0", scheme = "tika", title = "Tika", syntax = "tika:operation", producerOnly = true, label = "transformation")
 public class TikaEndpoint extends DefaultEndpoint {
 
     @UriParam

--- a/platforms/spring-boot/components-starter/camel-barcode-starter/src/main/java/org/apache/camel/dataformat/barcode/springboot/BarcodeDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-barcode-starter/src/main/java/org/apache/camel/dataformat/barcode/springboot/BarcodeDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.barcode.BarcodeDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BarcodeDataFormatConfiguration.class)
 public class BarcodeDataFormatAutoConfiguration {
 
-    @Bean(name = "barcode-dataformat")
-    @Scope("prototype")
+    @Bean(name = "barcode-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BarcodeDataFormat.class)
-    public BarcodeDataFormat configureBarcodeDataFormat(
-            CamelContext camelContext,
-            BarcodeDataFormatConfiguration configuration) throws Exception {
-        BarcodeDataFormat dataformat = new BarcodeDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(BarcodeDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBarcodeDataFormatFactory(
+            final CamelContext camelContext,
+            final BarcodeDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BarcodeDataFormat dataformat = new BarcodeDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BarcodeDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-beanio-starter/src/main/java/org/apache/camel/dataformat/beanio/springboot/BeanIODataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-beanio-starter/src/main/java/org/apache/camel/dataformat/beanio/springboot/BeanIODataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.beanio.BeanIODataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BeanIODataFormatConfiguration.class)
 public class BeanIODataFormatAutoConfiguration {
 
-    @Bean(name = "beanio-dataformat")
-    @Scope("prototype")
+    @Bean(name = "beanio-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BeanIODataFormat.class)
-    public BeanIODataFormat configureBeanIODataFormat(
-            CamelContext camelContext,
-            BeanIODataFormatConfiguration configuration) throws Exception {
-        BeanIODataFormat dataformat = new BeanIODataFormat();
-        if (CamelContextAware.class.isAssignableFrom(BeanIODataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBeanIODataFormatFactory(
+            final CamelContext camelContext,
+            final BeanIODataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BeanIODataFormat dataformat = new BeanIODataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BeanIODataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/csv/springboot/BindyCsvDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/csv/springboot/BindyCsvDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.bindy.csv.BindyCsvDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BindyCsvDataFormatConfiguration.class)
 public class BindyCsvDataFormatAutoConfiguration {
 
-    @Bean(name = "bindy-csv-dataformat")
-    @Scope("prototype")
+    @Bean(name = "bindy-csv-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BindyCsvDataFormat.class)
-    public BindyCsvDataFormat configureBindyCsvDataFormat(
-            CamelContext camelContext,
-            BindyCsvDataFormatConfiguration configuration) throws Exception {
-        BindyCsvDataFormat dataformat = new BindyCsvDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(BindyCsvDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBindyCsvDataFormatFactory(
+            final CamelContext camelContext,
+            final BindyCsvDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BindyCsvDataFormat dataformat = new BindyCsvDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BindyCsvDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/fixed/springboot/BindyFixedLengthDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/fixed/springboot/BindyFixedLengthDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.bindy.fixed.BindyFixedLengthDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,29 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BindyFixedLengthDataFormatConfiguration.class)
 public class BindyFixedLengthDataFormatAutoConfiguration {
 
-    @Bean(name = "bindy-fixed-dataformat")
-    @Scope("prototype")
+    @Bean(name = "bindy-fixed-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BindyFixedLengthDataFormat.class)
-    public BindyFixedLengthDataFormat configureBindyFixedLengthDataFormat(
-            CamelContext camelContext,
-            BindyFixedLengthDataFormatConfiguration configuration)
-            throws Exception {
-        BindyFixedLengthDataFormat dataformat = new BindyFixedLengthDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(BindyFixedLengthDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBindyFixedLengthDataFormatFactory(
+            final CamelContext camelContext,
+            final BindyFixedLengthDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BindyFixedLengthDataFormat dataformat = new BindyFixedLengthDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BindyFixedLengthDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/kvp/springboot/BindyKeyValuePairDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-bindy-starter/src/main/java/org/apache/camel/dataformat/bindy/kvp/springboot/BindyKeyValuePairDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.bindy.kvp.BindyKeyValuePairDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,29 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BindyKeyValuePairDataFormatConfiguration.class)
 public class BindyKeyValuePairDataFormatAutoConfiguration {
 
-    @Bean(name = "bindy-kvp-dataformat")
-    @Scope("prototype")
+    @Bean(name = "bindy-kvp-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BindyKeyValuePairDataFormat.class)
-    public BindyKeyValuePairDataFormat configureBindyKeyValuePairDataFormat(
-            CamelContext camelContext,
-            BindyKeyValuePairDataFormatConfiguration configuration)
-            throws Exception {
-        BindyKeyValuePairDataFormat dataformat = new BindyKeyValuePairDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(BindyKeyValuePairDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBindyKeyValuePairDataFormatFactory(
+            final CamelContext camelContext,
+            final BindyKeyValuePairDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BindyKeyValuePairDataFormat dataformat = new BindyKeyValuePairDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BindyKeyValuePairDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-boon-starter/src/main/java/org/apache/camel/component/boon/springboot/BoonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-boon-starter/src/main/java/org/apache/camel/component/boon/springboot/BoonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.boon.BoonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(BoonDataFormatConfiguration.class)
 public class BoonDataFormatAutoConfiguration {
 
-    @Bean(name = "boon-dataformat")
-    @Scope("prototype")
+    @Bean(name = "boon-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(BoonDataFormat.class)
-    public BoonDataFormat configureBoonDataFormat(CamelContext camelContext,
-            BoonDataFormatConfiguration configuration) throws Exception {
-        BoonDataFormat dataformat = new BoonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(BoonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureBoonDataFormatFactory(
+            final CamelContext camelContext,
+            final BoonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                BoonDataFormat dataformat = new BoonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(BoonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-castor-starter/src/main/java/org/apache/camel/dataformat/castor/springboot/CastorDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-castor-starter/src/main/java/org/apache/camel/dataformat/castor/springboot/CastorDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.castor.CastorDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(CastorDataFormatConfiguration.class)
 public class CastorDataFormatAutoConfiguration {
 
-    @Bean(name = "castor-dataformat")
-    @Scope("prototype")
+    @Bean(name = "castor-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(CastorDataFormat.class)
-    public CastorDataFormat configureCastorDataFormat(
-            CamelContext camelContext,
-            CastorDataFormatConfiguration configuration) throws Exception {
-        CastorDataFormat dataformat = new CastorDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(CastorDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureCastorDataFormatFactory(
+            final CamelContext camelContext,
+            final CastorDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                CastorDataFormat dataformat = new CastorDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(CastorDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/SerializationDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/SerializationDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.SerializationDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,29 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(SerializationDataFormatConfiguration.class)
 public class SerializationDataFormatAutoConfiguration {
 
-    @Bean(name = "serialization-dataformat")
-    @Scope("prototype")
+    @Bean(name = "serialization-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(SerializationDataFormat.class)
-    public SerializationDataFormat configureSerializationDataFormat(
-            CamelContext camelContext,
-            SerializationDataFormatConfiguration configuration)
-            throws Exception {
-        SerializationDataFormat dataformat = new SerializationDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(SerializationDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureSerializationDataFormatFactory(
+            final CamelContext camelContext,
+            final SerializationDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                SerializationDataFormat dataformat = new SerializationDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(SerializationDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/StringDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/StringDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.StringDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(StringDataFormatConfiguration.class)
 public class StringDataFormatAutoConfiguration {
 
-    @Bean(name = "string-dataformat")
-    @Scope("prototype")
+    @Bean(name = "string-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(StringDataFormat.class)
-    public StringDataFormat configureStringDataFormat(
-            CamelContext camelContext,
-            StringDataFormatConfiguration configuration) throws Exception {
-        StringDataFormat dataformat = new StringDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(StringDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureStringDataFormatFactory(
+            final CamelContext camelContext,
+            final StringDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                StringDataFormat dataformat = new StringDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(StringDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/ZipDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/impl/springboot/ZipDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.ZipDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(ZipDataFormatConfiguration.class)
 public class ZipDataFormatAutoConfiguration {
 
-    @Bean(name = "zip-dataformat")
-    @Scope("prototype")
+    @Bean(name = "zip-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(ZipDataFormat.class)
-    public ZipDataFormat configureZipDataFormat(CamelContext camelContext,
-            ZipDataFormatConfiguration configuration) throws Exception {
-        ZipDataFormat dataformat = new ZipDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(ZipDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureZipDataFormatFactory(
+            final CamelContext camelContext,
+            final ZipDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                ZipDataFormat dataformat = new ZipDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(ZipDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/CryptoDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/CryptoDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.converter.crypto.CryptoDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(CryptoDataFormatConfiguration.class)
 public class CryptoDataFormatAutoConfiguration {
 
-    @Bean(name = "crypto-dataformat")
-    @Scope("prototype")
+    @Bean(name = "crypto-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(CryptoDataFormat.class)
-    public CryptoDataFormat configureCryptoDataFormat(
-            CamelContext camelContext,
-            CryptoDataFormatConfiguration configuration) throws Exception {
-        CryptoDataFormat dataformat = new CryptoDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(CryptoDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureCryptoDataFormatFactory(
+            final CamelContext camelContext,
+            final CryptoDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                CryptoDataFormat dataformat = new CryptoDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(CryptoDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/PGPDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/PGPDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.converter.crypto.PGPDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(PGPDataFormatConfiguration.class)
 public class PGPDataFormatAutoConfiguration {
 
-    @Bean(name = "pgp-dataformat")
-    @Scope("prototype")
+    @Bean(name = "pgp-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(PGPDataFormat.class)
-    public PGPDataFormat configurePGPDataFormat(CamelContext camelContext,
-            PGPDataFormatConfiguration configuration) throws Exception {
-        PGPDataFormat dataformat = new PGPDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(PGPDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configurePGPDataFormatFactory(
+            final CamelContext camelContext,
+            final PGPDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                PGPDataFormat dataformat = new PGPDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(PGPDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-csv-starter/src/main/java/org/apache/camel/dataformat/csv/springboot/CsvDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-csv-starter/src/main/java/org/apache/camel/dataformat/csv/springboot/CsvDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.csv.CsvDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(CsvDataFormatConfiguration.class)
 public class CsvDataFormatAutoConfiguration {
 
-    @Bean(name = "csv-dataformat")
-    @Scope("prototype")
+    @Bean(name = "csv-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(CsvDataFormat.class)
-    public CsvDataFormat configureCsvDataFormat(CamelContext camelContext,
-            CsvDataFormatConfiguration configuration) throws Exception {
-        CsvDataFormat dataformat = new CsvDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(CsvDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureCsvDataFormatFactory(
+            final CamelContext camelContext,
+            final CsvDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                CsvDataFormat dataformat = new CsvDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(CsvDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-flatpack-starter/src/main/java/org/apache/camel/dataformat/flatpack/springboot/FlatpackDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-flatpack-starter/src/main/java/org/apache/camel/dataformat/flatpack/springboot/FlatpackDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.flatpack.FlatpackDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(FlatpackDataFormatConfiguration.class)
 public class FlatpackDataFormatAutoConfiguration {
 
-    @Bean(name = "flatpack-dataformat")
-    @Scope("prototype")
+    @Bean(name = "flatpack-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(FlatpackDataFormat.class)
-    public FlatpackDataFormat configureFlatpackDataFormat(
-            CamelContext camelContext,
-            FlatpackDataFormatConfiguration configuration) throws Exception {
-        FlatpackDataFormat dataformat = new FlatpackDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(FlatpackDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureFlatpackDataFormatFactory(
+            final CamelContext camelContext,
+            final FlatpackDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                FlatpackDataFormat dataformat = new FlatpackDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(FlatpackDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-gson-starter/src/main/java/org/apache/camel/component/gson/springboot/GsonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-gson-starter/src/main/java/org/apache/camel/component/gson/springboot/GsonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.gson.GsonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(GsonDataFormatConfiguration.class)
 public class GsonDataFormatAutoConfiguration {
 
-    @Bean(name = "json-gson-dataformat")
-    @Scope("prototype")
+    @Bean(name = "json-gson-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(GsonDataFormat.class)
-    public GsonDataFormat configureGsonDataFormat(CamelContext camelContext,
-            GsonDataFormatConfiguration configuration) throws Exception {
-        GsonDataFormat dataformat = new GsonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(GsonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureGsonDataFormatFactory(
+            final CamelContext camelContext,
+            final GsonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                GsonDataFormat dataformat = new GsonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(GsonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-hessian-starter/src/main/java/org/apache/camel/dataformat/hessian/springboot/HessianDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hessian-starter/src/main/java/org/apache/camel/dataformat/hessian/springboot/HessianDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.hessian.HessianDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(HessianDataFormatConfiguration.class)
 public class HessianDataFormatAutoConfiguration {
 
-    @Bean(name = "hessian-dataformat")
-    @Scope("prototype")
+    @Bean(name = "hessian-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(HessianDataFormat.class)
-    public HessianDataFormat configureHessianDataFormat(
-            CamelContext camelContext,
-            HessianDataFormatConfiguration configuration) throws Exception {
-        HessianDataFormat dataformat = new HessianDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(HessianDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureHessianDataFormatFactory(
+            final CamelContext camelContext,
+            final HessianDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                HessianDataFormat dataformat = new HessianDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(HessianDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-ical-starter/src/main/java/org/apache/camel/component/ical/springboot/ICalDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ical-starter/src/main/java/org/apache/camel/component/ical/springboot/ICalDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.ical.ICalDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(ICalDataFormatConfiguration.class)
 public class ICalDataFormatAutoConfiguration {
 
-    @Bean(name = "ical-dataformat")
-    @Scope("prototype")
+    @Bean(name = "ical-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(ICalDataFormat.class)
-    public ICalDataFormat configureICalDataFormat(CamelContext camelContext,
-            ICalDataFormatConfiguration configuration) throws Exception {
-        ICalDataFormat dataformat = new ICalDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(ICalDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureICalDataFormatFactory(
+            final CamelContext camelContext,
+            final ICalDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                ICalDataFormat dataformat = new ICalDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(ICalDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-jackson-starter/src/main/java/org/apache/camel/component/jackson/springboot/JacksonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jackson-starter/src/main/java/org/apache/camel/component/jackson/springboot/JacksonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JacksonDataFormatConfiguration.class)
 public class JacksonDataFormatAutoConfiguration {
 
-    @Bean(name = "json-jackson-dataformat")
-    @Scope("prototype")
+    @Bean(name = "json-jackson-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JacksonDataFormat.class)
-    public JacksonDataFormat configureJacksonDataFormat(
-            CamelContext camelContext,
-            JacksonDataFormatConfiguration configuration) throws Exception {
-        JacksonDataFormat dataformat = new JacksonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(JacksonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJacksonDataFormatFactory(
+            final CamelContext camelContext,
+            final JacksonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JacksonDataFormat dataformat = new JacksonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JacksonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-jacksonxml-starter/src/main/java/org/apache/camel/component/jacksonxml/springboot/JacksonXMLDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jacksonxml-starter/src/main/java/org/apache/camel/component/jacksonxml/springboot/JacksonXMLDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.jacksonxml.JacksonXMLDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,28 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JacksonXMLDataFormatConfiguration.class)
 public class JacksonXMLDataFormatAutoConfiguration {
 
-    @Bean(name = "jacksonxml-dataformat")
-    @Scope("prototype")
+    @Bean(name = "jacksonxml-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JacksonXMLDataFormat.class)
-    public JacksonXMLDataFormat configureJacksonXMLDataFormat(
-            CamelContext camelContext,
-            JacksonXMLDataFormatConfiguration configuration) throws Exception {
-        JacksonXMLDataFormat dataformat = new JacksonXMLDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(JacksonXMLDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJacksonXMLDataFormatFactory(
+            final CamelContext camelContext,
+            final JacksonXMLDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JacksonXMLDataFormat dataformat = new JacksonXMLDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JacksonXMLDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-jaxb-starter/src/main/java/org/apache/camel/converter/jaxb/springboot/JaxbDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jaxb-starter/src/main/java/org/apache/camel/converter/jaxb/springboot/JaxbDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.converter.jaxb.JaxbDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JaxbDataFormatConfiguration.class)
 public class JaxbDataFormatAutoConfiguration {
 
-    @Bean(name = "jaxb-dataformat")
-    @Scope("prototype")
+    @Bean(name = "jaxb-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JaxbDataFormat.class)
-    public JaxbDataFormat configureJaxbDataFormat(CamelContext camelContext,
-            JaxbDataFormatConfiguration configuration) throws Exception {
-        JaxbDataFormat dataformat = new JaxbDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(JaxbDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJaxbDataFormatFactory(
+            final CamelContext camelContext,
+            final JaxbDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JaxbDataFormat dataformat = new JaxbDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JaxbDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-jibx-starter/src/main/java/org/apache/camel/dataformat/jibx/springboot/JibxDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jibx-starter/src/main/java/org/apache/camel/dataformat/jibx/springboot/JibxDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.jibx.JibxDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JibxDataFormatConfiguration.class)
 public class JibxDataFormatAutoConfiguration {
 
-    @Bean(name = "jibx-dataformat")
-    @Scope("prototype")
+    @Bean(name = "jibx-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JibxDataFormat.class)
-    public JibxDataFormat configureJibxDataFormat(CamelContext camelContext,
-            JibxDataFormatConfiguration configuration) throws Exception {
-        JibxDataFormat dataformat = new JibxDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(JibxDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJibxDataFormatFactory(
+            final CamelContext camelContext,
+            final JibxDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JibxDataFormat dataformat = new JibxDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JibxDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-johnzon-starter/src/main/java/org/apache/camel/component/johnzon/springboot/JohnzonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-johnzon-starter/src/main/java/org/apache/camel/component/johnzon/springboot/JohnzonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.johnzon.JohnzonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JohnzonDataFormatConfiguration.class)
 public class JohnzonDataFormatAutoConfiguration {
 
-    @Bean(name = "json-johnzon-dataformat")
-    @Scope("prototype")
+    @Bean(name = "json-johnzon-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JohnzonDataFormat.class)
-    public JohnzonDataFormat configureJohnzonDataFormat(
-            CamelContext camelContext,
-            JohnzonDataFormatConfiguration configuration) throws Exception {
-        JohnzonDataFormat dataformat = new JohnzonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(JohnzonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJohnzonDataFormatFactory(
+            final CamelContext camelContext,
+            final JohnzonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JohnzonDataFormat dataformat = new JohnzonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JohnzonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-lzf-starter/src/main/java/org/apache/camel/dataformat/lzf/springboot/LZFDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-lzf-starter/src/main/java/org/apache/camel/dataformat/lzf/springboot/LZFDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.lzf.LZFDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(LZFDataFormatConfiguration.class)
 public class LZFDataFormatAutoConfiguration {
 
-    @Bean(name = "lzf-dataformat")
-    @Scope("prototype")
+    @Bean(name = "lzf-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(LZFDataFormat.class)
-    public LZFDataFormat configureLZFDataFormat(CamelContext camelContext,
-            LZFDataFormatConfiguration configuration) throws Exception {
-        LZFDataFormat dataformat = new LZFDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(LZFDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureLZFDataFormatFactory(
+            final CamelContext camelContext,
+            final LZFDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                LZFDataFormat dataformat = new LZFDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(LZFDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-protobuf-starter/src/main/java/org/apache/camel/dataformat/protobuf/springboot/ProtobufDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-protobuf-starter/src/main/java/org/apache/camel/dataformat/protobuf/springboot/ProtobufDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.protobuf.ProtobufDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(ProtobufDataFormatConfiguration.class)
 public class ProtobufDataFormatAutoConfiguration {
 
-    @Bean(name = "protobuf-dataformat")
-    @Scope("prototype")
+    @Bean(name = "protobuf-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(ProtobufDataFormat.class)
-    public ProtobufDataFormat configureProtobufDataFormat(
-            CamelContext camelContext,
-            ProtobufDataFormatConfiguration configuration) throws Exception {
-        ProtobufDataFormat dataformat = new ProtobufDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(ProtobufDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureProtobufDataFormatFactory(
+            final CamelContext camelContext,
+            final ProtobufDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                ProtobufDataFormat dataformat = new ProtobufDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(ProtobufDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-rss-starter/src/main/java/org/apache/camel/dataformat/rss/springboot/RssDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-rss-starter/src/main/java/org/apache/camel/dataformat/rss/springboot/RssDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.rss.RssDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(RssDataFormatConfiguration.class)
 public class RssDataFormatAutoConfiguration {
 
-    @Bean(name = "rss-dataformat")
-    @Scope("prototype")
+    @Bean(name = "rss-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(RssDataFormat.class)
-    public RssDataFormat configureRssDataFormat(CamelContext camelContext,
-            RssDataFormatConfiguration configuration) throws Exception {
-        RssDataFormat dataformat = new RssDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(RssDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureRssDataFormatFactory(
+            final CamelContext camelContext,
+            final RssDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                RssDataFormat dataformat = new RssDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(RssDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-snakeyaml-starter/src/main/java/org/apache/camel/component/snakeyaml/springboot/SnakeYAMLDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-snakeyaml-starter/src/main/java/org/apache/camel/component/snakeyaml/springboot/SnakeYAMLDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.snakeyaml.SnakeYAMLDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(SnakeYAMLDataFormatConfiguration.class)
 public class SnakeYAMLDataFormatAutoConfiguration {
 
-    @Bean(name = "yaml-snakeyaml-dataformat")
-    @Scope("prototype")
+    @Bean(name = "yaml-snakeyaml-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(SnakeYAMLDataFormat.class)
-    public SnakeYAMLDataFormat configureSnakeYAMLDataFormat(
-            CamelContext camelContext,
-            SnakeYAMLDataFormatConfiguration configuration) throws Exception {
-        SnakeYAMLDataFormat dataformat = new SnakeYAMLDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(SnakeYAMLDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureSnakeYAMLDataFormatFactory(
+            final CamelContext camelContext,
+            final SnakeYAMLDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                SnakeYAMLDataFormat dataformat = new SnakeYAMLDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(SnakeYAMLDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-soap-starter/src/main/java/org/apache/camel/dataformat/soap/springboot/SoapJaxbDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-soap-starter/src/main/java/org/apache/camel/dataformat/soap/springboot/SoapJaxbDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.soap.SoapJaxbDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(SoapJaxbDataFormatConfiguration.class)
 public class SoapJaxbDataFormatAutoConfiguration {
 
-    @Bean(name = "soapjaxb-dataformat")
-    @Scope("prototype")
+    @Bean(name = "soapjaxb-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(SoapJaxbDataFormat.class)
-    public SoapJaxbDataFormat configureSoapJaxbDataFormat(
-            CamelContext camelContext,
-            SoapJaxbDataFormatConfiguration configuration) throws Exception {
-        SoapJaxbDataFormat dataformat = new SoapJaxbDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(SoapJaxbDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureSoapJaxbDataFormatFactory(
+            final CamelContext camelContext,
+            final SoapJaxbDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                SoapJaxbDataFormat dataformat = new SoapJaxbDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(SoapJaxbDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-syslog-starter/src/main/java/org/apache/camel/component/syslog/springboot/SyslogDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-syslog-starter/src/main/java/org/apache/camel/component/syslog/springboot/SyslogDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.syslog.SyslogDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(SyslogDataFormatConfiguration.class)
 public class SyslogDataFormatAutoConfiguration {
 
-    @Bean(name = "syslog-dataformat")
-    @Scope("prototype")
+    @Bean(name = "syslog-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(SyslogDataFormat.class)
-    public SyslogDataFormat configureSyslogDataFormat(
-            CamelContext camelContext,
-            SyslogDataFormatConfiguration configuration) throws Exception {
-        SyslogDataFormat dataformat = new SyslogDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(SyslogDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureSyslogDataFormatFactory(
+            final CamelContext camelContext,
+            final SyslogDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                SyslogDataFormat dataformat = new SyslogDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(SyslogDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityCsvDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityCsvDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.univocity.UniVocityCsvDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,28 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(UniVocityCsvDataFormatConfiguration.class)
 public class UniVocityCsvDataFormatAutoConfiguration {
 
-    @Bean(name = "univocity-csv-dataformat")
-    @Scope("prototype")
+    @Bean(name = "univocity-csv-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(UniVocityCsvDataFormat.class)
-    public UniVocityCsvDataFormat configureUniVocityCsvDataFormat(
-            CamelContext camelContext,
-            UniVocityCsvDataFormatConfiguration configuration) throws Exception {
-        UniVocityCsvDataFormat dataformat = new UniVocityCsvDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(UniVocityCsvDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureUniVocityCsvDataFormatFactory(
+            final CamelContext camelContext,
+            final UniVocityCsvDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                UniVocityCsvDataFormat dataformat = new UniVocityCsvDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(UniVocityCsvDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityFixedWidthDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityFixedWidthDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.univocity.UniVocityFixedWidthDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,29 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(UniVocityFixedWidthDataFormatConfiguration.class)
 public class UniVocityFixedWidthDataFormatAutoConfiguration {
 
-    @Bean(name = "univocity-fixed-dataformat")
-    @Scope("prototype")
+    @Bean(name = "univocity-fixed-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(UniVocityFixedWidthDataFormat.class)
-    public UniVocityFixedWidthDataFormat configureUniVocityFixedWidthDataFormat(
-            CamelContext camelContext,
-            UniVocityFixedWidthDataFormatConfiguration configuration)
-            throws Exception {
-        UniVocityFixedWidthDataFormat dataformat = new UniVocityFixedWidthDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(UniVocityFixedWidthDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureUniVocityFixedWidthDataFormatFactory(
+            final CamelContext camelContext,
+            final UniVocityFixedWidthDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                UniVocityFixedWidthDataFormat dataformat = new UniVocityFixedWidthDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(UniVocityFixedWidthDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityTsvDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityTsvDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.univocity.UniVocityTsvDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,28 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(UniVocityTsvDataFormatConfiguration.class)
 public class UniVocityTsvDataFormatAutoConfiguration {
 
-    @Bean(name = "univocity-tsv-dataformat")
-    @Scope("prototype")
+    @Bean(name = "univocity-tsv-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(UniVocityTsvDataFormat.class)
-    public UniVocityTsvDataFormat configureUniVocityTsvDataFormat(
-            CamelContext camelContext,
-            UniVocityTsvDataFormatConfiguration configuration) throws Exception {
-        UniVocityTsvDataFormat dataformat = new UniVocityTsvDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(UniVocityTsvDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureUniVocityTsvDataFormatFactory(
+            final CamelContext camelContext,
+            final UniVocityTsvDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                UniVocityTsvDataFormat dataformat = new UniVocityTsvDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(UniVocityTsvDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xmlbeans-starter/src/main/java/org/apache/camel/converter/xmlbeans/springboot/XmlBeansDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xmlbeans-starter/src/main/java/org/apache/camel/converter/xmlbeans/springboot/XmlBeansDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.converter.xmlbeans.XmlBeansDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(XmlBeansDataFormatConfiguration.class)
 public class XmlBeansDataFormatAutoConfiguration {
 
-    @Bean(name = "xmlBeans-dataformat")
-    @Scope("prototype")
+    @Bean(name = "xmlBeans-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(XmlBeansDataFormat.class)
-    public XmlBeansDataFormat configureXmlBeansDataFormat(
-            CamelContext camelContext,
-            XmlBeansDataFormatConfiguration configuration) throws Exception {
-        XmlBeansDataFormat dataformat = new XmlBeansDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(XmlBeansDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureXmlBeansDataFormatFactory(
+            final CamelContext camelContext,
+            final XmlBeansDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                XmlBeansDataFormat dataformat = new XmlBeansDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(XmlBeansDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xmljson-starter/src/main/java/org/apache/camel/dataformat/xmljson/springboot/XmlJsonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xmljson-starter/src/main/java/org/apache/camel/dataformat/xmljson/springboot/XmlJsonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.xmljson.XmlJsonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(XmlJsonDataFormatConfiguration.class)
 public class XmlJsonDataFormatAutoConfiguration {
 
-    @Bean(name = "xmljson-dataformat")
-    @Scope("prototype")
+    @Bean(name = "xmljson-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(XmlJsonDataFormat.class)
-    public XmlJsonDataFormat configureXmlJsonDataFormat(
-            CamelContext camelContext,
-            XmlJsonDataFormatConfiguration configuration) throws Exception {
-        XmlJsonDataFormat dataformat = new XmlJsonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(XmlJsonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureXmlJsonDataFormatFactory(
+            final CamelContext camelContext,
+            final XmlJsonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                XmlJsonDataFormat dataformat = new XmlJsonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(XmlJsonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xmlrpc-starter/src/main/java/org/apache/camel/dataformat/xmlrpc/springboot/XmlRpcDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xmlrpc-starter/src/main/java/org/apache/camel/dataformat/xmlrpc/springboot/XmlRpcDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.xmlrpc.XmlRpcDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(XmlRpcDataFormatConfiguration.class)
 public class XmlRpcDataFormatAutoConfiguration {
 
-    @Bean(name = "xmlrpc-dataformat")
-    @Scope("prototype")
+    @Bean(name = "xmlrpc-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(XmlRpcDataFormat.class)
-    public XmlRpcDataFormat configureXmlRpcDataFormat(
-            CamelContext camelContext,
-            XmlRpcDataFormatConfiguration configuration) throws Exception {
-        XmlRpcDataFormat dataformat = new XmlRpcDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(XmlRpcDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureXmlRpcDataFormatFactory(
+            final CamelContext camelContext,
+            final XmlRpcDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                XmlRpcDataFormat dataformat = new XmlRpcDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(XmlRpcDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xmlsecurity-starter/src/main/java/org/apache/camel/dataformat/xmlsecurity/springboot/XMLSecurityDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xmlsecurity-starter/src/main/java/org/apache/camel/dataformat/xmlsecurity/springboot/XMLSecurityDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.xmlsecurity.XMLSecurityDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,28 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(XMLSecurityDataFormatConfiguration.class)
 public class XMLSecurityDataFormatAutoConfiguration {
 
-    @Bean(name = "secureXML-dataformat")
-    @Scope("prototype")
+    @Bean(name = "secureXML-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(XMLSecurityDataFormat.class)
-    public XMLSecurityDataFormat configureXMLSecurityDataFormat(
-            CamelContext camelContext,
-            XMLSecurityDataFormatConfiguration configuration) throws Exception {
-        XMLSecurityDataFormat dataformat = new XMLSecurityDataFormat();
-        if (CamelContextAware.class
-                .isAssignableFrom(XMLSecurityDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureXMLSecurityDataFormatFactory(
+            final CamelContext camelContext,
+            final XMLSecurityDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                XMLSecurityDataFormat dataformat = new XMLSecurityDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(XMLSecurityDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/JsonDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/JsonDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.xstream.JsonDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,26 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(JsonDataFormatConfiguration.class)
 public class JsonDataFormatAutoConfiguration {
 
-    @Bean(name = "json-xstream-dataformat")
-    @Scope("prototype")
+    @Bean(name = "json-xstream-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(JsonDataFormat.class)
-    public JsonDataFormat configureJsonDataFormat(CamelContext camelContext,
-            JsonDataFormatConfiguration configuration) throws Exception {
-        JsonDataFormat dataformat = new JsonDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(JsonDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureJsonDataFormatFactory(
+            final CamelContext camelContext,
+            final JsonDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                JsonDataFormat dataformat = new JsonDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(JsonDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/XStreamDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/XStreamDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.xstream.XStreamDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(XStreamDataFormatConfiguration.class)
 public class XStreamDataFormatAutoConfiguration {
 
-    @Bean(name = "xstream-dataformat")
-    @Scope("prototype")
+    @Bean(name = "xstream-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(XStreamDataFormat.class)
-    public XStreamDataFormat configureXStreamDataFormat(
-            CamelContext camelContext,
-            XStreamDataFormatConfiguration configuration) throws Exception {
-        XStreamDataFormat dataformat = new XStreamDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(XStreamDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureXStreamDataFormatFactory(
+            final CamelContext camelContext,
+            final XStreamDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                XStreamDataFormat dataformat = new XStreamDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(XStreamDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/platforms/spring-boot/components-starter/camel-zipfile-starter/src/main/java/org/apache/camel/dataformat/zipfile/springboot/ZipFileDataFormatAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-zipfile-starter/src/main/java/org/apache/camel/dataformat/zipfile/springboot/ZipFileDataFormatAutoConfiguration.java
@@ -20,7 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.zipfile.ZipFileDataFormat;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.util.IntrospectionSupport;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -35,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -48,27 +50,36 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @EnableConfigurationProperties(ZipFileDataFormatConfiguration.class)
 public class ZipFileDataFormatAutoConfiguration {
 
-    @Bean(name = "zipfile-dataformat")
-    @Scope("prototype")
+    @Bean(name = "zipfile-dataformat-factory")
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean(ZipFileDataFormat.class)
-    public ZipFileDataFormat configureZipFileDataFormat(
-            CamelContext camelContext,
-            ZipFileDataFormatConfiguration configuration) throws Exception {
-        ZipFileDataFormat dataformat = new ZipFileDataFormat();
-        if (CamelContextAware.class.isAssignableFrom(ZipFileDataFormat.class)) {
-            CamelContextAware contextAware = CamelContextAware.class
-                    .cast(dataformat);
-            if (contextAware != null) {
-                contextAware.setCamelContext(camelContext);
+    public DataFormatFactory configureZipFileDataFormatFactory(
+            final CamelContext camelContext,
+            final ZipFileDataFormatConfiguration configuration) {
+        return new DataFormatFactory() {
+            public DataFormat newInstance() {
+                ZipFileDataFormat dataformat = new ZipFileDataFormat();
+                if (CamelContextAware.class
+                        .isAssignableFrom(ZipFileDataFormat.class)) {
+                    CamelContextAware contextAware = CamelContextAware.class
+                            .cast(dataformat);
+                    if (contextAware != null) {
+                        contextAware.setCamelContext(camelContext);
+                    }
+                }
+                try {
+                    Map<String, Object> parameters = new HashMap<>();
+                    IntrospectionSupport.getProperties(configuration,
+                            parameters, null, false);
+                    IntrospectionSupport.setProperties(camelContext,
+                            camelContext.getTypeConverter(), dataformat,
+                            parameters);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+                return dataformat;
             }
-        }
-        Map<String, Object> parameters = new HashMap<>();
-        IntrospectionSupport.getProperties(configuration, parameters, null,
-                false);
-        IntrospectionSupport.setProperties(camelContext,
-                camelContext.getTypeConverter(), dataformat, parameters);
-        return dataformat;
+        };
     }
 
     public static class Condition extends SpringBootCondition {

--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/AnnotationProcessorHelper.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/AnnotationProcessorHelper.java
@@ -336,7 +336,7 @@ public final class AnnotationProcessorHelper {
                 try {
                     file = new File(uri.getPath());
                 } catch (Exception e) {
-                    warning(processingEnv, "Could not convert output directory resource URI to a file " + e);
+                    warning(processingEnv, "Cannot convert output directory resource URI to a file " + e);
                 }
             }
             if (file == null) {
@@ -381,10 +381,11 @@ public final class AnnotationProcessorHelper {
         Filer filer = processingEnv.getFiler();
 
         FileObject resource;
+        String relativeName = packageName + "/" + fileName;
         try {
-            resource = filer.getResource(StandardLocation.CLASS_OUTPUT, "", packageName + "/" + fileName);
+            resource = filer.getResource(StandardLocation.CLASS_OUTPUT, "", relativeName);
         } catch (Throwable e) {
-            return "Crap" + e.getMessage();
+            return "Cannot load classpath resource: " + relativeName + " due: " + e.getMessage();
         }
 
         if (resource == null) {

--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/CoreEipAnnotationProcessor.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/CoreEipAnnotationProcessor.java
@@ -168,6 +168,9 @@ public class CoreEipAnnotationProcessor {
             buffer.append("\n    \"title\": \"").append(asTitle(eipModel.getName())).append("\",");
         }
         buffer.append("\n    \"description\": \"").append(safeNull(eipModel.getDescription())).append("\",");
+        if (eipModel.getFirstVersion() != null) {
+            buffer.append("\n    \"firstVersion\": \"").append(safeNull(eipModel.getFirstVersion())).append("\",");
+        }
         buffer.append("\n    \"javaType\": \"").append(eipModel.getJavaType()).append("\",");
         buffer.append("\n    \"label\": \"").append(safeNull(eipModel.getLabel())).append("\",");
         buffer.append("\n    \"deprecated\": \"").append(eipModel.isDeprecated()).append("\",");
@@ -212,6 +215,9 @@ public class CoreEipAnnotationProcessor {
             }
             if (!Strings.isNullOrEmpty(metadata.title())) {
                 model.setTitle(metadata.title());
+            }
+            if (!Strings.isNullOrEmpty(metadata.firstVersion())) {
+                model.setFirstVersion(metadata.firstVersion());
             }
         }
 
@@ -940,6 +946,7 @@ public class CoreEipAnnotationProcessor {
         private boolean deprecated;
         private boolean input;
         private boolean output;
+        private String firstVersion;
 
         public String getName() {
             return name;
@@ -1013,6 +1020,13 @@ public class CoreEipAnnotationProcessor {
             return output ? "true" : "false";
         }
 
+        public String getFirstVersion() {
+            return firstVersion;
+        }
+
+        public void setFirstVersion(String firstVersion) {
+            this.firstVersion = firstVersion;
+        }
     }
 
     private static final class EipOption {

--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
@@ -156,6 +156,7 @@ public class EndpointAnnotationProcessor extends AbstractProcessor {
         String syntax = componentModel.getSyntax();
         String alternativeSyntax = componentModel.getAlternativeSyntax();
         String description = componentModel.getDescription();
+        String firstVersion = componentModel.getFirstVersion();
 
         writer.println("<html>");
         writer.println("<header>");
@@ -163,6 +164,9 @@ public class EndpointAnnotationProcessor extends AbstractProcessor {
         writer.println("</header>");
         writer.println("<body>");
         writer.println("<h1>" + title + "</h1>");
+        if (!Strings.isNullOrEmpty(firstVersion)) {
+            writer.println("<b>Available from version:</b> " + firstVersion + "<br/>");
+        }
         writer.println("<b>Scheme:</b> " + scheme + "<br/>");
         writer.println("<b>Syntax:</b> " + syntax + "<br/>");
         if (alternativeSyntax != null) {
@@ -277,6 +281,9 @@ public class EndpointAnnotationProcessor extends AbstractProcessor {
             buffer.append("\n    \"lenientProperties\": \"").append("true").append("\",");
         }
         buffer.append("\n    \"javaType\": \"").append(componentModel.getJavaType()).append("\",");
+        if (componentModel.getFirstVersion() != null) {
+            buffer.append("\n    \"firstVersion\": \"").append(componentModel.getFirstVersion()).append("\",");
+        }
         buffer.append("\n    \"groupId\": \"").append(componentModel.getGroupId()).append("\",");
         buffer.append("\n    \"artifactId\": \"").append(componentModel.getArtifactId()).append("\",");
         buffer.append("\n    \"version\": \"").append(componentModel.getVersionId()).append("\"");
@@ -506,6 +513,16 @@ public class EndpointAnnotationProcessor extends AbstractProcessor {
         model.setProducerOnly(uriEndpoint.producerOnly());
         model.setLenientProperties(uriEndpoint.lenientProperties());
         model.setAsync(implementsInterface(processingEnv, roundEnv, endpointClassElement, "org.apache.camel.AsyncEndpoint"));
+
+        // what is the first version this component was added to Apache Camel
+        String firstVersion = uriEndpoint.firstVersion();
+        if (Strings.isNullOrEmpty(firstVersion) && endpointClassElement.getAnnotation(Metadata.class) != null) {
+            // fallback to @Metadata if not from @UriEndpoint
+            firstVersion = endpointClassElement.getAnnotation(Metadata.class).firstVersion();
+        }
+        if (!Strings.isNullOrEmpty(firstVersion)) {
+            model.setFirstVersion(firstVersion);
+        }
 
         String data = loadResource(processingEnv, "META-INF/services/org/apache/camel/component", scheme);
         if (data != null) {

--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/model/ComponentModel.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/model/ComponentModel.java
@@ -25,6 +25,7 @@ public final class ComponentModel {
     private String javaType;
     private String title;
     private String description;
+    private String firstVersion;
     private String groupId;
     private String artifactId;
     private String versionId;
@@ -89,6 +90,14 @@ public final class ComponentModel {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getFirstVersion() {
+        return firstVersion;
+    }
+
+    public void setFirstVersion(String firstVersion) {
+        this.firstVersion = firstVersion;
     }
 
     public String getGroupId() {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageDataFormatMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageDataFormatMojo.java
@@ -188,6 +188,9 @@ public class PackageDataFormatMojo extends AbstractMojo {
                                 if (row.containsKey("javaType")) {
                                     dataFormatModel.setModelJavaType(row.get("javaType"));
                                 }
+                                if (row.containsKey("firstVersion")) {
+                                    dataFormatModel.setFirstVersion(row.get("firstVersion"));
+                                }
                                 // override description for camel-core, as otherwise its too generic
                                 if ("camel-core".equals(project.getArtifactId())) {
                                     if (row.containsKey("description")) {
@@ -417,6 +420,9 @@ public class PackageDataFormatMojo extends AbstractMojo {
         if (dataFormatModel.getDescription() != null) {
             buffer.append("\n    \"description\": \"").append(dataFormatModel.getDescription()).append("\",");
         }
+        if (dataFormatModel.getFirstVersion() != null) {
+            buffer.append("\n    \"firstVersion\": \"").append(dataFormatModel.getFirstVersion()).append("\",");
+        }
         buffer.append("\n    \"label\": \"").append(dataFormatModel.getLabel()).append("\",");
         buffer.append("\n    \"javaType\": \"").append(dataFormatModel.getJavaType()).append("\",");
         if (dataFormatModel.getModelJavaType() != null) {
@@ -437,6 +443,7 @@ public class PackageDataFormatMojo extends AbstractMojo {
         private String title;
         private String modelName;
         private String description;
+        private String firstVersion;
         private String label;
         private String javaType;
         private String modelJavaType;
@@ -482,6 +489,14 @@ public class PackageDataFormatMojo extends AbstractMojo {
 
         public void setDescription(String description) {
             this.description = description;
+        }
+
+        public String getFirstVersion() {
+            return firstVersion;
+        }
+
+        public void setFirstVersion(String firstVersion) {
+            this.firstVersion = firstVersion;
         }
 
         public String getLabel() {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageLanguageMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageLanguageMojo.java
@@ -194,6 +194,9 @@ public class PackageLanguageMojo extends AbstractMojo {
                                 if (row.containsKey("javaType")) {
                                     languageModel.setModelJavaType(row.get("javaType"));
                                 }
+                                if (row.containsKey("firstVersion")) {
+                                    languageModel.setFirstVersion(row.get("firstVersion"));
+                                }
                             }
                             log.debug("Model " + languageModel);
 
@@ -366,6 +369,9 @@ public class PackageLanguageMojo extends AbstractMojo {
         if (languageModel.getDescription() != null) {
             buffer.append("\n    \"description\": \"").append(languageModel.getDescription()).append("\",");
         }
+        if (languageModel.getFirstVersion() != null) {
+            buffer.append("\n    \"firstVersion\": \"").append(languageModel.getFirstVersion()).append("\",");
+        }
         buffer.append("\n    \"label\": \"").append(languageModel.getLabel()).append("\",");
         buffer.append("\n    \"javaType\": \"").append(languageModel.getJavaType()).append("\",");
         if (languageModel.getModelJavaType() != null) {
@@ -386,6 +392,7 @@ public class PackageLanguageMojo extends AbstractMojo {
         private String title;
         private String modelName;
         private String description;
+        private String firstVersion;
         private String label;
         private String javaType;
         private String modelJavaType;
@@ -431,6 +438,14 @@ public class PackageLanguageMojo extends AbstractMojo {
 
         public void setDescription(String description) {
             this.description = description;
+        }
+
+        public String getFirstVersion() {
+            return firstVersion;
+        }
+
+        public void setFirstVersion(String firstVersion) {
+            this.firstVersion = firstVersion;
         }
 
         public String getLabel() {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareReadmeMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareReadmeMojo.java
@@ -610,6 +610,7 @@ public class PrepareReadmeMojo extends AbstractMojo {
         component.setAlternativeSchemes(JSonSchemaHelper.getSafeValue("alternativeSchemes", rows));
         component.setTitle(JSonSchemaHelper.getSafeValue("title", rows));
         component.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        component.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         component.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         component.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         component.setConsumerOnly(JSonSchemaHelper.getSafeValue("consumerOnly", rows));
@@ -630,6 +631,7 @@ public class PrepareReadmeMojo extends AbstractMojo {
         dataFormat.setTitle(JSonSchemaHelper.getSafeValue("title", rows));
         dataFormat.setModelName(JSonSchemaHelper.getSafeValue("modelName", rows));
         dataFormat.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        dataFormat.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         dataFormat.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         dataFormat.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         dataFormat.setJavaType(JSonSchemaHelper.getSafeValue("javaType", rows));

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareUserGuideMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareUserGuideMojo.java
@@ -457,6 +457,7 @@ public class PrepareUserGuideMojo extends AbstractMojo {
         component.setAlternativeSchemes(JSonSchemaHelper.getSafeValue("alternativeSchemes", rows));
         component.setTitle(JSonSchemaHelper.getSafeValue("title", rows));
         component.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        component.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         component.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         component.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         component.setConsumerOnly(JSonSchemaHelper.getSafeValue("consumerOnly", rows));
@@ -477,6 +478,7 @@ public class PrepareUserGuideMojo extends AbstractMojo {
         dataFormat.setTitle(JSonSchemaHelper.getSafeValue("title", rows));
         dataFormat.setModelName(JSonSchemaHelper.getSafeValue("modelName", rows));
         dataFormat.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        dataFormat.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         dataFormat.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         dataFormat.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         dataFormat.setJavaType(JSonSchemaHelper.getSafeValue("javaType", rows));

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ReadmeComponentMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ReadmeComponentMojo.java
@@ -557,6 +557,7 @@ public class ReadmeComponentMojo extends AbstractMojo {
         component.setAlternativeSchemes(JSonSchemaHelper.getSafeValue("alternativeSchemes", rows));
         component.setTitle(JSonSchemaHelper.getSafeValue("title", rows));
         component.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        component.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         component.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         component.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         component.setConsumerOnly(JSonSchemaHelper.getSafeValue("consumerOnly", rows));
@@ -623,6 +624,7 @@ public class ReadmeComponentMojo extends AbstractMojo {
         dataFormat.setModelName(JSonSchemaHelper.getSafeValue("modelName", rows));
         dataFormat.setName(JSonSchemaHelper.getSafeValue("name", rows));
         dataFormat.setDescription(JSonSchemaHelper.getSafeValue("description", rows));
+        dataFormat.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         dataFormat.setLabel(JSonSchemaHelper.getSafeValue("label", rows));
         dataFormat.setDeprecated(JSonSchemaHelper.getSafeValue("deprecated", rows));
         dataFormat.setJavaType(JSonSchemaHelper.getSafeValue("javaType", rows));

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpringBootAutoConfigurationMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpringBootAutoConfigurationMojo.java
@@ -1211,6 +1211,7 @@ public class SpringBootAutoConfigurationMojo extends AbstractMojo {
         component.setAlternativeSyntax(getSafeValue("alternativeSyntax", rows));
         component.setTitle(getSafeValue("title", rows));
         component.setDescription(getSafeValue("description", rows));
+        component.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         component.setLabel(getSafeValue("label", rows));
         component.setDeprecated(getSafeValue("deprecated", rows));
         component.setConsumerOnly(getSafeValue("consumerOnly", rows));
@@ -1264,6 +1265,7 @@ public class SpringBootAutoConfigurationMojo extends AbstractMojo {
         dataFormat.setName(getSafeValue("name", rows));
         dataFormat.setModelName(getSafeValue("modelName", rows));
         dataFormat.setDescription(getSafeValue("description", rows));
+        dataFormat.setFirstVersion(JSonSchemaHelper.getSafeValue("firstVersion", rows));
         dataFormat.setLabel(getSafeValue("label", rows));
         dataFormat.setDeprecated(getSafeValue("deprecated", rows));
         dataFormat.setJavaType(getSafeValue("javaType", rows));

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentModel.java
@@ -28,6 +28,7 @@ public class ComponentModel {
     private String alternativeSchemes;
     private String title;
     private String description;
+    private String firstVersion;
     private String label;
     private String deprecated;
     private String consumerOnly;
@@ -93,6 +94,14 @@ public class ComponentModel {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getFirstVersion() {
+        return firstVersion;
+    }
+
+    public void setFirstVersion(String firstVersion) {
+        this.firstVersion = firstVersion;
     }
 
     public String getLabel() {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/DataFormatModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/DataFormatModel.java
@@ -26,6 +26,7 @@ public class DataFormatModel {
     private String modelName;
     private String title;
     private String description;
+    private String firstVersion;
     private String label;
     private String deprecated;
     private String javaType;
@@ -72,6 +73,14 @@ public class DataFormatModel {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getFirstVersion() {
+        return firstVersion;
+    }
+
+    public void setFirstVersion(String firstVersion) {
+        this.firstVersion = firstVersion;
     }
 
     public String getLabel() {

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
@@ -76,4 +76,9 @@ public @interface Metadata {
      */
     boolean secret() default false;
 
+    /**
+     * The first version this functionality was added to Apache Camel.
+     */
+    String firstVersion() default "";
+
 }

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/UriEndpoint.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/UriEndpoint.java
@@ -33,6 +33,11 @@ import java.lang.annotation.Target;
 public @interface UriEndpoint {
 
     /**
+     * The first version this endpoint was added to Apache Camel.
+     */
+    String firstVersion() default "";
+
+    /**
      * Represents the URI scheme name of this endpoint.
      * <p/>
      * Multiple scheme names can be defined as a comma separated value.


### PR DESCRIPTION
I'm opening this PR for review as there are some changes on CamelContext level so I'd like to gather some feedback.

As today the DataFormat resolution works as follow:
1. search int the registry if a DataFormat instance exists for a given name
2. if not found in registry create a new one from the resources (META-INF/services/...)

This my cause issues as per CAMEL-10542

The proposed solution introduces a new DataFormatFactory and a new method to DataFormatResolver to have a way to explicit request for a new instance so it looks like:

```java
public interface DataFormatResolver {
    // Resolve using registry then fallback to createDataFormat
    DataFormat resolveDataFormat(String name, CamelContext context);

    // Creates DataFormat using factory from registry or fallback to resources
    DataFormat createDataFormat(String name, CamelContext context);
} 
```

Model's DataFormatDefinition is now using createDataFormat except for CustomDataFormat which indeed is supposed to eventually share the same data format. 

I still need to implement some stuffs but the basic concept is here.
Any feedback would be really appreciated.
