### PR TITLE
Improvements to the HTTP based span decorators

### DIFF
--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
@@ -70,7 +70,16 @@ public class OpenTracingTracer extends ServiceSupport implements RoutePolicyFact
     private CamelContext camelContext;
 
     static {
-        ServiceLoader.load(SpanDecorator.class).forEach(d -> decorators.put(d.getComponent(), d));
+        ServiceLoader.load(SpanDecorator.class).forEach(d -> {
+            SpanDecorator existing = decorators.get(d.getComponent());
+            // Add span decorator if no existing decorator for the component,
+            // or if derived from the existing decorator's class, allowing
+            // custom decorators to be added if they extend the standard
+            // decorators
+            if (existing == null || existing.getClass().isInstance(d)) {
+                decorators.put(d.getComponent(), d);
+            }
+        });
     }
 
     public OpenTracingTracer() {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractHttpSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractHttpSpanDecorator.java
@@ -29,7 +29,10 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
     @Override
     public String getOperationName(Exchange exchange, Endpoint endpoint) {
         // Based on HTTP component documentation:
+        return getHttpMethod(exchange, endpoint);
+    }
 
+    public static String getHttpMethod(Exchange exchange, Endpoint endpoint) {
         // 1. Use method provided in header.
         Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);
         if (method instanceof String) {
@@ -63,6 +66,8 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
         if (httpUrl != null) {
             span.setTag(Tags.HTTP_URL.getKey(), httpUrl);
         }
+
+        span.setTag(Tags.HTTP_METHOD.getKey(), getHttpMethod(exchange, endpoint));
     }
 
     protected String getHttpURL(Exchange exchange, Endpoint endpoint) {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractInternalSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractInternalSpanDecorator.java
@@ -16,31 +16,16 @@
  */
 package org.apache.camel.opentracing.decorators;
 
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
-
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
-public class SqlSpanDecorator extends AbstractSpanDecorator {
-
-    public static final String CAMEL_SQL_QUERY = "CamelSqlQuery";
+public abstract class AbstractInternalSpanDecorator extends AbstractSpanDecorator {
 
     @Override
-    public String getComponent() {
-        return "sql";
-    }
-
-    @Override
-    public void pre(Span span, Exchange exchange, Endpoint endpoint) {
-        super.pre(span, exchange, endpoint);
-
-        span.setTag(Tags.DB_TYPE.getKey(), "sql");
-
-        Object sqlquery = exchange.getIn().getHeader(CAMEL_SQL_QUERY);
-        if (sqlquery instanceof String) {
-            span.setTag(Tags.DB_STATEMENT.getKey(), (String) sqlquery);
-        }
+    public String getOperationName(Exchange exchange, Endpoint endpoint) {
+        // Internal communications use descriptive names, so suitable
+        // as an operation name, but need to strip the scheme and any options
+        return stripSchemeAndOptions(endpoint);
     }
 
 }

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/AbstractSpanDecorator.java
@@ -25,6 +25,7 @@ import io.opentracing.tag.Tags;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.opentracing.SpanDecorator;
+import org.apache.camel.util.URISupport;
 
 /**
  * An abstract base implementation of the {@link SpanDecorator} interface.
@@ -66,7 +67,7 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
 
         // Including the endpoint URI provides access to any options that may have been provided, for
         // subsequent analysis
-        span.setTag("camel.uri", endpoint.getEndpointUri());
+        span.setTag("camel.uri", URISupport.sanitizeUri(endpoint.getEndpointUri()));
     }
 
     @Override

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/DirectSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/DirectSpanDecorator.java
@@ -16,31 +16,11 @@
  */
 package org.apache.camel.opentracing.decorators;
 
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
-
-import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-
-public class SqlSpanDecorator extends AbstractSpanDecorator {
-
-    public static final String CAMEL_SQL_QUERY = "CamelSqlQuery";
+public class DirectSpanDecorator extends AbstractInternalSpanDecorator {
 
     @Override
     public String getComponent() {
-        return "sql";
-    }
-
-    @Override
-    public void pre(Span span, Exchange exchange, Endpoint endpoint) {
-        super.pre(span, exchange, endpoint);
-
-        span.setTag(Tags.DB_TYPE.getKey(), "sql");
-
-        Object sqlquery = exchange.getIn().getHeader(CAMEL_SQL_QUERY);
-        if (sqlquery instanceof String) {
-            span.setTag(Tags.DB_STATEMENT.getKey(), (String) sqlquery);
-        }
+        return "direct";
     }
 
 }

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/JdbcSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/JdbcSpanDecorator.java
@@ -17,6 +17,8 @@
 package org.apache.camel.opentracing.decorators;
 
 import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
@@ -31,11 +33,11 @@ public class JdbcSpanDecorator extends AbstractSpanDecorator {
     public void pre(Span span, Exchange exchange, Endpoint endpoint) {
         super.pre(span, exchange, endpoint);
 
-        span.setTag("db.type", "sql");
+        span.setTag(Tags.DB_TYPE.getKey(), "sql");
 
         Object body = exchange.getIn().getBody();
         if (body instanceof String) {
-            span.setTag("db.statement", (String)body);
+            span.setTag(Tags.DB_STATEMENT.getKey(), (String)body);
         }
     }
 

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/MongoDBSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/MongoDBSpanDecorator.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
@@ -45,14 +47,14 @@ public class MongoDBSpanDecorator extends AbstractSpanDecorator {
     public void pre(Span span, Exchange exchange, Endpoint endpoint) {
         super.pre(span, exchange, endpoint);
 
-        span.setTag("db.type", getComponent());
+        span.setTag(Tags.DB_TYPE.getKey(), getComponent());
 
         Map<String, String> queryParameters = toQueryParameters(endpoint.getEndpointUri());
         String database = queryParameters.get("database");
         if (database != null) {
-            span.setTag("db.instance", database);
+            span.setTag(Tags.DB_INSTANCE.getKey(), database);
         }
-        span.setTag("db.statement", queryParameters.toString());
+        span.setTag(Tags.DB_STATEMENT.getKey(), queryParameters.toString());
     }
 
     public static Map<String, String> toQueryParameters(String uri) {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/SedaSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/SedaSpanDecorator.java
@@ -16,31 +16,11 @@
  */
 package org.apache.camel.opentracing.decorators;
 
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
-
-import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-
-public class SqlSpanDecorator extends AbstractSpanDecorator {
-
-    public static final String CAMEL_SQL_QUERY = "CamelSqlQuery";
+public class SedaSpanDecorator extends AbstractInternalSpanDecorator {
 
     @Override
     public String getComponent() {
-        return "sql";
-    }
-
-    @Override
-    public void pre(Span span, Exchange exchange, Endpoint endpoint) {
-        super.pre(span, exchange, endpoint);
-
-        span.setTag(Tags.DB_TYPE.getKey(), "sql");
-
-        Object sqlquery = exchange.getIn().getHeader(CAMEL_SQL_QUERY);
-        if (sqlquery instanceof String) {
-            span.setTag(Tags.DB_STATEMENT.getKey(), (String) sqlquery);
-        }
+        return "seda";
     }
 
 }

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/VmSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/VmSpanDecorator.java
@@ -16,31 +16,11 @@
  */
 package org.apache.camel.opentracing.decorators;
 
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
-
-import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-
-public class SqlSpanDecorator extends AbstractSpanDecorator {
-
-    public static final String CAMEL_SQL_QUERY = "CamelSqlQuery";
+public class VmSpanDecorator extends AbstractInternalSpanDecorator {
 
     @Override
     public String getComponent() {
-        return "sql";
-    }
-
-    @Override
-    public void pre(Span span, Exchange exchange, Endpoint endpoint) {
-        super.pre(span, exchange, endpoint);
-
-        span.setTag(Tags.DB_TYPE.getKey(), "sql");
-
-        Object sqlquery = exchange.getIn().getHeader(CAMEL_SQL_QUERY);
-        if (sqlquery instanceof String) {
-            span.setTag(Tags.DB_STATEMENT.getKey(), (String) sqlquery);
-        }
+        return "vm";
     }
 
 }

--- a/components/camel-opentracing/src/main/resources/META-INF/services/org.apache.camel.opentracing.SpanDecorator
+++ b/components/camel-opentracing/src/main/resources/META-INF/services/org.apache.camel.opentracing.SpanDecorator
@@ -16,6 +16,7 @@
 #
 
 org.apache.camel.opentracing.decorators.AhcSpanDecorator
+org.apache.camel.opentracing.decorators.DirectSpanDecorator
 org.apache.camel.opentracing.decorators.Http4SpanDecorator
 org.apache.camel.opentracing.decorators.HttpSpanDecorator
 org.apache.camel.opentracing.decorators.JdbcSpanDecorator
@@ -24,7 +25,10 @@ org.apache.camel.opentracing.decorators.MongoDBSpanDecorator
 org.apache.camel.opentracing.decorators.NettyHttp4SpanDecorator
 org.apache.camel.opentracing.decorators.NettyHttpSpanDecorator
 org.apache.camel.opentracing.decorators.RestletSpanDecorator
+org.apache.camel.opentracing.decorators.SedaSpanDecorator
 org.apache.camel.opentracing.decorators.ServletSpanDecorator
 org.apache.camel.opentracing.decorators.SqlSpanDecorator
 org.apache.camel.opentracing.decorators.TimerSpanDecorator
 org.apache.camel.opentracing.decorators.UndertowSpanDecorator
+org.apache.camel.opentracing.decorators.VmSpanDecorator
+

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ABCRouteTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ABCRouteTest.java
@@ -24,21 +24,21 @@ import org.junit.Test;
 public class ABCRouteTest extends CamelOpenTracingTestSupport {
 
     private static SpanTestData[] testdata = {
-        new SpanTestData().setLabel("seda:b server").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(1),
-        new SpanTestData().setLabel("seda:b client").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b client").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
-        new SpanTestData().setLabel("seda:c server").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(3),
-        new SpanTestData().setLabel("seda:c client").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c client").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
-        new SpanTestData().setLabel("seda:a server").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(5),
-        new SpanTestData().setLabel("seda:a client").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a client").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
-        new SpanTestData().setLabel("direct:start server").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(7),
-        new SpanTestData().setLabel("direct:start client").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start client").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_CLIENT)
     };
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
@@ -76,15 +76,16 @@ public class CamelOpenTracingTestSupport extends CamelTestSupport {
             assertEquals(testdata[i].getLabel(),
                 SpanDecorator.CAMEL_COMPONENT + URI.create((String) testdata[i].getUri()).getScheme(),
                 component);
+            assertEquals(testdata[i].getLabel(), testdata[i].getUri(),
+                tracer.finishedSpans().get(i).tags().get("camel.uri"));
 
-            // If span associated with TestSEDASpanDecorator, check that 'testop' and pre/post tags have been defined
+            // If span associated with TestSEDASpanDecorator, check that pre/post tags have been defined
             if ("camel-seda".equals(component)) {
-                assertEquals("testop", tracer.finishedSpans().get(i).operationName());
                 assertTrue(tracer.finishedSpans().get(i).tags().containsKey("pre"));
                 assertTrue(tracer.finishedSpans().get(i).tags().containsKey("post"));
-            } else {
-                assertEquals(testdata[i].getLabel(), testdata[i].getUri(), tracer.finishedSpans().get(i).operationName());
             }
+
+            assertEquals(testdata[i].getLabel(), testdata[i].getOperation(), tracer.finishedSpans().get(i).operationName());
 
             assertEquals(testdata[i].getLabel(), testdata[i].getKind(),
                 tracer.finishedSpans().get(i).tags().get(Tags.SPAN_KIND.getKey()));

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ClientRecipientListRouteTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ClientRecipientListRouteTest.java
@@ -24,21 +24,21 @@ import org.junit.Test;
 public class ClientRecipientListRouteTest extends CamelOpenTracingTestSupport {
 
     private static SpanTestData[] testdata = {
-        new SpanTestData().setLabel("seda:a server").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(1),
-        new SpanTestData().setLabel("seda:a client").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a client").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
-        new SpanTestData().setLabel("seda:b server").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(3),
-        new SpanTestData().setLabel("seda:b client").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b client").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
-        new SpanTestData().setLabel("seda:c server").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(5),
-        new SpanTestData().setLabel("seda:c client").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c client").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
-        new SpanTestData().setLabel("direct:start server").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(7),
-        new SpanTestData().setLabel("direct:start client").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start client").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_CLIENT)
     };
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MulticastRouteTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MulticastRouteTest.java
@@ -24,21 +24,21 @@ import org.junit.Test;
 public class MulticastRouteTest extends CamelOpenTracingTestSupport {
 
     private static SpanTestData[] testdata = {
-        new SpanTestData().setLabel("seda:b server").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(1),
-        new SpanTestData().setLabel("seda:b client").setUri("seda://b")
+        new SpanTestData().setLabel("seda:b client").setUri("seda://b").setOperation("b")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
-        new SpanTestData().setLabel("seda:c server").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(3),
-        new SpanTestData().setLabel("seda:c client").setUri("seda://c")
+        new SpanTestData().setLabel("seda:c client").setUri("seda://c").setOperation("c")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
-        new SpanTestData().setLabel("seda:a server").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(5),
-        new SpanTestData().setLabel("seda:a client").setUri("seda://a")
+        new SpanTestData().setLabel("seda:a client").setUri("seda://a").setOperation("a")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
-        new SpanTestData().setLabel("direct:start server").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(7),
-        new SpanTestData().setLabel("direct:start client").setUri("direct://start")
+        new SpanTestData().setLabel("direct:start client").setUri("direct://start").setOperation("start")
             .setKind(Tags.SPAN_KIND_CLIENT)
     };
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/RouteConcurrentTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/RouteConcurrentTest.java
@@ -27,13 +27,13 @@ import org.junit.Test;
 public class RouteConcurrentTest extends CamelOpenTracingTestSupport {
 
     private static SpanTestData[] testdata = {
-        new SpanTestData().setLabel("seda:foo client").setUri("seda://foo")
+        new SpanTestData().setLabel("seda:foo client").setUri("seda://foo").setOperation("foo")
             .setKind(Tags.SPAN_KIND_CLIENT),
-        new SpanTestData().setLabel("seda:bar client").setUri("seda://bar")
+        new SpanTestData().setLabel("seda:bar client").setUri("seda://bar").setOperation("bar")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(2),
-        new SpanTestData().setLabel("seda:foo server").setUri("seda://foo?concurrentConsumers=5")
+        new SpanTestData().setLabel("seda:foo server").setUri("seda://foo?concurrentConsumers=5").setOperation("foo")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(0),
-        new SpanTestData().setLabel("seda:bar server").setUri("seda://bar?concurrentConsumers=5")
+        new SpanTestData().setLabel("seda:bar server").setUri("seda://bar?concurrentConsumers=5").setOperation("bar")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(1)
     };
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanTestData.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanTestData.java
@@ -20,6 +20,7 @@ public class SpanTestData {
 
     private String label;
     private String uri;
+    private String operation;
     private String kind;
     private int parentId = -1;
 
@@ -38,6 +39,15 @@ public class SpanTestData {
 
     public SpanTestData setUri(String uri) {
         this.uri = uri;
+        return this;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public SpanTestData setOperation(String operation) {
+        this.operation = operation;
         return this;
     }
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/TestSEDASpanDecorator.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/TestSEDASpanDecorator.java
@@ -19,19 +19,9 @@ package org.apache.camel.opentracing;
 import io.opentracing.Span;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.opentracing.decorators.AbstractSpanDecorator;
+import org.apache.camel.opentracing.decorators.SedaSpanDecorator;
 
-public class TestSEDASpanDecorator extends AbstractSpanDecorator {
-
-    @Override
-    public String getComponent() {
-        return "seda";
-    }
-
-    @Override
-    public String getOperationName(Exchange exchange, Endpoint endpoint) {
-        return "testop";
-    }
+public class TestSEDASpanDecorator extends SedaSpanDecorator {
 
     @Override
     public void pre(Span span, Exchange exchange, Endpoint endpoint) {

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/TwoServiceTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/TwoServiceTest.java
@@ -24,13 +24,13 @@ import org.junit.Test;
 public class TwoServiceTest extends CamelOpenTracingTestSupport {
 
     private static SpanTestData[] testdata = {
-        new SpanTestData().setLabel("ServiceB server").setUri("direct://ServiceB")
+        new SpanTestData().setLabel("ServiceB server").setUri("direct://ServiceB").setOperation("ServiceB")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(1),
-        new SpanTestData().setLabel("ServiceB client").setUri("direct://ServiceB")
+        new SpanTestData().setLabel("ServiceB client").setUri("direct://ServiceB").setOperation("ServiceB")
             .setKind(Tags.SPAN_KIND_CLIENT).setParentId(2),
-        new SpanTestData().setLabel("ServiceA server").setUri("direct://ServiceA")
+        new SpanTestData().setLabel("ServiceA server").setUri("direct://ServiceA").setOperation("ServiceA")
             .setKind(Tags.SPAN_KIND_SERVER).setParentId(3),
-        new SpanTestData().setLabel("ServiceA client").setUri("direct://ServiceA")
+        new SpanTestData().setLabel("ServiceA client").setUri("direct://ServiceA").setOperation("ServiceA")
             .setKind(Tags.SPAN_KIND_CLIENT)
     };
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/AbstractSpanDecoratorTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/AbstractSpanDecoratorTest.java
@@ -44,7 +44,9 @@ public class AbstractSpanDecoratorTest {
             }
         };
 
-        assertEquals(TEST_URI, decorator.getOperationName(null, endpoint));
+        // Operation name is scheme, as no specific span decorator to
+        // identify an appropriate name
+        assertEquals("test", decorator.getOperationName(null, endpoint));
     }
 
     @Test
@@ -94,6 +96,33 @@ public class AbstractSpanDecoratorTest {
         assertEquals("error", span.logEntries().get(0).fields().get("event"));
         assertEquals("Exception", span.logEntries().get(0).fields().get("error.kind"));
         assertEquals(e.getMessage(), span.logEntries().get(0).fields().get("message"));
+    }
+
+    @Test
+    public void testStripSchemeNoOptions() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("direct:hello");
+
+        assertEquals("hello", AbstractSpanDecorator.stripSchemeAndOptions(endpoint));
+    }
+
+    @Test
+    public void testStripSchemeNoOptionsWithSlashes() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("direct://hello");
+
+        assertEquals("hello", AbstractSpanDecorator.stripSchemeAndOptions(endpoint));
+    }
+
+    @Test
+    public void testStripSchemeAndOptions() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("direct:hello?world=true");
+
+        assertEquals("hello", AbstractSpanDecorator.stripSchemeAndOptions(endpoint));
     }
 
 }

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/JdbcSpanDecoratorTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/JdbcSpanDecoratorTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.opentracing.decorators;
 
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -48,8 +50,8 @@ public class JdbcSpanDecoratorTest {
 
         decorator.pre(span, exchange, endpoint);
 
-        assertEquals("sql", span.tags().get("db.type"));
-        assertEquals(SQL_STATEMENT, span.tags().get("db.statement"));
+        assertEquals("sql", span.tags().get(Tags.DB_TYPE.getKey()));
+        assertEquals(SQL_STATEMENT, span.tags().get(Tags.DB_STATEMENT.getKey()));
     }
 
 }

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/MongoDBSpanDecoratorTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/MongoDBSpanDecoratorTest.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.opentracing.SpanDecorator;
 import org.junit.Test;
@@ -66,9 +68,9 @@ public class MongoDBSpanDecoratorTest {
 
         decorator.pre(span, null, endpoint);
 
-        assertEquals("mongodb", span.tags().get("db.type"));
-        assertEquals("flights", span.tags().get("db.instance"));
-        assertTrue(span.tags().containsKey("db.statement"));
+        assertEquals("mongodb", span.tags().get(Tags.DB_TYPE.getKey()));
+        assertEquals("flights", span.tags().get(Tags.DB_INSTANCE.getKey()));
+        assertTrue(span.tags().containsKey(Tags.DB_STATEMENT.getKey()));
     }
 
 }

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/SqlSpanDecoratorTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/SqlSpanDecoratorTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.opentracing.decorators;
 
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -48,8 +50,8 @@ public class SqlSpanDecoratorTest {
 
         decorator.pre(span, exchange, endpoint);
 
-        assertEquals("sql", span.tags().get("db.type"));
-        assertEquals(SQL_STATEMENT, span.tags().get("db.statement"));
+        assertEquals("sql", span.tags().get(Tags.DB_TYPE.getKey()));
+        assertEquals(SQL_STATEMENT, span.tags().get(Tags.DB_STATEMENT.getKey()));
     }
 
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -488,7 +488,7 @@
     <openstack4j-guava-version>17.0</openstack4j-guava-version>
     <opentracing-java-globaltracer-version>0.1.0</opentracing-java-globaltracer-version>
     <opentracing-java-spanmanager-version>0.0.3</opentracing-java-spanmanager-version>
-    <opentracing-version>0.20.9</opentracing-version>
+    <opentracing-version>0.20.10</opentracing-version>
     <ops4j-base-version>1.5.0</ops4j-base-version>
     <optaplanner-version>6.5.0.Final</optaplanner-version>
     <oro-bundle-version>2.0.8_6</oro-bundle-version>


### PR DESCRIPTION
This PR includes the following:
[x] Updated opentracing-java version to 0.20.10
[x] Use constants for DB tags available in 0.20.10
[x] Changed default operation to be component name
[x] Added mechanism to enable custom decorator for particular component to override standard one
[x] Added span decorators for direct/vm/seda components