### PR TITLE
CAMEL-10890 Failed test in some http components

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/PipelineHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/PipelineHelper.java
@@ -110,6 +110,10 @@ public final class PipelineHelper {
         if (answer.hasOut()) {
             answer.setIn(answer.getOut());
             answer.setOut(null);
+            if (answer.hasProperties() && answer.getProperties().containsKey(Exchange.OUTPUT_TYPE)) {
+                answer.setProperty(Exchange.INPUT_TYPE, answer.getProperty(Exchange.OUTPUT_TYPE));
+                answer.removeProperty(Exchange.OUTPUT_TYPE);
+            }
         }
         return answer;
     }

--- a/camel-core/src/main/java/org/apache/camel/util/ExchangeHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ExchangeHelper.java
@@ -327,14 +327,29 @@ public final class ExchangeHelper {
             } else if (result.getPattern().isOutCapable() && !result.hasOut() && !result.isFailed()) {
                 // copy IN to OUT as we expect a OUT response
                 result.getOut().copyFrom(source.getIn());
+                if (source.hasProperties() && source.getProperties().containsKey(Exchange.INPUT_TYPE)) {
+                    result.setProperty(Exchange.OUTPUT_TYPE, source.getProperty(Exchange.INPUT_TYPE));
+                }
             }
             return;
         }
 
         if (result != source) {
             result.setException(source.getException());
+            if (source.hasProperties()) {
+                source.getProperties().forEach((key, value) -> {
+                    // excluding INPUT/OUTPUT - explicitly copy them if needed later
+                    if (!key.equals(Exchange.INPUT_TYPE) && !key.equals(Exchange.OUTPUT_TYPE)) {
+                        result.setProperty(key, value);
+                    }
+                });
+            }
+
             if (source.hasOut()) {
                 result.getOut().copyFrom(source.getOut());
+                if (source.hasProperties() && source.getProperties().containsKey(Exchange.OUTPUT_TYPE)) {
+                    result.setProperty(Exchange.OUTPUT_TYPE, source.getProperty(Exchange.OUTPUT_TYPE));
+                }
             } else if (result.getPattern() == ExchangePattern.InOptionalOut) {
                 // special case where the result is InOptionalOut and with no OUT response
                 // so we should return null to indicate this fact
@@ -347,18 +362,20 @@ public final class ExchangeHelper {
                 if (result.getPattern().isOutCapable()) {
                     // only set OUT if its OUT capable
                     result.getOut().copyFrom(source.getIn());
+                    if (source.hasProperties() && source.getProperties().containsKey(Exchange.INPUT_TYPE)) {
+                        result.setProperty(Exchange.OUTPUT_TYPE, source.getProperty(Exchange.INPUT_TYPE));
+                    }
                 } else {
                     // if not replace IN instead to keep the MEP
                     result.getIn().copyFrom(source.getIn());
+                    if (source.hasProperties() && source.getProperties().containsKey(Exchange.INPUT_TYPE)) {
+                        result.setProperty(Exchange.INPUT_TYPE, source.getProperty(Exchange.INPUT_TYPE));
+                    }
                     // clear any existing OUT as the result is on the IN
                     if (result.hasOut()) {
                         result.setOut(null);
                     }
                 }
-            }
-
-            if (source.hasProperties()) {
-                result.getProperties().putAll(source.getProperties());
             }
         }
     }
@@ -384,6 +401,9 @@ public final class ExchangeHelper {
             } else if (result.getPattern().isOutCapable() && !result.hasOut() && !result.isFailed()) {
                 // copy IN to OUT as we expect a OUT response
                 result.getOut().copyFrom(source.getIn());
+                if (result.hasProperties() && result.getProperties().containsKey(Exchange.INPUT_TYPE)) {
+                    result.setProperty(Exchange.OUTPUT_TYPE, result.getProperty(Exchange.INPUT_TYPE));
+                }
             }
             return;
         }

--- a/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
@@ -175,6 +175,7 @@ public class TransformerRouteTest extends ContextTestSupport {
                             LOG.info("Asserting input -> XOrder convertion");
                             assertEquals(XOrder.class, exchange.getIn().getBody().getClass());
                             exchange.getIn().setBody("response");
+                            exchange.setProperty(Exchange.INPUT_TYPE, new DataType(String.class));
                         }
                     }).to("mock:xyzresult");
                 

--- a/camel-core/src/test/java/org/apache/camel/impl/validator/ValidatorRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/validator/ValidatorRouteTest.java
@@ -102,7 +102,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                     .inputTypeWithValidate("json:JsonXOrder")
                     .outputType("json:JsonXOrderResponse")
                     .setBody(simple("{name:XOrderResponse}"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("json:JsonXOrderResponse"));
+                    .setProperty(Exchange.INPUT_TYPE, constant("json:JsonXOrderResponse"));
                 
                 context.addComponent("myxml", new MyXmlComponent());
                 validator()
@@ -113,7 +113,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                     .outputTypeWithValidate("xml:XmlXOrderResponse")
                     .validate(exchangeProperty(VALIDATOR_INVOKED).isNull())
                     .setBody(simple("<XOrderResponse/>"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("xml:XmlXOrderResponse"));
+                    .setProperty(Exchange.INPUT_TYPE, constant("xml:XmlXOrderResponse"));
                 
                 validator()
                     .type("other:OtherXOrder")
@@ -126,7 +126,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                     .outputTypeWithValidate("other:OtherXOrderResponse")
                     .validate(exchangeProperty(VALIDATOR_INVOKED).isEqualTo(OtherXOrderValidator.class))
                     .setBody(simple("name=XOrderResponse"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("other:OtherXOrderResponse"));
+                    .setProperty(Exchange.INPUT_TYPE, constant("other:OtherXOrderResponse"));
             }
         };
     }

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/transformer/SpringTransformerRouteTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/transformer/SpringTransformerRouteTest.xml
@@ -63,6 +63,7 @@
                 <throwException exceptionType="java.lang.Exception" message="expected XOrder object but was '${body}'"/>
             </when>
             <setBody><constant>response</constant></setBody>
+            <setProperty propertyName="CamelInputType"><constant>java:java.lang.String</constant></setProperty>
             <to uri="mock:xyzresult"/>
         </route>
         

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/validator/SpringValidatorRouteTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/validator/SpringValidatorRouteTest.xml
@@ -38,7 +38,7 @@
             <inputType urn="json:JsonXOrder" validate="true"/>
             <outputType urn="json:JsonXOrderResponse"/>
             <setBody><constant>{name:XOrderResponse}</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>json:JsonXOrderResponse</constant></setProperty>
+            <setProperty propertyName="CamelInputType"><constant>json:JsonXOrderResponse</constant></setProperty>
         </route>
 
         <route>
@@ -49,7 +49,7 @@
                 <simple>${exchangeProperty.validator-invoked} == null</simple>
             </validate>
             <setBody><constant>&lt;XOrderResponse/&gt;</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>xml:XmlXOrderResponse</constant></setProperty>
+            <setProperty propertyName="CamelInputType"><constant>xml:XmlXOrderResponse</constant></setProperty>
         </route>
         
         <route>
@@ -60,7 +60,7 @@
                 <simple>${exchangeProperty.validator-invoked} == 'org.apache.camel.impl.validator.ValidatorRouteTest$OtherXOrderValidator'</simple>
             </validate>
             <setBody><constant>name=XOrderResponse</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>other:OtherXOrderResponse</constant></setProperty>
+            <setProperty propertyName="CamelInputType"><constant>other:OtherXOrderResponse</constant></setProperty>
         </route>
         
     </camelContext>


### PR DESCRIPTION
Instead of handling all the cases in ContractAdvice, added INPUT/OUTPUT property copy when message copy occurs between IN and OUT. This enables it to keep type metadata in sync in much cleaner way.