### PR TITLE
CAMEL-11079: session keepAlive in batch consumer

### DIFF
--- a/components/camel-sjms/src/main/docs/sjms-batch-component.adoc
+++ b/components/camel-sjms/src/main/docs/sjms-batch-component.adoc
@@ -148,7 +148,7 @@ with the following path and query parameters:
 | **destinationName** | *Required* The destination name. Only queues are supported names may be prefixed by 'queue:'. |  | String
 |=======================================================================
 
-#### Query Parameters (22 parameters):
+#### Query Parameters (23 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -171,6 +171,7 @@ with the following path and query parameters:
 | **asyncStartListener** (advanced) | Whether to startup the consumer message listener asynchronously when starting a route. For example if a JmsConsumer cannot get a connection to a remote JMS broker then it may block while retrying and/or failover. This will cause Camel to block while starting routes. By setting this option to true you will let routes startup while the JmsConsumer connects to the JMS broker using a dedicated thread in asynchronous mode. If this option is used then beware that if the connection could not be established then an exception is logged at WARN level and the consumer will not be able to receive messages; You can then restart the route to retry. | false | boolean
 | **headerFilterStrategy** (advanced) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | **jmsKeyFormatStrategy** (advanced) | Pluggable strategy for encoding and decoding JMS keys so they can be compliant with the JMS specification. Camel provides two implementations out of the box: default and passthrough. The default strategy will safely marshal dots and hyphens (. and -). The passthrough strategy leaves the key as is. Can be used for JMS brokers which do not care whether JMS header keys contain illegal characters. You can provide your own implementation of the org.apache.camel.component.jms.JmsKeyFormatStrategy and refer to it using the notation. |  | JmsKeyFormatStrategy
+| **keepAliveDelay** (advanced) | The delay in millis between attempts to re-establish a valid session. If this is a positive value the SjmsBatchConsumer will attempt to create a new session if it sees an IllegalStateException during message consumption. This delay value allows you to pause between attempts to prevent spamming the logs. If this is a negative value (default is -1) then the SjmsBatchConsumer will behave as it always has before - that is it will bail out and the route will shut down if it sees an IllegalStateException. | -1 | int
 | **messageCreatedStrategy** (advanced) | To use the given MessageCreatedStrategy which are invoked when Camel creates new instances of javax.jms.Message objects when Camel is sending a JMS message. |  | MessageCreatedStrategy
 | **recoveryInterval** (advanced) | Specifies the interval between recovery attempts i.e. when a connection is being refreshed in milliseconds. The default is 5000 ms that is 5 seconds. | 5000 | int
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
@@ -298,7 +298,7 @@ public class SjmsBatchConsumer extends DefaultConsumer {
         public AtomicBoolean getCompletionTimeoutTrigger() {
             return completionTimeoutTrigger;
         }
-        public void setKeepAliveDelay(int i){
+        public void setKeepAliveDelay(int i) {
             keepAliveDelay = i;
         }
 
@@ -325,11 +325,15 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                     } catch (javax.jms.IllegalStateException ex) {
                         // from consumeBatchesOnLoop
                         // if keepAliveDelay was not specified (defaults to -1) just rethrow to break the loop. This preserves original default behavior
-                        if(keepAliveDelay < 0) throw ex;
+                        if (keepAliveDelay < 0) {
+                            throw ex;
+                        }
                         // this will log the exception and the parent loop will create a new session
                         getExceptionHandler().handleException("Exception caught consuming from " + destinationName, ex);
                         //sleep to avoid log spamming
-                        if(keepAliveDelay > 0) Thread.sleep(keepAliveDelay);
+                        if (keepAliveDelay > 0) {
+                            Thread.sleep(keepAliveDelay);
+                        }
                     } finally {
                         closeJmsSession(session);
                     }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
@@ -128,7 +128,7 @@ public class SjmsBatchConsumer extends DefaultConsumer {
         super.doStart();
 
         boolean recovery = getEndpoint().isAsyncStartListener();
-        StartConsumerTask task = new StartConsumerTask(recovery, getEndpoint().getRecoveryInterval());
+        StartConsumerTask task = new StartConsumerTask(recovery, getEndpoint().getRecoveryInterval(), getEndpoint().getKeepAliveDelay());
 
         if (recovery) {
             // use a background thread to keep starting the consumer until
@@ -145,11 +145,13 @@ public class SjmsBatchConsumer extends DefaultConsumer {
 
         private boolean recoveryEnabled;
         private int recoveryInterval;
+        private int keepAliveDelay;
         private long attempt;
 
-        public StartConsumerTask(boolean recoveryEnabled, int recoveryInterval) {
+        public StartConsumerTask(boolean recoveryEnabled, int recoveryInterval, int keepAliveDelay) {
             this.recoveryEnabled = recoveryEnabled;
             this.recoveryInterval = recoveryInterval;
+            this.keepAliveDelay = keepAliveDelay;
         }
 
         @Override
@@ -183,6 +185,7 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                     final List<AtomicBoolean> triggers = new ArrayList<>();
                     for (int i = 0; i < consumerCount; i++) {
                         BatchConsumptionLoop loop = new BatchConsumptionLoop();
+                        loop.setKeepAliveDelay(keepAliveDelay);
                         triggers.add(loop.getCompletionTimeoutTrigger());
                         jmsConsumerExecutors.submit(loop);
                     }
@@ -290,16 +293,20 @@ public class SjmsBatchConsumer extends DefaultConsumer {
 
         private final AtomicBoolean completionTimeoutTrigger = new AtomicBoolean();
         private final BatchConsumptionTask task = new BatchConsumptionTask(completionTimeoutTrigger);
+        private int keepAliveDelay;
 
         public AtomicBoolean getCompletionTimeoutTrigger() {
             return completionTimeoutTrigger;
+        }
+        public void setKeepAliveDelay(int i){
+            keepAliveDelay = i;
         }
 
         @Override
         public void run() {
             try {
                 // this loop is intended to keep the consumer up and running as long as it's supposed to be, but allow it to bail if signaled
-                while (running.get()) {
+                while (running.get() || isStarting()) {
                     // a batch corresponds to a single session that will be committed or rolled back by a background thread
                     final Session session = connection.createSession(TRANSACTED, Session.CLIENT_ACKNOWLEDGE);
                     try {
@@ -315,10 +322,12 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                         }
                     } catch (javax.jms.IllegalStateException ex) {
                         // from consumeBatchesOnLoop
+                        // if keepAliveDelay was not specified just rethrow to break the loop. This preserves original default behavior
+                        if(keepAliveDelay == -1) throw ex;
                         // this will log the exception and the parent loop will create a new session
                         getExceptionHandler().handleException("Exception caught consuming from " + destinationName, ex);
-                        //rest a minute to avoid destroying the logs
-                        Thread.sleep(2000);
+                        //sleep to avoid log spamming
+                        Thread.sleep(keepAliveDelay);
                     } finally {
                         closeJmsSession(session);
                     }
@@ -401,6 +410,8 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                     long waitTime = (usingTimeout && (timeElapsed > 0))
                             ? getReceiveWaitTime(timeElapsed)
                             : pollDuration;
+
+
                     Message message = consumer.receive(waitTime);
 
                     if (running.get()) {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
@@ -322,12 +322,12 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                         }
                     } catch (javax.jms.IllegalStateException ex) {
                         // from consumeBatchesOnLoop
-                        // if keepAliveDelay was not specified just rethrow to break the loop. This preserves original default behavior
-                        if(keepAliveDelay == -1) throw ex;
+                        // if keepAliveDelay was not specified (defaults to -1) just rethrow to break the loop. This preserves original default behavior
+                        if(keepAliveDelay < 0) throw ex;
                         // this will log the exception and the parent loop will create a new session
                         getExceptionHandler().handleException("Exception caught consuming from " + destinationName, ex);
                         //sleep to avoid log spamming
-                        Thread.sleep(keepAliveDelay);
+                        if(keepAliveDelay > 0) Thread.sleep(keepAliveDelay);
                     } finally {
                         closeJmsSession(session);
                     }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
@@ -305,8 +305,10 @@ public class SjmsBatchConsumer extends DefaultConsumer {
         @Override
         public void run() {
             try {
-                // this loop is intended to keep the consumer up and running as long as it's supposed to be, but allow it to bail if signaled
-                while (running.get() || isStarting()) {
+                // This loop is intended to keep the consumer up and running as long as it's supposed to be, but allow it to bail if signaled.
+                // I'm using a do/while loop because the first time through we want to attempt it regardless of any other conditions... we
+                // only want to try AGAIN if the keepAlive is set.
+                do {
                     // a batch corresponds to a single session that will be committed or rolled back by a background thread
                     final Session session = connection.createSession(TRANSACTED, Session.CLIENT_ACKNOWLEDGE);
                     try {
@@ -331,7 +333,7 @@ public class SjmsBatchConsumer extends DefaultConsumer {
                     } finally {
                         closeJmsSession(session);
                     }
-                }
+                }while (running.get() || isStarting());
             } catch (Throwable ex) {
                 // from consumeBatchesOnLoop
                 // catch anything besides the IllegalStateException and exit the application

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
@@ -399,8 +399,18 @@ public class SjmsBatchEndpoint extends DefaultEndpoint implements HeaderFilterSt
         return recoveryInterval;
     }
 
+    /**
+     * The delay in millis between attempts to re-establish a valid session.
+     * If this is a positive value the SjmsBatchConsumer will attempt to create a new session if it sees an IllegalStateException
+     * during message consumption. This delay value allows you to pause between attempts to prevent spamming the logs.
+     * If this is a negative value (default is -1) then the SjmsBatchConsumer will behave as it always has before - that is
+     * it will bail out and the route will shut down if it sees an IllegalStateException.
+     */
+    public void setKeepAliveDelay(int keepAliveDelay) {
+         this.keepAliveDelay = keepAliveDelay;
+    }
     public int getKeepAliveDelay() {
-        return recoveryInterval;
+        return keepAliveDelay;
     }
 
     /**

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
@@ -407,7 +407,7 @@ public class SjmsBatchEndpoint extends DefaultEndpoint implements HeaderFilterSt
      * it will bail out and the route will shut down if it sees an IllegalStateException.
      */
     public void setKeepAliveDelay(int keepAliveDelay) {
-         this.keepAliveDelay = keepAliveDelay;
+        this.keepAliveDelay = keepAliveDelay;
     }
     public int getKeepAliveDelay() {
         return keepAliveDelay;

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpoint.java
@@ -93,6 +93,8 @@ public class SjmsBatchEndpoint extends DefaultEndpoint implements HeaderFilterSt
     private boolean asyncStartListener;
     @UriParam(label = "advanced", defaultValue = "5000")
     private int recoveryInterval = 5000;
+    @UriParam(label = "advanced", defaultValue = "-1")
+    private int keepAliveDelay = -1;
 
     public SjmsBatchEndpoint() {
     }
@@ -394,6 +396,10 @@ public class SjmsBatchEndpoint extends DefaultEndpoint implements HeaderFilterSt
     }
 
     public int getRecoveryInterval() {
+        return recoveryInterval;
+    }
+
+    public int getKeepAliveDelay() {
         return recoveryInterval;
     }
 

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumerAsyncStartTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumerAsyncStartTest.java
@@ -21,6 +21,7 @@ import javax.jms.ConnectionFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.sjms.SjmsComponent;
+import org.apache.camel.component.sjms.support.MockConnectionFactory;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 
@@ -32,7 +33,7 @@ public class SjmsBatchConsumerAsyncStartTest extends SjmsBatchConsumerTest {
     public CamelContext createCamelContext() throws Exception {
         SimpleRegistry registry = new SimpleRegistry();
         registry.put("testStrategy", new ListAggregationStrategy());
-        ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(broker.getTcpConnectorUri());
+        ConnectionFactory connectionFactory = new MockConnectionFactory(broker.getTcpConnectorUri());
 
         SjmsComponent sjmsComponent = new SjmsComponent();
         sjmsComponent.setConnectionFactory(connectionFactory);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumerTest.java
@@ -33,6 +33,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.camel.util.StopWatch;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -48,6 +49,9 @@ public class SjmsBatchConsumerTest extends CamelTestSupport {
     public CamelContext createCamelContext() throws Exception {
         SimpleRegistry registry = new SimpleRegistry();
         registry.put("testStrategy", new ListAggregationStrategy());
+        // the only thing special about this MockConnectionFactor is it allows us to call returnBadSessionNTimes(int)
+        // which will cause the MockSession to throw an IllegalStateException <int> times before returning a valid one.
+        // This gives us the ability to test bad sessions
         ConnectionFactory connectionFactory = new MockConnectionFactory(broker.getTcpConnectorUri());
 
         SjmsComponent sjmsComponent = new SjmsComponent();

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnection.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnection.java
@@ -1,18 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.sjms.support;
 
+import javax.jms.JMSException;
+import javax.jms.Session;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.management.JMSStatsImpl;
 import org.apache.activemq.transport.Transport;
 import org.apache.activemq.util.IdGenerator;
 
-import javax.jms.JMSException;
-import javax.jms.Session;
-
 /**
  * Created by bryan.love on 3/22/17.
  */
 public class MockConnection extends ActiveMQConnection {
-    private int returnBadSessionNTimes = 0;
+    private int returnBadSessionNTimes;
 
     protected MockConnection(final Transport transport, IdGenerator clientIdGenerator, IdGenerator connectionIdGenerator, JMSStatsImpl factoryStats, int returnBadSessionNTimes) throws Exception {
         super(transport,  clientIdGenerator,  connectionIdGenerator,  factoryStats);
@@ -22,22 +37,23 @@ public class MockConnection extends ActiveMQConnection {
     public Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
         this.checkClosedOrFailed();
         this.ensureConnectionInfoSent();
-        if(!transacted) {
-            if(acknowledgeMode == 0) {
+        if (!transacted) {
+            if (acknowledgeMode == 0) {
                 throw new JMSException("acknowledgeMode SESSION_TRANSACTED cannot be used for an non-transacted Session");
             }
 
-            if(acknowledgeMode < 0 || acknowledgeMode > 4) {
-                throw new JMSException("invalid acknowledgeMode: " + acknowledgeMode + ". Valid values are Session.AUTO_ACKNOWLEDGE (1), Session.CLIENT_ACKNOWLEDGE (2), Session.DUPS_OK_ACKNOWLEDGE (3), ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE (4) or for transacted sessions Session.SESSION_TRANSACTED (0)");
+            if (acknowledgeMode < 0 || acknowledgeMode > 4) {
+                throw new JMSException("invalid acknowledgeMode: " + acknowledgeMode + ". Valid values are Session.AUTO_ACKNOWLEDGE (1), Session.CLIENT_ACKNOWLEDGE (2), "
+                + "Session.DUPS_OK_ACKNOWLEDGE (3), ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE (4) or for transacted sessions Session.SESSION_TRANSACTED (0)");
             }
         }
 
         boolean useBadSession = false;
-        if(returnBadSessionNTimes > 0){
+        if (returnBadSessionNTimes > 0) {
             useBadSession = true;
             returnBadSessionNTimes = returnBadSessionNTimes - 1;
         }
-        return new MockSession(this, this.getNextSessionId(), transacted?0:acknowledgeMode, this.isDispatchAsync(), this.isAlwaysSessionAsync(), useBadSession);
+        return new MockSession(this, this.getNextSessionId(), transacted ? 0 : acknowledgeMode, this.isDispatchAsync(), this.isAlwaysSessionAsync(), useBadSession);
 
     }
 }

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnection.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnection.java
@@ -1,0 +1,43 @@
+package org.apache.camel.component.sjms.support;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.management.JMSStatsImpl;
+import org.apache.activemq.transport.Transport;
+import org.apache.activemq.util.IdGenerator;
+
+import javax.jms.JMSException;
+import javax.jms.Session;
+
+/**
+ * Created by bryan.love on 3/22/17.
+ */
+public class MockConnection extends ActiveMQConnection {
+    private int returnBadSessionNTimes = 0;
+
+    protected MockConnection(final Transport transport, IdGenerator clientIdGenerator, IdGenerator connectionIdGenerator, JMSStatsImpl factoryStats, int returnBadSessionNTimes) throws Exception {
+        super(transport,  clientIdGenerator,  connectionIdGenerator,  factoryStats);
+        this.returnBadSessionNTimes = returnBadSessionNTimes;
+    }
+
+    public Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
+        this.checkClosedOrFailed();
+        this.ensureConnectionInfoSent();
+        if(!transacted) {
+            if(acknowledgeMode == 0) {
+                throw new JMSException("acknowledgeMode SESSION_TRANSACTED cannot be used for an non-transacted Session");
+            }
+
+            if(acknowledgeMode < 0 || acknowledgeMode > 4) {
+                throw new JMSException("invalid acknowledgeMode: " + acknowledgeMode + ". Valid values are Session.AUTO_ACKNOWLEDGE (1), Session.CLIENT_ACKNOWLEDGE (2), Session.DUPS_OK_ACKNOWLEDGE (3), ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE (4) or for transacted sessions Session.SESSION_TRANSACTED (0)");
+            }
+        }
+
+        boolean useBadSession = false;
+        if(returnBadSessionNTimes > 0){
+            useBadSession = true;
+            returnBadSessionNTimes = returnBadSessionNTimes - 1;
+        }
+        return new MockSession(this, this.getNextSessionId(), transacted?0:acknowledgeMode, this.isDispatchAsync(), this.isAlwaysSessionAsync(), useBadSession);
+
+    }
+}

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnectionFactory.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnectionFactory.java
@@ -1,0 +1,42 @@
+package org.apache.camel.component.sjms.support;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.management.JMSStatsImpl;
+import org.apache.activemq.transport.Transport;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by bryan.love on 3/22/17.
+ */
+public class MockConnectionFactory extends ActiveMQConnectionFactory {
+    private int returnBadSessionNTimes = 0;
+
+    public Connection createConnection() throws JMSException {
+        return this.createActiveMQConnection();
+    }
+    public MockConnectionFactory(String brokerURL) {
+        super(createURI(brokerURL));
+    }
+    private static URI createURI(String brokerURL) {
+        try {
+            return new URI(brokerURL);
+        } catch (URISyntaxException var2) {
+            throw (IllegalArgumentException)(new IllegalArgumentException("Invalid broker URI: " + brokerURL)).initCause(var2);
+        }
+    }
+
+    protected ActiveMQConnection createActiveMQConnection(Transport transport, JMSStatsImpl stats) throws Exception {
+        MockConnection connection = new MockConnection(transport, this.getClientIdGenerator(), this.getConnectionIdGenerator(), stats, returnBadSessionNTimes);
+        return connection;
+    }
+
+    public void returnBadSessionNTimes(int returnBadSessionNTimes) {
+        this.returnBadSessionNTimes = returnBadSessionNTimes;
+    }
+
+}

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnectionFactory.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockConnectionFactory.java
@@ -1,26 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.sjms.support;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.jms.Connection;
+import javax.jms.JMSException;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.management.JMSStatsImpl;
 import org.apache.activemq.transport.Transport;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * Created by bryan.love on 3/22/17.
  */
 public class MockConnectionFactory extends ActiveMQConnectionFactory {
-    private int returnBadSessionNTimes = 0;
+    private int returnBadSessionNTimes;
 
-    public Connection createConnection() throws JMSException {
-        return this.createActiveMQConnection();
-    }
     public MockConnectionFactory(String brokerURL) {
         super(createURI(brokerURL));
+    }
+    public Connection createConnection() throws JMSException {
+        return this.createActiveMQConnection();
     }
     private static URI createURI(String brokerURL) {
         try {

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockMessageConsumer.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockMessageConsumer.java
@@ -1,0 +1,29 @@
+package org.apache.camel.component.sjms.support;
+
+import org.apache.activemq.ActiveMQMessageConsumer;
+import org.apache.activemq.ActiveMQSession;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ConsumerId;
+import org.apache.activemq.command.MessageDispatch;
+
+import javax.jms.IllegalStateException;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+/**
+ * Created by bryan.love on 3/22/17.
+ */
+public class MockMessageConsumer extends ActiveMQMessageConsumer{
+    private boolean isBadSession;
+
+    public MockMessageConsumer(ActiveMQSession session, ConsumerId consumerId, ActiveMQDestination dest, String name, String selector, int prefetch, int maximumPendingMessageCount, boolean noLocal, boolean browser, boolean dispatchAsync, MessageListener messageListener, boolean isBadSession) throws JMSException {
+        super(session, consumerId, dest, name, selector, prefetch, maximumPendingMessageCount, noLocal, browser, dispatchAsync, messageListener);
+        this.isBadSession = isBadSession;
+    }
+
+    public Message receive(long timeout) throws JMSException {
+        if(isBadSession) throw new IllegalStateException("asdf");
+        return super.receive(timeout);
+    }
+}

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockMessageConsumer.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockMessageConsumer.java
@@ -1,29 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.sjms.support;
-
-import org.apache.activemq.ActiveMQMessageConsumer;
-import org.apache.activemq.ActiveMQSession;
-import org.apache.activemq.command.ActiveMQDestination;
-import org.apache.activemq.command.ConsumerId;
-import org.apache.activemq.command.MessageDispatch;
 
 import javax.jms.IllegalStateException;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageListener;
+import org.apache.activemq.ActiveMQMessageConsumer;
+import org.apache.activemq.ActiveMQSession;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ConsumerId;
 
 /**
  * Created by bryan.love on 3/22/17.
  */
-public class MockMessageConsumer extends ActiveMQMessageConsumer{
+public class MockMessageConsumer extends ActiveMQMessageConsumer {
     private boolean isBadSession;
 
-    public MockMessageConsumer(ActiveMQSession session, ConsumerId consumerId, ActiveMQDestination dest, String name, String selector, int prefetch, int maximumPendingMessageCount, boolean noLocal, boolean browser, boolean dispatchAsync, MessageListener messageListener, boolean isBadSession) throws JMSException {
+    public MockMessageConsumer(ActiveMQSession session, ConsumerId consumerId, ActiveMQDestination dest, String name, String selector, int prefetch,
+                               int maximumPendingMessageCount, boolean noLocal, boolean browser, boolean dispatchAsync, MessageListener messageListener,
+                               boolean isBadSession) throws JMSException {
         super(session, consumerId, dest, name, selector, prefetch, maximumPendingMessageCount, noLocal, browser, dispatchAsync, messageListener);
         this.isBadSession = isBadSession;
     }
 
     public Message receive(long timeout) throws JMSException {
-        if(isBadSession) throw new IllegalStateException("asdf");
+        if (isBadSession) {
+            throw new IllegalStateException("asdf");
+        }
         return super.receive(timeout);
     }
 }

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockSession.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockSession.java
@@ -1,18 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.sjms.support;
 
-import org.apache.activemq.*;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQMessageTransformation;
+import org.apache.activemq.ActiveMQPrefetchPolicy;
+import org.apache.activemq.ActiveMQSession;
+import org.apache.activemq.CustomDestination;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTempQueue;
 import org.apache.activemq.command.SessionId;
 
-import javax.jms.*;
 
 /**
  * Created by bryan.love on 3/22/17.
  */
 public class MockSession extends ActiveMQSession {
-    private boolean isBadSession = false;
+    private boolean isBadSession;
 
     protected MockSession(ActiveMQConnection connection, SessionId sessionId, int acknowledgeMode, boolean asyncDispatch, boolean sessionAsyncDispatch, boolean isBadSession) throws JMSException {
         super(connection,  sessionId,  acknowledgeMode,  asyncDispatch,  sessionAsyncDispatch);
@@ -20,26 +45,27 @@ public class MockSession extends ActiveMQSession {
     }
     public Queue createQueue(String queueName) throws JMSException {
         this.checkClosed();
-        return (Queue)(queueName.startsWith("ID:")?new ActiveMQTempQueue(queueName):new ActiveMQQueue(queueName));
+        return (Queue)(queueName.startsWith("ID:") ? new ActiveMQTempQueue(queueName) : new ActiveMQQueue(queueName));
     }
 
     public MessageConsumer createConsumer(Destination destination, String messageSelector, boolean noLocal, MessageListener messageListener) throws JMSException {
         this.checkClosed();
-        if(destination instanceof CustomDestination) {
+        if (destination instanceof CustomDestination) {
             CustomDestination prefetchPolicy1 = (CustomDestination)destination;
             return prefetchPolicy1.createConsumer(this, messageSelector, noLocal);
         } else {
             ActiveMQPrefetchPolicy prefetchPolicy = this.connection.getPrefetchPolicy();
             boolean prefetch = false;
             int prefetch1;
-            if(destination instanceof Topic) {
+            if (destination instanceof Topic) {
                 prefetch1 = prefetchPolicy.getTopicPrefetch();
             } else {
                 prefetch1 = prefetchPolicy.getQueuePrefetch();
             }
 
             ActiveMQDestination activemqDestination = ActiveMQMessageTransformation.transformDestination(destination);
-            return new MockMessageConsumer(this, this.getNextConsumerId(), activemqDestination, (String)null, messageSelector, prefetch1, prefetchPolicy.getMaximumPendingMessageLimit(), noLocal, false, this.isAsyncDispatch(), messageListener, isBadSession);
+            return new MockMessageConsumer(this, this.getNextConsumerId(), activemqDestination, (String)null, messageSelector, prefetch1, prefetchPolicy.getMaximumPendingMessageLimit(),
+                                           noLocal, false, this.isAsyncDispatch(), messageListener, isBadSession);
         }
     }
 }

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockSession.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/MockSession.java
@@ -1,0 +1,45 @@
+package org.apache.camel.component.sjms.support;
+
+import org.apache.activemq.*;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTempQueue;
+import org.apache.activemq.command.SessionId;
+
+import javax.jms.*;
+
+/**
+ * Created by bryan.love on 3/22/17.
+ */
+public class MockSession extends ActiveMQSession {
+    private boolean isBadSession = false;
+
+    protected MockSession(ActiveMQConnection connection, SessionId sessionId, int acknowledgeMode, boolean asyncDispatch, boolean sessionAsyncDispatch, boolean isBadSession) throws JMSException {
+        super(connection,  sessionId,  acknowledgeMode,  asyncDispatch,  sessionAsyncDispatch);
+        this.isBadSession = isBadSession;
+    }
+    public Queue createQueue(String queueName) throws JMSException {
+        this.checkClosed();
+        return (Queue)(queueName.startsWith("ID:")?new ActiveMQTempQueue(queueName):new ActiveMQQueue(queueName));
+    }
+
+    public MessageConsumer createConsumer(Destination destination, String messageSelector, boolean noLocal, MessageListener messageListener) throws JMSException {
+        this.checkClosed();
+        if(destination instanceof CustomDestination) {
+            CustomDestination prefetchPolicy1 = (CustomDestination)destination;
+            return prefetchPolicy1.createConsumer(this, messageSelector, noLocal);
+        } else {
+            ActiveMQPrefetchPolicy prefetchPolicy = this.connection.getPrefetchPolicy();
+            boolean prefetch = false;
+            int prefetch1;
+            if(destination instanceof Topic) {
+                prefetch1 = prefetchPolicy.getTopicPrefetch();
+            } else {
+                prefetch1 = prefetchPolicy.getQueuePrefetch();
+            }
+
+            ActiveMQDestination activemqDestination = ActiveMQMessageTransformation.transformDestination(destination);
+            return new MockMessageConsumer(this, this.getNextConsumerId(), activemqDestination, (String)null, messageSelector, prefetch1, prefetchPolicy.getMaximumPendingMessageLimit(), noLocal, false, this.isAsyncDispatch(), messageListener, isBadSession);
+        }
+    }
+}


### PR DESCRIPTION
Problem:
When using failover in queue consumption, if a connection is bumped to another broker then the session in SjmsBatchConsumer becomes invalid and an IllegalStateException is thrown, which causes the route (and possibly the application) to exit.

Solution:
Introduce a new URI param that allows the SjmsBatchConsumer to create a new session when this situation occurs, but default the param to a value that preserves the original behavior so nobody gets a nasty surprise.

I Know the mock classes I created to support the test are less than ideal, but that's an area of inexperience for me, and they do work as intended.