### PR TITLE
CAMEL-11008: Consumer/Producer templates are not stopped when auto-configured in Spring Boot

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -222,8 +222,10 @@ public class CamelAutoConfiguration {
     // Camel handles the lifecycle of this bean
     @ConditionalOnMissingBean(ProducerTemplate.class)
     ProducerTemplate producerTemplate(CamelContext camelContext,
-                                      CamelConfigurationProperties config) {
-        return camelContext.createProducerTemplate(config.getProducerTemplateCacheSize());
+                                      CamelConfigurationProperties config) throws Exception {
+        final ProducerTemplate producerTemplate = camelContext.createProducerTemplate(config.getProducerTemplateCacheSize());
+        camelContext.addService(producerTemplate);
+        return producerTemplate;
     }
 
     /**
@@ -233,8 +235,10 @@ public class CamelAutoConfiguration {
     // Camel handles the lifecycle of this bean
     @ConditionalOnMissingBean(ConsumerTemplate.class)
     ConsumerTemplate consumerTemplate(CamelContext camelContext,
-                                      CamelConfigurationProperties config) {
-        return camelContext.createConsumerTemplate(config.getConsumerTemplateCacheSize());
+                                      CamelConfigurationProperties config) throws Exception {
+        final ConsumerTemplate consumerTemplate = camelContext.createConsumerTemplate(config.getConsumerTemplateCacheSize());
+        camelContext.addService(consumerTemplate);
+        return consumerTemplate;
     }
 
     // SpringCamelContext integration

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelSpringBootTemplateShutdownTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelSpringBootTemplateShutdownTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.support.ServiceSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.AbstractApplicationContext;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CamelSpringBootTemplateShutdownTest {
+
+    CamelContext camelContext;
+
+    AbstractApplicationContext applicationContext;
+
+    ConsumerTemplate consumerTemplate;
+
+    ProducerTemplate producerTemplate;
+
+    @Before
+    public void setupApplicationContext() {
+        applicationContext = new AnnotationConfigApplicationContext(CamelAutoConfiguration.class);
+        camelContext = applicationContext.getBean(CamelContext.class);
+        consumerTemplate = applicationContext.getBean(ConsumerTemplate.class);
+        producerTemplate = applicationContext.getBean(ProducerTemplate.class);
+    }
+
+    @Test
+    public void shouldStopTemplatesWithCamelShutdown() throws Exception {
+        assertTrue(((ServiceSupport) consumerTemplate).isStarted());
+        assertTrue(((ServiceSupport) producerTemplate).isStarted());
+
+        camelContext.stop();
+
+        assertTrue(((ServiceSupport) camelContext).isStopped());
+        assertTrue(((ServiceSupport) consumerTemplate).isStopped());
+        assertTrue(((ServiceSupport) producerTemplate).isStopped());
+    }
+
+    @Test
+    public void shouldStopTemplatesWithApplicationContextShutdown() throws Exception {
+        assertTrue(((ServiceSupport) consumerTemplate).isStarted());
+        assertTrue(((ServiceSupport) producerTemplate).isStarted());
+
+        applicationContext.close();
+
+        assertFalse(applicationContext.isActive());
+        assertTrue(((ServiceSupport) camelContext).isStopped());
+        assertTrue(((ServiceSupport) consumerTemplate).isStopped());
+        assertTrue(((ServiceSupport) producerTemplate).isStopped());
+    }
+
+}


### PR DESCRIPTION
In [CAMEL-9431|https://issues.apache.org/jira/browse/CAMEL-9431] producer/consumer templates did not receive their own `destroyMethod` methods. I've changed those to use `stop` for `destroyMethod`, a proper solution might be that `DefaultCamelContext` tracks all templates and stops them on shutdown, or make them `CamelContextAware` and `addService` them to CamelContext, or `addService` them in `createProducerTemplate` `createConsumerTemplate`.
I've decided to do a simple fix here and provide a unit test that can be used to validate the best solution to the problem.