### PR TITLE
Remove dependency on OpenTracing contrib GlobalTracer, as this is bei…

### DIFF
--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-globaltracer</artifactId>
-      <version>${opentracing-java-globaltracer-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spanmanager</artifactId>
       <version>${opentracing-java-spanmanager-version}</version>
     </dependency>

--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -24,7 +24,7 @@ Include the `camel-opentracing` component in your POM, along with any specific d
 
 To explicitly configure OpenTracing support, instantiate the `OpenTracingTracer` and initialize the camel
 context. You can optionally specify a `Tracer`, or alternatively it can be implicitly discovered using the
-`GlobalTracer`.
+`Registry` or `ServiceLoader`.
 
 [source,java]
 --------------------------------------------------------------------------------------------------
@@ -52,6 +52,9 @@ If you are using link:spring-boot.html[Spring Boot] then you can add
 the `camel-opentracing-starter` dependency, and turn on OpenTracing by annotating
 the main class with `@CamelOpenTracing`.
 
+The `Tracer` will be implicitly obtained from the camel context's `Registry`, or the `ServiceLoader`, unless
+a `Tracer` bean has been defined by the application.
+
 #### Java Agent
 
 The third approach is to use a Java Agent to automatically configure the OpenTracing support.
@@ -68,8 +71,9 @@ The OpenTracing Java Agent is associated with the following dependency:
     </dependency>
 ---------------------------------------------------------------------------------------------------------
 
-How this agent is used will be specific to how you execute your application. _Service2_ in the https://github.com/apache/camel/tree/master/examples/camel-example-opentracing[camel-example-opentracing] downloads the agent into a local folder and then uses the `exec-maven-plugin` to launch the service with the `-javaagent` command line option. 
+The `Tracer` used will be implicitly loaded from the camel context `Registry` or using the `ServiceLoader`.
 
+How this agent is used will be specific to how you execute your application. _Service2_ in the https://github.com/apache/camel/tree/master/examples/camel-example-opentracing[camel-example-opentracing] downloads the agent into a local folder and then uses the `exec-maven-plugin` to launch the service with the `-javaagent` command line option. 
 
 ### Example
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/agent/InstallOpenTracingTracerRuleTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.opentracing.agent;
 
 import java.util.List;
 
-import io.opentracing.contrib.global.GlobalTracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.mock.MockTracer.Propagator;
@@ -29,9 +28,9 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.JndiRegistry;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class InstallOpenTracingTracerRuleTest extends CamelTestSupport {
@@ -44,11 +43,6 @@ public class InstallOpenTracingTracerRuleTest extends CamelTestSupport {
     @Produce(uri = "direct:start")
     protected ProducerTemplate template;
 
-    @BeforeClass
-    public static void initClass() throws Exception {
-        GlobalTracer.register(tracer);
-    }
-
     @Before
     public void init() {
         tracer.reset();
@@ -56,6 +50,16 @@ public class InstallOpenTracingTracerRuleTest extends CamelTestSupport {
 
     public static MockTracer getTracer() {
         return tracer;
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry registry = super.createRegistry();
+
+        // Add the mock tracer to the registry
+        registry.bind("tracer", tracer);
+
+        return registry;
     }
 
     @Override

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -496,7 +496,6 @@
     <openstack4j-version>3.0.2</openstack4j-version>
     <openstack4j-guava-version>17.0</openstack4j-guava-version>
     <opentracing-java-agent-version>0.0.10</opentracing-java-agent-version>
-    <opentracing-java-globaltracer-version>0.1.0</opentracing-java-globaltracer-version>
     <opentracing-java-spanmanager-version>0.0.3</opentracing-java-spanmanager-version>
     <opentracing-version>0.20.10</opentracing-version>
     <ops4j-base-version>1.5.0</ops4j-base-version>

--- a/platforms/spring-boot/components-starter/camel-opentracing-starter/src/main/java/org/apache/camel/opentracing/starter/OpenTracingAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-opentracing-starter/src/main/java/org/apache/camel/opentracing/starter/OpenTracingAutoConfiguration.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.opentracing.starter;
 
+import io.opentracing.Tracer;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.opentracing.OpenTracingTracer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -29,12 +32,18 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(value = "camel.opentracing.enabled", matchIfMissing = true)
 public class OpenTracingAutoConfiguration {
 
+    @Autowired(required = false)
+    private Tracer tracer;
+
     @Bean(initMethod = "", destroyMethod = "")
     // Camel handles the lifecycle of this bean
     @ConditionalOnMissingBean(OpenTracingTracer.class)
     OpenTracingTracer openTracingEventNotifier(CamelContext camelContext,
                         OpenTracingConfigurationProperties config) {
         OpenTracingTracer ottracer = new OpenTracingTracer();
+        if (tracer != null) {
+            ottracer.setTracer(tracer);
+        }
         ottracer.init(camelContext);
 
         return ottracer;


### PR DESCRIPTION
…ng relocated in the near future, and is not essential for camel-opentracing. Also enable a Spring app to provide a Tracer bean.