### PR TITLE
CAMEL-11060: fall back to context source base DN

### DIFF
--- a/components/camel-spring-ldap/src/main/docs/spring-ldap-component.adoc
+++ b/components/camel-spring-ldap/src/main/docs/spring-ldap-component.adoc
@@ -71,7 +71,8 @@ with the following path and query parameters:
 The component supports producer endpoint only. An attempt to create a
 consumer endpoint will result in an `UnsupportedOperationException`. +
  The body of the message must be a map (an instance of `java.util.Map`).
-This map must contain at least an entry with the key *`dn`* (not needed for function_driven operation) that
+Unless a base DN is specified by in the configuration of your ContextSource,
+this map must contain at least an entry with the key *`dn`* (not needed for function_driven operation) that
 specifies the root node for the LDAP operation to be performed. Other
 entries of the map are operation-specific (see below).
 

--- a/components/camel-spring-ldap/src/main/java/org/apache/camel/component/springldap/SpringLdapProducer.java
+++ b/components/camel-spring-ldap/src/main/java/org/apache/camel/component/springldap/SpringLdapProducer.java
@@ -27,8 +27,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.ldap.query.LdapQueryBuilder;
 
 public class SpringLdapProducer extends DefaultProducer {
@@ -89,12 +91,19 @@ public class SpringLdapProducer extends DefaultProducer {
             throw new UnsupportedOperationException("LDAP operation must not be empty, but you provided an empty operation");
         }
 
+        LdapTemplate ldapTemplate = endpoint.getLdapTemplate();
+
         String dn = (String)body.get(DN);
+        if (StringUtils.isBlank(dn)) {
+            ContextSource contextSource = ldapTemplate.getContextSource();
+            if (contextSource instanceof BaseLdapPathContextSource) {
+		dn = ((BaseLdapPathContextSource) contextSource).getBaseLdapPathAsString();
+	    }
+        }
         if (operation != LdapOperation.FUNCTION_DRIVEN && (StringUtils.isBlank(dn))) {
             throw new UnsupportedOperationException("DN must not be empty, but you provided an empty DN");
         }
 
-        LdapOperations ldapTemplate = endpoint.getLdapTemplate();
         switch (operation) {
         case SEARCH:
             String filter = (String)body.get(FILTER);


### PR DESCRIPTION
This patch makes the Spring LDAP component so that if no "dn" parameter is specified, it uses the base defined on the Spring LDAP ContextSource. An error will only occur if the base is defined in neither place.