### PR TITLE
CAMEL-11092 If setting Exchange.REST_HTTP_URI the RestProducer should remove Exchange.HTTP_PATH header

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/rest/RestProducer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/rest/RestProducer.java
@@ -194,6 +194,14 @@ public class RestProducer extends DefaultAsyncProducer {
             }
             // the http uri for the rest call to be used
             inMessage.setHeader(Exchange.REST_HTTP_URI, overrideUri);
+
+            // when chaining RestConsumer with RestProducer, the
+            // HTTP_PATH header will be present, we remove it here
+            // as the REST_HTTP_URI contains the full URI for the
+            // request and every other HTTP producer will concatenate
+            // REST_HTTP_URI with HTTP_PATH resulting in incorrect
+            // URIs
+            inMessage.removeHeader(Exchange.HTTP_PATH);
         }
 
         final String produces = getEndpoint().getProduces();


### PR DESCRIPTION
Submitted for review, I might not be aware of all that goes on, thanks 🥇

As most HTTP components generate URIs by concatenating `Exchange.REST_HTTP_URI` and `Exchange.HTTP_PATH` when the REST producer generates `Exchange.REST_HTTP_URI` header that contains the whole URI to be used it should remove the `Exchange.HTTP_PATH` header in order to
prevent incorrect URIs.

For example `Exchange.HTTP_PATH` is set by the REST consumer to `/api/pet/123`, and REST producer is configured with `Exchange.REST_HTTP_URI` with URI `/api/pet/{petId}` if the `Exchange.HTTP_PATH` is not removed HTTP component (IMHO all except for Restlet) would try to send the request to `/api/pet/{petId}/api/pet/123`