### PR TITLE
CAMEL-10885 Add mask option to log EIP

### DIFF
--- a/camel-core/readme-eip.adoc
+++ b/camel-core/readme-eip.adoc
@@ -67,6 +67,9 @@ Number of EIPs: 61 (2 deprecated)
 | link:src/main/docs/eips/loadBalance-eip.adoc[Load Balance] +
 `<loadBalance>` | Balances message processing among a number of nodes
 
+| link:src/main/docs/eips/log-eip.adoc[Log] +
+`<log>` | Logs a message to the underlying logging mechanism
+
 | link:src/main/docs/eips/loop-eip.adoc[Loop] +
 `<loop>` | Processes a message multiple times
 

--- a/camel-core/readme-eip.adoc
+++ b/camel-core/readme-eip.adoc
@@ -4,7 +4,7 @@ Enterprise Integration Patterns
 Camel supports most of the link:http://www.eaipatterns.com/toc.html[Enterprise Integration Patterns] from the excellent book by link:http://www.amazon.com/exec/obidos/search-handle-url/105-9796798-8100401?%5Fencoding=UTF8&search-type=ss&index=books&field-author=Gregor%20Hohpe[Gregor Hohpe] and link:http://www.amazon.com/exec/obidos/search-handle-url/105-9796798-8100401?%5Fencoding=UTF8&search-type=ss&index=books&field-author=Bobby%20Woolf[Bobby Woolf].
 
 // eips: START
-Number of EIPs: 61 (2 deprecated)
+Number of EIPs: 62 (2 deprecated)
 
 [width="100%",cols="4,6",options="header"]
 |=======================================================================
@@ -68,7 +68,7 @@ Number of EIPs: 61 (2 deprecated)
 `<loadBalance>` | Balances message processing among a number of nodes
 
 | link:src/main/docs/eips/log-eip.adoc[Log] +
-`<log>` | Logs a message to the underlying logging mechanism
+`<log>` | Logs the defined message to the logger
 
 | link:src/main/docs/eips/loop-eip.adoc[Loop] +
 `<loop>` | Processes a message multiple times

--- a/camel-core/src/main/docs/eips/log-eip.adoc
+++ b/camel-core/src/main/docs/eips/log-eip.adoc
@@ -150,19 +150,20 @@ In some scenarios it is required that the bundle associated with logger should b
 ### Masking sensitive information like password
 *Available as of Camel 2.19*
 
-You can enable security masking for log DSL by setting `logEipMask` flag to `true`.
+You can enable security masking for logging by setting `logMask` flag to `true`.
+Note that this option also affects link:log.html[Log] component.
 
 To enable mask in Java DSL at CamelContext level:
 [source,java]
 --------------------------------------------------------
 CamelContext context = ...
-context.setLogEipMask(true);
+context.setLogMask(true);
 --------------------------------------------------------
 
 And in XML:
 [source,java]
 --------------------------------------------------------
-<camelContext logEipMask="true">
+<camelContext logMask="true">
 ...
 --------------------------------------------------------
 
@@ -170,15 +171,19 @@ And in XML:
 You can also turn it on|off at route level. To enable mask in Java DSL at route level:
 [source,java]
 --------------------------------------------------------
-from("direct:start").logEipMask().log("Processing ${id}").to("bean:foo");
+from("direct:start").logMask().log("Processing ${id}").to("bean:foo");
 --------------------------------------------------------
 
 And in XML:
 [source,java]
 --------------------------------------------------------
-<route logEipMask="true">
+<route logMask="true">
 ...
 --------------------------------------------------------
+
+`org.apache.camel.processor.DefaultMaskingFormatter` is used for the masking by default.
+If you want to use a custom masking formatter, put it into registry with the name `CamelCustomLogMask`.
+Note that the masking formatter must implement `org.apache.camel.spi.MaskingFormatter`.
 
 
 ### Using This Pattern

--- a/camel-core/src/main/docs/eips/log-eip.adoc
+++ b/camel-core/src/main/docs/eips/log-eip.adoc
@@ -1,0 +1,185 @@
+## Log EIP
+
+How can I log the processing of a link:message.html[Message]?
+
+Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
+* You can use the link:log.html[Log] component which logs the Message content.
+* You can use the link:tracer.html[Tracer] which trace logs message flow.
+* You can also use a link:processor.html[Processor] or link:bean.html[Bean] and log from Java code.
+* You can use the log DSL.
+
+// eip options: START
+The Log EIP supports 5 options which are listed below:
+
+
+[width="100%",cols="3,1m,6",options="header"]
+|=======================================================================
+| Name | Java Type | Description
+| message | String | *Required* Sets the log message (uses simple language)
+| loggingLevel | LoggingLevel | Sets the logging level. The default value is INFO
+| logName | String | Sets the name of the logger
+| marker | String | To use slf4j marker
+| loggerRef | String | To refer to a custom logger instance to lookup from the registry.
+|=======================================================================
+// eip options: END
+
+
+## Using log DSL
+
+In *Camel 2.2* you can use the log DSL which allows you to use link:simple.html[Simple] language to construct a dynamic message which gets logged.
+
+For example you can do
+
+[source,java]
+--------------------------------------------------------
+from("direct:start").log("Processing ${id}").to("bean:foo");
+--------------------------------------------------------
+
+Which will construct a String message at runtime using the Simple language. The log message will by logged at INFO level using the route id as the log name. By default a route is named route-1, route-2 etc. But you can use the routeId("myCoolRoute") to set a route name of choice.
+
+INFO:Difference between log in the DSL and [Log] component
+The log DSL is much lighter and meant for logging human logs such as Starting to do ... etc. It can only log a message based on the Simple language. On the other hand Log component is a full fledged component which involves using endpoints and etc. The Log component is meant for logging the Message itself and you have many URI options to control what you would like to be logged.
+
+INFO:Using Logger instance from the the Registry
+As of *Camel 2.12.4/2.13.1*, if no logger name or logger instance is passed to log DSL, there is a Registry lookup performed to find single instance of org.slf4j.Logger. If such an instance is found, it is used instead of creating a new logger instance. If more instances are found, the behavior defaults to creating a new instance of logger.
+
+INFO:Logging message body with streamed messages
+If the message body is stream based, then logging the message body, may cause the message body to be empty afterwards. See this FAQ. For streamed messages you can use Stream caching to allow logging the message body and be able to read the message body afterwards again.
+
+The log DSL have overloaded methods to set the logging level and/or name as well.
+[source,java]
+--------------------------------------------------------
+from("direct:start").log(LoggingLevel.DEBUG, "Processing ${id}").to("bean:foo");
+--------------------------------------------------------
+
+and to set a logger name
+[source,java]
+--------------------------------------------------------
+from("direct:start").log(LoggingLevel.DEBUG, "com.mycompany.MyCoolRoute", "Processing ${id}").to("bean:foo");
+--------------------------------------------------------
+
+Since *Camel 2.12.4/2.13.1* the logger instance may be used as well:
+[source,java]
+--------------------------------------------------------
+from("direct:start").log(LoggingLeven.DEBUG, org.slf4j.LoggerFactory.getLogger("com.mycompany.mylogger"), "Processing ${id}").to("bean:foo");
+--------------------------------------------------------
+
+For example you can use this to log the file name being processed if you consume files.
+[source,java]
+--------------------------------------------------------
+from("file://target/files").log(LoggingLevel.DEBUG, "Processing file ${file:name}").to("bean:foo");
+--------------------------------------------------------
+
+### Using log DSL from Spring
+
+In Spring DSL it is also easy to use log DSL as shown below:
+[source,xml]
+--------------------------------------------------------
+<route id="foo">
+    <from uri="direct:foo"/>
+    <log message="Got ${body}"/>
+    <to uri="mock:foo"/>
+</route>
+--------------------------------------------------------
+
+The log tag has attributes to set the message, loggingLevel and logName. For example:
+[source,xml]
+--------------------------------------------------------
+<route id="baz">
+    <from uri="direct:baz"/>
+    <log message="Me Got ${body}" loggingLevel="FATAL" logName="com.mycompany.MyCoolRoute"/>
+    <to uri="mock:baz"/>
+</route>
+--------------------------------------------------------
+
+Since Camel *2.12.4/2.13.1* it is possible to reference logger instance. For example:
+[source,xml]
+--------------------------------------------------------
+<bean id="myLogger" class="org.slf4j.LoggerFactory" factory-method="getLogger" xmlns="http://www.springframework.org/schema/beans">
+    <constructor-arg value="com.mycompany.mylogger" />
+</bean>
+ 
+<route id="moo" xmlns="http://camel.apache.org/schema/spring">
+    <from uri="direct:moo"/>
+    <log message="Me Got ${body}" loggingLevel="INFO" loggerRef="myLogger"/>
+    <to uri="mock:baz"/>
+</route>
+--------------------------------------------------------
+
+### Configuring log name globally
+*Available as of Camel 2.17*
+
+By default the log name is the route id. If you want to use a different log name, you would need to configure the logName option. However if you have many logs and you want all of them to use the same log name, then you would need to set that logName option on all of them.
+
+With Camel 2.17 onwards you can configure a global log name that is used instead of the route id, eg
+[source,java]
+--------------------------------------------------------
+CamelContext context = ...
+context.getProperties().put(Exchange.LOG_EIP_NAME, "com.foo.myapp");
+--------------------------------------------------------
+
+And in XML
+[source,xml]
+--------------------------------------------------------
+<camelContext ...>
+  <properties>
+    <property key="CamelLogEipName" value="com.foo.myapp"/>
+  </properties>
+--------------------------------------------------------
+
+### Using slf4j Marker
+*Available as of Camel 2.9*
+
+You can specify a marker name in the DSL
+[source,xml]
+--------------------------------------------------------
+<route id="baz">
+    <from uri="direct:baz"/>
+    <log message="Me Got ${body}" loggingLevel="FATAL" logName="com.mycompany.MyCoolRoute" marker="myMarker"/>
+    <to uri="mock:baz"/>
+</route>
+--------------------------------------------------------
+
+### Using log DSL in OSGi
+*Improvement as of Camel 2.12.4/2.13.1*
+
+When using log DSL inside OSGi (e.g., in Karaf), the underlying logging mechanisms are provided by PAX logging. It searches for a bundle which invokes org.slf4j.LoggerFactory.getLogger() method and associates the bundle with the logger instance. Passing only logger name to log DSL results in associating camel-core bundle with the logger instance created.
+
+In some scenarios it is required that the bundle associated with logger should be the bundle which contains route definition. This is possible using provided logger instance both for Java DSL and Spring DSL (see the examples above).
+
+### Masking sensitive information like password
+*Available as of Camel 2.19*
+
+You can enable security masking for log DSL by setting `logEipMask` flag to `true`.
+
+To enable mask in Java DSL at CamelContext level:
+[source,java]
+--------------------------------------------------------
+CamelContext context = ...
+context.setLogEipMask(true);
+--------------------------------------------------------
+
+And in XML:
+[source,java]
+--------------------------------------------------------
+<camelContext logEipMask="true">
+...
+--------------------------------------------------------
+
+
+You can also turn it on|off at route level. To enable mask in Java DSL at route level:
+[source,java]
+--------------------------------------------------------
+from("direct:start").logEipMask().log("Processing ${id}").to("bean:foo");
+--------------------------------------------------------
+
+And in XML:
+[source,java]
+--------------------------------------------------------
+<route logEipMask="true">
+...
+--------------------------------------------------------
+
+
+### Using This Pattern
+If you would like to use this EIP Pattern then please read the link:getting-started.html[Getting Started], you may also find the link:architecture.html[Architecture] useful particularly the description of link:endpoint.html[Endpoint] and link:uris.html[URIs]. Then you could try out some of the link:examples.html[Examples] first before trying this pattern out.

--- a/camel-core/src/main/docs/log-component.adoc
+++ b/camel-core/src/main/docs/log-component.adoc
@@ -86,7 +86,7 @@ with the following path and query parameters:
 | **loggerName** | *Required* The logger name to use |  | String
 |=======================================================================
 
-#### Query Parameters (25 parameters):
+#### Query Parameters (26 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -96,6 +96,7 @@ with the following path and query parameters:
 | **groupInterval** (producer) | If specified will group message stats by this time interval (in millis) |  | Long
 | **groupSize** (producer) | An integer that specifies a group size for throughput logging. |  | Integer
 | **level** (producer) | Logging level to use. The default value is INFO. | INFO | String
+| **logMask** (producer) | If true mask sensitive information like password or passphrase in the log. |  | Boolean
 | **marker** (producer) | An optional Marker name to use. |  | String
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **maxChars** (formatting) | Limits the number of characters logged per line. | 10000 | int
@@ -181,6 +182,48 @@ The following will be logged:
 ------------------------------------------------------------------------------------------------------------------------------------
 "Received: 1000 new messages, with total 2000 so far. Last group took: 10000 millis which is: 100 messages per second. average: 100"
 ------------------------------------------------------------------------------------------------------------------------------------
+
+### Masking sensitive information like password
+*Available as of Camel 2.19*
+
+You can enable security masking for logging by setting `logMask` flag to `true`.
+Note that this option also affects link:logeip.html[Log EIP].
+
+To enable mask in Java DSL at CamelContext level:
+[source,java]
+--------------------------------------------------------
+CamelContext context = ...
+context.setLogMask(true);
+--------------------------------------------------------
+
+And in XML:
+[source,java]
+--------------------------------------------------------
+<camelContext logMask="true">
+...
+--------------------------------------------------------
+
+
+You can also turn it on|off at endpoint level. To enable mask in Java DSL at endpoint level,
+add logMask=true option in the URI for the log endpoint:
+[source,java]
+--------------------------------------------------------
+from("direct:start").to("log:foo?logMask=true");
+--------------------------------------------------------
+
+And in XML:
+[source,java]
+--------------------------------------------------------
+<route>
+  <from uri="direct:foo"/>
+  <to uri="log:foo?logMask=true"/>
+...
+--------------------------------------------------------
+
+`org.apache.camel.processor.DefaultMaskingFormatter` is used for the masking by default.
+If you want to use a custom masking formatter, put it into registry with the name `CamelCustomLogMask`.
+Note that the masking formatter must implement `org.apache.camel.spi.MaskingFormatter`.
+
 
 ### Full customization of the logging output
 

--- a/camel-core/src/main/java/org/apache/camel/RuntimeConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/RuntimeConfiguration.java
@@ -67,18 +67,18 @@ public interface RuntimeConfiguration {
     Boolean isMessageHistory();
 
     /**
-     * Sets whether security mask for Log EIP is enabled or not (default is disabled).
+     * Sets whether security mask for Logging is enabled or not (default is disabled).
      * 
-     * @param logEipMask <tt>true</tt> if mask is enabled
+     * @param logMask <tt>true</tt> if mask is enabled
      */
-    void setLogEipMask(Boolean logEipMask);
+    void setLogMask(Boolean logMask);
 
     /**
-     * Gets whether security mask for Log EIP is enabled or not.
+     * Gets whether security mask for Logging is enabled or not.
      * 
      * @return <tt>true</tt> if mask is enabled
      */
-    Boolean isLogEipMask();
+    Boolean isLogMask();
 
     /**
      * Sets whether to log exhausted message body with message history.

--- a/camel-core/src/main/java/org/apache/camel/RuntimeConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/RuntimeConfiguration.java
@@ -67,6 +67,20 @@ public interface RuntimeConfiguration {
     Boolean isMessageHistory();
 
     /**
+     * Sets whether security mask for Log EIP is enabled or not (default is disabled).
+     * 
+     * @param logEipMask <tt>true</tt> if mask is enabled
+     */
+    void setLogEipMask(Boolean logEipMask);
+
+    /**
+     * Gets whether security mask for Log EIP is enabled or not.
+     * 
+     * @return <tt>true</tt> if mask is enabled
+     */
+    Boolean isLogEipMask();
+
+    /**
      * Sets whether to log exhausted message body with message history.
      *
      * @param logExhaustedMessageBody whether message body should be logged

--- a/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
+++ b/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
@@ -148,6 +148,9 @@ public interface ManagedCamelContextMBean extends ManagedPerformanceCounterMBean
     @ManagedAttribute(description = "Whether message history is enabled")
     boolean isMessageHistory();
 
+    @ManagedAttribute(description = "Whether security mask for Log EIP is enabled")
+    boolean isLogEipMask();
+
     @ManagedAttribute(description = "Whether MDC logging is supported")
     boolean isUseMDCLogging();
 

--- a/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
+++ b/camel-core/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
@@ -148,8 +148,8 @@ public interface ManagedCamelContextMBean extends ManagedPerformanceCounterMBean
     @ManagedAttribute(description = "Whether message history is enabled")
     boolean isMessageHistory();
 
-    @ManagedAttribute(description = "Whether security mask for Log EIP is enabled")
-    boolean isLogEipMask();
+    @ManagedAttribute(description = "Whether security mask for Logging is enabled")
+    boolean isLogMask();
 
     @ManagedAttribute(description = "Whether MDC logging is supported")
     boolean isUseMDCLogging();

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -240,6 +240,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
     private Boolean autoStartup = Boolean.TRUE;
     private Boolean trace = Boolean.FALSE;
     private Boolean messageHistory = Boolean.TRUE;
+    private Boolean logEipMask = Boolean.FALSE;
     private Boolean logExhaustedMessageBody = Boolean.FALSE;
     private Boolean streamCache = Boolean.FALSE;
     private Boolean handleFault = Boolean.FALSE;
@@ -2705,6 +2706,14 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
 
     public void setMessageHistory(Boolean messageHistory) {
         this.messageHistory = messageHistory;
+    }
+
+    public void setLogEipMask(Boolean useLogEipMask) {
+        this.logEipMask = useLogEipMask;
+    }
+
+    public Boolean isLogEipMask() {
+        return logEipMask != null && logEipMask;
     }
 
     public Boolean isLogExhaustedMessageBody() {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -240,7 +240,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
     private Boolean autoStartup = Boolean.TRUE;
     private Boolean trace = Boolean.FALSE;
     private Boolean messageHistory = Boolean.TRUE;
-    private Boolean logEipMask = Boolean.FALSE;
+    private Boolean logMask = Boolean.FALSE;
     private Boolean logExhaustedMessageBody = Boolean.FALSE;
     private Boolean streamCache = Boolean.FALSE;
     private Boolean handleFault = Boolean.FALSE;
@@ -2708,12 +2708,12 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         this.messageHistory = messageHistory;
     }
 
-    public void setLogEipMask(Boolean useLogEipMask) {
-        this.logEipMask = useLogEipMask;
+    public void setLogMask(Boolean logMask) {
+        this.logMask = logMask;
     }
 
-    public Boolean isLogEipMask() {
-        return logEipMask != null && logEipMask;
+    public Boolean isLogMask() {
+        return logMask != null && logMask;
     }
 
     public Boolean isLogExhaustedMessageBody() {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultRouteContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultRouteContext.java
@@ -63,7 +63,7 @@ public class DefaultRouteContext implements RouteContext {
     private boolean routeAdded;
     private Boolean trace;
     private Boolean messageHistory;
-    private Boolean logEipMask;
+    private Boolean logMask;
     private Boolean logExhaustedMessageBody;
     private Boolean streamCache;
     private Boolean handleFault;
@@ -311,16 +311,16 @@ public class DefaultRouteContext implements RouteContext {
         }
     }
 
-    public void setLogEipMask(Boolean logEipMask) {
-        this.logEipMask = logEipMask;
+    public void setLogMask(Boolean logMask) {
+        this.logMask = logMask;
     }
 
-    public Boolean isLogEipMask() {
-        if (logEipMask != null) {
-            return logEipMask;
+    public Boolean isLogMask() {
+        if (logMask != null) {
+            return logMask;
         } else {
             // fallback to the option from camel context
-            return getCamelContext().isLogEipMask();
+            return getCamelContext().isLogMask();
         }
     }
 

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultRouteContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultRouteContext.java
@@ -63,6 +63,7 @@ public class DefaultRouteContext implements RouteContext {
     private boolean routeAdded;
     private Boolean trace;
     private Boolean messageHistory;
+    private Boolean logEipMask;
     private Boolean logExhaustedMessageBody;
     private Boolean streamCache;
     private Boolean handleFault;
@@ -307,6 +308,19 @@ public class DefaultRouteContext implements RouteContext {
         } else {
             // fallback to the option from camel context
             return getCamelContext().isMessageHistory();
+        }
+    }
+
+    public void setLogEipMask(Boolean logEipMask) {
+        this.logEipMask = logEipMask;
+    }
+
+    public Boolean isLogEipMask() {
+        if (logEipMask != null) {
+            return logEipMask;
+        } else {
+            // fallback to the option from camel context
+            return getCamelContext().isLogEipMask();
         }
     }
 

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -268,6 +268,10 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
         return context.isMessageHistory() != null ? context.isMessageHistory() : false;
     }
 
+    public boolean isLogEipMask() {
+        return context.isLogEipMask() != null ? context.isLogEipMask() : false;
+    }
+
     public boolean isUseMDCLogging() {
         return context.isUseMDCLogging();
     }

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -268,8 +268,8 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
         return context.isMessageHistory() != null ? context.isMessageHistory() : false;
     }
 
-    public boolean isLogEipMask() {
-        return context.isLogEipMask() != null ? context.isLogEipMask() : false;
+    public boolean isLogMask() {
+        return context.isLogMask() != null ? context.isLogMask() : false;
     }
 
     public boolean isUseMDCLogging() {

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
@@ -159,8 +159,8 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
         return route.getRouteContext().isMessageHistory();
     }
 
-    public Boolean getLogEipMask() {
-        return route.getRouteContext().isLogEipMask();
+    public Boolean getLogMask() {
+        return route.getRouteContext().isLogMask();
     }
 
     public String getRoutePolicyList() {

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
@@ -159,6 +159,10 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
         return route.getRouteContext().isMessageHistory();
     }
 
+    public Boolean getLogEipMask() {
+        return route.getRouteContext().isLogEipMask();
+    }
+
     public String getRoutePolicyList() {
         List<RoutePolicy> policyList = route.getRouteContext().getRoutePolicyList();
 

--- a/camel-core/src/main/java/org/apache/camel/model/Constants.java
+++ b/camel-core/src/main/java/org/apache/camel/model/Constants.java
@@ -37,6 +37,8 @@ public final class Constants {
 
     public static final String PLACEHOLDER_QNAME = "http://camel.apache.org/schema/placeholder";
 
+    public static final String CUSTOM_LOG_MASK_REF = "CamelCustomLogMask";
+
     private Constants() {
     }
 

--- a/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  *
  * @version 
  */
-@Metadata(label = "configuration")
+@Metadata(label = "eip,configuration")
 @XmlRootElement(name = "log")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LogDefinition extends NoOutputDefinition<LogDefinition> {

--- a/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
@@ -28,8 +28,10 @@ import org.apache.camel.Expression;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
 import org.apache.camel.processor.LogProcessor;
+import org.apache.camel.processor.MaskingStringFormatter;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.RouteContext;
+import org.apache.camel.spi.StringFormatter;
 import org.apache.camel.util.CamelContextHelper;
 import org.apache.camel.util.CamelLogger;
 import org.apache.camel.util.ObjectHelper;
@@ -123,7 +125,11 @@ public class LogDefinition extends NoOutputDefinition<LogDefinition> {
         LoggingLevel level = getLoggingLevel() != null ? getLoggingLevel() : LoggingLevel.INFO;
         CamelLogger camelLogger = new CamelLogger(logger, level, getMarker());
 
-        return new LogProcessor(exp, camelLogger);
+        StringFormatter formatter = routeContext.getCamelContext().getRegistry().lookupByNameAndType("logEipFormatter", StringFormatter.class);
+        if (formatter == null && routeContext.isLogEipMask()) {
+            formatter = new MaskingStringFormatter();
+        }
+        return new LogProcessor(exp, camelLogger, formatter);
     }
 
     @Override

--- a/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/LogDefinition.java
@@ -27,11 +27,11 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
+import org.apache.camel.processor.DefaultMaskingFormatter;
 import org.apache.camel.processor.LogProcessor;
-import org.apache.camel.processor.MaskingStringFormatter;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.RouteContext;
-import org.apache.camel.spi.StringFormatter;
 import org.apache.camel.util.CamelContextHelper;
 import org.apache.camel.util.CamelLogger;
 import org.apache.camel.util.ObjectHelper;
@@ -125,11 +125,18 @@ public class LogDefinition extends NoOutputDefinition<LogDefinition> {
         LoggingLevel level = getLoggingLevel() != null ? getLoggingLevel() : LoggingLevel.INFO;
         CamelLogger camelLogger = new CamelLogger(logger, level, getMarker());
 
-        StringFormatter formatter = routeContext.getCamelContext().getRegistry().lookupByNameAndType("logEipFormatter", StringFormatter.class);
-        if (formatter == null && routeContext.isLogEipMask()) {
-            formatter = new MaskingStringFormatter();
+        return new LogProcessor(exp, camelLogger, getMaskingFormatter(routeContext));
+    }
+
+    private MaskingFormatter getMaskingFormatter(RouteContext routeContext) {
+        if (routeContext.isLogMask()) {
+            MaskingFormatter formatter = routeContext.getCamelContext().getRegistry().lookupByNameAndType(Constants.CUSTOM_LOG_MASK_REF, MaskingFormatter.class);
+            if (formatter == null) {
+                formatter = new DefaultMaskingFormatter();
+            }
+            return formatter;
         }
-        return new LogProcessor(exp, camelLogger, formatter);
+        return null;
     }
 
     @Override

--- a/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -77,6 +77,7 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     private String streamCache;
     private String trace;
     private String messageHistory;
+    private String logEipMask;
     private String handleFault;
     private String delayer;
     private String autoStartup;
@@ -478,6 +479,27 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
+     * Enable security mask in Log EIP for this route.
+     *
+     * @return the builder
+     */
+    public RouteDefinition logEipMask() {
+        setLogEipMask("true");
+        return this;
+    }
+
+    /**
+     * Sets whether security mask in Log EIP is enabled for this route.
+     *
+     * @param logEipMask whether to enable security mask in Log EIP (true or false), the value can be a property placeholder
+     * @return the builder
+     */
+    public RouteDefinition logEipMask(String logEipMask) {
+        setLogEipMask(logEipMask);
+        return this;
+    }
+
+    /**
      * Disable message history for this route.
      *
      * @return the builder
@@ -875,6 +897,21 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
+     * Whether security mask for Log EIP is enabled on this route.
+     */
+    public String getLogEipMask() {
+        return logEipMask;
+    }
+
+    /**
+     * Whether security mask for Log EIP is enabled on this route.
+     */
+    @XmlAttribute @Metadata(defaultValue = "false")
+    public void setLogEipMask(String logEipMask) {
+        this.logEipMask = logEipMask;
+    }
+
+    /**
      * Whether handle fault is enabled on this route.
      */
     public String getHandleFault() {
@@ -1128,6 +1165,17 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
                 routeContext.setMessageHistory(isMessageHistory);
                 if (isMessageHistory) {
                     log.debug("Message history is enabled on route: {}", getId());
+                }
+            }
+        }
+
+        // configure Log EIP mask
+        if (logEipMask != null) {
+            Boolean isLogEipMask = CamelContextHelper.parseBoolean(camelContext, getLogEipMask());
+            if (isLogEipMask != null) {
+                routeContext.setLogEipMask(isLogEipMask);
+                if (isLogEipMask) {
+                    log.debug("Security mask for Log EIP is enabled on route: {}", getId());
                 }
             }
         }

--- a/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -77,7 +77,7 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     private String streamCache;
     private String trace;
     private String messageHistory;
-    private String logEipMask;
+    private String logMask;
     private String handleFault;
     private String delayer;
     private String autoStartup;
@@ -479,23 +479,23 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Enable security mask in Log EIP for this route.
+     * Enable security mask for Logging on this route.
      *
      * @return the builder
      */
-    public RouteDefinition logEipMask() {
-        setLogEipMask("true");
+    public RouteDefinition logMask() {
+        setLogMask("true");
         return this;
     }
 
     /**
-     * Sets whether security mask in Log EIP is enabled for this route.
+     * Sets whether security mask for logging is enabled on this route.
      *
-     * @param logEipMask whether to enable security mask in Log EIP (true or false), the value can be a property placeholder
+     * @param logMask whether to enable security mask for Logging (true or false), the value can be a property placeholder
      * @return the builder
      */
-    public RouteDefinition logEipMask(String logEipMask) {
-        setLogEipMask(logEipMask);
+    public RouteDefinition logMask(String logMask) {
+        setLogMask(logMask);
         return this;
     }
 
@@ -897,18 +897,18 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
     }
 
     /**
-     * Whether security mask for Log EIP is enabled on this route.
+     * Whether security mask for Logging is enabled on this route.
      */
-    public String getLogEipMask() {
-        return logEipMask;
+    public String getLogMask() {
+        return logMask;
     }
 
     /**
-     * Whether security mask for Log EIP is enabled on this route.
+     * Whether security mask for Logging is enabled on this route.
      */
     @XmlAttribute @Metadata(defaultValue = "false")
-    public void setLogEipMask(String logEipMask) {
-        this.logEipMask = logEipMask;
+    public void setLogMask(String logMask) {
+        this.logMask = logMask;
     }
 
     /**
@@ -1170,12 +1170,12 @@ public class RouteDefinition extends ProcessorDefinition<RouteDefinition> {
         }
 
         // configure Log EIP mask
-        if (logEipMask != null) {
-            Boolean isLogEipMask = CamelContextHelper.parseBoolean(camelContext, getLogEipMask());
-            if (isLogEipMask != null) {
-                routeContext.setLogEipMask(isLogEipMask);
-                if (isLogEipMask) {
-                    log.debug("Security mask for Log EIP is enabled on route: {}", getId());
+        if (logMask != null) {
+            Boolean isLogMask = CamelContextHelper.parseBoolean(camelContext, getLogMask());
+            if (isLogMask != null) {
+                routeContext.setLogMask(isLogMask);
+                if (isLogMask) {
+                    log.debug("Security mask for Logging is enabled on route: {}", getId());
                 }
             }
         }

--- a/camel-core/src/main/java/org/apache/camel/processor/CamelLogProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/CamelLogProcessor.java
@@ -23,6 +23,7 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
 import org.apache.camel.spi.ExchangeFormatter;
 import org.apache.camel.spi.IdAware;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.util.AsyncProcessorHelper;
 import org.apache.camel.util.CamelLogger;
 
@@ -39,6 +40,7 @@ public class CamelLogProcessor implements AsyncProcessor, IdAware {
     private String id;
     private CamelLogger log;
     private ExchangeFormatter formatter;
+    private MaskingFormatter maskingFormatter;
 
     public CamelLogProcessor() {
         this(new CamelLogger(CamelLogProcessor.class.getName()));
@@ -49,9 +51,10 @@ public class CamelLogProcessor implements AsyncProcessor, IdAware {
         this.log = log;
     }
 
-    public CamelLogProcessor(CamelLogger log, ExchangeFormatter formatter) {
+    public CamelLogProcessor(CamelLogger log, ExchangeFormatter formatter, MaskingFormatter maskingFormatter) {
         this(log);
         this.formatter = formatter;
+        this.maskingFormatter = maskingFormatter;
     }
 
     @Override
@@ -73,7 +76,11 @@ public class CamelLogProcessor implements AsyncProcessor, IdAware {
 
     public boolean process(Exchange exchange, AsyncCallback callback) {
         if (log.shouldLog()) {
-            log.log(formatter.format(exchange));
+            String output = formatter.format(exchange);
+            if (maskingFormatter != null) {
+                output = maskingFormatter.format(output);
+            }
+            log.log(output);
         }
         callback.done(true);
         return true;
@@ -107,6 +114,10 @@ public class CamelLogProcessor implements AsyncProcessor, IdAware {
         log.setMarker(marker);
     }
 
+    public void setMaskingFormatter(MaskingFormatter maskingFormatter) {
+        this.maskingFormatter = maskingFormatter;
+    }
+
     /**
      * {@link ExchangeFormatter} that calls <tt>toString</tt> on the {@link Exchange}.
      */
@@ -115,4 +126,5 @@ public class CamelLogProcessor implements AsyncProcessor, IdAware {
             return exchange.toString();
         }
     }
+
 }

--- a/camel-core/src/main/java/org/apache/camel/processor/DefaultMaskingFormatter.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/DefaultMaskingFormatter.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.spi.ExchangeFormatter;
-import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 import org.apache.camel.util.MessageHelper;
@@ -37,11 +37,11 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 
 /**
- * The {@link StringFormatter} that searches the specified keywards in the source
+ * The {@link MaskingFormatter} that searches the specified keywards in the source
  * and replace its value with mask string. By default passphrase, password and secretKey
  * are used as keywards to replace its value.
  */
-public class MaskingStringFormatter implements StringFormatter {
+public class DefaultMaskingFormatter implements MaskingFormatter {
 
     private static final Set<String> DEFAULT_KEYWORDS = new HashSet<String>(Arrays.asList("passphrase", "password", "secretKey"));
     private Set<String> keywords;
@@ -53,15 +53,15 @@ public class MaskingStringFormatter implements StringFormatter {
     private Pattern xmlElementMaskPattern;
     private Pattern jsonMaskPattern;
 
-    public MaskingStringFormatter() {
+    public DefaultMaskingFormatter() {
         this(DEFAULT_KEYWORDS, true, true, true);
     }
 
-    public MaskingStringFormatter(boolean maskKeyValue, boolean maskXml, boolean maskJson) {
+    public DefaultMaskingFormatter(boolean maskKeyValue, boolean maskXml, boolean maskJson) {
         this(DEFAULT_KEYWORDS, maskKeyValue, maskXml, maskJson);
     }
 
-    public MaskingStringFormatter(Set<String> keywords, boolean maskKeyValue, boolean maskXmlElement, boolean maskJson) {
+    public DefaultMaskingFormatter(Set<String> keywords, boolean maskKeyValue, boolean maskXmlElement, boolean maskJson) {
         this.keywords = keywords;
         setMaskKeyValue(maskKeyValue);
         setMaskXmlElement(maskXmlElement);

--- a/camel-core/src/main/java/org/apache/camel/processor/LogProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/LogProcessor.java
@@ -22,7 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
-import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.support.ServiceSupport;
 import org.apache.camel.util.AsyncProcessorHelper;
 import org.apache.camel.util.CamelLogger;
@@ -37,9 +37,9 @@ public class LogProcessor extends ServiceSupport implements AsyncProcessor, Trac
     private String id;
     private final Expression expression;
     private final CamelLogger logger;
-    private final StringFormatter formatter;
+    private final MaskingFormatter formatter;
 
-    public LogProcessor(Expression expression, CamelLogger logger, StringFormatter formatter) {
+    public LogProcessor(Expression expression, CamelLogger logger, MaskingFormatter formatter) {
         this.expression = expression;
         this.logger = logger;
         this.formatter = formatter;
@@ -93,7 +93,7 @@ public class LogProcessor extends ServiceSupport implements AsyncProcessor, Trac
         return logger;
     }
 
-    public StringFormatter getLogFormatter() {
+    public MaskingFormatter getLogFormatter() {
         return formatter;
     }
 

--- a/camel-core/src/main/java/org/apache/camel/processor/LogProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/LogProcessor.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
+import org.apache.camel.spi.StringFormatter;
 import org.apache.camel.support.ServiceSupport;
 import org.apache.camel.util.AsyncProcessorHelper;
 import org.apache.camel.util.CamelLogger;
@@ -36,10 +37,12 @@ public class LogProcessor extends ServiceSupport implements AsyncProcessor, Trac
     private String id;
     private final Expression expression;
     private final CamelLogger logger;
+    private final StringFormatter formatter;
 
-    public LogProcessor(Expression expression, CamelLogger logger) {
+    public LogProcessor(Expression expression, CamelLogger logger, StringFormatter formatter) {
         this.expression = expression;
         this.logger = logger;
+        this.formatter = formatter;
     }
 
     public void process(Exchange exchange) throws Exception {
@@ -51,6 +54,9 @@ public class LogProcessor extends ServiceSupport implements AsyncProcessor, Trac
         try {
             if (logger.shouldLog()) {
                 String msg = expression.evaluate(exchange, String.class);
+                if (formatter != null) {
+                    msg = formatter.format(msg);
+                }
                 logger.doLog(msg);
             }
         } catch (Exception e) {
@@ -85,6 +91,10 @@ public class LogProcessor extends ServiceSupport implements AsyncProcessor, Trac
 
     public CamelLogger getLogger() {
         return logger;
+    }
+
+    public StringFormatter getLogFormatter() {
+        return formatter;
     }
 
     @Override

--- a/camel-core/src/main/java/org/apache/camel/processor/MaskingStringFormatter.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/MaskingStringFormatter.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.spi.ExchangeFormatter;
+import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.spi.UriParam;
+import org.apache.camel.spi.UriParams;
+import org.apache.camel.util.MessageHelper;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
+
+/**
+ * The {@link StringFormatter} that searches the specified keywards in the source
+ * and replace its value with mask string. By default passphrase, password and secretKey
+ * are used as keywards to replace its value.
+ */
+public class MaskingStringFormatter implements StringFormatter {
+
+    private static final Set<String> DEFAULT_KEYWORDS = new HashSet<String>(Arrays.asList("passphrase", "password", "secretKey"));
+    private Set<String> keywords;
+    private boolean maskKeyValue;
+    private boolean maskXmlElement;
+    private boolean maskJson;
+    private String maskString = "xxxxx";
+    private Pattern keyValueMaskPattern;
+    private Pattern xmlElementMaskPattern;
+    private Pattern jsonMaskPattern;
+
+    public MaskingStringFormatter() {
+        this(DEFAULT_KEYWORDS, true, true, true);
+    }
+
+    public MaskingStringFormatter(boolean maskKeyValue, boolean maskXml, boolean maskJson) {
+        this(DEFAULT_KEYWORDS, maskKeyValue, maskXml, maskJson);
+    }
+
+    public MaskingStringFormatter(Set<String> keywords, boolean maskKeyValue, boolean maskXmlElement, boolean maskJson) {
+        this.keywords = keywords;
+        setMaskKeyValue(maskKeyValue);
+        setMaskXmlElement(maskXmlElement);
+        setMaskJson(maskJson);
+    }
+
+    public String format(String source) {
+        if (keywords == null || keywords.isEmpty()) {
+            return source;
+        }
+
+        String answer = source;
+        if (maskKeyValue) {
+            answer = keyValueMaskPattern.matcher(answer).replaceAll("$1\"" + maskString + "\"");
+        }
+        if (maskXmlElement) {
+            answer = xmlElementMaskPattern.matcher(answer).replaceAll("$1" + maskString + "$3");
+        }
+        if (maskJson) {
+            answer = jsonMaskPattern.matcher(answer).replaceAll("$1\"" + maskString + "\"");
+        }
+        return answer;
+    }
+
+    public boolean isMaskKeyValue() {
+        return maskKeyValue;
+    }
+
+    public void setMaskKeyValue(boolean maskKeyValue) {
+        this.maskKeyValue = maskKeyValue;
+        if (maskKeyValue) {
+            keyValueMaskPattern = createKeyValueMaskPattern(keywords);
+        } else {
+            keyValueMaskPattern = null;
+        }
+    }
+
+    public boolean isMaskXmlElement() {
+        return maskXmlElement;
+    }
+
+    public void setMaskXmlElement(boolean maskXml) {
+        this.maskXmlElement = maskXml;
+        if (maskXml) {
+            xmlElementMaskPattern = createXmlElementMaskPattern(keywords);
+        } else {
+            xmlElementMaskPattern = null;
+        }
+    }
+
+    public boolean isMaskJson() {
+        return maskJson;
+    }
+
+    public void setMaskJson(boolean maskJson) {
+        this.maskJson = maskJson;
+        if (maskJson) {
+            jsonMaskPattern = createJsonMaskPattern(keywords);
+        } else {
+            jsonMaskPattern = null;
+        }
+    }
+
+    public String getMaskString() {
+        return maskString;
+    }
+
+    public void setMaskString(String maskString) {
+        this.maskString = maskString;
+    }
+
+    protected Pattern createKeyValueMaskPattern(Set<String> keywords) {
+        StringBuilder regex = createOneOfThemRegex(keywords);
+        if (regex == null) {
+            return null;
+        }
+        regex.insert(0, "([\\w]*(?:");
+        regex.append(")[\\w]*[\\s]*?=[\\s]*?)([\\S&&[^'\",\\}\\]\\)]]+[\\S&&[^,\\}\\]\\)>]]*?|\"[^\"]*?\"|'[^']*?')");
+        return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+    }
+
+    protected Pattern createXmlElementMaskPattern(Set<String> keywords) {
+        StringBuilder regex = createOneOfThemRegex(keywords);
+        if (regex == null) {
+            return null;
+        }
+        regex.insert(0, "(<([\\w]*(?:");
+        regex.append(")[\\w]*)(?:[\\s]+.+)*?>[\\s]*?)(?:[\\S&&[^<]]+(?:\\s+[\\S&&[^<]]+)*?)([\\s]*?</\\2>)");
+        return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+    }
+
+    protected Pattern createJsonMaskPattern(Set<String> keywords) {
+        StringBuilder regex = createOneOfThemRegex(keywords);
+        if (regex == null) {
+            return null;
+        }
+        regex.insert(0, "(\"(?:[^\"]|(?:\\\"))*?(?:");
+        regex.append(")(?:[^\"]|(?:\\\"))*?\"\\s*?\\:\\s*?)(?:\"(?:[^\"]|(?:\\\"))*?\")");
+        return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+    }
+
+    protected StringBuilder createOneOfThemRegex(Set<String> keywords) {
+        StringBuilder regex = new StringBuilder();
+        if (keywords == null || keywords.isEmpty()) {
+            return null;
+        }
+        String[] strKeywords = keywords.toArray(new String[0]);
+        regex.append(Pattern.quote(strKeywords[0]));
+        if (strKeywords.length > 1) {
+            for (int i = 1; i < strKeywords.length; i++) {
+                regex.append('|');
+                regex.append(Pattern.quote(strKeywords[i]));
+            }
+        }
+        return regex;
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/processor/interceptor/TraceInterceptor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/interceptor/TraceInterceptor.java
@@ -30,6 +30,7 @@ import org.apache.camel.impl.OnCompletionRouteNode;
 import org.apache.camel.impl.OnExceptionRouteNode;
 import org.apache.camel.model.AggregateDefinition;
 import org.apache.camel.model.CatchDefinition;
+import org.apache.camel.model.Constants;
 import org.apache.camel.model.FinallyDefinition;
 import org.apache.camel.model.InterceptDefinition;
 import org.apache.camel.model.OnCompletionDefinition;
@@ -37,9 +38,11 @@ import org.apache.camel.model.OnExceptionDefinition;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.ProcessorDefinitionHelper;
 import org.apache.camel.processor.CamelLogProcessor;
+import org.apache.camel.processor.DefaultMaskingFormatter;
 import org.apache.camel.processor.DelegateAsyncProcessor;
 import org.apache.camel.spi.ExchangeFormatter;
 import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spi.RouteContext;
 import org.apache.camel.spi.TracedRouteNodes;
 import org.apache.camel.util.ServiceHelper;
@@ -82,6 +85,17 @@ public class TraceInterceptor extends DelegateAsyncProcessor implements Exchange
 
     public void setRouteContext(RouteContext routeContext) {
         this.routeContext = routeContext;
+        prepareMaskingFormatter(routeContext);
+    }
+
+    private void prepareMaskingFormatter(RouteContext routeContext) {
+        if (routeContext.isLogMask()) {
+            MaskingFormatter formatter = routeContext.getCamelContext().getRegistry().lookupByNameAndType(Constants.CUSTOM_LOG_MASK_REF, MaskingFormatter.class);
+            if (formatter == null) {
+                formatter = new DefaultMaskingFormatter();
+            }
+            logger.setMaskingFormatter(formatter);
+        }
     }
 
     @Override

--- a/camel-core/src/main/java/org/apache/camel/processor/interceptor/Tracer.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/interceptor/Tracer.java
@@ -102,7 +102,7 @@ public class Tracer implements InterceptStrategy, Service {
      */
     public synchronized CamelLogProcessor getLogger(ExchangeFormatter formatter) {
         if (logger == null) {
-            logger = new CamelLogProcessor(new CamelLogger(getLogName(), getLogLevel()), formatter);
+            logger = new CamelLogProcessor(new CamelLogger(getLogName(), getLogLevel()), formatter, null);
         }
         return logger;
     }

--- a/camel-core/src/main/java/org/apache/camel/spi/MaskingFormatter.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/MaskingFormatter.java
@@ -19,10 +19,10 @@ package org.apache.camel.spi;
 import org.apache.camel.Exchange;
 
 /**
- * A plugin used to format a log String, for example to mask security information
+ * A plugin used to mask a log String, for example security information
  * like password or passphrase.
  */
-public interface StringFormatter {
+public interface MaskingFormatter {
 
     /**
      * Format a given string.

--- a/camel-core/src/main/java/org/apache/camel/spi/StringFormatter.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/StringFormatter.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spi;
+
+import org.apache.camel.Exchange;
+
+/**
+ * A plugin used to format a log String, for example to mask security information
+ * like password or passphrase.
+ */
+public interface StringFormatter {
+
+    /**
+     * Format a given string.
+     *
+     * @param source the source string
+     * @return formatted string
+     */
+    String format(String source);
+}

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedCamelContextTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedCamelContextTest.java
@@ -91,6 +91,9 @@ public class ManagedCamelContextTest extends ManagementTestSupport {
         Boolean messageHistory = (Boolean) mbeanServer.getAttribute(on, "MessageHistory");
         assertEquals(Boolean.TRUE, messageHistory);
 
+        Boolean logEipMask = (Boolean) mbeanServer.getAttribute(on, "LogEipMask");
+        assertEquals(Boolean.FALSE, logEipMask);
+
         Integer total = (Integer) mbeanServer.getAttribute(on, "TotalRoutes");
         assertEquals(2, total.intValue());
 

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedCamelContextTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedCamelContextTest.java
@@ -91,8 +91,8 @@ public class ManagedCamelContextTest extends ManagementTestSupport {
         Boolean messageHistory = (Boolean) mbeanServer.getAttribute(on, "MessageHistory");
         assertEquals(Boolean.TRUE, messageHistory);
 
-        Boolean logEipMask = (Boolean) mbeanServer.getAttribute(on, "LogEipMask");
-        assertEquals(Boolean.FALSE, logEipMask);
+        Boolean logMask = (Boolean) mbeanServer.getAttribute(on, "LogMask");
+        assertEquals(Boolean.FALSE, logMask);
 
         Integer total = (Integer) mbeanServer.getAttribute(on, "TotalRoutes");
         assertEquals(2, total.intValue());
@@ -307,8 +307,8 @@ public class ManagedCamelContextTest extends ManagementTestSupport {
         int pos2 = json.indexOf("groupDelay");
         assertTrue("LoggerName should come before groupDelay", pos < pos2);
 
-        assertEquals(29, StringHelper.countChar(json, '{'));
-        assertEquals(29, StringHelper.countChar(json, '}'));
+        assertEquals(30, StringHelper.countChar(json, '{'));
+        assertEquals(30, StringHelper.countChar(json, '}'));
 
         assertTrue(json.contains("\"scheme\": \"log\""));
         assertTrue(json.contains("\"label\": \"core,monitoring\""));

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedEndpointExplainTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedEndpointExplainTest.java
@@ -49,7 +49,7 @@ public class ManagedEndpointExplainTest extends ManagementTestSupport {
         assertEquals(4, data.size());
 
         data = (TabularData) mbeanServer.invoke(on, "explain", new Object[]{true}, new String[]{"boolean"});
-        assertEquals(26, data.size());
+        assertEquals(27, data.size());
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/processor/DefaultMaskingFormatterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/DefaultMaskingFormatterTest.java
@@ -29,11 +29,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class MaskingStringFormatterTest {
+public class DefaultMaskingFormatterTest {
 
     @Test
     public void testDefaultOption() throws Exception {
-        MaskingStringFormatter formatter = new MaskingStringFormatter();
+        DefaultMaskingFormatter formatter = new DefaultMaskingFormatter();
         String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
         Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
 
@@ -46,7 +46,7 @@ public class MaskingStringFormatterTest {
 
     @Test
     public void testDisableKeyValueMask() throws Exception {
-        MaskingStringFormatter formatter = new MaskingStringFormatter(false, true, true);
+        DefaultMaskingFormatter formatter = new DefaultMaskingFormatter(false, true, true);
         String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
         Assert.assertEquals("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'", answer);
 
@@ -59,7 +59,7 @@ public class MaskingStringFormatterTest {
 
     @Test
     public void testDisableXmlElementMask() throws Exception {
-        MaskingStringFormatter formatter = new MaskingStringFormatter(true, false, true);
+        DefaultMaskingFormatter formatter = new DefaultMaskingFormatter(true, false, true);
         String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
         Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
 
@@ -72,7 +72,7 @@ public class MaskingStringFormatterTest {
 
     @Test
     public void testDisableJsonMask() throws Exception {
-        MaskingStringFormatter formatter = new MaskingStringFormatter(true, true, false);
+        DefaultMaskingFormatter formatter = new DefaultMaskingFormatter(true, true, false);
         String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
         Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
 
@@ -85,7 +85,7 @@ public class MaskingStringFormatterTest {
 
     @Test
     public void testCustomMaskString() throws Exception {
-        MaskingStringFormatter formatter = new MaskingStringFormatter();
+        DefaultMaskingFormatter formatter = new DefaultMaskingFormatter();
         formatter.setMaskString("**********");
         String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
         Assert.assertEquals("key=value, myPassword=\"**********\",\n myPassphrase=\"**********\", secretKey=\"**********\"", answer);

--- a/camel-core/src/test/java/org/apache/camel/processor/LogEipMaskTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/LogEipMaskTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.util.jndi.JndiTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogEipMaskTest {
+
+    protected MockStringFormatter globalFormatter;
+    protected JndiRegistry registry;
+
+    protected CamelContext createCamelContext() throws Exception {
+        registry = new JndiRegistry(JndiTest.createInitialContext());
+        globalFormatter = new MockStringFormatter();
+        CamelContext context = new DefaultCamelContext(registry);
+        context.addRoutes(createRouteBuilder());
+        return context;
+    }
+
+    @Test
+    public void testLogEipMask() throws Exception {
+        CamelContext context = createCamelContext();
+        MockEndpoint mock = context.getEndpoint("mock:foo", MockEndpoint.class);
+        mock.expectedMessageCount(1);
+        context.setLogEipMask(true);
+        context.start();
+        context.createProducerTemplate().sendBody("direct:foo", "mask password=\"my passw0rd!\"");
+        context.createProducerTemplate().sendBody("direct:noMask", "no-mask password=\"my passw0rd!\"");
+        mock.assertIsSatisfied();
+        context.stop();
+    }
+
+    @Test
+    public void testCustomFormatter() throws Exception {
+        CamelContext context = createCamelContext();
+        registry.bind("logEipFormatter", globalFormatter);
+        context.start();
+        context.createProducerTemplate().sendBody("direct:foo", "mock password=\"my passw0rd!\"");
+        Assert.assertEquals("Got mock password=\"my passw0rd!\"", globalFormatter.received);
+        context.stop();
+    }
+
+    public static class MockStringFormatter implements StringFormatter {
+        private String received;
+        @Override
+        public String format(String source) {
+            received = source;
+            return source;
+        }
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:foo").routeId("foo").log("Got ${body}").to("mock:foo");
+                from("direct:noMask").routeId("noMask").logEipMask("false").log("Got ${body}").to("mock:noMask");
+            }
+        };
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/processor/MaskingStringFormatterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/MaskingStringFormatterTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MaskingStringFormatterTest {
+
+    @Test
+    public void testDefaultOption() throws Exception {
+        MaskingStringFormatter formatter = new MaskingStringFormatter();
+        String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
+        Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+
+        answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
+        Assert.assertEquals("<xmlPassword>\n xxxxx \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
+
+        answer = formatter.format("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}");
+        Assert.assertEquals("{\"key\" : \"value\", \"My Password\":\"xxxxx\", \"My SecretPassphrase\" : \"xxxxx\", \"My SecretKey2\" : \"xxxxx\"}", answer);
+    }
+
+    @Test
+    public void testDisableKeyValueMask() throws Exception {
+        MaskingStringFormatter formatter = new MaskingStringFormatter(false, true, true);
+        String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
+        Assert.assertEquals("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'", answer);
+
+        answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
+        Assert.assertEquals("<xmlPassword>\n xxxxx \n</xmlPassword>\n<user password=\"asdf qwert\"/>", answer);
+
+        answer = formatter.format("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}");
+        Assert.assertEquals("{\"key\" : \"value\", \"My Password\":\"xxxxx\", \"My SecretPassphrase\" : \"xxxxx\", \"My SecretKey2\" : \"xxxxx\"}", answer);
+    }
+
+    @Test
+    public void testDisableXmlElementMask() throws Exception {
+        MaskingStringFormatter formatter = new MaskingStringFormatter(true, false, true);
+        String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
+        Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+
+        answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
+        Assert.assertEquals("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
+
+        answer = formatter.format("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}");
+        Assert.assertEquals("{\"key\" : \"value\", \"My Password\":\"xxxxx\", \"My SecretPassphrase\" : \"xxxxx\", \"My SecretKey2\" : \"xxxxx\"}", answer);
+    }
+
+    @Test
+    public void testDisableJsonMask() throws Exception {
+        MaskingStringFormatter formatter = new MaskingStringFormatter(true, true, false);
+        String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
+        Assert.assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+
+        answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
+        Assert.assertEquals("<xmlPassword>\n xxxxx \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
+
+        answer = formatter.format("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}");
+        Assert.assertEquals("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}", answer);
+    }
+
+    @Test
+    public void testCustomMaskString() throws Exception {
+        MaskingStringFormatter formatter = new MaskingStringFormatter();
+        formatter.setMaskString("**********");
+        String answer = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
+        Assert.assertEquals("key=value, myPassword=\"**********\",\n myPassphrase=\"**********\", secretKey=\"**********\"", answer);
+
+        answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
+        Assert.assertEquals("<xmlPassword>\n ********** \n</xmlPassword>\n<user password=\"**********\"/>", answer);
+
+        answer = formatter.format("{\"key\" : \"value\", \"My Password\":\"foo\", \"My SecretPassphrase\" : \"foo bar\", \"My SecretKey2\" : \"!@#$%^&*() -+[]{};:'\"}");
+        Assert.assertEquals("{\"key\" : \"value\", \"My Password\":\"**********\", \"My SecretPassphrase\" : \"**********\", \"My SecretKey2\" : \"**********\"}", answer);
+    }
+
+}

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
@@ -93,6 +93,8 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
     @XmlAttribute
     private String messageHistory;
     @XmlAttribute
+    private String logEipMask;
+    @XmlAttribute
     private String logExhaustedMessageBody;
     @XmlAttribute
     private String streamCache = "false";
@@ -534,6 +536,14 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
 
     public void setMessageHistory(String messageHistory) {
         this.messageHistory = messageHistory;
+    }
+
+    public String getLogEipMask() {
+        return logEipMask;
+    }
+
+    public void setLogEipMask(String logEipMask) {
+        this.logEipMask = logEipMask;
     }
 
     public String getLogExhaustedMessageBody() {

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/CamelContextFactoryBean.java
@@ -93,7 +93,7 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
     @XmlAttribute
     private String messageHistory;
     @XmlAttribute
-    private String logEipMask;
+    private String logMask;
     @XmlAttribute
     private String logExhaustedMessageBody;
     @XmlAttribute
@@ -538,12 +538,12 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Blu
         this.messageHistory = messageHistory;
     }
 
-    public String getLogEipMask() {
-        return logEipMask;
+    public String getLogMask() {
+        return logMask;
     }
 
-    public void setLogEipMask(String logEipMask) {
-        this.logEipMask = logEipMask;
+    public void setLogMask(String logMask) {
+        this.logMask = logMask;
     }
 
     public String getLogExhaustedMessageBody() {

--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/xml/CamelContextFactoryBean.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/xml/CamelContextFactoryBean.java
@@ -81,6 +81,9 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Def
     private String messageHistory;
 
     @XmlAttribute
+    private String logMask;
+
+    @XmlAttribute
     private String logExhaustedMessageBody;
 
     @XmlAttribute
@@ -541,6 +544,14 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Def
 
     public void setMessageHistory(String messageHistory) {
         this.messageHistory = messageHistory;
+    }
+
+    public String getLogMask() {
+        return logMask;
+    }
+
+    public void setLogMask(String logMask) {
+        this.logMask = logMask;
     }
 
     @Override

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -727,7 +727,7 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
 
     public abstract String getMessageHistory();
 
-    public abstract String getLogEipMask();
+    public abstract String getLogMask();
 
     public abstract String getLogExhaustedMessageBody();
 
@@ -824,8 +824,8 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
         if (getMessageHistory() != null) {
             ctx.setMessageHistory(CamelContextHelper.parseBoolean(getContext(), getMessageHistory()));
         }
-        if (getLogEipMask() != null) {
-            ctx.setLogEipMask(CamelContextHelper.parseBoolean(getContext(), getLogEipMask()));
+        if (getLogMask() != null) {
+            ctx.setLogMask(CamelContextHelper.parseBoolean(getContext(), getLogMask()));
         }
         if (getLogExhaustedMessageBody() != null) {
             ctx.setLogExhaustedMessageBody(CamelContextHelper.parseBoolean(getContext(), getLogExhaustedMessageBody()));

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -727,6 +727,8 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
 
     public abstract String getMessageHistory();
 
+    public abstract String getLogEipMask();
+
     public abstract String getLogExhaustedMessageBody();
 
     public abstract String getStreamCache();
@@ -821,6 +823,9 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
         }
         if (getMessageHistory() != null) {
             ctx.setMessageHistory(CamelContextHelper.parseBoolean(getContext(), getMessageHistory()));
+        }
+        if (getLogEipMask() != null) {
+            ctx.setLogEipMask(CamelContextHelper.parseBoolean(getContext(), getLogEipMask()));
         }
         if (getLogExhaustedMessageBody() != null) {
             ctx.setLogExhaustedMessageBody(CamelContextHelper.parseBoolean(getContext(), getLogExhaustedMessageBody()));

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -144,6 +144,7 @@ public class CamelAutoConfiguration {
         }
 
         camelContext.setMessageHistory(config.isMessageHistory());
+        camelContext.setLogMask(config.isLogMask());
         camelContext.setLogExhaustedMessageBody(config.isLogExhaustedMessageBody());
         camelContext.setHandleFault(config.isHandleFault());
         camelContext.setAutoStartup(config.isAutoStartup());

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelConfigurationProperties.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelConfigurationProperties.java
@@ -252,6 +252,13 @@ public class CamelConfigurationProperties {
     private boolean messageHistory = true;
 
     /**
+     * Sets whether log mask is enabled or not.
+     *
+     * Default is false.
+     */
+    private boolean logMask = false;
+
+    /**
      * Sets whether to log exhausted message body with message history.
      *
      * Default is false.
@@ -635,6 +642,14 @@ public class CamelConfigurationProperties {
 
     public void setMessageHistory(boolean messageHistory) {
         this.messageHistory = messageHistory;
+    }
+
+    public boolean isLogMask() {
+        return logMask;
+    }
+
+    public void setLogMask(boolean logMask) {
+        this.logMask = logMask;
     }
 
     public boolean isLogExhaustedMessageBody() {

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
@@ -102,7 +102,7 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
     @XmlAttribute @Metadata(defaultValue = "true")
     private String messageHistory;
     @XmlAttribute @Metadata(defaultValue = "false")
-    private String logEipMask;
+    private String logMask;
     @XmlAttribute
     private String logExhaustedMessageBody;
     @XmlAttribute
@@ -637,15 +637,15 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
         this.messageHistory = messageHistory;
     }
 
-    public String getLogEipMask() {
-        return logEipMask;
+    public String getLogMask() {
+        return logMask;
     }
 
     /**
-     * Sets whether security mask for Log EIP is enabled or not.
+     * Sets whether security mask for Logging is enabled or not.
      */
-    public void setLogEipMask(String logEipMask) {
-        this.logEipMask = logEipMask;
+    public void setLogMask(String logMask) {
+        this.logMask = logMask;
     }
 
     public String getLogExhaustedMessageBody() {

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
@@ -101,6 +101,8 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
     private String trace;
     @XmlAttribute @Metadata(defaultValue = "true")
     private String messageHistory;
+    @XmlAttribute @Metadata(defaultValue = "false")
+    private String logEipMask;
     @XmlAttribute
     private String logExhaustedMessageBody;
     @XmlAttribute
@@ -633,6 +635,17 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
      */
     public void setMessageHistory(String messageHistory) {
         this.messageHistory = messageHistory;
+    }
+
+    public String getLogEipMask() {
+        return logEipMask;
+    }
+
+    /**
+     * Sets whether security mask for Log EIP is enabled or not.
+     */
+    public void setLogEipMask(String logEipMask) {
+        this.logEipMask = logEipMask;
     }
 
     public String getLogExhaustedMessageBody() {

--- a/components/camel-spring/src/test/java/org/apache/camel/component/log/SpringLogMaskTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/component/log/SpringLogMaskTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.log;
+
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.Constants;
+import org.apache.camel.spi.MaskingFormatter;
+import org.apache.camel.spring.SpringCamelContext;
+import org.apache.camel.spring.SpringTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @version 
+ */
+public class SpringLogMaskTest {
+
+    @Test
+    public void testLogMask() throws Exception {
+        final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/component/log/SpringLogMaskTest-context.xml");
+        SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
+        context.start();
+        MockEndpoint mock = context.getEndpoint("mock:mask", MockEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+        template.sendBodyAndHeader("direct:mask", "password=passw0rd@", "headerPassword", "#header-password$");
+        template.sendBodyAndProperty("direct:mask", "password=passw0rd@", "propertyPassphrase", "#property-passphrase$");
+        context.stop();
+        mock.expectedMessageCount(2);
+    }
+
+    @Test
+    public void testLogMaskDisabled() throws Exception {
+        final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/component/log/SpringLogMaskTest-context.xml");
+        SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
+        context.start();
+        MockEndpoint mock = context.getEndpoint("mock:no-mask", MockEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+        template.sendBodyAndHeader("direct:no-mask", "password=passw0rd@", "headerPassword", "#header-password$");
+        template.sendBodyAndProperty("direct:no-mask", "password=passw0rd@", "propertyPassphrase", "#property-passphrase$");
+        context.stop();
+        mock.expectedMessageCount(2);
+    }
+
+    @Test
+    public void testCustomLogMask() throws Exception {
+        final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/component/log/SpringCustomLogMaskTest-context.xml");
+        SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
+        MockMaskingFormatter customFormatter = applicationContext.getBean(Constants.CUSTOM_LOG_MASK_REF, MockMaskingFormatter.class);
+        context.start();
+        ProducerTemplate template = context.createProducerTemplate();
+        template.sendBodyAndHeader("direct:mock", "password=passw0rd@", "headerPassword", "#header-password$");
+        context.stop();
+        Assert.assertTrue(customFormatter.received.contains("password=passw0rd@"));
+    }
+
+    public static class MockMaskingFormatter implements MaskingFormatter {
+        private String received;
+        @Override
+        public String format(String source) {
+            received = source;
+            return source;
+        }
+    }
+
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringLogEipMaskTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringLogEipMaskTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.processor;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.LogEipMaskTest;
+import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.spring.SpringCamelContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
+
+public class SpringLogEipMaskTest {
+
+    @Test
+    public void testLogEipMask() throws Exception {
+        final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/logEipMaskTest.xml");
+        SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
+        MockEndpoint mock = context.getEndpoint("mock:foo", MockEndpoint.class);
+        mock.expectedMessageCount(1);
+        context.setLogEipMask(true);
+        context.start();
+        context.createProducerTemplate().sendBody("direct:foo", "mask password=\"my passw0rd!\"");
+        context.createProducerTemplate().sendBody("direct:noMask", "no-mask password=\"my passw0rd!\"");
+        mock.assertIsSatisfied();
+        context.stop();
+    }
+
+    @Test
+    public void testCustomFormatter() throws Exception {
+        final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/logEipCustomFormatterTest.xml");
+        SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
+        context.start();
+        MockStringFormatter customFormatter = applicationContext.getBean("logEipFormatter", MockStringFormatter.class);
+        context.createProducerTemplate().sendBody("direct:foo", "mock password=\"my passw0rd!\"");
+        Assert.assertEquals("Got mock password=\"my passw0rd!\"", customFormatter.received);
+        context.stop();
+    }
+
+    public static class MockStringFormatter implements StringFormatter {
+        private String received;
+        @Override
+        public String format(String source) {
+            received = source;
+            return source;
+        }
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringLogEipMaskTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringLogEipMaskTest.java
@@ -18,8 +18,9 @@ package org.apache.camel.spring.processor;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.Constants;
 import org.apache.camel.processor.LogEipMaskTest;
-import org.apache.camel.spi.StringFormatter;
+import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spring.SpringCamelContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +37,6 @@ public class SpringLogEipMaskTest {
         SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
         MockEndpoint mock = context.getEndpoint("mock:foo", MockEndpoint.class);
         mock.expectedMessageCount(1);
-        context.setLogEipMask(true);
         context.start();
         context.createProducerTemplate().sendBody("direct:foo", "mask password=\"my passw0rd!\"");
         context.createProducerTemplate().sendBody("direct:noMask", "no-mask password=\"my passw0rd!\"");
@@ -49,13 +49,13 @@ public class SpringLogEipMaskTest {
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/logEipCustomFormatterTest.xml");
         SpringCamelContext context = SpringCamelContext.springCamelContext(applicationContext);
         context.start();
-        MockStringFormatter customFormatter = applicationContext.getBean("logEipFormatter", MockStringFormatter.class);
+        MockMaskingFormatter customFormatter = applicationContext.getBean(Constants.CUSTOM_LOG_MASK_REF, MockMaskingFormatter.class);
         context.createProducerTemplate().sendBody("direct:foo", "mock password=\"my passw0rd!\"");
         Assert.assertEquals("Got mock password=\"my passw0rd!\"", customFormatter.received);
         context.stop();
     }
 
-    public static class MockStringFormatter implements StringFormatter {
+    public static class MockMaskingFormatter implements MaskingFormatter {
         private String received;
         @Override
         public String format(String source) {

--- a/components/camel-spring/src/test/resources/org/apache/camel/component/log/SpringCustomLogMaskTest-context.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/log/SpringCustomLogMaskTest-context.xml
@@ -22,20 +22,14 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
 
-    <camelContext logMask="true" xmlns="http://camel.apache.org/schema/spring">
+    <bean id="CamelCustomLogMask" class="org.apache.camel.component.log.SpringLogMaskTest.MockMaskingFormatter"/>
 
-        <route id="foo">
-            <from uri="direct:foo"/>
-            <log message="Got ${body}"/>
-            <to uri="mock:foo"/>
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <route id="mask">
+            <from uri="direct:mock"/>
+            <to uri="log:mock?logMask=true"/>
+            <to uri="mock:mock"/>
         </route>
-
-        <route id="noMask" logMask="false">
-            <from uri="direct:noMask"/>
-            <log message="Got ${body}"/>
-            <to uri="mock:noMask"/>
-        </route>
-
     </camelContext>
 
 </beans>

--- a/components/camel-spring/src/test/resources/org/apache/camel/component/log/SpringLogMaskTest-context.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/log/SpringLogMaskTest-context.xml
@@ -23,19 +23,16 @@
     ">
 
     <camelContext logMask="true" xmlns="http://camel.apache.org/schema/spring">
-
-        <route id="foo">
-            <from uri="direct:foo"/>
-            <log message="Got ${body}"/>
-            <to uri="mock:foo"/>
+        <route id="mask">
+            <from uri="direct:mask"/>
+            <to uri="log:mask?showHeaders=true&amp;showProperties=true"/>
+            <to uri="mock:mask"/>
         </route>
-
-        <route id="noMask" logMask="false">
-            <from uri="direct:noMask"/>
-            <log message="Got ${body}"/>
-            <to uri="mock:noMask"/>
+        <route id="no-mask">
+            <from uri="direct:no-mask"/>
+            <to uri="log:no-mask?showHeaders=true&amp;showProperties=true&amp;logMask=false"/>
+            <to uri="mock:no-mask"/>
         </route>
-
     </camelContext>
 
 </beans>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipCustomFormatterTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipCustomFormatterTest.xml
@@ -22,11 +22,11 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
 
-    <bean id="logEipFormatter" class="org.apache.camel.spring.processor.SpringLogEipMaskTest.MockStringFormatter"/>
+    <bean id="CamelCustomLogMask" class="org.apache.camel.spring.processor.SpringLogEipMaskTest.MockMaskingFormatter"/>
 
     <camelContext xmlns="http://camel.apache.org/schema/spring">
 
-        <route id="foo">
+        <route id="foo" logMask="true">
             <from uri="direct:foo"/>
             <log message="Got ${body}"/>
             <to uri="mock:foo"/>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipCustomFormatterTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipCustomFormatterTest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <bean id="logEipFormatter" class="org.apache.camel.spring.processor.SpringLogEipMaskTest.MockStringFormatter"/>
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+
+        <route id="foo">
+            <from uri="direct:foo"/>
+            <log message="Got ${body}"/>
+            <to uri="mock:foo"/>
+        </route>
+
+    </camelContext>
+
+</beans>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipMaskTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/logEipMaskTest.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <camelContext logEipMask="true" xmlns="http://camel.apache.org/schema/spring">
+
+        <route id="foo">
+            <from uri="direct:foo"/>
+            <log message="Got ${body}"/>
+            <to uri="mock:foo"/>
+        </route>
+
+        <route id="noMask" logEipMask="false">
+            <from uri="direct:noMask"/>
+            <log message="Got ${body}"/>
+            <to uri="mock:noMask"/>
+        </route>
+
+    </camelContext>
+
+</beans>

--- a/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/AbstractLocalCamelController.java
+++ b/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/AbstractLocalCamelController.java
@@ -83,7 +83,7 @@ public abstract class AbstractLocalCamelController extends AbstractCamelControll
             answer.put("allowUseOriginalMessage", context.isAllowUseOriginalMessage());
             answer.put("messageHistory", context.isMessageHistory());
             answer.put("tracing", context.isTracing());
-            answer.put("logEipMask", context.isLogEipMask());
+            answer.put("logMask", context.isLogMask());
             answer.put("shutdownTimeout", context.getShutdownStrategy().getTimeUnit().toSeconds(context.getShutdownStrategy().getTimeout()));
             answer.put("classResolver", context.getClassResolver().toString());
             answer.put("packageScanClassResolver", context.getPackageScanClassResolver().toString());

--- a/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/AbstractLocalCamelController.java
+++ b/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/AbstractLocalCamelController.java
@@ -83,6 +83,7 @@ public abstract class AbstractLocalCamelController extends AbstractCamelControll
             answer.put("allowUseOriginalMessage", context.isAllowUseOriginalMessage());
             answer.put("messageHistory", context.isMessageHistory());
             answer.put("tracing", context.isTracing());
+            answer.put("logEipMask", context.isLogEipMask());
             answer.put("shutdownTimeout", context.getShutdownStrategy().getTimeUnit().toSeconds(context.getShutdownStrategy().getTimeout()));
             answer.put("classResolver", context.getClassResolver().toString());
             answer.put("packageScanClassResolver", context.getPackageScanClassResolver().toString());

--- a/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/ContextInfoCommand.java
+++ b/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/ContextInfoCommand.java
@@ -80,6 +80,7 @@ public class ContextInfoCommand extends AbstractContextCommand {
         out.println(stringEscape.unescapeJava("\tAllow UseOriginalMessage: " + row.get("allowUseOriginalMessage")));
         out.println(stringEscape.unescapeJava("\tMessage History: " + row.get("messageHistory")));
         out.println(stringEscape.unescapeJava("\tTracing: " + row.get("tracing")));
+        out.println(stringEscape.unescapeJava("\tLog EIP Mask: " + row.get("logEipMask")));
         out.println("");
         out.println(stringEscape.unescapeJava("\u001B[1mProperties\u001B[0m"));
         for (Map.Entry<String, Object> entry : row.entrySet()) {

--- a/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/ContextInfoCommand.java
+++ b/platforms/commands/commands-core/src/main/java/org/apache/camel/commands/ContextInfoCommand.java
@@ -80,7 +80,7 @@ public class ContextInfoCommand extends AbstractContextCommand {
         out.println(stringEscape.unescapeJava("\tAllow UseOriginalMessage: " + row.get("allowUseOriginalMessage")));
         out.println(stringEscape.unescapeJava("\tMessage History: " + row.get("messageHistory")));
         out.println(stringEscape.unescapeJava("\tTracing: " + row.get("tracing")));
-        out.println(stringEscape.unescapeJava("\tLog EIP Mask: " + row.get("logEipMask")));
+        out.println(stringEscape.unescapeJava("\tLog Mask: " + row.get("logMask")));
         out.println("");
         out.println(stringEscape.unescapeJava("\u001B[1mProperties\u001B[0m"));
         for (Map.Entry<String, Object> entry : row.entrySet()) {


### PR DESCRIPTION
Introduced a StringFormatter interface to plugin a formatter into the Log EIP processor. MaskingStringFormatter is the implementation which masks sensitive information like password and passphrase for key=value, XML and JSON.

Like Log Component looks for a ExchangeFormatter with the name "logFormatter" in registry to be used for a default formatter, LogDefinition looks for a "logEipFormatter" for the default formatter. It can be overridden by specifying formatterRef option in Log DSL. It also introduced a series of logWithFormatter()/logWithFormatterRef() to be used in Java DSL.

Any feedback would be really appreciated. As those addition of the methods doesn't look really cool, that would be great if you could have better idea...

In the meantime, as it seems there's no log-eip.adoc in the src/main/docs/eips yet, I'll look into how it could be generated and add more commit here once it succeeds.