### PR TITLE
cassandra-kubernates, cxf-blueprint, hazelcast-kubernates: Fixed typo…

### DIFF
--- a/examples/camel-example-cassandra-kubernetes/ReadMe.md
+++ b/examples/camel-example-cassandra-kubernetes/ReadMe.md
@@ -13,8 +13,8 @@ Once your Minikube node is up and running you'll need to run the following comma
 In your src/main/resource/fabric8/ folder you'll find two yaml file. Run the following command using them:
 
 ```
-kubectl create -f src/main/resource/fabric8/cassandra-service.yaml
-kubectl create -f src/main/resource/fabric8/cassandra-statefulset.yaml
+kubectl create -f src/main/resources/fabric8/cassandra-service.yaml
+kubectl create -f src/main/resources/fabric8/cassandra-statefulset.yaml
 ```
 
 To check the correct startup of the cluster run the following command:

--- a/examples/camel-example-cxf-blueprint/README.md
+++ b/examples/camel-example-cxf-blueprint/README.md
@@ -20,7 +20,7 @@ You will need to compile this example first:
 
 To run the example on Apache Karaf 4.x or newer
 
-#### Step 1: Laraf
+#### Step 1: Karaf
 
 Launch the server
 

--- a/examples/camel-example-hazelcast-kubernetes/ReadMe.md
+++ b/examples/camel-example-hazelcast-kubernetes/ReadMe.md
@@ -12,11 +12,11 @@ This example is based on:
 First thing you'll need to do is preparing the environment.
 
 Once your Minikube node is up and running you'll need to run the following command.
-In your src/main/resource/fabric8/ folder you'll find two yaml file. Run the following command using them:
+In your src/main/resources/fabric8/ folder you'll find two yaml file. Run the following command using them:
 
 ```
-kubectl create -f src/main/resource/fabric8/hazelcast-service.yaml
-kubectl create -f src/main/resource/fabric8/hazelcast-deployment.yaml
+kubectl create -f src/main/resources/fabric8/hazelcast-service.yaml
+kubectl create -f src/main/resources/fabric8/hazelcast-deployment.yaml
 ```
 
 To check the correct startup of the Hazelcast instance run the following command:

--- a/examples/camel-example-netty-http/README.md
+++ b/examples/camel-example-netty-http/README.md
@@ -9,7 +9,6 @@ There is 4 modules in this example:
 * `shared-netty-http-server` - The Shared Netty HTTP server that the other Camel applications uses
 * `myapp-one` - A Camel application that reuses the shared Netty HTTP server
 * `myapp-two` - A Camel application that reuses the shared Netty HTTP server
-* `myapp-cdi` - A Camel CDI application that reuses the shared Netty HTTP server
 
 ### Build
 
@@ -52,25 +51,11 @@ karaf@root()> install -s mvn:org.apache.camel/camel-example-netty-myapp-one/2.17
 karaf@root()> install -s mvn:org.apache.camel/camel-example-netty-myapp-two/2.17.0
 ```
 
-If you want to test the Camel CDI application, you first need to install the required features:
-
-```sh
-karaf@root()> feature:install pax-cdi-weld camel-cdi
-```
-
-And then install the Camel CDI application:
-
-```sh
-karaf@root()> install -s mvn:org.apache.camel/camel-example-netty-myapp-cdi/2.17.0
-```
-
 From a web browser you can then try the example by accessing the followign URLs:
 
 <http://localhost:8888/one>
 
 <http://localhost:8888/two>
-
-<http://localhost:8888/cdi>
 
 Camel commands can be used to gain some insights on the CDI Camel
 context, e.g.:
@@ -82,7 +67,7 @@ context, e.g.:
      Context           Status              Total #       Failed #     Inflight #   Uptime        
      -------           ------              -------       --------     ----------   ------        
      camel-1           Started                   1              0              0   1 minute  
-     netty-myapp-cdi   Started                   1              0              0   1 minute  
+     camel-2           Started                   1              0              0   1 minute  
     ```
 
 Or by tailing the log with:
@@ -94,20 +79,16 @@ karaf@root()> log:tail
 The following messages should be displayed:
 
 ```
-22016-05-06 15:38:31,340 | INFO  | l Console Thread | CdiExtender                      | 83 - org.ops4j.pax.cdi.extender - 1.0.0.RC1 | creating CDI container for bean bundle org.apache.camel.camel-example-netty-myapp-cdi [97] with extension bundles [org.ops4j.pax.cdi.extension [82], org.apache.camel.camel-cdi [92]]
- 2016-05-06 15:38:31,340 | INFO  | l Console Thread | AbstractCdiContainer             | 81 - org.ops4j.pax.cdi.spi - 1.0.0.RC1 | Starting CDI container for bundle org.apache.camel.camel-example-netty-myapp-cdi [97]
- 2016-05-06 15:38:31,595 | INFO  | l Console Thread | CdiCamelExtension                | 92 - org.apache.camel.camel-cdi - 2.17.0 | Camel CDI is starting Camel context [netty-myapp-cdi]
- 2016-05-06 15:38:31,595 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | Apache Camel 2.17.0 (CamelContext: netty-myapp-cdi) is starting
- 2016-05-06 15:38:31,595 | INFO  | l Console Thread | ManagedManagementStrategy        | 58 - org.apache.camel.camel-core - 2.17.0 | JMX is enabled
- 2016-05-06 15:38:31,612 | INFO  | l Console Thread | DefaultTypeConverter             | 58 - org.apache.camel.camel-core - 2.17.0 | Loaded 182 type converters
- 2016-05-06 15:38:31,621 | INFO  | l Console Thread | DefaultRuntimeEndpointRegistry   | 58 - org.apache.camel.camel-core - 2.17.0 | Runtime endpoint registry is in extended mode gathering usage statistics of all incoming and outgoing endpoints (cache limit: 1000)
- 2016-05-06 15:38:31,639 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | AllowUseOriginalMessage is enabled. If access to the original message is not needed, then its recommended to turn this option off as it may improve performance.
- 2016-05-06 15:38:31,639 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | StreamCaching is not in use. If using streams then its recommended to enable stream caching. See more details at http://camel.apache.org/stream-caching.html
- 2016-05-06 15:38:31,639 | INFO  | l Console Thread | NettyHttpEndpoint                | 66 - org.apache.camel.camel-netty-http - 2.17.0 | NettyHttpConsumer: Consumer[http://localhost/cdi] is using NettySharedHttpServer on port: 8888
- 2016-05-06 15:38:31,649 | INFO  | l Console Thread | NettyConsumer                    | 65 - org.apache.camel.camel-netty - 2.17.0 | Netty consumer bound to: localhost:8888
- 2016-05-06 15:38:31,649 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | Route: http-route-cdi started and consuming from: Endpoint[http://localhost/cdi]
- 2016-05-06 15:38:31,650 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | Total 1 routes, of which 1 are started.
- 2016-05-06 15:38:31,650 | INFO  | l Console Thread | DefaultCamelContext              | 58 - org.apache.camel.camel-core - 2.17.0 | Apache Camel 2.17.0 (CamelContext: netty-myapp-cdi) started in 0.055 seconds
+2017-05-10 21:36:55,582 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | Attempting to start Camel Context camel-2
+2017-05-10 21:36:55,582 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | Apache Camel 2.17.0 (CamelContext: camel-2) is starting
+2017-05-10 21:36:55,583 | INFO  | nt Dispatcher: 1 | ManagedManagementStrategy        | 54 - org.apache.camel.camel-core - 2.17.0 | JMX is enabled
+2017-05-10 21:36:55,624 | INFO  | nt Dispatcher: 1 | DefaultRuntimeEndpointRegistry   | 54 - org.apache.camel.camel-core - 2.17.0 | Runtime endpoint registry is in extended mode gathering usage statistics of all incoming and outgoing endpoints (cache limit: 1000)
+2017-05-10 21:36:55,638 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | StreamCaching is not in use. If using streams then its recommended to enable stream caching. See more details at http://camel.apache.org/stream-caching.html
+2017-05-10 21:36:55,639 | INFO  | nt Dispatcher: 1 | NettyHttpEndpoint                | 60 - org.apache.camel.camel-netty-http - 2.17.0 | NettyHttpConsumer: Consumer[http://localhost/two] is using NettySharedHttpServer on port: 8888
+2017-05-10 21:36:55,646 | INFO  | nt Dispatcher: 1 | NettyConsumer                    | 59 - org.apache.camel.camel-netty - 2.17.0 | Netty consumer bound to: localhost:8888
+2017-05-10 21:36:55,646 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | Route: http-route-two started and consuming from: http://localhost/two
+2017-05-10 21:36:55,647 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | Total 1 routes, of which 1 are started.
+2017-05-10 21:36:55,647 | INFO  | nt Dispatcher: 1 | BlueprintCamelContext            | 52 - org.apache.camel.camel-blueprint - 2.17.0 | Apache Camel 2.17.0 (CamelContext: camel-2) started in 0.065 seconds
 ```
 
 Hit <kbd>ctrl</kbd>+<kbd>c</kbd> to exit the log command.

--- a/examples/camel-example-servlet-tomcat-no-spring/pom.xml
+++ b/examples/camel-example-servlet-tomcat-no-spring/pom.xml
@@ -76,6 +76,9 @@
   </dependencies>
 
   <build>
+
+    <finalName>${project.artifactId}</finalName>
+
     <plugins>
       <!-- allows running this example with mvn jetty:run -->
       <plugin>


### PR DESCRIPTION
… in readme

servlet-tomcat-no-spring: added finalName so the contextPath would match with the URL described in readme