### PR TITLE
CAMEL-10908 Introduce DataTypeAware interface and let MessageSupport …

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/DynamicRouter.java
+++ b/camel-core/src/main/java/org/apache/camel/DynamicRouter.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Target( {ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface DynamicRouter {
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/Exchange.java
+++ b/camel-core/src/main/java/org/apache/camel/Exchange.java
@@ -233,9 +233,6 @@ public interface Exchange {
     String XSLT_FATAL_ERROR = "CamelXsltFatalError";
     String XSLT_WARNING     = "CamelXsltWarning";
 
-    String INPUT_TYPE  = "CamelInputType";
-    String OUTPUT_TYPE = "CamelOutputType";
-
     /**
      * Returns the {@link ExchangePattern} (MEP) of this exchange.
      *

--- a/camel-core/src/main/java/org/apache/camel/model/InputTypeDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/InputTypeDefinition.java
@@ -23,14 +23,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.camel.spi.Metadata;
 
 /**
- * Set data type of the input message.
+ * Set the expected data type of the input message. If the actual message type is different at runtime,
+ * camel look for a required {@link Transformer} and apply if exists. If validate attribute is true
+ * then camel applies {@link Validator} as well.
  * Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
  * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
  * It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml'
  * is specified, all the XML message matches. It's handy to add only one transformer/validator
  * for all the transformation from/to XML.
  * 
- * {@see OutputTypeDefinition}
+ * @see {@link OutputTypeDefinition} {@link Transformer} {@link Validator}
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "inputType")

--- a/camel-core/src/main/java/org/apache/camel/model/OutputTypeDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/OutputTypeDefinition.java
@@ -23,14 +23,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.camel.spi.Metadata;
 
 /**
- * Sets data type of the output message.
+ * Set the expected data type of the output message. If the actual message type is different at runtime,
+ * camel look for a required {@link Transformer} and apply if exists. If validate attribute is true
+ * then camel applies {@link Validator} as well.
  * Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
  * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
  * It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml'
  * is specified, all the XML message matches. It's handy to add only one transformer/validator
  * for all the XML-Java transformation.
  * 
- * {@see InputTypeDefinition}
+ * @see {@link InputTypeDefinition} {@link Transformer} {@link Validator}
  */
 @Metadata(label = "configuration")
 @XmlRootElement(name = "outputType")

--- a/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -635,7 +635,10 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an input type.
+     * Declare the expected data type of the input message. If the actual message type is different
+     * at runtime, camel look for a required {@link Transformer} and apply if exists.
+     * The type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
+     * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
      * 
      * @see {@link org.apache.camel.spi.Transformer}
      * @param urn input type URN
@@ -649,7 +652,11 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an input type with validation enabled.
+     * Declare the expected data type of the input message with content validation enabled.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists, and then applies {@link Validator} as well.
+     * The type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
+     * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
      * 
      * @see {@link org.apache.camel.spi.Transformer}, {@link org.apache.camel.spi.Validator}
      * @param urn input type URN
@@ -663,7 +670,9 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an input type with Java class.
+     * Declare the expected data type of the input message by Java class.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists.
      * 
      * @see {@link org.apache.camel.spi.Transformer}
      * @param clazz Class object of the input type
@@ -677,7 +686,9 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an input type with Java class with validation enabled.
+     * Declare the expected data type of the input message by Java class with content validation enabled.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists, and then applies {@link Validator} as well.
      * 
      * @see {@link org.apache.camel.spi.Transformer}, {@link org.apache.camel.spi.Validator}
      * @param clazz Class object of the input type
@@ -691,7 +702,10 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an output type.
+     * Declare the expected data type of the output message. If the actual message type is different
+     * at runtime, camel look for a required {@link Transformer} and apply if exists.
+     * The type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
+     * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
      * 
      * @see {@link org.apache.camel.spi.Transformer}
      * @param urn output type URN
@@ -705,7 +719,11 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an output type with validation enabled.
+     * Declare the expected data type of the output message with content validation enabled.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists, and then applies {@link Validator} as well.
+     * The type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name'
+     * is a fully qualified class name. For example {@code java:java.lang.String}, {@code json:ABCOrder}.
      * 
      * @see {@link org.apache.camel.spi.Transformer}, {@link org.apache.camel.spi.Validator}
      * @param urn output type URN
@@ -719,7 +737,9 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an output type with Java class.
+     * Declare the expected data type of the output message by Java class.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists.
      * 
      * @see {@link org.apache.camel.spi.Transformer}
      * @param clazz Class object of the output type
@@ -733,7 +753,9 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Declare an output type with Java class with validation enabled.
+     * Declare the expected data type of the ouput message by Java class with content validation enabled.
+     * If the actual message type is different at runtime, camel look for a required
+     * {@link Transformer} and apply if exists, and then applies {@link Validator} as well.
      * 
      * @see {@link org.apache.camel.spi.Transformer}, {@link org.apache.camel.spi.Validator}
      * @param clazz Class object of the output type

--- a/camel-core/src/main/java/org/apache/camel/spi/DataType.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/DataType.java
@@ -20,6 +20,17 @@ import org.apache.camel.util.StringHelper;
 
 /**
  * Represents the data type URN which is used for message data type contract.
+ * Java class doesn't always explain the data type completely, for example XML and JSON
+ * data format is sometimes serialized as a {@code String}, {@code InputStream} or etc.
+ * The {@link DataTypeAware} message stores the DataType as a part of the message to carry
+ * those data type information even if it's marshaled, so that it could be
+ * leveraged to detect required {@link Transformer} and {@link Validator}.
+ * DataType consists of two parts, 'model' and 'name'. Its string representation is
+ * 'model:name' connected with colon. For example 'java:com.example.Order', 'xml:ABCOrder'
+ * or 'json:XYZOrder'. These type name other than java class name allows the message to
+ * carry the name of the message data structure even if it's marshaled.
+ * 
+ * @see {@link DataTypeAware} {@link Transformer} {@link Validator}
  */
 public class DataType {
 

--- a/camel-core/src/main/java/org/apache/camel/spi/DataTypeAware.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/DataTypeAware.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spi;
+
+/**
+ * Allows {@link org.apache.camel.Message} to store a {@link DataType} which
+ * represents the data type of the Message. Sometimes message content is marshaled
+ * into {@code String}, {@code InputStream} or etc, and the data type structure is
+ * not available until it's unmarshaled into Java object. The {@link DataType} stored
+ * in a DataTypeAware message carries that missing data type information even if it's
+ * marshaled, and whatever the Java class of the body is. This type information is used
+ * to detect required {@link Transformer} and {@link Validator}.
+ * 
+ * @see {@link DataType} {@link Transformer} {@link Validator}
+ */
+public interface DataTypeAware {
+
+    /**
+     * Set the data type of the message.
+     * @param type data type
+     */
+    void setDataType(DataType type);
+
+    /**
+     * Get the data type of the message.
+     * @return data type
+     */
+    DataType getDataType();
+
+    /**
+     * Set the message body with data type.
+     * @param body message body
+     * @param type data type
+     */
+    void setBody(Object body, DataType type);
+
+}

--- a/camel-core/src/main/java/org/apache/camel/spi/Transformer.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/Transformer.java
@@ -27,15 +27,11 @@ import org.apache.camel.support.ServiceSupport;
 /**
  * <a href="http://camel.apache.org/transformer.html">Transformer</a>
  * performs message transformation according to the declared data type.
- * There are two Exchange property indicates current message type, {@link Exchange#INPUT_TYPE}
- * holds input message type and {@link Exchange#OUTPUT_TYPE} holds output message type. If the
- * input type and/or output type declared by {@link InputTypeDefinition}
- * and/or {@link OutputTypeDefinition} in the route definition is different from those property
- * at runtime, camel internal processor look for a Transformer which transforms from
- * the current message type to the expected message type.
+ * {@link ContractAdvice} looks for a required Transformer and apply if
+ * input/output type declared on a route is different from current message type.
  *  
- * @see InputTypeDefinition
- * @see OutputTypeDefinition
+ * @see {@link ContractAdvice}
+ * {@link DataType} {@link InputTypeDefinition} {@link OutputTypeDefinition}
  */
 public abstract class Transformer extends ServiceSupport implements CamelContextAware {
 

--- a/camel-core/src/main/java/org/apache/camel/spi/Validator.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/Validator.java
@@ -26,17 +26,13 @@ import org.apache.camel.model.OutputTypeDefinition;
 import org.apache.camel.support.ServiceSupport;
 
 /**
- * <a href="http://camel.apache.org/transformer.html">Transformer</a>
- * performs message transformation according to the declared data type.
- * There are two Exchange property indicates current message type, {@link Exchange#INPUT_TYPE}
- * holds input message type and {@link Exchange#OUTPUT_TYPE} holds output message type. If the
- * input type and/or output type declared by {@link InputTypeDefinition}
- * and/or {@link OutputTypeDefinition} in the route definition is different from those property
- * at runtime, camel internal processor look for a Transformer which transforms from
- * the current message type to the expected message type.
+ * <a href="http://camel.apache.org/validator.html">Validator</a>
+ * performs message content validation according to the declared data type.
+ * {@link ContractAdvice} applies Validator if input/output type is declared on
+ * a route with validation enabled.
  *  
- * @see InputTypeDefinition
- * @see OutputTypeDefinition
+ * @see {@link ContractAdvice}
+ * {@link InputTypeDefinition} {@link OutputTypeDefinition}
  */
 public abstract class Validator extends ServiceSupport implements CamelContextAware {
 

--- a/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerContractTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerContractTest.java
@@ -30,6 +30,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.DataFormatDefinition;
 import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.DataType;
+import org.apache.camel.spi.DataTypeAware;
 import org.apache.camel.spi.RouteContext;
 import org.junit.Test;
 
@@ -115,7 +117,10 @@ public class TransformerContractTest extends ContextTestSupport {
         mocka.setExpectedCount(1);
         mocka2.setExpectedCount(1);
         mockb.setExpectedCount(1);
-        Object answer = template.requestBody("direct:a", "<foo/>");
+        Exchange answer = template.send("direct:a", ex -> {
+            DataTypeAware message = (DataTypeAware)ex.getIn();
+            message.setBody("<foo/>", new DataType("xml"));
+        });
         mocka.assertIsSatisfied();
         mocka2.assertIsSatisfied();
         mockb.assertIsSatisfied();
@@ -125,7 +130,7 @@ public class TransformerContractTest extends ContextTestSupport {
         assertEquals("<foo/>", exa.getIn().getBody());
         assertEquals(A.class, exb.getIn().getBody().getClass());
         assertEquals(B.class, exa2.getIn().getBody().getClass());
-        assertEquals("<fooResponse/>", new String((byte[])answer));
+        assertEquals("<fooResponse/>", new String((byte[])answer.getIn().getBody()));
     }
 
     public static class MyTypeConverters implements TypeConverters {

--- a/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
@@ -42,6 +42,7 @@ import org.apache.camel.impl.DefaultExchange;
 import org.apache.camel.model.DataFormatDefinition;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.DataType;
+import org.apache.camel.spi.DataTypeAware;
 import org.apache.camel.spi.RouteContext;
 import org.apache.camel.spi.Transformer;
 import org.slf4j.Logger;
@@ -98,7 +99,7 @@ public class TransformerRouteTest extends ContextTestSupport {
         });
 
         Exchange exchange = new DefaultExchange(context, ExchangePattern.InOut);
-        exchange.getIn().setBody("{name:XOrder}");
+        ((DataTypeAware)exchange.getIn()).setBody("{name:XOrder}", new DataType("json:JsonXOrder"));
         Exchange answerEx = template.send("direct:dataFormat", exchange);
         if (answerEx.getException() != null) {
             throw answerEx.getException();

--- a/camel-core/src/test/java/org/apache/camel/impl/validator/ValidatorRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/validator/ValidatorRouteTest.java
@@ -64,7 +64,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
         if (answerEx.getException() != null) {
             throw answerEx.getException();
         }
-        assertEquals("{name:XOrderResponse}", answerEx.getOut().getBody(String.class));
+        assertEquals("{name:XOrderResponse}", answerEx.getIn().getBody(String.class));
     }
 
     public void testEndpointValidator() throws Exception {
@@ -101,8 +101,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                 from("direct:predicate")
                     .inputTypeWithValidate("json:JsonXOrder")
                     .outputType("json:JsonXOrderResponse")
-                    .setBody(simple("{name:XOrderResponse}"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("json:JsonXOrderResponse"));
+                    .setBody(simple("{name:XOrderResponse}"));
                 
                 context.addComponent("myxml", new MyXmlComponent());
                 validator()
@@ -112,8 +111,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                     .inputType("xml:XmlXOrder")
                     .outputTypeWithValidate("xml:XmlXOrderResponse")
                     .validate(exchangeProperty(VALIDATOR_INVOKED).isNull())
-                    .setBody(simple("<XOrderResponse/>"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("xml:XmlXOrderResponse"));
+                    .setBody(simple("<XOrderResponse/>"));
                 
                 validator()
                     .type("other:OtherXOrder")
@@ -125,8 +123,7 @@ public class ValidatorRouteTest extends ContextTestSupport {
                     .inputTypeWithValidate("other:OtherXOrder")
                     .outputTypeWithValidate("other:OtherXOrderResponse")
                     .validate(exchangeProperty(VALIDATOR_INVOKED).isEqualTo(OtherXOrderValidator.class))
-                    .setBody(simple("name=XOrderResponse"))
-                    .setProperty(Exchange.OUTPUT_TYPE, constant("other:OtherXOrderResponse"));
+                    .setBody(simple("name=XOrderResponse"));
             }
         };
     }

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/validator/SpringValidatorRouteTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/impl/validator/SpringValidatorRouteTest.xml
@@ -38,7 +38,6 @@
             <inputType urn="json:JsonXOrder" validate="true"/>
             <outputType urn="json:JsonXOrderResponse"/>
             <setBody><constant>{name:XOrderResponse}</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>json:JsonXOrderResponse</constant></setProperty>
         </route>
 
         <route>
@@ -49,7 +48,6 @@
                 <simple>${exchangeProperty.validator-invoked} == null</simple>
             </validate>
             <setBody><constant>&lt;XOrderResponse/&gt;</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>xml:XmlXOrderResponse</constant></setProperty>
         </route>
         
         <route>
@@ -60,7 +58,6 @@
                 <simple>${exchangeProperty.validator-invoked} == 'org.apache.camel.impl.validator.ValidatorRouteTest$OtherXOrderValidator'</simple>
             </validate>
             <setBody><constant>name=XOrderResponse</constant></setBody>
-            <setProperty propertyName="CamelOutputType"><constant>other:OtherXOrderResponse</constant></setProperty>
         </route>
         
     </camelContext>

--- a/examples/camel-example-transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/client/CamelClient.java
+++ b/examples/camel-example-transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/client/CamelClient.java
@@ -21,9 +21,12 @@ import java.io.File;
 import java.io.FileReader;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.example.transformer.demo.Order;
 import org.apache.camel.example.transformer.demo.OrderResponse;
+import org.apache.camel.spi.DataType;
+import org.apache.camel.spi.DataTypeAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -68,17 +71,21 @@ public final class CamelClient {
         
         String orderXml = "<order orderId=\"Order-XML-0001\" itemId=\"MIKAN\" quantity=\"365\"/>";
         LOG.info("---> Sending '{}' to 'direct:xml'", orderXml);
-        String responseXml = producer.requestBody("direct:xml", orderXml, String.class);
+        Exchange answerXml = producer.send("direct:xml", ex -> {
+            ((DataTypeAware)ex.getIn()).setBody(orderXml, new DataType("xml:XMLOrder"));
+        });
         Thread.sleep(1000);
-        LOG.info("---> Received '{}'", responseXml);
+        LOG.info("---> Received '{}'", answerXml.getOut().getBody(String.class));
         LOG.info("---> CSV log now contains:{}", getCsvLog());
         Thread.sleep(1000);
         
         String orderJson = "{\"orderId\":\"Order-JSON-0001\", \"itemId\":\"MIZUYO-KAN\", \"quantity\":\"16350\"}";
         LOG.info("---> Sending '{}' to 'direct:json'", orderJson);
-        String responseJson = producer.requestBody("direct:json", orderJson, String.class);
+        Exchange answerJson = producer.send("direct:json", ex -> {
+            ((DataTypeAware)ex.getIn()).setBody(orderJson, new DataType("json"));
+        });
         Thread.sleep(1000);
-        LOG.info("---> Received '{}'", responseJson);
+        LOG.info("---> Received '{}'", answerJson.getOut().getBody(String.class));
         LOG.info("---> CSV log now contains:{}", getCsvLog());
         Thread.sleep(1000);
         


### PR DESCRIPTION
…implement it

This also solves CAMEL-10890

This is a follow up of the discussion here:
https://github.com/apache/camel/pull/1492

Instead of carrying around the INPUT_TYPE/OUTPUT_TYPE exchange properties, introduced DataTypeAware which allows camel Message to store its DataType.