### PR TITLE
[CAMEL-11182]SolrParams are not honored when sending SolrInputDocument.

### DIFF
--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
@@ -137,6 +137,13 @@ public class SolrProducer extends DefaultProducer {
                 UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
                 updateRequest.add((SolrInputDocument) body);
 
+                for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
+                    if (entry.getKey().startsWith(SolrConstants.PARAM)) {
+                        String paramName = entry.getKey().substring(SolrConstants.PARAM.length());
+                        updateRequest.setParam(paramName, entry.getValue().toString());
+                    }
+                }
+
                 updateRequest.process(solrServer);
 
             } else if (body instanceof List<?>) {
@@ -145,6 +152,13 @@ public class SolrProducer extends DefaultProducer {
                 if (list.size() > 0 && list.get(0) instanceof SolrInputDocument) {
                     UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
                     updateRequest.add((List<SolrInputDocument>) list);
+
+                    for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
+                        if (entry.getKey().startsWith(SolrConstants.PARAM)) {
+                            String paramName = entry.getKey().substring(SolrConstants.PARAM.length());
+                            updateRequest.setParam(paramName, entry.getValue().toString());
+                        }
+                    }
 
                     updateRequest.process(solrServer);
                 } else {


### PR DESCRIPTION
This change is necessary when you intend to have an update processor chain to be trigerred or any such for which parameters are to be passed along with the url.