### PR TITLE
Instrument OpenTracing example service2 using the JavaAgent.

### DIFF
--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -38,6 +38,8 @@
     <title>OpenTracing</title>
 
     <camel.osgi.export.pkg>org.apache.camel.opentracing.*</camel.osgi.export.pkg>
+
+    <opentracing-agent.lib>${project.build.directory}/lib</opentracing-agent.lib>
   </properties>
 
   <dependencies>
@@ -65,6 +67,12 @@
     </dependency>
 
     <!-- test dependencies -->
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-agent</artifactId>
+      <scope>test</scope>
+      <version>${opentracing-java-agent-version}</version>
+    </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
@@ -98,5 +106,72 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/agent/*Test.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-agent</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.opentracing.contrib</groupId>
+                  <artifactId>opentracing-agent</artifactId>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${opentracing-agent.lib}</outputDirectory>
+                  <destFileName>opentracing-agent.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -javaagent:${opentracing-agent.lib}/opentracing-agent.jar
+            -Dorg.jboss.byteman.verbose
+          </argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/agent/*Test.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>final-verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
@@ -41,6 +41,8 @@ import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.management.event.ExchangeSendingEvent;
 import org.apache.camel.management.event.ExchangeSentEvent;
 import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.opentracing.propagation.CamelHeadersExtractAdapter;
+import org.apache.camel.opentracing.propagation.CamelHeadersInjectAdapter;
 import org.apache.camel.spi.RoutePolicy;
 import org.apache.camel.spi.RoutePolicyFactory;
 import org.apache.camel.support.EventNotifierSupport;

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/propagation/CamelHeadersExtractAdapter.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/propagation/CamelHeadersExtractAdapter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.opentracing;
+package org.apache.camel.opentracing.propagation;
 
 import java.util.HashMap;
 import java.util.Iterator;

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/propagation/CamelHeadersInjectAdapter.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/propagation/CamelHeadersInjectAdapter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.opentracing;
+package org.apache.camel.opentracing.propagation;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -35,6 +35,9 @@ public final class CamelHeadersInjectAdapter implements TextMap {
 
     @Override
     public void put(String key, String value) {
-        this.map.put(key, value);
+        // Assume any header property that begins with 'Camel' is for internal use
+        if (!key.startsWith("Camel")) {
+            this.map.put(key, value);
+        }
     }
 }

--- a/components/camel-opentracing/src/main/resources/otagent/apache-camel.btm
+++ b/components/camel-opentracing/src/main/resources/otagent/apache-camel.btm
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 # State 0 - camel context not initialized
 # State 1 - camel context initialized

--- a/components/camel-opentracing/src/main/resources/otagent/apache-camel.btm
+++ b/components/camel-opentracing/src/main/resources/otagent/apache-camel.btm
@@ -1,0 +1,16 @@
+
+# State 0 - camel context not initialized
+# State 1 - camel context initialized
+
+RULE apache-camel: Install OpenTracing tracer
+CLASS org.apache.camel.impl.DefaultCamelContext
+METHOD startRouteDefinitions
+HELPER io.opentracing.contrib.agent.OpenTracingHelper
+BIND
+  ottracer:org.apache.camel.opentracing.OpenTracingTracer = new org.apache.camel.opentracing.OpenTracingTracer();
+AT ENTRY
+IF getState($0) == 0
+DO
+  ottracer.init($0);
+  setState($0, 1);
+ENDRULE

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
@@ -34,9 +34,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- * @author gbrown
- */
 public class InstallOpenTracingTracerRuleTest extends CamelTestSupport {
 
     private static MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentracing.agent;
+
+import java.util.List;
+
+import io.opentracing.contrib.global.GlobalTracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.tag.Tags;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author gbrown
+ */
+public class InstallOpenTracingTracerRuleTest extends CamelTestSupport {
+
+    private static MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @BeforeClass
+    public static void initClass() throws Exception {
+        GlobalTracer.register(tracer);
+    }
+
+    @Before
+    public void init() {
+        tracer.reset();
+    }
+
+    public static MockTracer getTracer() {
+        return tracer;
+    }
+
+    @Override
+    public boolean isDumpRouteCoverage() {
+        return true;
+    }
+
+    @Test
+    public void testSendMatchingMessage() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody,  "foo",  "bar");
+
+        resultEndpoint.assertIsSatisfied();
+
+        List<MockSpan> spans = getTracer().finishedSpans();
+        assertEquals(3, spans.size());
+        assertEquals("mock", spans.get(0).operationName());
+        assertEquals("start", spans.get(1).operationName());
+        assertEquals("start", spans.get(2).operationName());
+        assertEquals(Tags.SPAN_KIND_CLIENT, spans.get(0).tags().get(Tags.SPAN_KIND.getKey()));
+        assertEquals(Tags.SPAN_KIND_SERVER, spans.get(1).tags().get(Tags.SPAN_KIND.getKey()));
+        assertEquals(Tags.SPAN_KIND_CLIENT, spans.get(2).tags().get(Tags.SPAN_KIND.getKey()));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").filter(header("foo").isEqualTo("bar")).to("mock:result");
+            }
+        };
+    }
+}

--- a/examples/camel-example-opentracing/README.md
+++ b/examples/camel-example-opentracing/README.md
@@ -32,12 +32,16 @@ $ cd service1
 $ mvn compile spring-boot:run
 ```
 
+This service uses an annotation _CamelOpenTracing_ to indicate that the service should be traced.
+
 When service1 is ready then start service2
 
 ```sh
 $ cd service2
-$ mvn compile camel:run
+$ mvn compile exec:exec
 ```
+
+This service is instrumented using an OpenTracing Java Agent, so the code does not need to be modified. The only requirement is that the OpenTracing Tracer and Camel OpenTracing component dependencies are added, and that the _opentracing-agent.jar_ Java Agent is specified when executing the service.
 
 And then start the client that calls service1 every 30 seconds.
 
@@ -45,6 +49,8 @@ And then start the client that calls service1 every 30 seconds.
 $ cd client
 $ mvn compile camel:run
 ```
+
+The client application explicitly instantiates and initializes the OpenTracing Tracer with the _CamelContext_.
 
 The shells will show *SPAN FINISHED* messages indicating what spans have been reported from the client
 and two services.

--- a/examples/camel-example-opentracing/service2/pom.xml
+++ b/examples/camel-example-opentracing/service2/pom.xml
@@ -30,6 +30,10 @@
   <name>Camel :: Example :: OpenTracing :: Service 2</name>
   <description>An example showing how to trace incoming and outgoing messages from Camel with OpenTracing</description>
 
+  <properties>
+    <opentracing-agent.lib>${project.build.directory}/lib</opentracing-agent.lib>
+  </properties>
+
   <!-- import Camel BOM -->
   <dependencyManagement>
     <dependencies>
@@ -52,17 +56,47 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-opentracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-undertow</artifactId>
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-nio</artifactId>
+      <version>${jboss-xnio-version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
+
+    <!-- OpenTracing dependencies -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-opentracing</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-example-opentracing-loggingtracer</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-agent</artifactId>
+      <version>${opentracing-java-agent-version}</version>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>
@@ -70,37 +104,42 @@
   <build>
 
     <plugins>
-      <!-- allows the routes to be run via 'mvn camel:run' -->
       <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-        <version>${project.version}</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-agent</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.opentracing.contrib</groupId>
+                  <artifactId>opentracing-agent</artifactId>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${opentracing-agent.lib}</outputDirectory>
+                  <destFileName>opentracing-agent.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <mainClass>sample.camel.Service2Application</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-javaagent:${opentracing-agent.lib}/opentracing-agent.jar</argument>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>sample.camel.Service2Application</argument>
+          </arguments>
         </configuration>
-        <dependencies>  
-          <!-- logging -->
-          <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j2-version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2-version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2-version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>${log4j2-version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
 

--- a/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Route.java
+++ b/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Route.java
@@ -17,14 +17,11 @@
 package sample.camel;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.opentracing.OpenTracingTracer;
 
 public class Service2Route extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        OpenTracingTracer ottracer = new OpenTracingTracer();
-        ottracer.init(getContext());
 
         from("undertow:http://0.0.0.0:7070/service2").routeId("service2").streamCaching()
                 .log(" Service2 request: ${body}")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -492,6 +492,7 @@
     <openshift-java-client-version>2.7.0.Final</openshift-java-client-version>
     <openstack4j-version>3.0.2</openstack4j-version>
     <openstack4j-guava-version>17.0</openstack4j-guava-version>
+    <opentracing-java-agent-version>0.0.10</opentracing-java-agent-version>
     <opentracing-java-globaltracer-version>0.1.0</opentracing-java-globaltracer-version>
     <opentracing-java-spanmanager-version>0.0.3</opentracing-java-spanmanager-version>
     <opentracing-version>0.20.10</opentracing-version>


### PR DESCRIPTION
Fix issue with baggage propagating Camel prefixed headers, causing outbound component to throw exception.
Added agent rule test.