### PR TITLE
CAMEL-10803 Base undertow component on http-common

### DIFF
--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -38,7 +38,7 @@ You can append query options to the URI in the following format,
 
 
 // component options: START
-The Undertow component supports 4 options which are listed below.
+The Undertow component supports 8 options which are listed below.
 
 
 
@@ -48,6 +48,10 @@ The Undertow component supports 4 options which are listed below.
 | **undertowHttpBinding** (advanced) | To use a custom HttpBinding to control the mapping between Camel message and HttpClient. |  | UndertowHttpBinding
 | **sslContextParameters** (security) | To configure security using SSLContextParameters |  | SSLContextParameters
 | **hostOptions** (advanced) | To configure common options such as thread pools |  | UndertowHostOptions
+| **httpBinding** (advanced) | To use a custom HttpBinding to control the mapping between Camel message and HttpClient. |  | HttpBinding
+| **httpConfiguration** (advanced) | To use the shared HttpConfiguration as base configuration. |  | HttpConfiguration
+| **allowJavaSerialized Object** (advanced) | Whether to allow java serialization when a request uses context-type=application/x-java-serialized-object. This is by default turned off. If you enable this then be aware that Java will deserialize the incoming data from the request to Java and that can be a potential security risk. | false | boolean
+| **headerFilterStrategy** (filter) | To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | **resolveProperty Placeholders** (advanced) | Whether the component should resolve property placeholders on itself when starting. Only properties which are of String type can use property placeholders. | true | boolean
 |=======================================================================
 // component options: END
@@ -70,30 +74,63 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **httpURI** | *Required* The url of the HTTP endpoint to use. |  | URI
+| **httpUri** | *Required* The url of the HTTP endpoint to call. |  | URI
 |=======================================================================
 
-#### Query Parameters (17 parameters):
+#### Query Parameters (50 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
+| **chunked** (common) | If this option is false the Servlet will disable the HTTP streaming and set the content-length header on the response | true | boolean
+| **disableStreamCache** (common) | Determines whether or not the raw input stream from Servlet is cached or not (Camel will read the stream into a in memory/overflow to file Stream caching) cache. By default Camel will cache the Servlet input stream to support reading it multiple times to ensure it Camel can retrieve all data from the stream. However you can set this option to true when you for example need to access the raw stream such as streaming it directly to a file or other persistent store. DefaultHttpBinding will copy the request input stream into a stream cache and put it into message body if this option is false to support reading the stream multiple times. If you use Servlet to bridge/proxy an endpoint then consider enabling this option to improve performance in case you do not need to read the message payload multiple times. The http/http4 producer will by default cache the response body stream. If setting this option to true then the producers will not cache the response body stream but use the response stream as-is as the message body. | false | boolean
+| **headerFilterStrategy** (common) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
+| **transferException** (common) | If enabled and an Exchange failed processing on the consumer side and if the caused Exception was send back serialized in the response as a application/x-java-serialized-object content type. On the producer side the exception will be deserialized and thrown as is instead of the HttpOperationFailedException. The caused exception is required to be serialized. This is by default turned off. If you enable this then be aware that Java will deserialize the incoming data from the request to Java and that can be a potential security risk. | false | boolean
+| **httpBinding** (common) | To use a custom HttpBinding to control the mapping between Camel message and HttpClient. |  | HttpBinding
+| **async** (consumer) | Configure the consumer to work in async mode | false | boolean
 | **bridgeErrorHandler** (consumer) | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored. | false | boolean
 | **httpMethodRestrict** (consumer) | Used to only allow consuming if the HttpMethod matches such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
-| **matchOnUriPrefix** (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | true | Boolean
-| **optionsEnabled** (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
+| **matchOnUriPrefix** (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | boolean
+| **responseBufferSize** (consumer) | To use a custom buffer size on the javax.servlet.ServletResponse. |  | Integer
+| **eagerCheckContentAvailable** (consumer) | Whether to eager check whether the HTTP requests has content if the content-length header is 0 or not present. This can be turned on in case HTTP clients do not send streamed data. | false | boolean
 | **exceptionHandler** (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
-| **cookieHandler** (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler
+| **optionsEnabled** (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
+| **traceEnabled** (consumer) | Specifies whether to enable HTTP TRACE for this Servlet consumer. By default TRACE is turned off. | false | boolean
+| **bridgeEndpoint** (producer) | If the option is true HttpProducer will ignore the Exchange.HTTP_URI header and use the endpoint's URI for request. You may also set the option throwExceptionOnFailure to be false to let the HttpProducer send all the fault response back. | false | boolean
+| **connectionClose** (producer) | Specifies whether a Connection Close header must be added to HTTP Request. By default connectionClose is false. | false | boolean
+| **copyHeaders** (producer) | If this option is true then IN exchange headers will be copied to OUT exchange headers according to copy strategy. Setting this to false allows to only include the headers from the HTTP response (not propagating IN headers). | true | boolean
+| **httpMethod** (producer) | Configure the HTTP method to use. The HttpMethod header cannot override this option if set. |  | HttpMethods
+| **ignoreResponseBody** (producer) | If this option is true The http producer won't read response body and cache the input stream | false | boolean
 | **keepAlive** (producer) | Setting to ensure socket is not closed due to inactivity | true | Boolean
 | **options** (producer) | Sets additional channel options. The options that can be used are defined in org.xnio.Options. To configure from endpoint uri then prefix each option with option. such as option.close-abort=true&option.send-buffer=8192 |  | Map
+| **preserveHostHeader** (producer) | If the option is true HttpProducer will set the Host header to the value contained in the current exchange Host header useful in reverse proxy applications where you want the Host header received by the downstream server to reflect the URL called by the upstream client this allows applications which use the Host header to generate accurate URL's for a proxied service | false | boolean
 | **reuseAddresses** (producer) | Setting to facilitate socket multiplexing | true | Boolean
 | **tcpNoDelay** (producer) | Setting to improve TCP protocol performance | true | Boolean
-| **throwExceptionOnFailure** (producer) | If the option is true HttpProducer will ignore the Exchange.HTTP_URI header and use the endpoint's URI for request. You may also set the option throwExceptionOnFailure to be false to let the producer send all the fault response back. | true | Boolean
-| **transferException** (producer) | Option to disable throwing the HttpOperationFailedException in case of failed responses from the remote server. This allows you to get all responses regardless of the HTTP status code. | false | Boolean
-| **headerFilterStrategy** (advanced) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
+| **throwExceptionOnFailure** (producer) | Option to disable throwing the HttpOperationFailedException in case of failed responses from the remote server. This allows you to get all responses regardless of the HTTP status code. | true | boolean
+| **cookieHandler** (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler
+| **okStatusCodeRange** (producer) | The status codes which is considered a success response. The values are inclusive. The range must be defined as from-to with the dash included. | 200-299 | String
+| **urlRewrite** (producer) | Refers to a custom org.apache.camel.component.http.UrlRewrite which allows you to rewrite urls when you bridge/proxy endpoints. See more details at http://camel.apache.org/urlrewrite.html |  | UrlRewrite
+| **mapHttpMessageBody** (advanced) | If this option is true then IN exchange Body of the exchange will be mapped to HTTP body. Setting this to false will avoid the HTTP mapping. | true | boolean
+| **mapHttpMessageFormUrl EncodedBody** (advanced) | If this option is true then IN exchange Form Encoded body of the exchange will be mapped to HTTP. Setting this to false will avoid the HTTP Form Encoded body mapping. | true | boolean
+| **mapHttpMessageHeaders** (advanced) | If this option is true then IN exchange Headers of the exchange will be mapped to HTTP headers. Setting this to false will avoid the HTTP Headers mapping. | true | boolean
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **undertowHttpBinding** (advanced) | To use a custom UndertowHttpBinding to control the mapping between Camel message and undertow. |  | UndertowHttpBinding
+| **proxyAuthDomain** (proxy) | Proxy authentication domain to use with NTML |  | String
+| **proxyAuthHost** (proxy) | Proxy authentication host |  | String
+| **proxyAuthMethod** (proxy) | Proxy authentication method to use |  | String
+| **proxyAuthPassword** (proxy) | Proxy authentication password |  | String
+| **proxyAuthPort** (proxy) | Proxy authentication port |  | int
+| **proxyAuthScheme** (proxy) | Proxy authentication scheme to use |  | String
+| **proxyAuthUsername** (proxy) | Proxy authentication username |  | String
+| **proxyHost** (proxy) | Proxy hostname to use |  | String
+| **proxyPort** (proxy) | Proxy port to use |  | int
+| **authDomain** (security) | Authentication domain to use with NTML |  | String
+| **authHost** (security) | Authentication host to use with NTML |  | String
+| **authMethod** (security) | Authentication methods allowed to use as a comma separated list of values Basic Digest or NTLM. |  | String
+| **authMethodPriority** (security) | Which authentication method to prioritize to use either as Basic Digest or NTLM. |  | String
+| **authPassword** (security) | Authentication password |  | String
+| **authUsername** (security) | Authentication username |  | String
 | **sslContextParameters** (security) | To configure security using SSLContextParameters |  | SSLContextParameters
 |=======================================================================
 // endpoint options: END

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -162,9 +162,9 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
 
         String path = httpExchange.getRequestPath();
         UndertowEndpoint endpoint = (UndertowEndpoint) exchange.getFromEndpoint();
-        if (endpoint.getHttpURI() != null) {
+        if (ObjectHelper.isNotEmpty(endpoint.getHttpUri())) {
             // need to match by lower case as we want to ignore case on context-path
-            String endpointPath = endpoint.getHttpURI().getPath();
+            String endpointPath = endpoint.getHttpUri().getPath();
             String matchPath = path.toLowerCase(Locale.US);
             String match = endpointPath.toLowerCase(Locale.US);
             if (match != null && matchPath.startsWith(match)) {
@@ -285,7 +285,7 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
 
         int code = message.getHeader(Exchange.HTTP_RESPONSE_CODE, defaultCode, int.class);
 
-        httpExchange.setResponseCode(code);
+        httpExchange.setStatusCode(code);
 
         TypeConverter tc = message.getExchange().getContext().getTypeConverter();
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/RestUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/RestUndertowHttpBinding.java
@@ -36,7 +36,7 @@ public class RestUndertowHttpBinding extends DefaultUndertowHttpBinding {
         // so we need to map those placeholders with data from the incoming request context path
 
         UndertowEndpoint endpoint = (UndertowEndpoint) exchange.getFromEndpoint();
-        String consumerPath = endpoint.getHttpURI().getPath();
+        String consumerPath = endpoint.getHttpUri().getPath();
 
         if (useRestMatching(consumerPath)) {
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
@@ -117,7 +117,7 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
         this.endpoint = endpoint;
         this.request = request;
         this.body = body;
-        throwExceptionOnFailure = endpoint.getThrowExceptionOnFailure();
+        throwExceptionOnFailure = endpoint.isThrowExceptionOnFailure();
     }
 
     @Override

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -17,9 +17,14 @@
 package org.apache.camel.component.undertow;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 
 import io.undertow.Handlers;
+import io.undertow.io.IoCallback;
+import io.undertow.io.Sender;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.form.EagerFormParsingHandler;
@@ -28,17 +33,23 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.MimeMappings;
 import io.undertow.util.StatusCodes;
+
 import org.apache.camel.Exchange;
+import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.impl.DefaultConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xnio.IoUtils;
 
 /**
  * The Undertow consumer which is also an Undertow HttpHandler implementation to handle incoming request.
  */
 public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
+
+    static final int CHUNK_BUFF_SIZE = 1024 * 1024;
 
     private static final Logger LOG = LoggerFactory.getLogger(UndertowConsumer.class);
 
@@ -88,10 +99,12 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
     public void handleRequest(HttpServerExchange httpExchange) throws Exception {
         HttpString requestMethod = httpExchange.getRequestMethod();
 
-        if (Methods.OPTIONS.equals(requestMethod) && !getEndpoint().isOptionsEnabled()) {
+        final UndertowEndpoint endpoint = getEndpoint();
+        final Sender responseSender = httpExchange.getResponseSender();
+        if (Methods.OPTIONS.equals(requestMethod) && !endpoint.isOptionsEnabled()) {
             String allowedMethods;
-            if (getEndpoint().getHttpMethodRestrict() != null) {
-                allowedMethods = "OPTIONS," + getEndpoint().getHttpMethodRestrict();
+            if (endpoint.getHttpMethodRestrict() != null) {
+                allowedMethods = "OPTIONS," + endpoint.getHttpMethodRestrict();
             } else {
                 allowedMethods = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,CONNECT,PATCH";
             }
@@ -100,7 +113,7 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_TYPE, MimeMappings.DEFAULT_MIME_MAPPINGS.get("txt"));
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_LENGTH, 0);
             httpExchange.getResponseHeaders().put(Headers.ALLOW, allowedMethods);
-            httpExchange.getResponseSender().close();
+            responseSender.close();
             return;
         }
 
@@ -112,7 +125,7 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
 
         //create new Exchange
         //binding is used to extract header and payload(if available)
-        Exchange camelExchange = getEndpoint().createExchange(httpExchange);
+        Exchange camelExchange = endpoint.createExchange(httpExchange);
 
         //Unit of Work to process the Exchange
         createUoW(camelExchange);
@@ -125,27 +138,130 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
         }
 
         Object body = getResponseBody(httpExchange, camelExchange);
-        TypeConverter tc = getEndpoint().getCamelContext().getTypeConverter();
+        TypeConverter tc = endpoint.getCamelContext().getTypeConverter();
 
         if (body == null) {
             LOG.trace("No payload to send as reply for exchange: " + camelExchange);
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_TYPE, MimeMappings.DEFAULT_MIME_MAPPINGS.get("txt"));
-            httpExchange.getResponseSender().send("No response available");
+            responseSender.send("No response available");
+
+            return;
+        }
+
+        final Message message = fetchMessage(camelExchange);
+        final boolean chunked = message.getHeader(Exchange.HTTP_CHUNKED, endpoint.isChunked(), Boolean.class);
+        if (chunked) {
+            sendChunked(responseSender, message);
         } else {
             ByteBuffer bodyAsByteBuffer = tc.convertTo(ByteBuffer.class, body);
-            httpExchange.getResponseSender().send(bodyAsByteBuffer);
+            responseSender.send(bodyAsByteBuffer);
         }
-        httpExchange.getResponseSender().close();
     }
 
-    private Object getResponseBody(HttpServerExchange httpExchange, Exchange camelExchange) throws IOException {
-        Object result;
-        if (camelExchange.hasOut()) {
-            result = getEndpoint().getUndertowHttpBinding().toHttpResponse(httpExchange, camelExchange.getOut());
+    /**
+     * Sends the given message body as HTTP/1.1 chunked transfer.
+     *
+     * @param responseSender
+     *            Undertow {@link Sender} to transfer the body to
+     * @param message
+     *            Camel message from which the body is sent
+     * @throws InvalidPayloadException
+     *             if the message does not contain a body of {@link ReadableByteChannel} or {@link InputStream} type
+     * @throws IOException
+     */
+    void sendChunked(final Sender responseSender, final Message message) throws InvalidPayloadException, IOException {
+        final Object body = message.getBody();
+
+        if (body instanceof ReadableByteChannel) {
+            sendChunked(responseSender, (ReadableByteChannel) body);
         } else {
-            result = getEndpoint().getUndertowHttpBinding().toHttpResponse(httpExchange, camelExchange.getIn());
+            final InputStream stream = message.getMandatoryBody(InputStream.class);
+
+            sendChunked(responseSender, Channels.newChannel(stream));
         }
-        return result;
+    }
+
+    /**
+     * Sends the bytes received on the {@link ReadableByteChannel} to the exchange using HTTP/1.1 chuncked transfer.
+     * 
+     * @param httpExchange
+     *            Undertow HTTP exchange to transfer upon
+     * @param channel
+     *            the channel on which the response to be sent resides
+     * @throws IOException
+     */
+    void sendChunked(final Sender responseSender, final ReadableByteChannel channel) throws IOException {
+        final ByteBuffer buffy = ByteBuffer.allocate(CHUNK_BUFF_SIZE);
+
+        final int read = channel.read(buffy);
+        if (read == -1) {
+            return;
+        }
+
+        buffy.flip();
+        final IoCallback callback = new IoCallback() {
+            @Override
+            public void onComplete(final HttpServerExchange exchange, final Sender sender) {
+                if (buffy.hasRemaining()) {
+                    sender.send(buffy, this);
+                } else {
+                    buffy.clear();
+
+                    try {
+                        final int read = channel.read(buffy);
+                        if (read == -1) {
+                            responseSender.close();
+                            return;
+                        }
+
+                        buffy.flip();
+                        sender.send(buffy, this);
+                    } catch (final IOException e) {
+                        try {
+                            handleException("Unable to read from the given body", e);
+                        } finally {
+                            exchange.endExchange();
+                            IoUtils.safeClose(exchange.getConnection());
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onException(final HttpServerExchange exchange, final Sender sender,
+                    final IOException exception) {
+                try {
+                    handleException("Unable to send response to client", exception);
+                } finally {
+                    exchange.endExchange();
+                    IoUtils.safeClose(exchange.getConnection());
+                }
+            }
+        };
+
+        responseSender.send(buffy, callback);
+    }
+
+    /**
+     * Returns the OUT, or if not present the IN message.
+     *
+     * @param exchange
+     *            exchange containing IN or OUT messages
+     * @return OUT or IN message if OUT message is not present
+     */
+    Message fetchMessage(final Exchange exchange) {
+        if (exchange.hasOut()) {
+            return exchange.getOut();
+        } else {
+            return exchange.getIn();
+        }
+    }
+
+    Object getResponseBody(HttpServerExchange httpExchange, Exchange camelExchange) throws IOException {
+        final Message message = fetchMessage(camelExchange);
+        final UndertowHttpBinding undertowHttpBinding = getEndpoint().getUndertowHttpBinding();
+
+        return undertowHttpBinding.toHttpResponse(httpExchange, message);
     }
 
 }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -70,9 +70,9 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             UndertowEndpoint endpoint = getEndpoint();
 
             registrationInfo = new HttpHandlerRegistrationInfo();
-            registrationInfo.setUri(endpoint.getHttpURI());
+            registrationInfo.setUri(endpoint.getHttpUri());
             registrationInfo.setMethodRestrict(endpoint.getHttpMethodRestrict());
-            registrationInfo.setMatchOnUriPrefix(endpoint.getMatchOnUriPrefix());
+            registrationInfo.setMatchOnUriPrefix(endpoint.isMatchOnUriPrefix());
         }
         return registrationInfo;
     }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -20,9 +20,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.Map;
+
 import javax.net.ssl.SSLContext;
 
 import io.undertow.server.HttpServerExchange;
+
 import org.apache.camel.AsyncEndpoint;
 import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
@@ -30,14 +32,10 @@ import org.apache.camel.Message;
 import org.apache.camel.PollingConsumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
-import org.apache.camel.http.common.cookie.CookieHandler;
-import org.apache.camel.impl.DefaultEndpoint;
-import org.apache.camel.spi.HeaderFilterStrategy;
+import org.apache.camel.http.common.HttpCommonEndpoint;
 import org.apache.camel.spi.HeaderFilterStrategyAware;
-import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
-import org.apache.camel.spi.UriPath;
 import org.apache.camel.util.jsse.SSLContextParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,34 +43,23 @@ import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 
+
 /**
  * The undertow component provides HTTP-based endpoints for consuming and producing HTTP requests.
  */
 @UriEndpoint(firstVersion = "2.16.0", scheme = "undertow", title = "Undertow", syntax = "undertow:httpURI",
         consumerClass = UndertowConsumer.class, label = "http", lenientProperties = true)
-public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, HeaderFilterStrategyAware {
+public class UndertowEndpoint extends HttpCommonEndpoint implements AsyncEndpoint, HeaderFilterStrategyAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(UndertowEndpoint.class);
     private UndertowComponent component;
     private SSLContext sslContext;
     private OptionMap optionMap;
 
-    @UriPath @Metadata(required = "true")
-    private URI httpURI;
     @UriParam(label = "advanced")
     private UndertowHttpBinding undertowHttpBinding;
-    @UriParam(label = "advanced")
-    private HeaderFilterStrategy headerFilterStrategy = new UndertowHeaderFilterStrategy();
     @UriParam(label = "security")
     private SSLContextParameters sslContextParameters;
-    @UriParam(label = "consumer")
-    private String httpMethodRestrict;
-    @UriParam(label = "consumer", defaultValue = "true")
-    private Boolean matchOnUriPrefix = true;
-    @UriParam(label = "producer", defaultValue = "true")
-    private Boolean throwExceptionOnFailure = Boolean.TRUE;
-    @UriParam(label = "producer", defaultValue = "false")
-    private Boolean transferException = Boolean.FALSE;
     @UriParam(label = "producer", defaultValue = "true")
     private Boolean keepAlive = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "true")
@@ -81,15 +68,14 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private Boolean reuseAddresses = Boolean.TRUE;
     @UriParam(label = "producer", prefix = "option.", multiValue = true)
     private Map<String, Object> options;
-    @UriParam(label = "consumer",
-            description = "Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off.")
-    private boolean optionsEnabled;
-    @UriParam(label = "producer")
-    private CookieHandler cookieHandler;
 
-    public UndertowEndpoint(String uri, UndertowComponent component) throws URISyntaxException {
-        super(uri, component);
+    public UndertowEndpoint(String uri, UndertowComponent component, URI httpUri) throws URISyntaxException {
+        super(uri, component, httpUri);
         this.component = component;
+
+        // set Undertow component defaults
+        setHeaderFilterStrategy(new UndertowHeaderFilterStrategy());
+        setMatchOnUriPrefix(true);
     }
 
     @Override
@@ -140,50 +126,6 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
         return sslContext;
     }
 
-    public URI getHttpURI() {
-        return httpURI;
-    }
-
-    /**
-     * The url of the HTTP endpoint to use.
-     */
-    public void setHttpURI(URI httpURI) {
-        this.httpURI = httpURI;
-    }
-
-    public String getHttpMethodRestrict() {
-        return httpMethodRestrict;
-    }
-
-    /**
-     * Used to only allow consuming if the HttpMethod matches, such as GET/POST/PUT etc. Multiple methods can be specified separated by comma.
-     */
-    public void setHttpMethodRestrict(String httpMethodRestrict) {
-        this.httpMethodRestrict = httpMethodRestrict;
-    }
-
-    public Boolean getMatchOnUriPrefix() {
-        return matchOnUriPrefix;
-    }
-
-    /**
-     * Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found.
-     */
-    public void setMatchOnUriPrefix(Boolean matchOnUriPrefix) {
-        this.matchOnUriPrefix = matchOnUriPrefix;
-    }
-
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
-        return headerFilterStrategy;
-    }
-
-    /**
-     * To use a custom HeaderFilterStrategy to filter header to and from Camel message.
-     */
-    public void setHeaderFilterStrategy(HeaderFilterStrategy headerFilterStrategy) {
-        this.headerFilterStrategy = headerFilterStrategy;
-    }
-
     public SSLContextParameters getSslContextParameters() {
         return sslContextParameters;
     }
@@ -195,36 +137,12 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
         this.sslContextParameters = sslContextParameters;
     }
 
-    public Boolean getThrowExceptionOnFailure() {
-        return throwExceptionOnFailure;
-    }
-
-    /**
-     * If the option is true, HttpProducer will ignore the Exchange.HTTP_URI header, and use the endpoint's URI for request.
-     * You may also set the option throwExceptionOnFailure to be false to let the producer send all the fault response back.
-     */
-    public void setThrowExceptionOnFailure(Boolean throwExceptionOnFailure) {
-        this.throwExceptionOnFailure = throwExceptionOnFailure;
-    }
-
-    public Boolean getTransferException() {
-        return transferException;
-    }
-
-    /**
-     * Option to disable throwing the HttpOperationFailedException in case of failed responses from the remote server.
-     * This allows you to get all responses regardless of the HTTP status code.
-     */
-    public void setTransferException(Boolean transferException) {
-        this.transferException = transferException;
-    }
-
     public UndertowHttpBinding getUndertowHttpBinding() {
         if (undertowHttpBinding == null) {
             // create a new binding and use the options from this endpoint
             undertowHttpBinding = new DefaultUndertowHttpBinding();
             undertowHttpBinding.setHeaderFilterStrategy(getHeaderFilterStrategy());
-            undertowHttpBinding.setTransferException(getTransferException());
+            undertowHttpBinding.setTransferException(isTransferException());
         }
         return undertowHttpBinding;
     }
@@ -279,28 +197,6 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
      */
     public void setOptions(Map<String, Object> options) {
         this.options = options;
-    }
-
-    public boolean isOptionsEnabled() {
-        return optionsEnabled;
-    }
-
-    /**
-     * Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off.
-     */
-    public void setOptionsEnabled(boolean optionsEnabled) {
-        this.optionsEnabled = optionsEnabled;
-    }
-
-    public CookieHandler getCookieHandler() {
-        return cookieHandler;
-    }
-
-    /**
-     * Configure a cookie handler to maintain a HTTP session
-     */
-    public void setCookieHandler(CookieHandler cookieHandler) {
-        this.cookieHandler = cookieHandler;
     }
 
     @Override

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
@@ -48,7 +48,7 @@ public final class UndertowHelper {
         // rest producer may provide an override url to be used which we should discard if using (hence the remove)
         String uri = (String) exchange.getIn().removeHeader(Exchange.REST_HTTP_URI);
         if (uri == null) {
-            uri = endpoint.getHttpURI().toASCIIString();
+            uri = endpoint.getHttpUri().toASCIIString();
         }
 
         // resolve placeholders in uri
@@ -98,7 +98,7 @@ public final class UndertowHelper {
             queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
         }
         if (queryString == null) {
-            queryString = endpoint.getHttpURI().getRawQuery();
+            queryString = endpoint.getHttpUri().getRawQuery();
         }
         // We should user the query string from the HTTP_URI header
         if (queryString == null) {
@@ -117,7 +117,9 @@ public final class UndertowHelper {
             Object existing = headers.get(key);
             List<Object> list;
             if (existing instanceof List) {
-                list = (List<Object>) existing;
+                @SuppressWarnings("unchecked")
+                final List<Object> tmp = (List<Object>) existing;
+                list = tmp;
             } else {
                 list = new ArrayList<Object>();
                 list.add(existing);
@@ -149,7 +151,7 @@ public final class UndertowHelper {
             queryString = uri.getQuery();
         }
         if (queryString == null) {
-            queryString = endpoint.getHttpURI().getRawQuery();
+            queryString = endpoint.getHttpUri().getRawQuery();
         }
 
         // compute what method to use either GET or POST

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowConsumerSendChunkedResponseTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowConsumerSendChunkedResponseTest.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UndertowConsumerSendChunkedResponseTest extends BaseUndertowTest {
+
+    private final class DummyInputStream extends InputStream {
+        int c;
+
+        @Override
+        public int read() throws IOException {
+            if (c < TRANSFER_SIZE) {
+                return Math.abs(c++) % 255;
+            } else {
+                return -1;
+            }
+        }
+    }
+
+    static final int BUFFER_SIZE = 8192;
+
+    static final int TRANSFER_SIZE = BUFFER_SIZE * 2 + BUFFER_SIZE / 2;
+
+    private byte[] expected;
+
+    @Before
+    public void calculateExpectedDigest() throws NoSuchAlgorithmException, IOException {
+        MessageDigest digest = MessageDigest.getInstance("SHA1");
+
+        int read = -1;
+        byte[] buffy = new byte[64 * 1024];
+
+        try (InputStream in = new DummyInputStream()) {
+            while ((read = in.read(buffy)) != -1) {
+                digest.update(buffy, 0, read);
+            }
+        }
+
+        expected = digest.digest();
+    }
+
+    @Test
+    public void shouldTransferInChunks() throws IOException, NoSuchAlgorithmException {
+        int chunkLength = 0;
+        int sumChunkLength = 0;
+
+        MessageDigest received = MessageDigest.getInstance("SHA1");
+
+        try (Socket socket = new Socket("localhost", getPort());
+                OutputStream out = socket.getOutputStream();
+                InputStream in = socket.getInputStream()) {
+            out.write("GET /chunked HTTP/1.1\r\n\r\n".getBytes());
+
+            int read = -1;
+            while ((read = in.read()) != -1) {
+                if (read == '\r' && in.read() == '\n' && in.read() == '\r' && in.read() == '\n') {
+                    // we have reached end of headers
+                    break;
+                }
+            }
+
+            int data;
+            while ((data = in.read()) != -1) {
+                if (Character.isDigit(data)) {
+                    chunkLength = chunkLength * 16 + Character.digit(data, 16);
+                    // still reading chunk length
+                    continue;
+                } else {
+                    sumChunkLength += chunkLength;
+                }
+
+                if (chunkLength == 0) {
+                    break;
+                }
+
+                // read the '\n', '\r' was read by the while loop condition and it did not pass isDigit test
+                assertEquals("The last byte between two chunks should be `\\n`", '\n', in.read());
+
+                byte[] buffy = new byte[chunkLength];
+                chunkLength = 0;
+
+                read = in.read(buffy);
+                assertEquals("Should have read the chunk size", '\r', chunkLength, read);
+
+                received.update(buffy);
+
+                assertEquals("The second to last byte at the end of the chunk should be `\\r`", '\r', in.read());
+                assertEquals("The last byte at the end of the chunk should be `\\n`", '\n', in.read());
+            }
+        }
+
+        assertEquals("Sum of all chunks should be the transfered length", TRANSFER_SIZE, sumChunkLength);
+        assertEquals("The very last chunk should be 0-length", 0, chunkLength);
+        assertArrayEquals("The digest of transfered bytes should be as expected", expected, received.digest());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("undertow:http://localhost:{{port}}/chunked?chunked=true").process(new Processor() {
+                    @Override
+                    public void process(final Exchange exchange) throws Exception {
+                        exchange.getIn().setBody(new BufferedInputStream(new DummyInputStream(), BUFFER_SIZE));
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpProducerTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpProducerTest.java
@@ -18,13 +18,17 @@ package org.apache.camel.component.undertow;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
 
 public class UndertowHttpProducerTest extends BaseUndertowTest {
 
     @Test
     public void testHttpSimple() throws Exception {
-        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+        final MockEndpoint mock = getMockEndpoint("mock:input");
+
+        mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+        mock.expectedHeaderReceived("Host", "localhost:" + getPort());
 
         String out = template.requestBody("http://localhost:{{port}}/foo", null, String.class);
         assertEquals("Bye World", out);
@@ -34,7 +38,10 @@ public class UndertowHttpProducerTest extends BaseUndertowTest {
 
     @Test
     public void testHttpSimpleHeader() throws Exception {
-        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+        final MockEndpoint mock = getMockEndpoint("mock:input");
+
+        mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+        mock.expectedHeaderReceived("Host", "localhost:" + getPort());
 
         String out = template.requestBodyAndHeader("http://localhost:{{port}}/foo", null, Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);
@@ -44,9 +51,11 @@ public class UndertowHttpProducerTest extends BaseUndertowTest {
 
     @Test
     public void testHttpSimpleHeaderAndBody() throws Exception {
+        final MockEndpoint mock = getMockEndpoint("mock:input");
 
-        getMockEndpoint("mock:input").expectedBodiesReceived("Hello World");
-        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+        mock.expectedBodiesReceived("Hello World");
+        mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+        mock.expectedHeaderReceived("Host", "localhost:" + getPort());
 
         String out = template.requestBodyAndHeader("http://localhost:{{port}}/foo", "Hello World", Exchange.HTTP_METHOD, "POST", String.class);
         assertEquals("Bye World", out);

--- a/platforms/spring-boot/components-starter/camel-undertow-starter/src/main/java/org/apache/camel/component/undertow/springboot/UndertowComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-undertow-starter/src/main/java/org/apache/camel/component/undertow/springboot/UndertowComponentConfiguration.java
@@ -17,6 +17,9 @@
 package org.apache.camel.component.undertow.springboot;
 
 import org.apache.camel.component.undertow.UndertowHttpBinding;
+import org.apache.camel.http.common.HttpBinding;
+import org.apache.camel.http.common.HttpConfiguration;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.util.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -45,6 +48,31 @@ public class UndertowComponentConfiguration {
      * To configure common options such as thread pools
      */
     private UndertowHostOptionsNestedConfiguration hostOptions;
+    /**
+     * To use a custom HttpBinding to control the mapping between Camel message
+     * and HttpClient.
+     */
+    @NestedConfigurationProperty
+    private HttpBinding httpBinding;
+    /**
+     * To use the shared HttpConfiguration as base configuration.
+     */
+    @NestedConfigurationProperty
+    private HttpConfiguration httpConfiguration;
+    /**
+     * Whether to allow java serialization when a request uses
+     * context-type=application/x-java-serialized-object. This is by default
+     * turned off. If you enable this then be aware that Java will deserialize
+     * the incoming data from the request to Java and that can be a potential
+     * security risk.
+     */
+    private Boolean allowJavaSerializedObject = false;
+    /**
+     * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
+     * header to and from Camel message.
+     */
+    @NestedConfigurationProperty
+    private HeaderFilterStrategy headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -76,6 +104,39 @@ public class UndertowComponentConfiguration {
     public void setHostOptions(
             UndertowHostOptionsNestedConfiguration hostOptions) {
         this.hostOptions = hostOptions;
+    }
+
+    public HttpBinding getHttpBinding() {
+        return httpBinding;
+    }
+
+    public void setHttpBinding(HttpBinding httpBinding) {
+        this.httpBinding = httpBinding;
+    }
+
+    public HttpConfiguration getHttpConfiguration() {
+        return httpConfiguration;
+    }
+
+    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+        this.httpConfiguration = httpConfiguration;
+    }
+
+    public Boolean getAllowJavaSerializedObject() {
+        return allowJavaSerializedObject;
+    }
+
+    public void setAllowJavaSerializedObject(Boolean allowJavaSerializedObject) {
+        this.allowJavaSerializedObject = allowJavaSerializedObject;
+    }
+
+    public HeaderFilterStrategy getHeaderFilterStrategy() {
+        return headerFilterStrategy;
+    }
+
+    public void setHeaderFilterStrategy(
+            HeaderFilterStrategy headerFilterStrategy) {
+        this.headerFilterStrategy = headerFilterStrategy;
     }
 
     public Boolean getResolvePropertyPlaceholders() {


### PR DESCRIPTION
# Please don't merge

I would like some feedback on this first. Still to do:
- [x] Make `UndertowComponent` and `UndertowEndpoint` extend `HttpCommonComponent` and `HttpCommonEndpoint`
- [ ] Implement support for options from `http-common` component
   - [x] `chunked`
   - [ ] `disableStreamCache`
   - [ ] `proxyHost`
   - [ ] `proxyPort`
   - [ ] `authMethodPriority`
   - [ ] `connectionClose`
   - [ ] `traceEnabled`
   - [ ] `responseBufferSize`
   - [ ] `ignoreResponseBody`
   - [ ] `copyHeaders`
   - [ ] `eagerCheckContentAvailable`
   - [ ] `mapHttpMessageBody`
   - [ ] `mapHttpMessageHeaders`
   - [ ] `mapHttpMessageFormUrlEncodedBody`
   - [ ] `okStatusCodeRange`
   - [ ] `urlRewrite`
   - [ ] `async` (though Undertow is heavily async, so may be ignored)
