### PR TITLE
[CAMEL-10779] Authentication : provide a way to use refresh_token mode in addition to password method

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/README.md
+++ b/components/camel-salesforce/camel-salesforce-component/README.md
@@ -88,7 +88,7 @@ Install the Warehouse package, tested with _Spring 2013_ (version 1.2) that can 
 
 You'll need to access a Merchandise record and run a `Test Report` in order for them to appear in _Recent Items_ and _Recent Reports_. Do this by accessing _Warehouse_ application from the menu in the top right, and selecting _Merchandise_ click _Go!_ (preselected is View: _All_) and click on the single Merchandise item available. Next go to Reports and select and run _Test Report_ from _Test Reports_. This is needed by the integration tests as they access recent items and recently run reports.
 
-Create `Camel` connected application by selecting under _Apps_ in _Build_ and _Create_ sections by clicking _New_ in _Connected Apps_ section. Fill in the required fields and in the _API (Enable OAuth Settings)_ section thick _Enable OAuth Settings_ and move all scopes from _Available OAuth Scopes_ to _Selected OAuth Scopes_. For _Callback URL_ you can use any URL it's not needed by the REST API used by the Camel Salesforce component. Make note of _Consumer Key_ and _Consumer Secret_ you'll need to specify them in `test-salesforce-login.properties`, more on that below.
+Create `Camel` connected application by selecting under _Apps_ in _Build_ and _Create_ sections by clicking _New_ in _Connected Apps_ section. Fill in the required fields and in the _API (Enable OAuth Settings)_ section thick _Enable OAuth Settings_ and move all scopes from _Available OAuth Scopes_ to _Selected OAuth Scopes_. For _Callback URL_ you can use any URL it's not needed by the REST API used by the Camel Salesforce component. Make note of _Consumer Key_ and _Consumer Secret_, or if your partner provide just _Consumer Refresh Token_ you'll need to specify them in `test-salesforce-login.properties`,  more on that below.
 
 Next enable relaxed IP restrictions, by editing the policy of the _Camel_ connected application in _Connected Apps_ under _Administer_ and _Manage Apps_ pick _Relax IP restrictions_ for _IP Relaxation_.  
 
@@ -96,6 +96,7 @@ Create `test-salesforce-login.properties` in `camel-salesforce` directory (one u
 
     clientId=<Consumer Key of the `Camel` connected App>
     clientSecret=<Consumer Secret of the `Camel` connected app>
+    refreshToken=<Consumer Refresh Token of the `Camel` connected app>
     userName=<Username of the user with the `System Administrator With Hard Delete` profile>
     password=<Password of the above user>
     loginUrl=https://login.salesforce.com/

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceLoginConfig.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceLoginConfig.java
@@ -26,6 +26,7 @@ public class SalesforceLoginConfig {
     private String loginUrl;
     private String clientId;
     private String clientSecret;
+    private String refreshToken;
     private String userName;
     private String password;
     // allow lazy login into Salesforce
@@ -45,6 +46,16 @@ public class SalesforceLoginConfig {
         this.clientSecret = clientSecret;
         this.userName = userName;
         this.password = password;
+        this.lazyLogin = lazyLogin;
+    }
+
+    public SalesforceLoginConfig(String loginUrl,
+            String clientId, String clientSecret,
+            String refreshToken, boolean lazyLogin) {
+        this.loginUrl = loginUrl;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.refreshToken = refreshToken;
         this.lazyLogin = lazyLogin;
     }
 
@@ -79,6 +90,18 @@ public class SalesforceLoginConfig {
      */
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+    }
+
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * Salesforce connected application Consumer token
+     */
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public String getUserName() {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
@@ -72,8 +72,13 @@ public class SalesforceSession implements Service {
         ObjectHelper.notNull(config.getLoginUrl(), "loginUrl");
         ObjectHelper.notNull(config.getClientId(), "clientId");
         ObjectHelper.notNull(config.getClientSecret(), "clientSecret");
-        ObjectHelper.notNull(config.getUserName(), "userName");
-        ObjectHelper.notNull(config.getPassword(), "password");
+
+        if (config.getRefreshToken() == null) {
+            ObjectHelper.notNull(config.getUserName(), "userName");
+            ObjectHelper.notNull(config.getPassword(), "password");
+        } else {
+            ObjectHelper.notNull(config.getRefreshToken(), "refreshToken");
+        }
 
         this.httpClient = httpClient;
         this.timeout = timeout;
@@ -132,12 +137,18 @@ public class SalesforceSession implements Service {
         LOG.info("Login user {} at Salesforce loginUrl: {}", config.getUserName(), loginUrl);
         final Fields fields = new Fields(true);
 
-        fields.put("grant_type", "password");
         fields.put("client_id", config.getClientId());
         fields.put("client_secret", config.getClientSecret());
-        fields.put("username", config.getUserName());
-        fields.put("password", config.getPassword());
         fields.put("format", "json");
+
+        if (config.getRefreshToken() == null) {
+            fields.put("grant_type", "password");
+            fields.put("username", config.getUserName());
+            fields.put("password", config.getPassword());
+        } else {
+            fields.put("grant_type", "refresh_token");
+            fields.put("refresh_token", config.getRefreshToken());
+        }
 
         final Request post;
         if (conversation == null) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
@@ -73,7 +73,7 @@ public class SalesforceSession implements Service {
         ObjectHelper.notNull(config.getClientId(), "clientId");
         ObjectHelper.notNull(config.getClientSecret(), "clientSecret");
 
-        if (config.getRefreshToken() == null) {
+        if (ObjectHelper.isEmpty(config.getRefreshToken())) {
             ObjectHelper.notNull(config.getUserName(), "userName");
             ObjectHelper.notNull(config.getPassword(), "password");
         } else {
@@ -141,7 +141,7 @@ public class SalesforceSession implements Service {
         fields.put("client_secret", config.getClientSecret());
         fields.put("format", "json");
 
-        if (config.getRefreshToken() == null) {
+        if (ObjectHelper.isEmpty(config.getRefreshToken())) {
             fields.put("grant_type", "password");
             fields.put("username", config.getUserName());
             fields.put("password", config.getPassword());

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
@@ -34,28 +34,44 @@ public class LoginConfigHelper extends Assert {
         Properties properties = new Properties();
         InputStream stream = null;
         try {
+            final SalesforceLoginConfig config;
             stream = new FileInputStream(TEST_LOGIN_PROPERTIES);
             properties.load(stream);
 
-            final SalesforceLoginConfig config = new SalesforceLoginConfig(
-                properties.getProperty("loginUrl", SalesforceLoginConfig.DEFAULT_LOGIN_URL),
-                properties.getProperty("clientId"),
-                properties.getProperty("clientSecret"),
-                properties.getProperty("userName"),
-                properties.getProperty("password"),
-                Boolean.parseBoolean(properties.getProperty("lazyLogin", "false")));
+            if (properties.getProperty("refreshToken")== null) {
+                config = new SalesforceLoginConfig(
+                        properties.getProperty("loginUrl", SalesforceLoginConfig.DEFAULT_LOGIN_URL),
+                        properties.getProperty("clientId"),
+                        properties.getProperty("clientSecret"),
+                        properties.getProperty("userName"),
+                        properties.getProperty("password"),
+                        Boolean.parseBoolean(properties.getProperty("lazyLogin", "false")));
+            } else {
+                config = new SalesforceLoginConfig(
+                        properties.getProperty("loginUrl", SalesforceLoginConfig.DEFAULT_LOGIN_URL),
+                        properties.getProperty("clientId"), //
+                        properties.getProperty("clientSecret"), //
+                        properties.getProperty("refreshToken"), //
+                        Boolean.parseBoolean(properties.getProperty("lazyLogin", "false")));
+            }
+
 
             assertNotNull("Null loginUrl", config.getLoginUrl());
             assertNotNull("Null clientId", config.getClientId());
             assertNotNull("Null clientSecret", config.getClientSecret());
-            assertNotNull("Null userName", config.getUserName());
-            assertNotNull("Null password", config.getPassword());
+            if (properties.getProperty("refreshToken")== null) {
+                assertNotNull("Null userName", config.getUserName());
+                assertNotNull("Null password", config.getPassword());
+            } else {
+                assertNotNull("Null refreshToken", config.getRefreshToken());
+            }
+
 
             return config;
 
         } catch (FileNotFoundException e) {
             throw new FileNotFoundException("Create a properties file named "
-                + TEST_LOGIN_PROPERTIES + " with clientId, clientSecret, userName, and password"
+                + TEST_LOGIN_PROPERTIES + " with clientId, clientSecret, userName, and password or with clientId, clientSecret and refreshToken"
                 + " for a Salesforce account with Merchandise and Invoice objects from Salesforce Guides.");
         } finally {
             if (stream != null) {

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.apache.camel.util.ObjectHelper;
 import org.junit.Assert;
 
 public class LoginConfigHelper extends Assert {
@@ -38,7 +39,7 @@ public class LoginConfigHelper extends Assert {
             stream = new FileInputStream(TEST_LOGIN_PROPERTIES);
             properties.load(stream);
 
-            if (properties.getProperty("refreshToken")== null) {
+            if (ObjectHelper.isEmpty(properties.getProperty("refreshToken"))) {
                 config = new SalesforceLoginConfig(
                         properties.getProperty("loginUrl", SalesforceLoginConfig.DEFAULT_LOGIN_URL),
                         properties.getProperty("clientId"),
@@ -59,7 +60,7 @@ public class LoginConfigHelper extends Assert {
             assertNotNull("Null loginUrl", config.getLoginUrl());
             assertNotNull("Null clientId", config.getClientId());
             assertNotNull("Null clientSecret", config.getClientSecret());
-            if (properties.getProperty("refreshToken")== null) {
+            if (ObjectHelper.isEmpty(properties.getProperty("refreshToken"))) {
                 assertNotNull("Null userName", config.getUserName());
                 assertNotNull("Null password", config.getPassword());
             } else {

--- a/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
@@ -832,7 +832,7 @@ public class SalesforceComponentConfiguration {
          */
         private String clientSecret;
         /**
-         * Salesforce connected application Consumer token
+         * Salesforce connected application OAuth refresh token
          */
         private String refreshToken;
         /**

--- a/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
@@ -832,6 +832,10 @@ public class SalesforceComponentConfiguration {
          */
         private String clientSecret;
         /**
+         * Salesforce connected application Consumer token
+         */
+        private String refreshToken;
+        /**
          * Salesforce account user name
          */
         private String userName;
@@ -868,6 +872,14 @@ public class SalesforceComponentConfiguration {
 
         public void setClientSecret(String clientSecret) {
             this.clientSecret = clientSecret;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+
+        public void setRefreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
         }
 
         public String getUserName() {


### PR DESCRIPTION
Objective is to enrich the SalesforceSession.getLoginRequest(HttpConversation) method and add 
fields.put("grant_type", "refresh_token");
as an alternative to 
fields.put("grant_type", "password");

jira: https://issues.apache.org/jira/browse/CAMEL-10779