### PR TITLE
CAMEL-11058: Remove OData 3.0 version info from the camel-olingo2

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
@@ -3,7 +3,7 @@
 *Available as of Camel version 2.14.0*
 
 The Olingo2 component utilizes http://olingo.apache.org/[Apache Olingo]
-version 2.0 APIs to interact with OData 2.0 and 3.0 compliant services.
+version 2.0 APIs to interact with OData 2.0 compliant services.
 A number of popular commercial and enterprise vendors and products
 support the OData protocol. A sample list of supporting products can be
 found on the OData http://www.odata.org/ecosystem/[website].

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
@@ -36,7 +36,7 @@ import org.apache.camel.util.component.ApiMethod;
 import org.apache.camel.util.component.ApiMethodPropertiesHelper;
 
 /**
- * Communicates with OData 2.0 and 3.0 services using Apache Olingo.
+ * Communicates with OData 2.0 services using Apache Olingo.
  */
 @UriEndpoint(firstVersion = "2.14.0", scheme = "olingo2", title = "Olingo2", syntax = "olingo2:apiName/methodName", consumerClass = Olingo2Consumer.class, label = "cloud")
 public class Olingo2Endpoint extends AbstractApiEndpoint<Olingo2ApiName, Olingo2Configuration> {


### PR DESCRIPTION
Component camel-olingo2 doesn't support OData 3.0 as olingo-odata2 library never did it.
It would be nice to remove this info (OData 3.0) from the documentation and endpoint comment
