### PR TITLE
camel-elasticsearch5: use dynamic ports in test

### DIFF
--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchBaseTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchBaseTest.java
@@ -24,12 +24,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.Netty4Plugin;
@@ -42,22 +42,28 @@ public class ElasticsearchBaseTest extends CamelTestSupport {
     public static Node node;
     public static TransportClient client;
 
+    protected static final int ES_TRANSPORT_PORT = AvailablePortFinder.getNextAvailable();
+
     private static class PluginConfigurableNode extends Node {
         PluginConfigurableNode(Settings settings, Collection<Class<? extends Plugin>> classpathPlugins) {
             super(InternalSettingsPreparer.prepareEnvironment(settings, null), classpathPlugins);
         }
     }
 
+    @SuppressWarnings("resource")
     @BeforeClass
     public static void cleanupOnce() throws Exception {
         deleteDirectory("target/data");
 
         // create an embedded node to resume
-        node = new PluginConfigurableNode(Settings.builder().put("http.enabled", true).put("path.data", "target/data")
-                .put("path.home", "target/home").build(), Arrays.asList(Netty4Plugin.class)).start();
-        client = new PreBuiltTransportClient(Settings.EMPTY)
-                .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), 9300));
-    } 
+        node = new PluginConfigurableNode(Settings.builder()
+            .put("http.enabled", true)
+            .put("path.data", "target/data")
+            .put("path.home", "target/home")
+            .put("transport.profiles.default.port", ES_TRANSPORT_PORT)
+            .build(), Arrays.asList(Netty4Plugin.class)).start();
+        client = new PreBuiltTransportClient(Settings.EMPTY).addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), ES_TRANSPORT_PORT));
+    }
 
     @AfterClass
     public static void teardownOnce() throws IOException {

--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchBulkTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchBulkTest.java
@@ -52,8 +52,7 @@ public class ElasticsearchBulkTest extends ElasticsearchBaseTest {
 
         // given
         BulkRequest request = new BulkRequest();
-        request.add(new IndexRequest(prefix + "foo", prefix + "bar", prefix + "baz")
-                .source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"));
+        request.add(new IndexRequest(prefix + "foo", prefix + "bar", prefix + "baz").source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"));
 
         // when
         @SuppressWarnings("unchecked")
@@ -71,8 +70,7 @@ public class ElasticsearchBulkTest extends ElasticsearchBaseTest {
 
         // given
         BulkRequest request = new BulkRequest();
-        request.add(new IndexRequest(prefix + "foo", prefix + "bar", prefix + "baz")
-                .source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"));
+        request.add(new IndexRequest(prefix + "foo", prefix + "bar", prefix + "baz").source("{\"" + prefix + "content\": \"" + prefix + "hello\"}"));
 
         // when
         BulkResponse response = template.requestBody("direct:bulk", request, BulkResponse.class);
@@ -87,8 +85,8 @@ public class ElasticsearchBulkTest extends ElasticsearchBaseTest {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("direct:bulk_index").to("elasticsearch5://elasticsearch?operation=BULK_INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:bulk").to("elasticsearch5://elasticsearch?operation=BULK&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
+                from("direct:bulk_index").to("elasticsearch5://elasticsearch?operation=BULK_INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:bulk").to("elasticsearch5://elasticsearch?operation=BULK&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
             }
         };
     }

--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchClusterBaseTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchClusterBaseTest.java
@@ -20,7 +20,7 @@ import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.CamelContext;
+import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.elasticsearch.client.transport.TransportClient;
@@ -36,15 +36,20 @@ import static org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner.newCo
 public class ElasticsearchClusterBaseTest extends CamelTestSupport {
 
     public static ElasticsearchClusterRunner runner;
-    public static String clusterName;  
+    public static String clusterName;
     public static TransportClient client;
 
+    protected static final int ES_BASE_TRANSPORT_PORT = AvailablePortFinder.getNextAvailable();
+    protected static final int ES_FIRST_NODE_TRANSPORT_PORT = AvailablePortFinder.getNextAvailable(ES_BASE_TRANSPORT_PORT + 1);
+    protected static final int ES_BASE_HTTP_PORT = AvailablePortFinder.getNextAvailable(ES_BASE_TRANSPORT_PORT + 10);
+
+    @SuppressWarnings("resource")
     @BeforeClass
     public static void cleanUpOnce() throws Exception {
         deleteDirectory("target/testcluster/");
         clusterName = "es-cl-run-" + System.currentTimeMillis();
         // create runner instance
-        
+
         runner = new ElasticsearchClusterRunner();
         // create ES nodes
         runner.onBuild(new ElasticsearchClusterRunner.Builder() {
@@ -53,28 +58,29 @@ public class ElasticsearchClusterBaseTest extends CamelTestSupport {
                 settingsBuilder.put("http.cors.enabled", true);
                 settingsBuilder.put("http.cors.allow-origin", "*");
             }
-        }).build(
-                newConfigs()
-                .clusterName(clusterName)
-                .numOfNode(3)
-                .basePath("target/testcluster/")
-                .useLogger());
+        }).build(newConfigs()
+                 .clusterName(clusterName)
+                 .numOfNode(3)
+                 .baseTransportPort(ES_BASE_TRANSPORT_PORT)
+                 .baseHttpPort(ES_BASE_HTTP_PORT)
+                 .basePath("target/testcluster/")
+                 .useLogger());
 
         // wait for green status
         runner.ensureGreen();
-        
-        client = new PreBuiltTransportClient(getSettings())
-                .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), 9301));
+
+        client = new PreBuiltTransportClient(getSettings()).addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), ES_FIRST_NODE_TRANSPORT_PORT));
     }
-    
+
     private static Settings getSettings() {
         return Settings.builder()
-                .put("cluster.name", clusterName)
-                .put("client.transport.ignore_cluster_name", false)
-                .put("client.transport.sniff", true)
-                .build();
+            .put("cluster.name", clusterName)
+            .put("http.enabled", true)
+            .put("client.transport.ignore_cluster_name", false)
+            .put("client.transport.sniff", true)
+            .build();
     }
-    
+
     @AfterClass
     public static void teardownOnce() throws Exception {
         if (client != null) {
@@ -87,7 +93,7 @@ public class ElasticsearchClusterBaseTest extends CamelTestSupport {
             runner.clean();
         }
     }
-    
+
     @Override
     public boolean isCreateCamelContextPerClass() {
         // let's speed up the tests using the same context

--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchClusterIndexTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchClusterIndexTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class ElasticsearchClusterIndexTest extends ElasticsearchClusterBaseTest {
 
     @Test
-    public void indexWithIpAndPort()  throws Exception {
+    public void indexWithIpAndPort() throws Exception {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.INDEX);
@@ -35,25 +35,24 @@ public class ElasticsearchClusterIndexTest extends ElasticsearchClusterBaseTest 
 
         String indexId = template.requestBodyAndHeaders("direct:indexWithIpAndPort", map, headers, String.class);
         assertNotNull("indexId should be set", indexId);
-        
+
         headers.clear();
-        
+
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.INDEX);
         headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
         headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "status");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "2");
 
-
         indexId = template.requestBodyAndHeaders("direct:indexWithIpAndPort", map, headers, String.class);
         assertNotNull("indexId should be set", indexId);
-        
+
         assertEquals("Cluster must be of three nodes", runner.getNodeSize(), 3);
         assertEquals("Index id 1 must exists", true, client.prepareGet("twitter", "tweet", "1").get().isExists());
         assertEquals("Index id 2 must exists", true, client.prepareGet("twitter", "status", "2").get().isExists());
     }
 
     @Test
-    public void indexWithTransportAddresses()  throws Exception {
+    public void indexWithTransportAddresses() throws Exception {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.INDEX);
@@ -63,13 +62,13 @@ public class ElasticsearchClusterIndexTest extends ElasticsearchClusterBaseTest 
 
         String indexId = template.requestBodyAndHeaders("direct:indexWithTransportAddresses", map, headers, String.class);
         assertNotNull("indexId should be set", indexId);
-        
+
         assertEquals("Cluster must be of three nodes", runner.getNodeSize(), 3);
         assertEquals("Index id 4 must exists", true, client.prepareGet("facebook", "post", "4").get().isExists());
     }
 
     @Test
-    public void indexWithIpAndTransportAddresses()  throws Exception {
+    public void indexWithIpAndTransportAddresses() throws Exception {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<String, Object>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.INDEX);
@@ -77,10 +76,10 @@ public class ElasticsearchClusterIndexTest extends ElasticsearchClusterBaseTest 
         headers.put(ElasticsearchConstants.PARAM_INDEX_TYPE, "search");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "5");
 
-        //should ignore transport addresses configuration
+        // should ignore transport addresses configuration
         String indexId = template.requestBodyAndHeaders("direct:indexWithIpAndTransportAddresses", map, headers, String.class);
         assertNotNull("indexId should be set", indexId);
-        
+
         assertEquals("Cluster must be of three nodes", runner.getNodeSize(), 3);
         assertEquals("Index id 5 must exists", true, client.prepareGet("ebay", "search", "5").get().isExists());
     }
@@ -90,10 +89,13 @@ public class ElasticsearchClusterIndexTest extends ElasticsearchClusterBaseTest 
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("direct:indexWithIpAndPort").to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9301");
-                from("direct:indexWithTransportAddresses").to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&transportAddresses=localhost:9301");
-                from("direct:indexWithIpAndTransportAddresses").
-                    to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9301&transportAddresses=localhost:4444,localhost:5555");
+                from("direct:indexWithIpAndPort")
+                    .to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_FIRST_NODE_TRANSPORT_PORT);
+                from("direct:indexWithTransportAddresses")
+                    .to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&transportAddresses=localhost:" + ES_FIRST_NODE_TRANSPORT_PORT);
+                from("direct:indexWithIpAndTransportAddresses")
+                    .to("elasticsearch5://" + clusterName + "?operation=INDEX&indexName=twitter&indexType=tweet&transportAddresses=localhost:4444,localhost:5555&ip=localhost&port="
+                        + ES_FIRST_NODE_TRANSPORT_PORT);
             }
         };
     }

--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchGetSearchDeleteExistsUpdateTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchGetSearchDeleteExistsUpdateTest.java
@@ -340,15 +340,15 @@ public class ElasticsearchGetSearchDeleteExistsUpdateTest extends ElasticsearchB
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("direct:start").to("elasticsearch5://elasticsearch?operation=INDEX&ip=localhost&port=9300");
-                from("direct:index").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:get").to("elasticsearch5://elasticsearch?operation=GET_BY_ID&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:multiget").to("elasticsearch5://elasticsearch?operation=MULTIGET&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:delete").to("elasticsearch5://elasticsearch?operation=DELETE&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:search").to("elasticsearch5://elasticsearch?operation=SEARCH&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:update").to("elasticsearch5://elasticsearch?operation=UPDATE&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:exists").to("elasticsearch5://elasticsearch?operation=EXISTS&ip=localhost&port=9300");
-                from("direct:multisearch").to("elasticsearch5://elasticsearch?operation=MULTISEARCH&indexName=test&ip=localhost&port=9300");
+                from("direct:start").to("elasticsearch5://elasticsearch?operation=INDEX&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:index").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:get").to("elasticsearch5://elasticsearch?operation=GET_BY_ID&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:multiget").to("elasticsearch5://elasticsearch?operation=MULTIGET&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:delete").to("elasticsearch5://elasticsearch?operation=DELETE&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:search").to("elasticsearch5://elasticsearch?operation=SEARCH&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:update").to("elasticsearch5://elasticsearch?operation=UPDATE&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:exists").to("elasticsearch5://elasticsearch?operation=EXISTS&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:multisearch").to("elasticsearch5://elasticsearch?operation=MULTISEARCH&indexName=test&ip=localhost&port=" + ES_TRANSPORT_PORT);
             }
         };
     }

--- a/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchIndexTest.java
+++ b/components/camel-elasticsearch5/src/test/java/org/apache/camel/component/elasticsearch5/ElasticsearchIndexTest.java
@@ -69,9 +69,9 @@ public class ElasticsearchIndexTest extends ElasticsearchBaseTest {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("direct:start").to("elasticsearch5://elasticsearch?ip=localhost&port=9300");
-                from("direct:index").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
-                from("direct:indexWithReplication").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=9300");
+                from("direct:start").to("elasticsearch5://elasticsearch?ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:index").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
+                from("direct:indexWithReplication").to("elasticsearch5://elasticsearch?operation=INDEX&indexName=twitter&indexType=tweet&ip=localhost&port=" + ES_TRANSPORT_PORT);
             }
         };
     }


### PR DESCRIPTION
The component test was hardcoded with number of ES ports (http, transport, etc.) and can to lead conflicts on CI server