### PR TITLE
CAMEL-10759 Inline multi-value rabbitmq args in URI

### DIFF
--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -89,7 +89,7 @@ The RabbitMQ component supports 60 endpoint options which are listed below:
 | publisherAcknowledgements | producer | false | boolean | When true the message will be published with publisher acknowledgements turned on
 | publisherAcknowledgementsTimeout | producer |  | long | The amount of time in milliseconds to wait for a basic.ack response from RabbitMQ server
 | addresses | advanced |  | Address[] | If this option is set camel-rabbitmq will try to create connection based on the setting of option addresses. The addresses value is a string which looks like server1:12345 server2:12345
-| args | advanced |  | Map | Specify arguments for configuring the different RabbitMQ concepts a different prefix is required for each: Queue: arg.queue. Exchange: arg.exchange. Binding: arg.binding. For example to declare a queue with message ttl argument: http://localhost:5672/exchange/queueargs=arg.queue.x-message-ttl=60000
+| args | advanced |  | Map | Specify arguments for configuring the different RabbitMQ concepts a different prefix is required for each: Exchange: arg.exchange. Queue: arg.queue. Binding: arg.binding. For example to declare a queue with message ttl argument: http://localhost:5672/exchange/queueargs=arg.queue.x-message-ttl=60000
 | automaticRecoveryEnabled | advanced |  | Boolean | Enables connection automatic recovery (uses connection implementation that performs automatic recovery when connection shutdown is not initiated by the application)
 | bindingArgs | advanced |  | Map | Key/value args for configuring the queue binding parameters when declare=true
 | clientProperties | advanced |  | Map | Connection client properties (client info used in negotiating with the server)

--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -45,7 +45,7 @@ The RabbitMQ component has no options.
 
 
 // endpoint options: START
-The RabbitMQ component supports 59 endpoint options which are listed below:
+The RabbitMQ component supports 60 endpoint options which are listed below:
 
 {% raw %}
 [width="100%",cols="2,1,1m,1m,5",options="header"]
@@ -89,6 +89,7 @@ The RabbitMQ component supports 59 endpoint options which are listed below:
 | publisherAcknowledgements | producer | false | boolean | When true the message will be published with publisher acknowledgements turned on
 | publisherAcknowledgementsTimeout | producer |  | long | The amount of time in milliseconds to wait for a basic.ack response from RabbitMQ server
 | addresses | advanced |  | Address[] | If this option is set camel-rabbitmq will try to create connection based on the setting of option addresses. The addresses value is a string which looks like server1:12345 server2:12345
+| args | advanced |  | Map | Specify arguments for configuring the different RabbitMQ concepts a different prefix is required for each: Queue: arg.queue. Exchange: arg.exchange. Binding: arg.binding. For example to declare a queue with message ttl argument: http://localhost:5672/exchange/queueargs=arg.queue.x-message-ttl=60000
 | automaticRecoveryEnabled | advanced |  | Boolean | Enables connection automatic recovery (uses connection implementation that performs automatic recovery when connection shutdown is not initiated by the application)
 | bindingArgs | advanced |  | Map | Key/value args for configuring the queue binding parameters when declare=true
 | clientProperties | advanced |  | Map | Connection client properties (client info used in negotiating with the server)

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQComponent.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQComponent.java
@@ -17,18 +17,24 @@
 package org.apache.camel.component.rabbitmq;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
-
 import javax.net.ssl.TrustManager;
 
 import com.rabbitmq.client.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.UriEndpointComponent;
+import org.apache.camel.util.IntrospectionSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RabbitMQComponent extends UriEndpointComponent {
+
+    public static final String ARG_PREFIX = "arg.";
+    public static final String EXCHANGE_ARG_PREFIX = "exchange.";
+    public static final String QUEUE_ARG_PREFIX = "queue.";
+    public static final String BINDING_ARG_PREFIX = "binding.";
 
     private static final Logger LOG = LoggerFactory.getLogger(RabbitMQComponent.class);
 
@@ -74,6 +80,17 @@ public class RabbitMQComponent extends UriEndpointComponent {
             LOG.debug("Creating RabbitMQEndpoint with host {}:{} and exchangeName: {}",
                     new Object[]{endpoint.getHostname(), endpoint.getPortNumber(), endpoint.getExchangeName()});
         }
+
+        HashMap<String, Object> args = new HashMap<>();
+        args.putAll(IntrospectionSupport.extractProperties(params, ARG_PREFIX));
+        endpoint.setArgs(args);
+
+        HashMap<String, Object> argsCopy = new HashMap<>(args);
+        
+        // Combine the three types of rabbit arguments with their individual endpoint properties
+        endpoint.getExchangeArgs().putAll(IntrospectionSupport.extractProperties(argsCopy, EXCHANGE_ARG_PREFIX));
+        endpoint.getQueueArgs().putAll(IntrospectionSupport.extractProperties(argsCopy, QUEUE_ARG_PREFIX));
+        endpoint.getBindingArgs().putAll(IntrospectionSupport.extractProperties(argsCopy, BINDING_ARG_PREFIX));
 
         return endpoint;
     }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -50,7 +50,7 @@ import org.apache.camel.spi.UriPath;
  * The rabbitmq component allows you produce and consume messages from <a href="http://www.rabbitmq.com/">RabbitMQ</a> instances.
  */
 @UriEndpoint(firstVersion = "2.12.0", scheme = "rabbitmq", title = "RabbitMQ", syntax = "rabbitmq:hostname:portNumber/exchangeName",
-        consumerClass = RabbitMQConsumer.class, label = "messaging", lenientProperties = true)
+        consumerClass = RabbitMQConsumer.class, label = "messaging")
 public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     // header to indicate that the message body needs to be de-serialized
     public static final String SERIALIZE_HEADER = "CamelSerialize";
@@ -942,10 +942,5 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     public void setExclusive(boolean exclusive) {
         this.exclusive = exclusive;
     }
-
-    public boolean isLenientProperties() {
-        // true to allow dynamic URI options to be configured
-        return true;
-    }
-
+   
 }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -49,7 +49,8 @@ import org.apache.camel.spi.UriPath;
 /**
  * The rabbitmq component allows you produce and consume messages from <a href="http://www.rabbitmq.com/">RabbitMQ</a> instances.
  */
-@UriEndpoint(firstVersion = "2.12.0", scheme = "rabbitmq", title = "RabbitMQ", syntax = "rabbitmq:hostname:portNumber/exchangeName", consumerClass = RabbitMQConsumer.class, label = "messaging")
+@UriEndpoint(firstVersion = "2.12.0", scheme = "rabbitmq", title = "RabbitMQ", syntax = "rabbitmq:hostname:portNumber/exchangeName",
+        consumerClass = RabbitMQConsumer.class, label = "messaging", lenientProperties = true)
 public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     // header to indicate that the message body needs to be de-serialized
     public static final String SERIALIZE_HEADER = "CamelSerialize";
@@ -148,6 +149,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     private Map<String, Object> queueArgs = new HashMap<>();
     @UriParam(label = "advanced")
     private Map<String, Object> bindingArgs = new HashMap<>();
+    @UriParam(label = "advanced", prefix = "arg.", multiValue = true)
+    private Map<String, Object> args;
     @UriParam(label = "advanced")
     private ArgsConfigurer queueArgsConfigurer;
     @UriParam(label = "advanced")
@@ -794,6 +797,27 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
         return bindingArgs;
     }
 
+    /**
+     * Specify arguments for configuring the different RabbitMQ concepts, a different prefix is
+     * required for each:
+     * <ul>
+     *     <li>Queue: arg.queue.</li>
+     *     <li>Exchange: arg.exchange.</li>
+     *     <li>Binding: arg.binding.</li>
+     * </ul>
+     * For example to declare a queue with message ttl argument:
+     *
+     * http://localhost:5672/exchange/queue?args=arg.queue.x-message-ttl=60000
+     *
+     */
+    public void setArgs(Map<String, Object> args) {
+        this.args = args;
+    }
+
+    public Map<String, Object> getArgs() {
+        return args;
+    }
+
     public ArgsConfigurer getQueueArgsConfigurer() {
         return queueArgsConfigurer;
     }
@@ -917,6 +941,11 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
      */
     public void setExclusive(boolean exclusive) {
         this.exclusive = exclusive;
+    }
+
+    public boolean isLenientProperties() {
+        // true to allow dynamic URI options to be configured
+        return true;
     }
 
 }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -143,17 +143,22 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     private boolean mandatory;
     @UriParam(label = "producer")
     private boolean immediate;
-    @UriParam(label = "advanced")
-    private Map<String, Object> exchangeArgs = new HashMap<>();
-    @UriParam(label = "advanced")
-    private Map<String, Object> queueArgs = new HashMap<>();
-    @UriParam(label = "advanced")
-    private Map<String, Object> bindingArgs = new HashMap<>();
     @UriParam(label = "advanced", prefix = "arg.", multiValue = true)
     private Map<String, Object> args;
     @UriParam(label = "advanced")
+    @Deprecated
+    private Map<String, Object> exchangeArgs = new HashMap<>();
+    @UriParam(label = "advanced")
+    @Deprecated
+    private Map<String, Object> queueArgs = new HashMap<>();
+    @UriParam(label = "advanced")
+    @Deprecated
+    private Map<String, Object> bindingArgs = new HashMap<>();
+    @UriParam(label = "advanced")
+    @Deprecated
     private ArgsConfigurer queueArgsConfigurer;
     @UriParam(label = "advanced")
+    @Deprecated
     private ArgsConfigurer exchangeArgsConfigurer;
     @UriParam(label = "advanced")
     private long requestTimeout = 20000;
@@ -765,44 +770,11 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     }
 
     /**
-     * Key/value args for configuring the exchange parameters when declare=true
-     */
-    public void setExchangeArgs(Map<String, Object> exchangeArgs) {
-        this.exchangeArgs = exchangeArgs;
-    }
-
-    public Map<String, Object> getExchangeArgs() {
-        return exchangeArgs;
-    }
-
-    /**
-     * Key/value args for configuring the queue parameters when declare=true
-     */
-    public void setQueueArgs(Map<String, Object> queueArgs) {
-        this.queueArgs = queueArgs;
-    }
-
-    public Map<String, Object> getQueueArgs() {
-        return queueArgs;
-    }
-
-    /**
-     * Key/value args for configuring the queue binding parameters when declare=true
-     */
-    public void setBindingArgs(Map<String, Object> bindingArgs) {
-        this.bindingArgs = bindingArgs;
-    }
-
-    public Map<String, Object> getBindingArgs() {
-        return bindingArgs;
-    }
-
-    /**
      * Specify arguments for configuring the different RabbitMQ concepts, a different prefix is
      * required for each:
      * <ul>
-     *     <li>Queue: arg.queue.</li>
      *     <li>Exchange: arg.exchange.</li>
+     *     <li>Queue: arg.queue.</li>
      *     <li>Binding: arg.binding.</li>
      * </ul>
      * For example to declare a queue with message ttl argument:
@@ -818,12 +790,54 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
         return args;
     }
 
+    /**
+     * Key/value args for configuring the exchange parameters when declare=true
+     *
+     * @Deprecated Use args instead e.g arg.exchange.x-message-ttl=1000
+     */
+    @Deprecated
+    public void setExchangeArgs(Map<String, Object> exchangeArgs) {
+        this.exchangeArgs = exchangeArgs;
+    }
+
+    public Map<String, Object> getExchangeArgs() {
+        return exchangeArgs;
+    }
+
+    /**
+     * Key/value args for configuring the queue parameters when declare=true
+     *
+     * @Deprecated Use args instead e.g arg.queue.x-message-ttl=1000
+     */
+    public void setQueueArgs(Map<String, Object> queueArgs) {
+        this.queueArgs = queueArgs;
+    }
+
+    public Map<String, Object> getQueueArgs() {
+        return queueArgs;
+    }
+
+    /**
+     * Key/value args for configuring the queue binding parameters when declare=true
+     *
+     * @Deprecated Use args instead e.g arg.binding.foo=bar
+     */
+    public void setBindingArgs(Map<String, Object> bindingArgs) {
+        this.bindingArgs = bindingArgs;
+    }
+
+    public Map<String, Object> getBindingArgs() {
+        return bindingArgs;
+    }
+
     public ArgsConfigurer getQueueArgsConfigurer() {
         return queueArgsConfigurer;
     }
 
     /**
      * Set the configurer for setting the queue args in Channel.queueDeclare
+     *
+     * @Deprecated Use args instead e.g arg.queue.x-message-ttl=1000
      */
     public void setQueueArgsConfigurer(ArgsConfigurer queueArgsConfigurer) {
         this.queueArgsConfigurer = queueArgsConfigurer;
@@ -835,6 +849,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
 
     /**
      * Set the configurer for setting the exchange args in Channel.exchangeDeclare
+     *
+     * @Deprecated Use args instead e.g arg.exchange.x-message-ttl=1000
      */
     public void setExchangeArgsConfigurer(ArgsConfigurer exchangeArgsConfigurer) {
         this.exchangeArgsConfigurer = exchangeArgsConfigurer;


### PR DESCRIPTION
Following discussion in PR #1425

- New inline multi-value map property 'args' on rabbitmq component for specifying rabbitmq args
- Combines all definition with the individually properties via setExchangeArgs, setQueueArgs & setBindingArgs
- Property args just delegates via it's three map prefixes: arg.exchange., arg.queue. & arg.binding.