### PR TITLE
CAMEL-7809: Ensure the cron schedule is updated when the job is rescheduled

### DIFF
--- a/components/camel-quartz2/src/main/java/org/apache/camel/pollconsumer/quartz2/QuartzScheduledPollConsumerScheduler.java
+++ b/components/camel-quartz2/src/main/java/org/apache/camel/pollconsumer/quartz2/QuartzScheduledPollConsumerScheduler.java
@@ -168,11 +168,11 @@ public class QuartzScheduledPollConsumerScheduler extends ServiceSupport impleme
             id = "trigger-" + getCamelContext().getUuidGenerator().generateUuid();
         }
 
-        Trigger existingTrigger = null;
+        CronTrigger existingTrigger = null;
         TriggerKey triggerKey = null;
         if (triggerId != null && triggerGroup != null) {
             triggerKey = new TriggerKey(triggerId, triggerGroup);
-            existingTrigger = quartzScheduler.getTrigger(triggerKey);
+            existingTrigger = (CronTrigger)quartzScheduler.getTrigger(triggerKey);
         }
 
         // Is an trigger already exist for this triggerId ?
@@ -208,8 +208,11 @@ public class QuartzScheduledPollConsumerScheduler extends ServiceSupport impleme
 
             QuartzHelper.updateJobDataMap(getCamelContext(), job, null);
             LOG.debug("Updated jobData map to {}", jobData);
+            
+            // Ensure the cron schedule is updated
+            CronTrigger newTrigger = existingTrigger.getTriggerBuilder().withSchedule(CronScheduleBuilder.cronSchedule(getCron()).inTimeZone(getTimeZone())).build();
 
-            quartzScheduler.rescheduleJob(triggerKey, existingTrigger);
+            quartzScheduler.rescheduleJob(triggerKey, newTrigger);
         }
     }
 


### PR DESCRIPTION
The previous fix does not allow the Cron Schedule to be modified after initial creation.

This reschedules to the trigger to the latest schedule.

See: http://www.quartz-scheduler.org/documentation/quartz-2.x/cookbook/UpdateTrigger.html