### PR TITLE
Fix blueprint-cm schema location to v1.1.0 for a camel-test-blueprint test

### DIFF
--- a/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/configadmin-endpoint-no-defaults.xml
+++ b/components/camel-test-blueprint/src/test/resources/org/apache/camel/test/blueprint/configadmin-endpoint-no-defaults.xml
@@ -19,7 +19,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xsi:schemaLocation="
-             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.0.0.xsd
+             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
              http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
   <!-- blueprint property placeholders -->


### PR DESCRIPTION
Let me skip filing a JIRA as the fix is so tiny.