### PR TITLE
CAMEL-10874: Ensure Jetty client selector count is a minimum of 1.

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -724,7 +724,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent implements 
             return new HttpClientTransportOverHTTP();
         }
 
-        int selectors = Runtime.getRuntime().availableProcessors() / 2;
+        int selectors = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
 
         if (selectors >= maxThreads) {
             selectors = maxThreads - 1;


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/CAMEL-10874