### PR TITLE
[CAMEL-10840] CsvDataFormat.setRecordConverterRef not usable

### DIFF
--- a/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvRecordConverter.java
+++ b/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvRecordConverter.java
@@ -27,7 +27,7 @@ import org.apache.commons.csv.CSVRecord;
  * @param <T> Conversion type
  * @see org.apache.camel.dataformat.csv.CsvRecordConverters
  */
-interface CsvRecordConverter<T> {
+public interface CsvRecordConverter<T> {
     /**
      * Converts the CSV record into another type.
      *

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverterTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverterTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.camel.dataformat.csv;
 
 import java.util.Arrays;
@@ -26,11 +25,10 @@ import org.apache.camel.Message;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.apache.camel.util.CastUtils;
-
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.junit.Assert.*;
 
 /**
  * Test cases for {@link CsvRecordConverter}.

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverterTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverterTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dataformat.csv;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.camel.Message;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.apache.camel.util.CastUtils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Test cases for {@link CsvRecordConverter}.
+ */
+public class CsvDataFormatCustomRecordConverterTest extends CamelSpringTestSupport {
+
+    @Test
+    public void unmarshalTest() throws InterruptedException {
+        MockEndpoint mock = getMockEndpoint("mock:unmarshaled");
+        mock.expectedMessageCount(1);
+        template.sendBody("direct:unmarshal", getData());
+        mock.assertIsSatisfied();
+        Message message = mock.getReceivedExchanges().get(0).getIn();
+        List<List<String>> body = CastUtils.cast((List)message.getBody());
+        assertNotNull(body);
+        assertEquals(body.size(), 1);
+        List<String> row = body.get(0);
+        assertEquals(row.size(), 3);
+        assertEquals(row.toString(), "[Hello, Again, Democracy]");
+    }
+
+    private String getData() {
+        return Stream.of("A1", "B1", "C1").collect(Collectors.joining(";"));
+    }
+
+    @Override
+    protected ClassPathXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext(
+                                                  "org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverter.xml");
+    }
+}

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/converter/MyCvsRecordConverter.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/converter/MyCvsRecordConverter.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.dataformat.csv.converter;
 
 import java.util.Arrays;

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/converter/MyCvsRecordConverter.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/converter/MyCvsRecordConverter.java
@@ -1,0 +1,30 @@
+package org.apache.camel.dataformat.csv.converter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.camel.dataformat.csv.CsvRecordConverter;
+import org.apache.commons.csv.CSVRecord;
+
+/**
+ * Test {@link CsvRecordConverter} implementation.
+ * <p>
+ * This implementation is explicitely created in a subpackage to check the
+ * visibility of {@link CsvRecordConverter}.
+ * </p>
+ */
+public class MyCvsRecordConverter implements CsvRecordConverter<List<String>> {
+
+    private final String[] record;
+
+    public MyCvsRecordConverter(String... record) {
+        assert record != null : "Unspecified record";
+        this.record = record;
+    }
+
+    @Override
+    public List<String> convertRecord(CSVRecord record) {
+        assert record != null : "Unspecified record";
+        return Arrays.asList(this.record);
+    }
+}

--- a/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverter.xml
+++ b/components/camel-csv/src/test/resources/org/apache/camel/dataformat/csv/CsvDataFormatCustomRecordConverter.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+	<bean id="record-converter" class="org.apache.camel.dataformat.csv.converter.MyCvsRecordConverter">
+		<constructor-arg>
+			<array>
+				<value>Hello</value>
+				<value>Again</value>
+				<value>Democracy</value>
+			</array>
+		</constructor-arg>
+	</bean>
+
+	<camelContext id="csvCamelContext" xmlns="http://camel.apache.org/schema/spring">
+		<route>
+			<from uri="direct:unmarshal" />
+			<unmarshal>
+				<csv recordConverterRef="record-converter" delimiter=";" headerDisabled="true" />
+			</unmarshal>
+			<to uri="mock:unmarshaled" />
+		</route>
+	</camelContext>
+
+</beans>


### PR DESCRIPTION
Sorry, something went wrong with line breaks (**GitHub** is thinking that the whole file `CsvRecordConverter.java` has changed). The only relevant change is the *public* keyword added to the interface.