### PR TITLE
CAMEL-10607

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfProducer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfProducer.java
@@ -327,6 +327,9 @@ public class CxfProducer extends DefaultProducer implements AsyncProcessor {
         Object[] params = null;
         if (endpoint.getDataFormat() == DataFormat.POJO) {
             Object body = exchange.getIn().getBody();
+            if (body == null) {
+                return new Object[0];
+            }
             if (body instanceof Object[]) {
                 params = (Object[])body;
             } else if (body instanceof List) {

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/noparam/NoParamEndpoint.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/noparam/NoParamEndpoint.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cxf.noparam;
+
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WebService
+public class NoParamEndpoint {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NoParamEndpoint.class);
+
+    @WebMethod
+    public String noParamOperation() {
+        LOG.info("Processing no param");
+        return "Hello World!";
+    }
+
+}

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/noparam/NoParamTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/noparam/NoParamTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cxf.noparam;
+
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.component.cxf.CXFTestSupport;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class NoParamTest extends CamelSpringTestSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoParamTest.class);
+    @BeforeClass
+    public static void loadTestSupport() {
+        // Need to load the static class first
+        CXFTestSupport.getPort1();
+    }
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/component/cxf/noparam/camel-route.xml");
+    }
+
+    @Test
+    public void testNullBodoy() throws Exception {
+        Object body = template.sendBody("direct:noParam", ExchangePattern.InOut, null);
+        LOGGER.error(body.toString());
+    }
+
+}

--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/noparam/camel-cxf.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/noparam/camel-cxf.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cxf="http://camel.apache.org/schema/cxf" xmlns:jaxws="http://cxf.apache.org/jaxws"
+	xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd
+         http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd">
+
+	<import resource="classpath:META-INF/cxf/cxf.xml" />
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+
+	<!-- The camel CXF endpoint -->
+	<cxf:cxfEndpoint id="noParamEndpoint" address="http://localhost:${CXFTestSupport.port1}/camel-noparam/" serviceClass="org.apache.camel.component.cxf.noparam.NoParamEndpoint" />
+
+	<!-- JAX-WS endpoint of the same class -->
+	<jaxws:endpoint id="noParamEndpointCXF" address="http://localhost:${CXFTestSupport.port1}/cxf-noparam/" implementor="org.apache.camel.component.cxf.noparam.NoParamEndpoint" />
+
+</beans>

--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/noparam/camel-route.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/noparam/camel-route.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
+	distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under 
+	the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
+	obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+	in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+	ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+	the License. -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:camel="http://camel.apache.org/schema/spring"
+	xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+	<import resource="classpath:org/apache/camel/component/cxf/noparam/camel-cxf.xml" />
+
+	<camelContext xmlns="http://camel.apache.org/schema/spring">
+
+		<route>
+			<!-- route starts from the cxf webservice, see camel-cxf.xml for details -->
+			<from uri="cxf:bean:noParamEndpoint" />
+			<!-- and then create the OK reply for the webservice which is still waiting for a reply -->
+			<transform>
+				<constant>OK</constant>
+			</transform>
+			<to uri="mock:end" />
+		</route>
+
+		<route>
+			<from uri="direct:noParam"/>
+			<to uri="cxf:bean:noParamEndpoint"/>
+		</route>
+	</camelContext>
+
+</beans>


### PR DESCRIPTION
I think getParams should return empty array when body is null.
This solves https://issues.apache.org/jira/browse/CAMEL-10607