### PR TITLE
CAMEL-10966 Salesforce Maven Plugin Escape Strings

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
@@ -118,6 +118,11 @@
       <artifactId>velocity</artifactId>
       <version>${velocity-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity-tools</artifactId>
+      <version>${velocity-tools-version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/CamelSalesforceMojo.java
@@ -72,6 +72,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.tools.generic.EscapeTool;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.log.Log4JLogChute;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
@@ -614,6 +615,7 @@ public class CamelSalesforceMojo extends AbstractMojo {
                     context = new VelocityContext();
                     context.put("packageName", packageName);
                     context.put("utility", utility);
+                    context.put("esc", new EscapeTool());
                     context.put("field", field);
                     context.put("enumName", enumName);
                     context.put("generatedDate", generatedDate);

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-picklist.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-picklist.vm
@@ -37,7 +37,7 @@ public enum $enumName {
 #foreach ( $entry in $values)
 #set ( $value = $entry.Value )
     // $value
-    $utility.getEnumConstant($value)("$value")#if ( $foreach.hasNext ),#else;#end
+    $utility.getEnumConstant($value)("$esc.java($value)")#if ( $foreach.hasNext ),#else;#end
 
 #end
 #end


### PR DESCRIPTION
Salesforce Maven Plugin doesn't escape strings when doing the `camel-salesforce:generate` phase.

This PR uses the _velocity escape tool_ in order to escape strings.