### PR TITLE
CAMEL-10843 Ported camel-ignite wiki doc into adoc

### DIFF
--- a/components/camel-ignite/src/main/docs/ignite-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-component.adoc
@@ -1,0 +1,498 @@
+[[Ignite-Component]]
+## Ignite Component
+
+*Available as of Camel version 2.17*
+
+https://ignite.apache.org/[Apache Ignite] In-Memory Data Fabric is a high-performance, integrated and distributed in-memory platform for computing and transacting on large-scale data sets in real-time, orders of magnitude faster than possible with traditional disk-based or flash technologies. It is designed to deliver uncompromised performance for a wide set of in-memory computing use cases from high performance computing, to the industry most advanced data grid, highly available service grid, and streaming. See all https://ignite.apache.org/features.html[features].
+
+image:https://ignite.apache.org/images/apache-ignite.png[]
+
+This component offers seven endpoints to cover much of Ignite's functionality:
+
+* <<Ignite-Cache,Ignite Cache>>.
+* <<Ignite-Compute,Ignite Compute>>.
+* <<Ignite-Messaging,Ignite Messaging>>.
+* <<Ignite-Events,Ignite Events>>.
+* <<Ignite-Sets,Ignite Sets>>.
+* <<Ignite-Queues,Ignite Queues>>.
+* <<Ignite-IDGenerator,Ignite ID Generator>>.
+
+To use this component, add the following dependency to your pom.xml:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-ignite</artifactId>
+    <version>${camel.version}</version> <!-- use the same version as your Camel core version -->
+</dependency>
+----
+
+[IMPORTANT,title=Running in OSGi]
+====
+If running in an OSGi container, please don't miss the <<Ignite-OsgiSupport,OSGi Support>> section below.
+====
+
+// component options: START
+// component options: END
+
+// endpoint options: START
+// endpoint options: END
+
+
+[[Ignite-Cache]]
+CACHE: Ignite Cache Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This endpoint allows you to interact with an https://apacheignite.readme.io/docs/data-grid[Ignite Cache]:
+
+[source,text]
+----
+ignite:cache:cacheName?option1=value1&option2=value2...
+----
+
+Offers both a Producer (to invoke cache operations on an Ignite cache) and a Consumer (to consume changes from a continuous query).
+
+The cache value is always the body of the message, whereas the cache key is always stored in the `IgniteConstants.IGNITE_CACHE_KEY` message header.
+
+Even if you configure a fixed operation in the endpoint URI, you can vary it per-exchange by setting the `IgniteConstants.IGNITE_CACHE_OPERATION` message header.
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| operation | IgniteCacheOperation enum | --- |
+Cache operation to perform.
+Possible values: GET, PUT, REMOVE, SIZE, REBALANCE, QUERY, CLEAR. |
+N | Producer
+
+| failIfInexistentCache | boolean | false |
+Whether to fail the initialization if the cache doesn't exist.  |
+N | Producer
+
+| cachePeekMode | CachePeekMode (Ignite) enum | ALL |
+The cache peek mode used for SIZE operations. |
+N | Producer
+
+| query | Query | --- |
+The query used for QUERY operations (as a producer) or to launch the continuous query (as a consumer). You can use a reference to a registry bean with a syntax like: ?query=#myQuery. |
+Y for the consumer / N for the producer | Producer (for QUERY operation) and Consumer
+
+|remoteFilter | CacheEntryEventSerializableFilter | --- |
+An optional remote filter for the continuous query consumer. You can use a reference to a registry bean with a syntax like: ?remoteFilter=#myRemoteFilter. |
+N | Consumer
+
+| oneExchangePerUpdate | boolean | true |
+Whether to send one exchange per cache update, even if multiple changes arrive in a group. |
+N | Consumer
+
+| fireExistingQueryResults | boolean | false |
+When starting the continuous query consumer, whether to fire existing cache results. |
+N  | Consumer
+
+| autoUnsubscribe | boolean | ContinuousQuery.DFLT_AUTO_UNSUBSCRIBE |
+Auto-unsubscribe flag on the Continuous Query (see Ignite docs). |
+N | Consumer
+
+| pageSize | int | ContinuousQuery.DFLT_PAGE_SIZE |
+Page size on the Continuous Query (see Ignite docs). |
+N | Consumer
+
+| timeInterval | long | ContinuousQuery.DFLT_TIME_INTERVAL |
+Time interval in millis on the Continuous Query (see Ignite docs). | N | Consumer
+|=======================================================================
+
+Headers used
++++++++++++
+This endpoint uses the following headers:
+[width="100%",cols="1,1,1,4",options="header"]
+|=======================================================================
+| Header name | Constant | Expected type | Description
+| CamelIgniteCacheKey | IgniteConstants.IGNITE_CACHE_KEY | String |
+The cache key for the entry value in the message body.
+
+| CamelIgniteCacheQuery | IgniteConstants.IGNITE_CACHE_QUERY | Query |
+The query to run (producer) when invoking the QUERY operation.
+
+| CamelIgniteCacheOperation | IgniteConstants.IGNITE_CACHE_OPERATION | IgniteCacheOperation enum |
+Allows you to dynamically change the cache operation to execute (producer).
+
+| CamelIgniteCachePeekMode | IgniteConstants.IGNITE_CACHE_PEEK_MODE | CachePeekMode enum |
+Allows you to dynamically change the cache peek mode when running the SIZE operation.
+
+| CamelIgniteCacheEventType | IgniteConstants.IGNITE_CACHE_EVENT_TYPE | int (EventType constants) |
+This header carries the received event type when using the continuous query consumer.
+
+| CamelIgniteCacheName | IgniteConstants.IGNITE_CACHE_NAME | String |
+This header carries the cache name for which a continuous query event was received (consumer).
+It does not allow you to dynamically change the cache against which a producer operation is performed. Use EIPs for that (e.g. recipient list, dynamic router).
+
+| CamelIgniteCacheOldValue | IgniteConstants.IGNITE_CACHE_OLD_VALUE | Object |
+This header carries the old cache value when passed in the incoming cache event (consumer).
+|=======================================================================
+
+
+[[Ignite-Compute]]
+COMPUTE: Ignite Compute Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This endpoint allows you to run https://apacheignite.readme.io/docs/compute-grid[compute operations] on the cluster by passing in an IgniteCallable, an IgniteRunnable, an IgniteClosure, or collections of them, along with their parameters if necessary. 
+
+[source,text]
+----
+ignite:compute:endpointId?executionType=...&option1=value1&option2=value2...
+----
+
+This endpoint only supports producers.
+
+The host part of the endpoint URI is a symbolic endpoint ID, it is not used for any purposes.
+
+The endpoint tries to run the object passed in the body of the IN message as the compute job. It expects different payload types depending on the execution type.
+
+Expected payload types
++++++++++++++++++++++
+Each operation expects the indicated types:
+[width="100%",cols="1,4",options="header"]
+|=======================================================================
+| Operation | Expected payloads
+| CALL | Collection of IgniteCallable, or a single IgniteCallable.
+| BROADCAST | IgniteCallable, IgniteRunnable, IgniteClosure.
+| APPLY | IgniteClosure.
+| EXECUTE | ComputeTask, Class<? extends ComputeTask> or an object representing parameters if the taskName option is not null.
+| RUN | A Collection of IgniteRunnables, or a single IgniteRunnable.
+| AFFINITY_CALL | IgniteCallable.
+| AFFINITY_RUN | IgniteRunnable.
+|=======================================================================
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| executionType | IgniteComputeExecutionType enum | --- |
+The compute operation to perform. Possible values: CALL, BROADCAST, APPLY, EXECUTE, RUN, AFFINITY_CALL, AFFINITY_RUN.
+The component expects different payload types depending on the operation. See above. |
+Y | Producer
+
+| clusterGroupExpression | ClusterGroupExpression | --- |
+An expression that returns the Cluster Group for the IgniteCompute instance. |
+N | Producer
+
+| taskName | String | --- | The task name, only used when performing the EXECUTE if a ComputeTask is not passed in the payload. |
+N | Producer
+
+| computeName | String | --- | The name for the IgniteCompute instances produced by this endpoint. |
+N | Producer
+
+| timeoutMillis | Long | --- | The timeout for the compute job. | N | Producer
+|=======================================================================
+
+Headers used
++++++++++++
+This endpoint uses the following headers:
+[width="100%",cols="1,1,1,4",options="header"]
+|=======================================================================
+| Header name | Constant | Expected type | Description
+| CamelIgniteComputeExecutionType | IgniteConstants.IGNITE_COMPUTE_EXECUTION_TYPE | IgniteComputeExecutionType enum |
+ Allows you to dynamically change the compute operation to perform.
+
+| CamelIgniteComputeParameters | IgniteConstants.IGNITE_COMPUTE_PARAMS | Any object or Collection of objects. |
+Parameters for APPLY, BROADCAST and EXECUTE operations.
+
+| CamelIgniteComputeReducer | IgniteConstants.IGNITE_COMPUTE_REDUCER | IgniteReducer |
+Reducer for the APPLY and CALL operations.
+
+| CamelIgniteComputeAffinityCacheName | IgniteConstants.IGNITE_COMPUTE_AFFINITY_CACHE_NAME | String |
+Affinity cache name for the AFFINITY_CALL and AFFINITY_RUN operations.
+
+| CamelIgniteComputeAffinityKey | IgniteConstants.IGNITE_COMPUTE_AFFINITY_KEY | Object |
+Affinity key for the AFFINITY_CALL and AFFINITY_RUN operations.
+|=======================================================================
+
+
+[[Ignite-Messaging]]
+MESSAGING: Ignite Messaging Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Ignite Messaging endpoint allows you to send and consume messages from an https://apacheignite.readme.io/docs/messaging[Ignite topic].
+
+[source,text]
+----
+ignite:messaging:topicName?option1=value1&option2=value2...
+----
+
+This endpoint supports producers (to send messages) and consumers (to receive messages).
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| clusterGroupExpression | ClusterGroupExpression | --- |
+An expression that returns the Cluster Group for the IgniteMessaging instance. |
+N |Consumer and Producer
+
+| sendMode | IgniteMessagingSendMode enum | UNORDERED |
+The send mode to use.
+Possible values: UNORDERED, ORDERED. |
+N | Producer
+
+| timeout | Long | --- | The timeout for the send operation when using ordered messages. |
+N | Producer
+|=======================================================================
+
+Headers used
++++++++++++
+This endpoint uses the following headers:
+[width="100%",cols="1,1,1,4",options="header"]
+|=======================================================================
+| Header name | Constant | Expected type | Description
+| CamelIgniteMessagingTopic | IgniteConstants.IGNITE_MESSAGING_TOPIC | String |
+Allows you to dynamically change the topic to send messages to (producer). 
+It also carries the topic on which a message was received (consumer).
+
+| CamelIgniteMessagingUUID | IgniteConstants.IGNITE_MESSAGING_UUID | UUID |
+This header is filled in with the UUID of the subscription when a message arrives (consumer).
+|=======================================================================
+
+
+[[Ignite-Events]]
+EVENTS: Ignite Events Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Ignite Events endpoint allows you to https://apacheignite.readme.io/docs/events[receive events] from the Ignite cluster by creating a local event listener.
+
+[source,text]
+----
+ignite:events:endpointId?option1=value1&option2=value2...
+----
+
+This endpoint only supports consumers.
+The Exchanges created by this consumer put the received Event object into the body of the IN message.
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| events | Set<Integer> or String | EventType.EVTS_ALL |
+The event IDs to subscribe to. You can set a Set<Integer> directly where the IDs are the different constants in org.apache.ignite.events.EventType, or you can specify a comma-separated list of constant names.
+For example: EVT_CACHE_ENTRY_CREATED,EVT_CACHE_OBJECT_REMOVED,EVT_IGFS_DIR_CREATED. |
+N | Consumer
+| clusterGroupExpression | ClusterGroupExpression | --- |
+An expression that returns the Cluster Group to be used by the IgniteEvents instance. |
+N | Consumer
+|=======================================================================
+
+
+
+[[Ignite-Sets]]
+SETS: Ignite Sets Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Ignite Sets endpoint allows you to interact with https://apacheignite.readme.io/docs/queue-and-set[Ignite Set data structures].
+
+[source,text]
+----
+ignite:sets:setName?option1=value1&option2=value2...
+----
+
+This endpoint only supports producers.
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| operation | IgniteSetOperation enum | --- |
+The operation to invoke on the Ignite Set.
+Superseded by the IgniteConstants.IGNITE_SETS_OPERATION header in the IN message.
+Possible values: CONTAINS, ADD, SIZE, REMOVE, ITERATOR, CLEAR, RETAIN_ALL, ARRAY. |
+N | Producer
+
+| configuration | CollectionConfiguration | empty CollectionConfiguration |
+The configuration for this data structure. You can also specify inner properties by using the config. prefix.
+For example: ?config.backups=4 |
+N | Producer
+|=======================================================================
+
+Headers used
++++++++++++
+This endpoint uses the following headers:
+[width="100%",cols="1,1,1,4",options="header"]
+|=======================================================================
+| Header name | Constant | Expected type | Description
+| CamelIgniteSetsOperation | IgniteConstants.IGNITE_SETS_OPERATION | IgniteSetOperation enum |
+Allows you to dynamically change the set operation.
+|=======================================================================
+
+
+[[Ignite-Queues]]
+QUEUES: Ignite Queue Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Ignite Queue endpoint allows you to interact with https://apacheignite.readme.io/docs/queue-and-set[Ignite Queue data structures].
+
+[source,text]
+----
+ignite:queue:queueName?option1=value1&option2=value2...
+----
+
+This endpoint only supports producers.
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| operation | IgniteQueueOperation enum | --- |
+The operation to invoke on the Ignite Queue.
+Superseded by the IgniteConstants.IGNITE_QUEUE_OPERATION header in the IN message.
+Possible values: CONTAINS, ADD, SIZE, REMOVE, ITERATOR, CLEAR, RETAIN_ALL, ARRAY, DRAIN, ELEMENT, PEEK, OFFER, POLL, TAKE, PUT. |
+N | Producer
+
+| configuration | CollectionConfiguration | empty CollectionConfiguration |
+The configuration for this data structure. You can also specify inner properties by using the config. prefix.
+For example: ?config.backups=4 |
+N | Producer
+
+| timeoutMillis | Long | | --- |
+The timeout in milliseconds to use when invoking the OFFER or POLL operations. |
+N | Producer
+
+| capacity | int | --- (unbounded) |
+The queue capacity if you'd like to use a bounded queue. |
+N | Producer
+|=======================================================================
+
+Headers used
++++++++++++
+This endpoint uses the following headers:
+[width="100%",cols="1,1,1,4",options="header"]
+|=======================================================================
+| Header name | Constant | Expected type | Description
+| CamelIgniteQueueOperation | IgniteConstants.IGNITE_QUEUE_OPERATION | IgniteQueueOperation enum |
+Allows you to dynamically change the queue operation.
+
+| CamelIgniteQueueMaxElements | IgniteConstants.IGNITE_QUEUE_MAX_ELEMENTS | Integer or int |
+When invoking the DRAIN operation, the amount of items to drain.
+
+| CamelIgniteQueueTransferredCount | IgniteConstants.IGNITE_QUEUE_TRANSFERRED_COUNT | Integer or int |
+The amount of items transferred as the result of the DRAIN operation.
+
+| CamelIgniteQueueTimeoutMillis | IgniteConstants.IGNITE_QUEUE_TIMEOUT_MILLIS | Long or long |
+Dynamically sets the timeout in milliseconds to use when invoking the OFFER or POLL operations. 
+|=======================================================================
+
+
+[[Ignite-IDGenerator]]
+IDGEN: Ignite ID Generator Endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Ignite ID Generator endpoint allows you to interact with https://apacheignite.readme.io/docs/id-generator[Ignite Atomic Sequences and ID Generators].
+
+[source,text]
+----
+ignite:idgen:sequenceName?option1=value1&option2=value2...
+----
+
+This endpoint only supports producers.
+
+Options
+++++++
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description | Compulsory | Consumer/producer
+| operation | IgniteIdGenOperation enum | --- |
+The operation to invoke on the Ignite ID Generator.
+Superseded by the IgniteConstants.IGNITE_IDGEN_OPERATION header in the IN message.
+Possible values: ADD_AND_GET, GET, GET_AND_ADD, GET_AND_INCREMENT, INCREMENT_AND_GET. |
+N | Producer
+
+| configuration | CollectionConfiguration | empty CollectionConfiguration |
+The configuration for this data structure. You can also specify inner properties by using the config. prefix.
+For example: ?config.backups=4 |
+N | Producer
+|=======================================================================
+
+
+
+[[Ignite-InitializeComponent]]
+Initializing the Ignite component
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Each instance of the Ignite component is associated with an underlying org.apache.ignite.Ignite instance. You can interact with two Ignite clusters by initializing two instances of the Ignite component and binding them to different IgniteConfigurations. There are 3 ways to initialize the Ignite component:
+
+* By passing in an existing org.apache.ignite.Ignite instance. Here's an example using Spring config:
+
+[source,xml]
+------------------------------------------------------------
+<bean name="ignite" class="org.apache.camel.component.ignite.IgniteComponent">
+   <property name="ignite" ref="ignite" />
+</bean>
+------------------------------------------------------------
+
+* By passing in an IgniteConfiguration, either constructed programmatically or through inversion of control (e.g. Spring, Blueprint, etc.). Here's an example using Spring config:
+
+[source,xml]
+-------------------------------------------------------------------
+<bean name="ignite" class="org.apache.camel.component.ignite.IgniteComponent">
+   <property name="igniteConfiguration">
+      <bean class="org.apache.ignite.configuration.IgniteConfiguration">
+         [...]
+      </bean>
+   </property>
+</bean>
+-------------------------------------------------------------------
+
+* By passing in a URL, InputStream or String URL to a Spring-based configuration file. In all three cases, you inject them in the same property called configurationResource. Here's an example using Spring config:
+
+[source,xml]
+-------------------------------------------------------------------
+<bean name="ignite" class="org.apache.camel.component.ignite.IgniteComponent">
+   <property name="configurationResource" value="file:[...]/ignite-config.xml" />
+</bean>
+-------------------------------------------------------------------
+
+Additionally, if using Camel programmatically, there are several convenience static methods in IgniteComponent that return a component out of any of these configuration options:
+
+* IgniteComponent#fromIgnite(Ignite)
+* IgniteComponent#fromConfiguration(IgniteConfiguration)
+* IgniteComponent#fromInputStream(InputStream)
+* IgniteComponent#fromUrl(URL)
+* IgniteComponent#fromLocation(String)
+
+You may use those methods to quickly create an IgniteComponent with your chosen configuration technique.
+
+General options
+^^^^^^^^^^^^^^
+
+All endpoints share the following options:
+[width="100%",cols="1,1,1,4,1,1",options="header"]
+|=======================================================================
+| Option | Type | Default value | Description
+| propagateIncomingBodyIfNoReturnValue | boolean | true |
+If the underlying Ignite operation returns void (no return type), this flag determines whether the producer will copy the IN body into the OUT body.
+
+| treatCollectionsAsCacheObjects | boolean | false |
+Some Ignite operations can deal with multiple elements at once, if passed a Collection. Enabling this option will treat Collections as a single object, invoking the operation variant for cardinality 1.
+|=======================================================================
+
+OSGi Support
+^^^^^^^^^^^
+
+[TIP]
+====
+Apache Ignite supports OSGi from version 1.5.0.final onwards.
+====
+
+
+[NOTE,title=when installing on Apache Karaf]
+====
+1. Installing the camel-ignite feature will require the Ignite feature repository to be present.
+1. You must have exported from the JRE (system bundle) some low-level, non-standard packages that Ignite requires.
+====
+Please refer to the OSGi section in the Ignite documentation for more information.
+
+
+
+See Also
+^^^^^^^
+
+* http://camel.apache.org/configuring-camel.html[Configuring Camel]
+* http://camel.apache.org/component.html[Component]
+* http://camel.apache.org/endpoint.html[Endpoint]
+* http://camel.apache.org/getting-started.html[Getting Started]

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -293,6 +293,9 @@ Number of Components: 231 in 184 JAR artifacts (14 deprecated)
 | link:camel-ibatis/src/main/docs/ibatis-component.adoc[iBatis] (camel-ibatis) +
 `ibatis:statement` | 1.2 | *deprecated* Performs a query poll insert update or delete in a relational database using Apache iBATIS.
 
+| link:camel-ignite/src/main/docs/ignite-component.adoc[Ignite] (camel-ignite) +
+`ignite:endpointName` | 1.17 | The Ignite Component integrates Apache Camel with Apache Ignite
+
 | link:camel-infinispan/src/main/docs/infinispan-component.adoc[Infinispan] (camel-infinispan) +
 `infinispan:cacheName` | 2.13 | For reading/writing from/to Infinispan distributed key/value store and data grid.
 

--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -209,6 +209,7 @@
 	* [HTTP](http-component.adoc)
 	* [HTTP4](http4-component.adoc)
 	* [iBatis](ibatis-component.adoc)
+	* [Ignite](ignite-component.adoc)
 	* [IMAP](imap-component.adoc)
 	* [Infinispan](infinispan-component.adoc)
 	* [InfluxDB](influxdb-component.adoc)


### PR DESCRIPTION
Auto generation for the component/endpoint options doesn't work for now, not yet sure why, maybe it has multiple endpoints? Also the ignite entry is removed from components/readme.adoc on each full build like camel-solr. I'll look into why.