### PR TITLE
CAMEL-10958 camel-scala-starter starter module removed but references to it still exist

### DIFF
--- a/apache-camel/pom.xml
+++ b/apache-camel/pom.xml
@@ -1922,11 +1922,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-scala-starter</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-schematron-starter</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/apache-camel/src/main/descriptors/common-bin.xml
+++ b/apache-camel/src/main/descriptors/common-bin.xml
@@ -478,7 +478,6 @@
         <include>org.apache.camel:camel-salesforce-starter</include>
         <include>org.apache.camel:camel-sap-netweaver-starter</include>
         <include>org.apache.camel:camel-saxon-starter</include>
-        <include>org.apache.camel:camel-scala-starter</include>
         <include>org.apache.camel:camel-schematron-starter</include>
         <include>org.apache.camel:camel-script-starter</include>
         <include>org.apache.camel:camel-scr-starter</include>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2977,11 +2977,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
-        <artifactId>camel-scala-starter</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron-starter</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
+++ b/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
@@ -2084,11 +2084,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
-        <artifactId>camel-scala-starter</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-10958

Remove references to camel-scala-starter.