### PR TITLE
CAMEL-10141 skip camel-jibx build on java 9 as well

### DIFF
--- a/components/camel-jibx/pom.xml
+++ b/components/camel-jibx/pom.xml
@@ -83,7 +83,7 @@
                 <property>
                     <name>!maven.test.skip</name>
                 </property>
-                <jdk>!1.8</jdk>
+                <jdk>[,1.8)</jdk>
             </activation>
             <build>
                 <pluginManagement>
@@ -140,7 +140,7 @@
         <profile>
             <id>jdk8-test</id>
             <activation>
-                <jdk>1.8</jdk>
+                <jdk>[1.8,]</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-10141

We are skipping camel-jibx on JAVA 8 and it's failing on JAVA 9:

```
[ERROR] Failed to execute goal org.jibx:maven-jibx-plugin:1.3.1:test-bind (default) on project camel-jibx: Superclass java.lang.Object of class org.jibx.runtime.Utility not found -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.jibx:maven-jibx-plugin:1.3.1:test-bind (default) on project camel-jibx: Superclass java.lang.Object of class org.jibx.runtime.Utility not found
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:543)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Superclass java.lang.Object of class org.jibx.runtime.Utility not found
	at org.jibx.maven.AbstractBaseBindingMojo.compile(AbstractBaseBindingMojo.java:166)
	at org.jibx.maven.AbstractBaseBindingMojo.execute(AbstractBaseBindingMojo.java:133)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: java.lang.IllegalArgumentException: Superclass java.lang.Object of class org.jibx.runtime.Utility not found
	at org.jibx.binding.def.StringConversion.<init>(StringConversion.java:163)
	at org.jibx.binding.def.PrimitiveStringConversion.<init>(PrimitiveStringConversion.java:143)
	at org.jibx.binding.def.BindingDefinition.<clinit>(BindingDefinition.java:92)
	at org.jibx.binding.Compile.compile(Compile.java:210)
	at org.jibx.maven.AbstractBaseBindingMojo.compile(AbstractBaseBindingMojo.java:163)
	... 23 more
```