### PR TITLE
CAMEL-10883: Support HTTP 1.1 continue in Undertow

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -378,7 +378,7 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
         return body;
     }
 
-    private byte[] readFromChannel(StreamSourceChannel source) throws IOException {
+    byte[] readFromChannel(StreamSourceChannel source) throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final ByteBuffer buffer = ByteBuffer.wrap(new byte[1024]);
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -408,7 +408,6 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
                     }
                 });
                 source.resumeReads();
-                return out.toByteArray();
             } else {
                 buffer.flip();
                 out.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.arrayOffset() + buffer.limit());

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.undertow;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import io.undertow.Handlers;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.form.EagerFormParsingHandler;
@@ -77,8 +78,10 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
     }
 
     public HttpHandler getHttpHandler() {
-        // wrap with EagerFormParsingHandler to enable undertow form parsers
-        return new EagerFormParsingHandler().setNext(this);
+        // allow for HTTP 1.1 continue
+        return Handlers.httpContinueRead(
+                // wrap with EagerFormParsingHandler to enable undertow form parsers
+                new EagerFormParsingHandler().setNext(this));
     }
 
     @Override

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
@@ -1,0 +1,65 @@
+package org.apache.camel.component.undertow;
+
+import org.junit.Test;
+import org.xnio.XnioIoThread;
+import org.xnio.channels.EmptyStreamSourceChannel;
+import org.xnio.channels.StreamSourceChannel;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class DefaultUndertowHttpBindingTest {
+
+    @Test
+    public void readEntireDelayedPayload() throws Exception {
+        byte[] delayedPayload = "first ".getBytes();
+
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        StreamSourceChannel source = new EmptyStreamSourceChannel(
+                new XnioIoThread(null, 0) {
+                    @Override
+                    public void execute(Runnable runnable) {
+                        executor.execute(runnable);
+                    }
+
+                    @Override
+                    public Key executeAfter(Runnable runnable, long l, TimeUnit timeUnit) {
+                        execute(runnable);
+                        return null;
+                    }
+
+                    @Override
+                    public Key executeAtInterval(Runnable runnable, long l, TimeUnit timeUnit) {
+                        execute(runnable);
+                        return null;
+                    }
+                }) {
+            int chunk = 0;
+
+            @Override
+            public int read(ByteBuffer dst) throws IOException {
+                switch (chunk) {
+                    case 0:
+                        chunk++;
+                        return 0;
+                    case 1:
+                        dst.put(delayedPayload);
+                        chunk++;
+                        return 6;
+                }
+                return -1;
+            }
+        };
+
+        DefaultUndertowHttpBinding binding = new DefaultUndertowHttpBinding();
+        byte[] result = binding.readFromChannel(source);
+
+        assertThat(result, is(delayedPayload));
+    }
+}

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
@@ -1,9 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.undertow;
-
-import org.junit.Test;
-import org.xnio.XnioIoThread;
-import org.xnio.channels.EmptyStreamSourceChannel;
-import org.xnio.channels.StreamSourceChannel;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -12,6 +23,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.xnio.XnioIoThread;
+import org.xnio.channels.EmptyStreamSourceChannel;
+import org.xnio.channels.StreamSourceChannel;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -22,8 +38,8 @@ public class DefaultUndertowHttpBindingTest {
     @Test(timeout = 1000)
     public void readEntireDelayedPayload() throws Exception {
         String[] delayedPayloads = new String[] {
-                "",
-                "chunk",
+            "",
+            "chunk",
         };
 
         StreamSourceChannel source = source(delayedPayloads);
@@ -37,9 +53,9 @@ public class DefaultUndertowHttpBindingTest {
     @Test(timeout = 1000)
     public void readEntireMultiDelayedPayload() throws Exception {
         String[] delayedPayloads = new String[] {
-                "",
-                "first ",
-                "second",
+            "",
+            "first ",
+            "second",
         };
 
         StreamSourceChannel source = source(delayedPayloads);
@@ -59,10 +75,10 @@ public class DefaultUndertowHttpBindingTest {
     @Test(timeout = 1000)
     public void readEntireMultiDelayedWithPausePayload() throws Exception {
         String[] delayedPayloads = new String[] {
-                "",
-                "first ",
-                "",
-                "second",
+            "",
+            "first ",
+            "",
+            "second",
         };
 
         StreamSourceChannel source = source(delayedPayloads);
@@ -77,8 +93,8 @@ public class DefaultUndertowHttpBindingTest {
         Thread sourceThread = Thread.currentThread();
 
         return new EmptyStreamSourceChannel(thread()) {
-            int chunk = 0;
-            boolean mustWait = false;  // make sure that the caller is not spinning on read==0
+            int chunk;
+            boolean mustWait;  // make sure that the caller is not spinning on read==0
 
             @Override
             public int read(ByteBuffer dst) throws IOException {

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
@@ -49,11 +49,28 @@ public class DefaultUndertowHttpBindingTest {
                         .collect(Collectors.joining())));
     }
 
+    @Test(timeout = 1000)
+    public void readEntireMultiDelayedWithPausePayload() throws Exception {
+        String[] delayedPayloads = new String[] {
+                "first ",
+                "",
+                "second",
+        };
+
+        StreamSourceChannel source = source(delayedPayloads);
+
+        DefaultUndertowHttpBinding binding = new DefaultUndertowHttpBinding();
+        String result = new String(binding.readFromChannel(source));
+
+        assertThat(result, is(
+                Stream.of(delayedPayloads)
+                        .collect(Collectors.joining())));
+    }
+
     private StreamSourceChannel source(final String[] delayedPayloads) {
-        XnioIoThread thread = thread();
         Thread sourceThread = Thread.currentThread();
 
-        return new EmptyStreamSourceChannel(thread) {
+        return new EmptyStreamSourceChannel(thread()) {
             int chunk = 0;
 
             @Override

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/DefaultUndertowHttpBindingTest.java
@@ -87,6 +87,16 @@ public class DefaultUndertowHttpBindingTest {
                 }
                 return 0;
             }
+
+            @Override
+            public void resumeReads() {
+                /**
+                 * {@link io.undertow.server.HttpServerExchange.ReadDispatchChannel} delays resumes in the main thread
+                 */
+                if (sourceThread != Thread.currentThread()) {
+                    super.resumeReads();
+                }
+            }
         };
     }
 


### PR DESCRIPTION
Adding support for "continue" processing in Undertow is trivially done in UndertowConsumer.

However, the processing of delayed payloads could truncate the data - for me this happened reliably if the payload was more than 16KB. This has been replaced by a standard blocking channel which supports the processing expectations of Undertow's HttpServerExchange.