### PR TITLE
elasticsearch.version in elasticsearch5 component pom.xml was hardcoded

### DIFF
--- a/components/camel-elasticsearch5/pom.xml
+++ b/components/camel-elasticsearch5/pom.xml
@@ -31,7 +31,7 @@
   <description>Camel ElasticSearch 5.x support</description>
 
   <properties>
-    <elasticsearch.version>5.1.2</elasticsearch.version>
+    <elasticsearch.version>${elasticsearch5-version}</elasticsearch.version>
     <camel.osgi.export.pkg>org.apache.camel.component.elasticsearch5.*;${camel.osgi.version}</camel.osgi.export.pkg>
     <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=elasticsearch5</camel.osgi.export.service>
   </properties>


### PR DESCRIPTION
<elasticsearch.version> property in elasticsearch5 component pom.xml was hardcoded to 5.1.2 and now must be changed to ${elasticsearch5-version} property value from the parent/pom.xml
This property requires for subcomponent lucene inside elasticsearch.