### PR TITLE
CAMEL-10964: Add an itest for Jetty reverse proxy config with @BeanInject in RouteBuilder

### DIFF
--- a/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
+++ b/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
@@ -158,7 +158,8 @@ public abstract class AbstractFeatureTest {
 
     protected void overridePropertiesWithConfigAdmin(String pid, Properties props) throws IOException {
         ConfigurationAdmin configAdmin = getOsgiService(bundleContext, ConfigurationAdmin.class);
-        Configuration config = configAdmin.getConfiguration(pid);
+        // passing null as second argument ties the configuration to correct bundle.
+        Configuration config = configAdmin.getConfiguration(pid, null);
         if (config == null) {
             throw new IllegalArgumentException("Cannot find configuration with pid " + pid + " in OSGi ConfigurationAdmin service.");
         }

--- a/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/cxf/CamelCxfBeanInjectTest.java
+++ b/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/cxf/CamelCxfBeanInjectTest.java
@@ -44,7 +44,7 @@ import org.osgi.framework.Constants;
 @RunWith(PaxExam.class)
 public class CamelCxfBeanInjectTest extends AbstractFeatureTest {
 
-    private static final int PORT = AvailablePortFinder.getNextAvailable();
+    private static final int PORT = AvailablePortFinder.getNextAvailable(30000);
     private static final String ENDPOINT_ADDRESS = String.format(
         "http://localhost:%s/CamelCxfBeanInjectTest/router", PORT);
 


### PR DESCRIPTION
Actual fix for the issue is provided by CAMEL-10513.

https://issues.apache.org/jira/browse/CAMEL-10964