### PR TITLE
CAMEL-8351 - simple implementation for breadcrumbId to be set as camel exhange's header

### DIFF
--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConsumer.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceConsumer.java
@@ -83,11 +83,11 @@ public class SpringWebserviceConsumer extends DefaultConsumer implements Message
     
     private void populateExchangeWithBreadcrumbFromMessageContext(MessageContext messageContext, Exchange exchange) {
         SaajSoapMessage saajSoap = (SaajSoapMessage) messageContext.getRequest();
-        SOAPMessage soapMesssageRequest = null;
+        SOAPMessage soapMessageRequest = null;
         if (saajSoap != null) {
-            soapMesssageRequest = saajSoap.getSaajMessage();
-            if (soapMesssageRequest != null) {
-                MimeHeaders mimeHeaders = soapMesssageRequest.getMimeHeaders();
+            soapMessageRequest = saajSoap.getSaajMessage();
+            if (soapMessageRequest != null) {
+                MimeHeaders mimeHeaders = soapMessageRequest.getMimeHeaders();
                 if (mimeHeaders != null) {
                     String[] breadcrumbIdHeaderValues = mimeHeaders.getHeader(Exchange.BREADCRUMB_ID);
                     // expected to get one token

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/AddBreadcrumbHttpHeaderTestInterceptor.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/AddBreadcrumbHttpHeaderTestInterceptor.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.springframework.ws.client.WebServiceClientException;
+import org.springframework.ws.client.support.interceptor.ClientInterceptor;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.transport.context.TransportContext;
+import org.springframework.ws.transport.context.TransportContextHolder;
+import org.springframework.ws.transport.http.CommonsHttpConnection;
+
+public class AddBreadcrumbHttpHeaderTestInterceptor implements ClientInterceptor {
+
+    @Override
+    public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
+        // no extra op
+        TransportContext context = TransportContextHolder.getTransportContext();
+        CommonsHttpConnection connection = (CommonsHttpConnection) context.getConnection();
+        PostMethod postMethod = connection.getPostMethod();
+        postMethod.addRequestHeader("breadcrumbId", "ID-Ralfs-MacBook-Pro-local-50523-1423553069254-0-5");
+        return true;
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext messageContext) throws WebServiceClientException {
+        // no extra op
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(MessageContext messageContext) throws WebServiceClientException {
+        // no extra op
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
+         // noop
+
+    }
+
+}

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.ws;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.spring.ws.bean.CamelEndpointMapping;
+import org.apache.camel.component.spring.ws.jaxb.QuoteRequest;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.model.dataformat.JaxbDataFormat;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.ws.client.core.WebServiceTemplate;
+
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ConsumerBreadcrumbIdTest extends CamelTestSupport {
+
+    @Autowired
+    private CamelEndpointMapping endpointMapping;
+
+    @Autowired
+    private WebServiceTemplate webServiceTemplate;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context.setTracing(true);
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry registry = super.createRegistry();
+        registry.bind("endpointMapping", this.endpointMapping);
+        registry.bind("webServiceTemplate", this.webServiceTemplate);
+        return registry;
+    }
+    
+    @Test
+    public void consumeWebServiceWithPojoRequestWhichIsWithBreadcrumb() throws Exception {
+        QuoteRequest request = new QuoteRequest();
+        request.setSymbol("GOOG");
+
+        Object result = template.request("direct:webservice-marshall-asin", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                assertNotNull(exchange.getIn().getHeader("breadcrumbId"));
+                assertEquals(exchange.getIn().getHeader("breadcrumbId"), "ID-Ralfs-MacBook-Pro-local-50523-1423553069254-0-5");
+            }
+        });
+    }
+    
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() throws Exception {
+                JaxbDataFormat jaxb = new JaxbDataFormat(false);
+                jaxb.setContextPath("org.apache.camel.component.spring.ws.jaxb");
+          
+                // request webservice
+                from("direct:webservice-marshall-asin")
+                        .marshal(jaxb)
+                        .to("spring-ws:http://localhost/?soapAction=http://www.stockquotes.edu/GetQuoteAsIn&webServiceTemplate=#webServiceTemplate")
+                        .convertBodyTo(String.class);
+                
+                // provide web service
+                from("spring-ws:soapaction:http://www.stockquotes.edu/GetQuoteAsIn?endpointMapping=#endpointMapping").setHeader("setin", constant("true"))
+                                                                                                                         .process(new StockQuoteResponseProcessor());                
+                
+                
+            }
+        };
+    }
+
+}

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest.java
@@ -59,9 +59,7 @@ public class ConsumerBreadcrumbIdTest extends CamelTestSupport {
     public void consumeWebServiceWithPojoRequestWhichIsWithBreadcrumb() throws Exception {
         QuoteRequest request = new QuoteRequest();
         request.setSymbol("GOOG");
-
         Object result = template.request("direct:webservice-marshall-asin", new Processor() {
-
             @Override
             public void process(Exchange exchange) throws Exception {
                 assertNotNull(exchange.getIn().getHeader("breadcrumbId"));
@@ -74,23 +72,18 @@ public class ConsumerBreadcrumbIdTest extends CamelTestSupport {
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
-
             @Override
             public void configure() throws Exception {
                 JaxbDataFormat jaxb = new JaxbDataFormat(false);
                 jaxb.setContextPath("org.apache.camel.component.spring.ws.jaxb");
-          
                 // request webservice
                 from("direct:webservice-marshall-asin")
                         .marshal(jaxb)
                         .to("spring-ws:http://localhost/?soapAction=http://www.stockquotes.edu/GetQuoteAsIn&webServiceTemplate=#webServiceTemplate")
                         .convertBodyTo(String.class);
-                
                 // provide web service
                 from("spring-ws:soapaction:http://www.stockquotes.edu/GetQuoteAsIn?endpointMapping=#endpointMapping").setHeader("setin", constant("true"))
-                                                                                                                         .process(new StockQuoteResponseProcessor());                
-                
-                
+                                                                                                                         .process(new StockQuoteResponseProcessor());
             }
         };
     }

--- a/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest-context.xml
+++ b/components/camel-spring-ws/src/test/resources/org/apache/camel/component/spring/ws/ConsumerBreadcrumbIdTest-context.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+         http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <bean id="endpointMapping"
+          class="org.apache.camel.component.spring.ws.bean.CamelEndpointMapping"/>
+          
+    
+
+    <bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate">
+        <property name="defaultUri" value="http://localhost"/>
+        <property name="messageSender">
+            <bean class="net.javacrumbs.springws.test.helper.InMemoryWebServiceMessageSender"/>
+        </property>
+        <property name="interceptors">
+            <list>
+            	<bean id="addBreadcrumbHeaderTest" class="org.apache.camel.component.spring.ws.AddBreadcrumbHttpHeaderTestInterceptor" />
+            </list>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
simple implementation, if mimeheaders may have multiple values as string array for breadcrumbs header, breadcrumb generation strategy may need to be implemented and this may require a config uri param on the endpoint to inject such strategy