### PR TITLE
CAMEL-10141: make org.apache.camel.converter.IO...

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/IOConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/IOConverter.java
@@ -44,6 +44,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
@@ -59,6 +60,8 @@ import org.slf4j.LoggerFactory;
  */
 @Converter
 public final class IOConverter {
+
+    static Supplier<Charset> defaultCharset = Charset::defaultCharset;
 
     private static final Logger LOG = LoggerFactory.getLogger(IOConverter.class);
 
@@ -81,7 +84,7 @@ public final class IOConverter {
     public static InputStream toInputStream(File file, String charset) throws IOException {
         if (charset != null) {
             final BufferedReader reader = toReader(file, charset);
-            final Charset defaultStreamCharset = Charset.defaultCharset();
+            final Charset defaultStreamCharset = defaultCharset.get();
             return new InputStream() {
                 private ByteBuffer bufferBytes;
                 private CharBuffer bufferedChars = CharBuffer.allocate(4096);

--- a/camel-core/src/test/java/org/apache/camel/converter/IOConverterCharsetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/IOConverterCharsetTest.java
@@ -21,8 +21,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.camel.ContextTestSupport;
@@ -61,7 +61,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
         File file = new File("src/test/resources/org/apache/camel/converter/german.utf-8.txt");
         InputStream in = IOConverter.toInputStream(file, "UTF-8");
         // do read with default charset!
-        BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.ISO_8859_1));
         BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
         try {   
             String line = reader.readLine();
@@ -141,13 +141,9 @@ public class IOConverterCharsetTest extends ContextTestSupport {
     }
 
 
-    private void switchToDefaultCharset(String charset) {
-        try {
-            Field defaultCharset = Charset.class.getDeclaredField("defaultCharset");
-            defaultCharset.setAccessible(true);
-            defaultCharset.set(null, Charset.forName(charset));
-        } catch (Exception e) {
-            // Do nothing here
-        }
+    private void switchToDefaultCharset(final String charset) {
+        final Charset newCharset = Charset.forName(charset);
+
+        IOConverter.defaultCharset = () -> newCharset;
     }
 }


### PR DESCRIPTION
...ConverterCharsetTest tests pass on Java 9

Alternative implementation and test without using reflection.