### PR TITLE
CAMEL-10396: Corrected a bug where BeanInfo was missing a method overload

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -1327,6 +1327,15 @@ public final class ObjectHelper {
      * @return <tt>true</tt> if it override, <tt>false</tt> otherwise
      */
     public static boolean isOverridingMethod(Method source, Method target, boolean exact) {
+
+        if (source.equals(target)) {
+            return true;
+        } else if (source.getDeclaringClass() == target.getDeclaringClass()) {
+            return false;
+        } else if (!source.getDeclaringClass().isAssignableFrom(target.getDeclaringClass())) {
+            return false;
+        }
+
         if (!source.getName().equals(target.getName())) {
             return false;
         }

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import org.apache.camel.ContextTestSupport;
+import org.junit.Assert;
+
+/**
+ * @version
+ */
+public class BeanInfoOverloadedWithSubTypeParamTest extends ContextTestSupport {
+
+    public void testBeanInfoOverloadedWithSubTypedParam() {
+        BeanInfo beanInfo = new BeanInfo(context, Bean.class);
+        Assert.assertEquals(3, beanInfo.getMethods().size());
+    }
+
+    class Bean {
+        public void doSomething(RequestA request) {
+        }
+
+        public void doSomething(RequestB request) {
+        }
+
+        public void doSomething(RequestC request) {
+        }
+    }
+
+    class RequestA {
+    }
+
+    class RequestB {
+    }
+
+    class RequestC extends RequestB {
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
@@ -26,21 +26,16 @@ public class BeanInfoOverloadedWithSubTypeParamTest extends ContextTestSupport {
 
     public void testBeanInfoOverloadedWithSubTypedParam() {
         BeanInfo beanInfo = new BeanInfo(context, Bean.class);
-        Assert.assertEquals(3, beanInfo.getMethods().size());
+        Assert.assertEquals(2, beanInfo.getMethods().size());
     }
 
     class Bean {
-        public void doSomething(RequestA request) {
-        }
 
         public void doSomething(RequestB request) {
         }
 
         public void doSomething(RequestC request) {
         }
-    }
-
-    class RequestA {
     }
 
     class RequestB {

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanOverloadsWithAssignableParamTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanOverloadsWithAssignableParamTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+public class BeanOverloadsWithAssignableParamTest extends ContextTestSupport {
+
+    public void testToStringWithStringParam() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:stringParamResult");
+        mock.expectedBodiesReceived("toString(String) was called");
+        template.sendBody("direct:stringParam", "");
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:stringParam").bean(new MyOtherFooBean(), "toString(String)").to("mock:stringParamResult");
+            }
+        };
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/component/bean/MyOtherFooBean.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/MyOtherFooBean.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.component.bean;
 
-/**
- * @version 
- */
 public class MyOtherFooBean {
 
     public String echo(String s) {
@@ -27,5 +24,13 @@ public class MyOtherFooBean {
 
     public Integer echo(Integer i) {
         return i.intValue() * i.intValue();
+    }
+
+    public String toString(Object input) {
+        return "toString(Object) was called";
+    }
+
+    public String toString(String input) {
+        return "toString(String) was called";
     }
 }

--- a/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
@@ -37,6 +37,7 @@ import junit.framework.TestCase;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.bean.MyOtherFooBean;
 import org.apache.camel.component.bean.MyStaticClass;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultMessage;
@@ -865,5 +866,28 @@ public class ObjectHelperTest extends TestCase {
         } catch (IllegalArgumentException iae) {
             assertEquals("expected2 must be specified on: holder", iae.getMessage());
         }
+    }
+
+    public void testSameMethodIsOverride() throws Exception {
+        Method m = MyOtherFooBean.class.getMethod("toString", Object.class);
+        assertTrue(ObjectHelper.isOverridingMethod(m, m, false));
+    }
+
+    public void testOverloadIsNotOverride() throws Exception {
+        Method m1 = MyOtherFooBean.class.getMethod("toString", Object.class);
+        Method m2 = MyOtherFooBean.class.getMethod("toString", String.class);
+        assertFalse(ObjectHelper.isOverridingMethod(m2, m1, false));
+    }
+
+    public void testOverrideEquivalentSignatureFromSiblingClassIsNotOverride() throws Exception {
+        Method m1 = Double.class.getMethod("intValue");
+        Method m2 = Float.class.getMethod("intValue");
+        assertFalse(ObjectHelper.isOverridingMethod(m2, m1, false));
+    }
+
+    public void testOverrideEquivalentSignatureFromUpperClassIsOverride() throws Exception {
+        Method m1 = Double.class.getMethod("intValue");
+        Method m2 = Number.class.getMethod("intValue");
+        assertTrue(ObjectHelper.isOverridingMethod(m2, m1, false));
     }
 }


### PR DESCRIPTION
Actually the `toString(String)` overload was confused by `BeanInfo` to be an override of `toString(Object).`
Now both methods are available to the overload selection mechanism.
Could you please have a look at this PR ?

  Note that I may have discovered another issue in the overload selection mechanism where I can't select `toString(Object).` I need to qualify that a bit more and may open another ticket if needed.