### PR TITLE
CAMEL-11166 make camel-package-maven-plugin work on Java 9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5241,13 +5241,6 @@
             <plugin>
               <groupId>org.apache.camel</groupId>
               <artifactId>camel-package-maven-plugin</artifactId>
-              <dependencies>
-                <dependency>
-                  <groupId>javax.xml.ws</groupId>
-                  <artifactId>jaxws-api</artifactId>
-                  <version>2.2.11</version>
-                </dependency>
-              </dependencies>
             </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>

--- a/tooling/maven/camel-package-maven-plugin/pom.xml
+++ b/tooling/maven/camel-package-maven-plugin/pom.xml
@@ -164,4 +164,21 @@
       <artifactId>spi-annotations</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jigsaw</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
I propose a different solution to [CAMEL-11166](https://issues.apache.org/jira/browse/CAMEL-11166). @johnpoth and @davsclaus can you take a look, thanks 🥇 

This changes the dependency to `javax.annotation:javax.annotation-api:1.3` from `javax.xml.ws:jaxws-api:2.2.11` to have a smaller footprint, and places the dependency on the plugin instead of in the parent POM.
