### PR TITLE
CAMEL-10987: Remove TinyBundle from AbstractFeatureTest API to fix ClassNotFoundException in camel-itest-karaf

### DIFF
--- a/components/camel-test-karaf/pom.xml
+++ b/components/camel-test-karaf/pom.xml
@@ -37,7 +37,6 @@
     <label>testing,java,osgi</label>
 
     <karf-test-version>${karaf4-version}</karf-test-version>
-    <depends-maven-plugin-version>1.3.1</depends-maven-plugin-version>
     <camel.osgi.export.pkg>org.apache.camel.test.karaf</camel.osgi.export.pkg>
   </properties>
 

--- a/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
+++ b/components/camel-test-karaf/src/main/java/org/apache/camel/test/karaf/AbstractFeatureTest.java
@@ -110,7 +110,8 @@ public abstract class AbstractFeatureTest {
         return installBlueprintAsBundle(name, url, start, bundle -> {});
     }
 
-    protected Bundle installBlueprintAsBundle(String name, URL url, boolean start, Consumer<TinyBundle> consumer) throws BundleException {
+    protected Bundle installBlueprintAsBundle(String name, URL url, boolean start, Consumer<Object> consumer) throws BundleException {
+        // TODO Type Consumer<TinyBundle> cannot be used for this method signature to avoid bundle dependency to pax tinybundles
         TinyBundle bundle = TinyBundles.bundle();
         bundle.add("OSGI-INF/blueprint/blueprint-" + name.toLowerCase(Locale.ENGLISH) + ".xml", url);
         bundle.set("Manifest-Version", "2")
@@ -130,7 +131,8 @@ public abstract class AbstractFeatureTest {
         return installSpringAsBundle(name, url, start, bundle -> {});
     }
 
-    protected Bundle installSpringAsBundle(String name, URL url, boolean start, Consumer<TinyBundle> consumer) throws BundleException {
+    protected Bundle installSpringAsBundle(String name, URL url, boolean start, Consumer<Object> consumer) throws BundleException {
+        // TODO Type Consumer<TinyBundle> cannot be used for this method signature to avoid bundle dependency to pax tinybundles
         TinyBundle bundle = TinyBundles.bundle();
         bundle.add("META-INF/spring/spring-" + name.toLowerCase(Locale.ENGLISH) + ".xml", url);
         bundle.set("Manifest-Version", "2")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,6 +158,7 @@
     <cxf-xjc-plugin-version>3.0.5</cxf-xjc-plugin-version>
     <cxf-xjc-utils-version>3.0.5</cxf-xjc-utils-version>
     <deltaspike-version>1.7.2</deltaspike-version>
+    <depends-maven-plugin-version>1.3.1</depends-maven-plugin-version>
     <derby-version>10.11.1.1</derby-version>
     <disruptor-version>3.3.6</disruptor-version>
     <dnsjava-version>2.1.8</dnsjava-version>

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelBoxTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.itest.karaf;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -26,6 +27,7 @@ public class CamelBoxTest extends BaseKarafTest {
     public static final String COMPONENT = extractName(CamelBoxTest.class);
 
     @Test
+    @Ignore("CAMEL-10999 Karaf camel-box feature is not updated with new Box 2 SDK")
     public void test() throws Exception {
         testComponent(COMPONENT);
     }

--- a/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/CamelTypeConverterTest.java
+++ b/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/CamelTypeConverterTest.java
@@ -34,6 +34,7 @@ import org.ops4j.pax.exam.ProbeBuilder;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.ops4j.pax.tinybundles.core.TinyBundle;
 import org.osgi.framework.Constants;
 
 @RunWith(PaxExam.class)
@@ -45,7 +46,7 @@ public class CamelTypeConverterTest extends AbstractFeatureTest {
         URL blueprintUrl = ObjectHelper.loadResourceAsURL("org/apache/camel/itest/CamelTypeConverterTest.xml", CamelTypeConverterTest.class.getClassLoader());
         installBlueprintAsBundle("CamelTypeConverterTest", blueprintUrl, true, bundle -> {
             // install converter
-            bundle
+            ((TinyBundle) bundle)
                 .add("META-INF/services/org/apache/camel/TypeConverter", new ByteArrayInputStream("org.apache.camel.itest.typeconverter.MyConverter".getBytes()))
                 .add(MyConverter.class, InnerClassStrategy.NONE)
                 .set(Constants.DYNAMICIMPORT_PACKAGE, "*");

--- a/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/cxf/CamelCxfBeanInjectTest.java
+++ b/tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/cxf/CamelCxfBeanInjectTest.java
@@ -38,6 +38,7 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.ops4j.pax.tinybundles.core.TinyBundle;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 
@@ -53,7 +54,8 @@ public class CamelCxfBeanInjectTest extends AbstractFeatureTest {
         // install the camel blueprint xml file we use in this test
         URL url = ObjectHelper.loadResourceAsURL("org/apache/camel/itest/cxf/CamelCxfBeanInjectTest.xml", CamelCxfBeanInjectTest.class.getClassLoader());
         Bundle bundle = installBlueprintAsBundle("CamelCxfBeanInjectTest", url, false, b -> {
-            b.add(BeanInjectRouteBuilder.class, InnerClassStrategy.NONE)
+            ((TinyBundle) b)
+                .add(BeanInjectRouteBuilder.class, InnerClassStrategy.NONE)
                 .add(SimpleService.class, InnerClassStrategy.NONE)
                 .add(SimpleBean.class, InnerClassStrategy.NONE)
                 .set(Constants.DYNAMICIMPORT_PACKAGE, "*");


### PR DESCRIPTION
This fixes the direct issue at https://issues.apache.org/jira/browse/CAMEL-10987.

However, apparently camel-itest-karaf has been having much more potential issues. I'd like to address as much of them as possible here in pull reqs that follow.