### PR TITLE
CAMEL-11261 Revise Camel context destruction in Spring (Boot) applications

### DIFF
--- a/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SpringQuartzTwoAppsClusteredFailoverTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SpringQuartzTwoAppsClusteredFailoverTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.TestSupport;
 import org.apache.camel.util.IOHelper;
 import org.junit.Test;
+import org.quartz.Scheduler;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -61,6 +62,10 @@ public class SpringQuartzTwoAppsClusteredFailoverTest extends TestSupport {
 
         // now let's simulate a crash of the first app (the quartz instance 'app-one')
         log.warn("The first app is going to crash NOW!");
+        // we need to stop the Scheduler first as the CamelContext will gracefully shutdown and
+        // delete all scheduled jobs, so there would be nothing for the second CamelContext to
+        // failover from
+        app.getBean(Scheduler.class).shutdown();
         IOHelper.close(app);
 
         log.warn("Crashed...");

--- a/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/SpringQuartzConsumerTwoAppsClusteredRecoveryTest.java
+++ b/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/SpringQuartzConsumerTwoAppsClusteredRecoveryTest.java
@@ -32,8 +32,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Tests a Quartz based cluster setup of two Camel Apps being triggered through with recoverableJob option is true {@link QuartzConsumer}.
- * 
- * @version
  */
 public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest extends TestSupport {
 
@@ -41,25 +39,24 @@ public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest extends TestSuppor
     public void testQuartzPersistentStoreClusteredApp() throws Exception {
         // boot up the database the two apps are going to share inside a clustered quartz setup
         AbstractXmlApplicationContext db = new ClassPathXmlApplicationContext("org/apache/camel/component/quartz2/SpringQuartzConsumerClusteredAppDatabase.xml");
-        db.start();
 
         // now launch the first clustered app which will acquire the quartz database lock and become the master
         AbstractXmlApplicationContext app = new ClassPathXmlApplicationContext("org/apache/camel/component/quartz2/SpringQuartzConsumerRecoveryClusteredAppOne.xml");
-        app.start();
-        
+
         // now let's simulate a crash of the first app (the quartz instance 'app-one')
         log.warn("The first app is going to crash NOW!");
+        IOHelper.close(app);
 
         log.warn("Crashed...");
         log.warn("Crashed...");
         log.warn("Crashed...");
-        
+
         Thread.sleep(2000);
-        
+
         // as well as the second one which will run in slave mode as it will not be able to acquire the same lock
         AbstractXmlApplicationContext app2 = new ClassPathXmlApplicationContext("org/apache/camel/component/quartz2/SpringQuartzConsumerRecoveryClusteredAppTwo.xml");
         app2.start();
-        
+
         // wait long enough until the second app takes it over...
         Thread.sleep(20000);
         // inside the logs one can then clearly see how the route of the second app ('app-two') starts consuming:
@@ -81,22 +78,22 @@ public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest extends TestSuppor
         // and as the last step shutdown the second app as well as the database
         IOHelper.close(app2, db);
     }
-    
+
     private static class ClusteringPredicate implements Predicate {
 
         private final String expectedPayload;
-        
+
         ClusteringPredicate(boolean pings) {
             expectedPayload = pings ? "clustering PINGS!" : "clustering PONGS!";
         }
-        
+
         @Override
         public boolean matches(Exchange exchange) {
             return exchange.getIn().getBody().equals(expectedPayload);
         }
 
     }
-    
+
     public static class MyProcessor implements Processor, ApplicationContextAware {
         ApplicationContext applicationContext;
 
@@ -110,7 +107,7 @@ public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest extends TestSuppor
         public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
             this.applicationContext = applicationContext;
         }
-        
+
     }
 
 }

--- a/components/camel-quartz2/src/test/java/org/apache/camel/routepolicy/quartz2/SpringQuartzTwoAppsClusteredFailoverTest.java
+++ b/components/camel-quartz2/src/test/java/org/apache/camel/routepolicy/quartz2/SpringQuartzTwoAppsClusteredFailoverTest.java
@@ -22,13 +22,12 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.TestSupport;
 import org.apache.camel.util.IOHelper;
 import org.junit.Test;
+import org.quartz.Scheduler;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Tests a Quartz based cluster setup of two Camel Apps being triggered through {@link CronScheduledRoutePolicy}.
- * 
- * @version
  */
 public class SpringQuartzTwoAppsClusteredFailoverTest extends TestSupport {
 
@@ -36,15 +35,12 @@ public class SpringQuartzTwoAppsClusteredFailoverTest extends TestSupport {
     public void testQuartzPersistentStoreClusteredApp() throws Exception {
         // boot up the database the two apps are going to share inside a clustered quartz setup
         AbstractXmlApplicationContext db = new ClassPathXmlApplicationContext("org/apache/camel/routepolicy/quartz2/SpringQuartzClusteredAppDatabase.xml");
-        db.start();
 
         // now launch the first clustered app which will acquire the quartz database lock and become the master
         AbstractXmlApplicationContext app = new ClassPathXmlApplicationContext("org/apache/camel/routepolicy/quartz2/SpringQuartzClusteredAppOne.xml");
-        app.start();
 
         // as well as the second one which will run in slave mode as it will not be able to acquire the same lock
         AbstractXmlApplicationContext app2 = new ClassPathXmlApplicationContext("org/apache/camel/routepolicy/quartz2/SpringQuartzClusteredAppTwo.xml");
-        app2.start();
 
         CamelContext camel = app.getBean("camelContext", CamelContext.class);
 
@@ -61,6 +57,10 @@ public class SpringQuartzTwoAppsClusteredFailoverTest extends TestSupport {
 
         // now let's simulate a crash of the first app (the quartz instance 'app-one')
         log.warn("The first app is going to crash NOW!");
+        // we need to stop the Scheduler first as the CamelContext will gracefully shutdown and
+        // delete all scheduled jobs, so there would be nothing for the second CamelContext to
+        // failover from
+        app.getBean(Scheduler.class).shutdown();
         IOHelper.close(app);
 
         log.warn("Crashed...");

--- a/components/camel-spring-boot/pom.xml
+++ b/components/camel-spring-boot/pom.xml
@@ -83,6 +83,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core-xml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -41,20 +41,21 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
 
 /**
  * Collects routes and rests from the various sources (like Spring application context beans registry or opinionated
  * classpath locations) and injects these into the Camel context.
  */
-public class RoutesCollector implements ApplicationListener<ContextRefreshedEvent> {
+public class RoutesCollector implements ApplicationListener<ContextRefreshedEvent>, Ordered {
 
     // Static collaborators
 
     private static final Logger LOG = LoggerFactory.getLogger(RoutesCollector.class);
 
     // Collaborators
-    
+
     private final ApplicationContext applicationContext;
 
     private final List<CamelContextConfiguration> camelContextConfigurations;
@@ -191,6 +192,18 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
         } else {
             LOG.debug("Ignore ContextRefreshedEvent: {}", event);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        // RoutesCollector implements Ordered so that it's the
+        // second to last in ApplicationListener to receive events,
+        // SpringCamelContext should be the last one,
+        // CamelContextFactoryBean should be on par with
+        // RoutesCollector this is important for startup as we want
+        // all resources to be ready and all routes added to the 
+        // context
+        return LOWEST_PRECEDENCE - 1;
     }
 
     private void maybeStart(CamelContext camelContext) throws Exception {

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/TypeConversionConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/TypeConversionConfiguration.java
@@ -33,14 +33,18 @@ import org.springframework.core.convert.support.DefaultConversionService;
 @ConditionalOnProperty(value = "camel.springboot.typeConversion", matchIfMissing = true)
 public class TypeConversionConfiguration {
 
-    @Bean(initMethod = "", destroyMethod = "")
+    // We explicitly declare the destroyMethod to be "" as the Spring @Bean
+    // annotation defaults to AbstractBeanDefinition.INFER_METHOD otherwise
+    // and in that case ShutdownableService::shutdown/Service::close
+    // (BaseTypeConverterRegistry extends ServiceSupport) would be used for
+    // bean destruction. And we want Camel to handle the lifecycle.
+    @Bean(destroyMethod = "")
     // Camel handles the lifecycle of this bean
     TypeConverter typeConverter(CamelContext camelContext) {
         return camelContext.getTypeConverter();
     }
 
-    @Bean(initMethod = "", destroyMethod = "")
-    // Camel handles the lifecycle of this bean
+    @Bean
     SpringTypeConverter springTypeConverter(CamelContext camelContext, ConversionService[] conversionServices) {
         SpringTypeConverter springTypeConverter = new SpringTypeConverter(asList(conversionServices));
         camelContext.getTypeConverterRegistry().addFallbackTypeConverter(springTypeConverter, true);

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/StartupShutdownOrderTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/StartupShutdownOrderTest.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.support.ServiceSupport;
+import org.junit.Test;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.Lifecycle;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StartupShutdownOrderTest {
+
+    static class AutoCloseableBean implements AutoCloseable, TestState {
+
+        boolean closed;
+
+        private final ApplicationContext context;
+
+        public AutoCloseableBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(closed).as("AutoCloseable bean should be closed").isTrue();
+        }
+
+        @Override
+        public void close() {
+            assertThat(camelIsStopped(context)).as("AutoCloseable bean should be stopped after Camel").isTrue();
+            closed = true;
+        }
+    }
+
+    static class Beans {
+
+        @Bean
+        AutoCloseableBean autoCloseableBean(final ApplicationContext context) {
+            return new AutoCloseableBean(context);
+        }
+
+        @Bean
+        BeanWithShutdownMethod beanWithCloseMethod(final ApplicationContext context) {
+            return new BeanWithShutdownMethod(context);
+        }
+
+        @Bean
+        DisposeBean disposedBean(final ApplicationContext context) {
+            return new DisposeBean(context);
+        }
+
+        @Bean
+        InitBean initBean(final ApplicationContext context) {
+            return new InitBean(context);
+        }
+
+        @Bean
+        Lifecycle lifecycleBean(final ApplicationContext context) {
+            return new LifecycleBean(context);
+        }
+    }
+
+    static class BeanWithShutdownMethod implements TestState {
+
+        boolean shutdown;
+
+        private final ApplicationContext context;
+
+        public BeanWithShutdownMethod(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(shutdown).as("Bean with shutdown method should be shutdown").isTrue();
+        }
+
+        public void shutdown() {
+            assertThat(camelIsStopped(context)).as("@Bean with close() method should be stopped after Camel").isTrue();
+            shutdown = true;
+        }
+    }
+
+    static class DisposeBean implements DisposableBean, TestState {
+
+        boolean disposed;
+
+        private final ApplicationContext context;
+
+        public DisposeBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(disposed).as("DisposableBean should be disposed").isTrue();
+        }
+
+        @Override
+        public void destroy() throws Exception {
+            assertThat(camelIsStopped(context)).as("DisposableBean should be stopped after Camel").isTrue();
+            disposed = true;
+        }
+    }
+
+    static class InitBean implements InitializingBean, TestState {
+
+        ApplicationContext context;
+
+        boolean initialized;
+
+        @Autowired
+        public InitBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void afterPropertiesSet() throws Exception {
+            assertThat(camelIsStopped(context)).as("initializing bean should be started before Camel").isTrue();
+            initialized = true;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(initialized).as("InitializingBean should be initialized").isTrue();
+        }
+    }
+
+    static class LifecycleBean implements SmartLifecycle, TestState {
+
+        ApplicationContext context;
+
+        boolean started;
+
+        boolean stopped;
+
+        @Autowired
+        public LifecycleBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(started).as("Lifecycle should have been started").isTrue();
+            assertThat(stopped).as("Lifecycle should be stopped").isTrue();
+        }
+
+        @Override
+        public int getPhase() {
+            return 0;
+        }
+
+        @Override
+        public boolean isAutoStartup() {
+            return true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return started;
+        }
+
+        @Override
+        public void start() {
+            assertThat(camelIsStopped(context)).as("lifecycle bean should be started before Camel").isTrue();
+            started = true;
+        }
+
+        @Override
+        public void stop() {
+            assertThat(camelIsStopped(context)).as("lifecycle bean should be stopped after Camel").isTrue();
+            stopped = true;
+        }
+
+        @Override
+        public void stop(final Runnable callback) {
+            stop();
+            callback.run();
+        }
+    }
+
+    interface TestState {
+        void assertValid();
+    }
+
+    @Test
+    public void camelContextShouldBeStartedLastAndStoppedFirst() {
+        final ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+            CamelAutoConfiguration.class, Beans.class);
+
+        final ServiceSupport camelContext = (ServiceSupport) context.getBean(CamelContext.class);
+        final Map<String, TestState> testStates = context.getBeansOfType(TestState.class);
+
+        assertThat(camelContext.isStarted()).as("Camel context should be started").isTrue();
+
+        context.close();
+
+        assertThat(camelContext.isStopped()).as("Camel context should be stopped").isTrue();
+        testStates.values().stream().forEach(TestState::assertValid);
+    }
+
+    static ServiceSupport camel(final ApplicationContext context) {
+        return (ServiceSupport) context.getBean(CamelContext.class);
+    }
+
+    static boolean camelIsStarted(final ApplicationContext context) {
+        return camel(context).isStarted();
+    }
+
+    static boolean camelIsStopped(final ApplicationContext context) {
+        return !camelIsStarted(context);
+    }
+}

--- a/components/camel-spring-javaconfig/src/main/java/org/apache/camel/spring/javaconfig/CamelConfiguration.java
+++ b/components/camel-spring-javaconfig/src/main/java/org/apache/camel/spring/javaconfig/CamelConfiguration.java
@@ -158,7 +158,6 @@ public abstract class CamelConfiguration implements BeanFactoryAware, Applicatio
     @Bean
     public CamelContext camelContext() throws Exception {
         CamelContext camelContext = createCamelContext();
-        SpringCamelContext.setNoStart(true);
         setupCamelContext(camelContext);
         return camelContext;
     }

--- a/components/camel-spring-javaconfig/src/main/java/org/apache/camel/spring/javaconfig/RoutesCollector.java
+++ b/components/camel-spring-javaconfig/src/main/java/org/apache/camel/spring/javaconfig/RoutesCollector.java
@@ -25,12 +25,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.Ordered;
 
 /**
  * Collects routes and rests from the various sources (like Spring application context beans registry or opinionated
  * classpath locations) and injects these into the Camel context.
  */
-public class RoutesCollector implements ApplicationListener<ContextRefreshedEvent> {
+public class RoutesCollector implements ApplicationListener<ContextRefreshedEvent>, Ordered {
 
     // Static collaborators
 
@@ -92,6 +93,13 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
         } else {
             LOG.debug("Ignore ContextRefreshedEvent: {}", event);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        // we want the RoutesCollector to receive ContextRefreshedEvent
+        // before SpringCamelContext (see SpringCamelContext::getOrder)
+        return LOWEST_PRECEDENCE - 1;
     }
 
 }

--- a/components/camel-spring-javaconfig/src/test/java/org/apache/camel/spring/javaconfig/MainTest.java
+++ b/components/camel-spring-javaconfig/src/test/java/org/apache/camel/spring/javaconfig/MainTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.spring.javaconfig;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.spring.SpringCamelContext;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -33,7 +32,7 @@ public class MainTest extends Assert {
         runTests(context);
         context.stop();
     }
-    
+
     @Test
     public void testOptionBP() throws Exception {
         CamelContext context = createCamelContext(new String[]{"-bp", "org.apache.camel.spring.javaconfig.config"});
@@ -41,24 +40,24 @@ public class MainTest extends Assert {
         runTests(context);
         context.stop();
     }
-        
+
     private CamelContext createCamelContext(String[] options) throws Exception {
-        Main main = new Main();        
+        Main main = new Main();
         main.parseArguments(options);
         ApplicationContext applicationContext = main.createDefaultApplicationContext();
-        CamelContext context = SpringCamelContext.springCamelContext(applicationContext);
-        return context;        
+        CamelContext context = applicationContext.getBean(CamelContext.class);
+        return context;
     }
 
     private void runTests(CamelContext context) throws Exception {
         MockEndpoint resultEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);
         ProducerTemplate template = context.createProducerTemplate();
-        
+
         String expectedBody = "<matched/>";
         resultEndpoint.expectedBodiesReceived(expectedBody);
         template.sendBodyAndHeader("direct:start", expectedBody, "foo", "bar");
         resultEndpoint.assertIsSatisfied();
-        
+
         resultEndpoint.reset();
         resultEndpoint.expectedMessageCount(0);
         template.sendBodyAndHeader("direct:start", "<notMatched/>", "foo", "notMatchedHeaderValue");

--- a/components/camel-spring/pom.xml
+++ b/components/camel-spring/pom.xml
@@ -194,6 +194,12 @@
       <version>${cglib-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -33,16 +33,16 @@ import org.apache.camel.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.Lifecycle;
+import org.springframework.context.Phased;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.ContextStoppedEvent;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.Ordered;
 
 import static org.apache.camel.util.ObjectHelper.wrapRuntimeCamelException;
 
@@ -56,8 +56,8 @@ import static org.apache.camel.util.ObjectHelper.wrapRuntimeCamelException;
  *
  * @version 
  */
-public class SpringCamelContext extends DefaultCamelContext implements InitializingBean, DisposableBean,
-        ApplicationContextAware {
+public class SpringCamelContext extends DefaultCamelContext implements Lifecycle, ApplicationContextAware, Phased,
+        ApplicationListener<ApplicationEvent>, Ordered {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringCamelContext.class);
     private static final ThreadLocal<Boolean> NO_START = new ThreadLocal<Boolean>();
@@ -105,7 +105,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
         SpringCamelContext answer = new SpringCamelContext();
         answer.setApplicationContext(applicationContext);
         if (maybeStart) {
-            answer.afterPropertiesSet();
+            answer.start();
         }
         return answer;
     }
@@ -119,50 +119,75 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
         return springCamelContext(new ClassPathXmlApplicationContext(configLocations));
     }
 
-    public void afterPropertiesSet() throws Exception {
-        StopWatch watch = new StopWatch();
+    @Override
+    public void start() {
+        // for example from unit testing we want to start Camel later (manually)
+        if (Boolean.TRUE.equals(NO_START.get())) {
+            LOG.trace("Ignoring maybeStart() as NO_START is false");
+            return;
+        }
 
-        maybeStart();
-        
-        LOG.debug("afterPropertiesSet() took {} millis", watch.stop());
+        if (!isStarted() && !isStarting()) {
+            try {
+                StopWatch watch = new StopWatch();
+                super.start();
+                LOG.debug("start() took {} millis", watch.stop());
+            } catch (Exception e) {
+                throw wrapRuntimeCamelException(e);
+            }
+        } else {
+            // ignore as Camel is already started
+            LOG.trace("Ignoring maybeStart() as Apache Camel is already started");
+        }
     }
 
-    public void destroy() throws Exception {
-        stop();
+    @Override
+    public void stop() {
+        if (!isStopping() && !isStopped()) {
+            try {
+                super.stop();
+            } catch (Exception e) {
+                throw wrapRuntimeCamelException(e);
+            }
+        } else {
+            // ignore as Camel is already stopped
+            LOG.trace("Ignoring maybeStop() as Apache Camel is already stopped");
+        }
     }
 
+    @Override
     public void onApplicationEvent(ApplicationEvent event) {
         LOG.debug("onApplicationEvent: {}", event);
 
         if (event instanceof ContextRefreshedEvent) {
-            // now lets start the CamelContext so that all its possible
-            // dependencies are initialized
-            try {
-                maybeStart();
-            } catch (Exception e) {
-                throw wrapRuntimeCamelException(e);
-            }
-        } else if (event instanceof ContextClosedEvent) {
-            // ContextClosedEvent is emitted when Spring is about to be shutdown
-            if (isShutdownEager()) {
-                try {
-                    maybeStop();
-                } catch (Exception e) {
-                    throw wrapRuntimeCamelException(e);
-                }
-            }
-        } else if (event instanceof ContextStoppedEvent) {
-            // ContextStoppedEvent is emitted when Spring is end of shutdown
-            try {
-                maybeStop();
-            } catch (Exception e) {
-                throw wrapRuntimeCamelException(e);
-            }
+            // nominally we would prefer to use Lifecycle interface that
+            // would invoke start() method, but in order to do that 
+            // SpringCamelContext needs to implement SmartLifecycle
+            // (look at DefaultLifecycleProcessor::startBeans), but it
+            // cannot implement it as it already implements
+            // RuntimeConfiguration, and both SmartLifecycle and
+            // RuntimeConfiguration declare isAutoStartup method but
+            // with boolean and Boolean return types, and covariant
+            // methods with primitive types are not allowed by the JLS
+            // so we need to listen for ContextRefreshedEvent and start
+            // on its reception
+            start();
         }
 
         if (eventComponent != null) {
             eventComponent.onApplicationEvent(event);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        // SpringCamelContext implements Ordered so that it's the last
+        // in ApplicationListener to receive events, this is important
+        // for startup as we want all resources to be ready and all
+        // routes added to the context (see
+        // org.apache.camel.spring.boot.RoutesCollector)
+        // and we need to be after CamelContextFactoryBean
+        return LOWEST_PRECEDENCE;
     }
 
     // Properties
@@ -172,6 +197,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
         return applicationContext;
     }
 
+    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
         ClassLoader cl;
@@ -250,6 +276,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
         return getEndpoint("spring-event:default", EventEndpoint.class);
     }
 
+    @Override
     protected Endpoint convertBeanToEndpoint(String uri, Object bean) {
         // We will use the type convert to build the endpoint first
         Endpoint endpoint = getTypeConverter().convertTo(Endpoint.class, bean);
@@ -271,31 +298,6 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
         return new SpringModelJAXBContextFactory();
     }
 
-    private void maybeStart() throws Exception {
-        // for example from unit testing we want to start Camel later and not when Spring framework
-        // publish a ContextRefreshedEvent
-
-        if (NO_START.get() == null) {
-            if (!isStarted() && !isStarting()) {
-                start();
-            } else {
-                // ignore as Camel is already started
-                LOG.trace("Ignoring maybeStart() as Apache Camel is already started");
-            }
-        } else {
-            LOG.trace("Ignoring maybeStart() as NO_START is false");
-        }
-    }
-
-    private void maybeStop() throws Exception {
-        if (!isStopping() && !isStopped()) {
-            stop();
-        } else {
-            // ignore as Camel is already stopped
-            LOG.trace("Ignoring maybeStop() as Apache Camel is already stopped");
-        }
-    }
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -304,6 +306,26 @@ public class SpringCamelContext extends DefaultCamelContext implements Initializ
             sb.append(" with spring id ").append(applicationContext.getId());
         }
         return sb.toString();
+    }
+
+    @Override
+    public int getPhase() {
+        // the context is started by invoking start method which
+        // happens either on ContextRefreshedEvent or explicitly
+        // invoking the method, for instance CamelContextFactoryBean
+        // is using that to start the context, _so_ here we want to
+        // have maximum priority as the getPhase() will be used only
+        // for stopping, in order to be used for starting we would
+        // need to implement SmartLifecycle which we cannot
+        // (explained in comment in the onApplicationEvent method)
+        // we use LOWEST_PRECEDENCE here as this is taken into account
+        // only when stopping and then in reversed order
+        return LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isStarted();
     }
 
 }

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -123,7 +123,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
     public void start() {
         // for example from unit testing we want to start Camel later (manually)
         if (Boolean.TRUE.equals(NO_START.get())) {
-            LOG.trace("Ignoring maybeStart() as NO_START is false");
+            LOG.trace("Ignoring start() as NO_START is false");
             return;
         }
 
@@ -137,7 +137,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
             }
         } else {
             // ignore as Camel is already started
-            LOG.trace("Ignoring maybeStart() as Apache Camel is already started");
+            LOG.trace("Ignoring start() as Camel is already started");
         }
     }
 
@@ -151,7 +151,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
             }
         } else {
             // ignore as Camel is already stopped
-            LOG.trace("Ignoring maybeStop() as Apache Camel is already stopped");
+            LOG.trace("Ignoring stop() as Camel is already stopped");
         }
     }
 
@@ -325,7 +325,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
 
     @Override
     public boolean isRunning() {
-        return isStarted();
+        return !isStopping() && !isStopped();
     }
 
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/component/rest/SpringFromRestDuplicateTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/component/rest/SpringFromRestDuplicateTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.camel.component.rest;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- * @version
- */
 public class SpringFromRestDuplicateTest extends SpringTestSupport {
 
     @Override
@@ -31,7 +29,7 @@ public class SpringFromRestDuplicateTest extends SpringTestSupport {
         try {
             new ClassPathXmlApplicationContext("org/apache/camel/component/rest/SpringFromRestDuplicateTest.xml");
             fail("Should throw exception");
-        } catch (Exception e) {
+        } catch (RuntimeCamelException e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Duplicate verb detected in rest-dsl: get:{id}", iae.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/CircularComponentCreationTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/CircularComponentCreationTest.java
@@ -33,8 +33,7 @@ public class CircularComponentCreationTest {
             doTest("org/apache/camel/spring/CircularComponentCreationSimpleTest.xml");
 
             Assert.fail("Exception should have been thrown");
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof RuntimeCamelException);
+        } catch (RuntimeCamelException e) {
             Assert.assertTrue(e.getCause() instanceof FailedToCreateRouteException);
         }
     }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownOrderBaseTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownOrderBaseTest.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.support.ServiceSupport;
+import org.junit.Test;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.Lifecycle;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class StartupShutdownOrderBaseTest {
+
+    static class AutoCloseableBean implements AutoCloseable, TestState {
+
+        boolean closed;
+
+        private final ApplicationContext context;
+
+        public AutoCloseableBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(closed).as("AutoCloseable bean should be closed").isTrue();
+        }
+
+        @Override
+        public void close() {
+            assertThat(camelIsStopped(context)).as("AutoCloseable bean should be stopped after Camel").isTrue();
+            closed = true;
+        }
+    }
+
+    static class Beans {
+
+        @Bean
+        AutoCloseableBean autoCloseableBean(final ApplicationContext context) {
+            return new AutoCloseableBean(context);
+        }
+
+        @Bean
+        BeanWithShutdownMethod beanWithCloseMethod(final ApplicationContext context) {
+            return new BeanWithShutdownMethod(context);
+        }
+
+        @Bean
+        DisposeBean disposedBean(final ApplicationContext context) {
+            return new DisposeBean(context);
+        }
+
+        @Bean
+        InitBean initBean(final ApplicationContext context) {
+            return new InitBean(context);
+        }
+
+        @Bean
+        Lifecycle lifecycleBean(final ApplicationContext context) {
+            return new LifecycleBean(context);
+        }
+    }
+
+    static class BeanWithShutdownMethod implements TestState {
+
+        boolean shutdown;
+
+        private final ApplicationContext context;
+
+        public BeanWithShutdownMethod(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(shutdown).as("Bean with shutdown method should be shutdown").isTrue();
+        }
+
+        public void shutdown() {
+            assertThat(camelIsStopped(context)).as("@Bean with close() method should be stopped after Camel").isTrue();
+            shutdown = true;
+        }
+    }
+
+    static class DisposeBean implements DisposableBean, TestState {
+
+        boolean disposed;
+
+        private final ApplicationContext context;
+
+        public DisposeBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(disposed).as("DisposableBean should be disposed").isTrue();
+        }
+
+        @Override
+        public void destroy() throws Exception {
+            assertThat(camelIsStopped(context)).as("DisposableBean should be stopped after Camel").isTrue();
+            disposed = true;
+        }
+    }
+
+    static class InitBean implements InitializingBean, TestState {
+
+        ApplicationContext context;
+
+        boolean initialized;
+
+        @Autowired
+        public InitBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void afterPropertiesSet() throws Exception {
+            assertThat(camelIsStopped(context)).as("initializing bean should be started before Camel").isTrue();
+            initialized = true;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(initialized).as("InitializingBean should be initialized").isTrue();
+        }
+    }
+
+    static class LifecycleBean implements SmartLifecycle, TestState {
+
+        ApplicationContext context;
+
+        boolean started;
+
+        boolean stopped;
+
+        @Autowired
+        public LifecycleBean(final ApplicationContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void assertValid() {
+            assertThat(started).as("Lifecycle should have been started").isTrue();
+            assertThat(stopped).as("Lifecycle should be stopped").isTrue();
+        }
+
+        @Override
+        public int getPhase() {
+            return 0;
+        }
+
+        @Override
+        public boolean isAutoStartup() {
+            return true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return started;
+        }
+
+        @Override
+        public void start() {
+            assertThat(camelIsStopped(context)).as("lifecycle bean should be started before Camel").isTrue();
+            started = true;
+        }
+
+        @Override
+        public void stop() {
+            assertThat(camelIsStopped(context)).as("lifecycle bean should be stopped after Camel").isTrue();
+            stopped = true;
+        }
+
+        @Override
+        public void stop(final Runnable callback) {
+            stop();
+            callback.run();
+        }
+    }
+
+    interface TestState {
+        void assertValid();
+    }
+
+    @Test
+    public void camelContextShouldBeStartedLastAndStoppedFirst() {
+        final ConfigurableApplicationContext context = createContext();
+
+        final ServiceSupport camelContext = (ServiceSupport) context.getBean(CamelContext.class);
+        final Map<String, TestState> testStates = context.getBeansOfType(TestState.class);
+
+        assertThat(camelContext.isStarted()).as("Camel context should be started").isTrue();
+
+        context.close();
+
+        assertThat(camelContext.isStopped()).as("Camel context should be stopped").isTrue();
+        testStates.values().stream().forEach(TestState::assertValid);
+    }
+
+    abstract ConfigurableApplicationContext createContext();
+
+    static ServiceSupport camel(final ApplicationContext context) {
+        return (ServiceSupport) context.getBean(CamelContext.class);
+    }
+
+    static boolean camelIsStarted(final ApplicationContext context) {
+        return camel(context).isStarted();
+    }
+
+    static boolean camelIsStopped(final ApplicationContext context) {
+        return !camelIsStarted(context);
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownSpringCamelContextFactoryBeanOrderTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownSpringCamelContextFactoryBeanOrderTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class StartupShutdownSpringCamelContextFactoryBeanOrderTest extends StartupShutdownOrderBaseTest {
+    @Configuration
+    static class CamelContextConfiguration {
+        @Bean
+        CamelContextFactoryBean camelContext() {
+            final CamelContextFactoryBean factory = new CamelContextFactoryBean();
+            factory.setId("camelContext");
+
+            return factory;
+        }
+    }
+
+    @Override
+    ConfigurableApplicationContext createContext() {
+        final ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+            CamelContextConfiguration.class, Beans.class);
+        return context;
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownSpringCamelContextOrderTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/StartupShutdownSpringCamelContextOrderTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import org.apache.camel.CamelContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class StartupShutdownSpringCamelContextOrderTest extends StartupShutdownOrderBaseTest {
+    @Configuration
+    static class CamelContextConfiguration {
+        @Bean
+        CamelContext camelContext() {
+            return new SpringCamelContext();
+        }
+    }
+
+    @Override
+    ConfigurableApplicationContext createContext() {
+        final ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+            CamelContextConfiguration.class, Beans.class);
+        return context;
+    }
+
+}

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/SpringRouteNoFromTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/SpringRouteNoFromTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.camel.spring.config;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- *
- */
 public class SpringRouteNoFromTest extends SpringTestSupport {
 
     @Override
@@ -40,7 +38,7 @@ public class SpringRouteNoFromTest extends SpringTestSupport {
         try {
             answer = new ClassPathXmlApplicationContext("org/apache/camel/spring/config/SpringRouteNoFromTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
+        } catch (RuntimeCamelException e) {
             IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
             assertEquals("Route myRoute has no inputs: Route(myRoute)[[] -> [To[mock:result]]]", iae.getMessage());
             return null;

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/SpringRouteNoOutputTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/SpringRouteNoOutputTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.camel.spring.config;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- *
- */
 public class SpringRouteNoOutputTest extends SpringTestSupport {
 
     @Override
@@ -40,8 +38,8 @@ public class SpringRouteNoOutputTest extends SpringTestSupport {
         try {
             answer = new ClassPathXmlApplicationContext("org/apache/camel/spring/config/SpringRouteNoOutputTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
+        } catch (RuntimeCamelException e) {
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Route myRoute has no outputs: Route(myRoute)[[From[direct:start]] -> []]", iae.getMessage());
             return null;
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/file/SpringFileConsumerPreMoveTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/file/SpringFileConsumerPreMoveTest.java
@@ -18,22 +18,19 @@ package org.apache.camel.spring.file;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.file.FileConsumerPreMoveTest;
-import org.apache.camel.spring.SpringCamelContext;
-
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- * @version 
- */
 public class SpringFileConsumerPreMoveTest extends FileConsumerPreMoveTest {
     private AbstractXmlApplicationContext applicationContext;
 
+    @Override
     protected CamelContext createCamelContext() throws Exception {
-        applicationContext =  new ClassPathXmlApplicationContext("org/apache/camel/spring/file/SpringFileConsumerPreMoveTest.xml");
-        return SpringCamelContext.springCamelContext(applicationContext);
+        applicationContext = new ClassPathXmlApplicationContext(
+            "org/apache/camel/spring/file/SpringFileConsumerPreMoveTest.xml");
+        return applicationContext.getBean(CamelContext.class);
     }
-    
+
     @Override
     protected void tearDown() throws Exception {
         if (applicationContext != null) {
@@ -41,6 +38,5 @@ public class SpringFileConsumerPreMoveTest extends FileConsumerPreMoveTest {
         }
         super.tearDown();
     }
-    
 
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/issues/MisspelledRouteRefTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/issues/MisspelledRouteRefTest.java
@@ -17,30 +17,24 @@
 package org.apache.camel.spring.issues;
 
 import junit.framework.TestCase;
-import org.apache.camel.CamelException;
-import org.apache.camel.spring.Main;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/**
- * @version 
- */
+import org.apache.camel.CamelException;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.spring.Main;
+
+import static org.apache.camel.TestSupport.assertIsInstanceOf;
+
 public class MisspelledRouteRefTest extends TestCase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MisspelledRouteRefTest.class);
-
-    public void testApplicationContextFailed() {
+    public void testApplicationContextFailed() throws Exception {
         try {
-            Main main = new Main();
+            Main main = new Main(); 
             main.setApplicationContextUri("org/apache/camel/spring/issues/MisspelledRouteRefTest.xml");
             main.start();
             fail("Should have thrown an exception");
-        } catch (Exception e) {
-            //expected but want to see what it looks like...
-            LOG.debug("Exception message : " + e.getMessage());
-
-            CamelException cause = (CamelException) e.getCause();
-            assertEquals("Cannot find any routes with this RouteBuilder reference: RouteBuilderRef[xxxroute]", cause.getMessage());
+        } catch (RuntimeCamelException e) {
+            CamelException ce = assertIsInstanceOf(CamelException.class, e.getCause());
+            assertEquals("Cannot find any routes with this RouteBuilder reference: RouteBuilderRef[xxxroute]", ce.getMessage());
         }
     }
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/issues/SpringMainStartFailedIssueTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/issues/SpringMainStartFailedIssueTest.java
@@ -17,12 +17,10 @@
 package org.apache.camel.spring.issues;
 
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.spring.Main;
 
-/**
- * @version 
- */
 public class SpringMainStartFailedIssueTest extends TestSupport {
 
     public void testStartupFailed() throws Exception {
@@ -32,7 +30,7 @@ public class SpringMainStartFailedIssueTest extends TestSupport {
         try {
             main.run(args);
             fail("Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (RuntimeCamelException e) {
             assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
         }
 

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.spring.management;
 
+import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- * @version 
- */
 public class SpringCamelContextStartingFailedEventTest extends SpringTestSupport {
 
     @Override
@@ -35,8 +34,9 @@ public class SpringCamelContextStartingFailedEventTest extends SpringTestSupport
         try {
             new ClassPathXmlApplicationContext("org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.xml");
             fail("Should thrown an exception");
-        } catch (Exception e) {
-            assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause().getCause());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertIsInstanceOf(ResolveEndpointFailedException.class, ftcre.getCause());
             // expected
         }
 

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidDeadLetterUriTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidDeadLetterUriTest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.camel.spring.processor;
 
+import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.NoSuchEndpointException;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- * @version 
- */
 public class SpringDeadLetterChannelInvalidDeadLetterUriTest extends SpringTestSupport {
 
+    @Override
     protected AbstractXmlApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidDeadLetterUriTest.xml");
     }
@@ -36,8 +36,9 @@ public class SpringDeadLetterChannelInvalidDeadLetterUriTest extends SpringTestS
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (Exception e) {
-            NoSuchEndpointException cause = assertIsInstanceOf(NoSuchEndpointException.class, e.getCause().getCause());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            NoSuchEndpointException cause = assertIsInstanceOf(NoSuchEndpointException.class, ftcre.getCause());
             assertEquals("No endpoint could be found for: xxx, please check your classpath contains the needed Camel component jar.", cause.getMessage());
         }
     }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidOptionDeadLetterUriTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidOptionDeadLetterUriTest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.camel.spring.processor;
 
+import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- * @version 
- */
 public class SpringDeadLetterChannelInvalidOptionDeadLetterUriTest extends SpringTestSupport {
 
+    @Override
     protected AbstractXmlApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidOptionDeadLetterUriTest.xml");
     }
@@ -36,8 +36,9 @@ public class SpringDeadLetterChannelInvalidOptionDeadLetterUriTest extends Sprin
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (Exception e) {
-            ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause().getCause());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, ftcre.getCause());
             assertTrue(cause.getMessage().endsWith("Unknown parameters=[{foo=bar}]"));
         }
     }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDoubleLoadBalancerMisconfigurationTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDoubleLoadBalancerMisconfigurationTest.java
@@ -19,12 +19,10 @@ package org.apache.camel.spring.processor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.RuntimeCamelException;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
-/**
- * @version 
- */
 public class SpringDoubleLoadBalancerMisconfigurationTest extends ContextTestSupport {
 
     @Override
@@ -32,7 +30,7 @@ public class SpringDoubleLoadBalancerMisconfigurationTest extends ContextTestSup
         try {
             super.setUp();
             fail("Should have thrown exception");
-        } catch (Exception e) {
+        } catch (RuntimeCamelException e) {
             FailedToCreateRouteException fe = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
             IllegalArgumentException ie = assertIsInstanceOf(IllegalArgumentException.class, fe.getCause());
             assertTrue(ie.getMessage().startsWith("Loadbalancer already configured to: RandomLoadBalancer. Cannot set it to: LoadBalanceType[RoundRobinLoadBalancer"));
@@ -43,6 +41,7 @@ public class SpringDoubleLoadBalancerMisconfigurationTest extends ContextTestSup
         // noop
     }
 
+    @Override
     protected CamelContext createCamelContext() throws Exception {
         return createSpringCamelContext(this, "org/apache/camel/spring/processor/DoubleLoadBalancerMisconfigurationTest.xml");
     }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringRouteTopLevelMisconfiguredTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringRouteTopLevelMisconfiguredTest.java
@@ -18,31 +18,36 @@ package org.apache.camel.spring.processor;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
+import org.apache.camel.RuntimeCamelException;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
 public class SpringRouteTopLevelMisconfiguredTest extends ContextTestSupport {
 
+    @Override
     protected CamelContext createCamelContext() throws Exception {
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringRouteTopLevelOnExceptionMisconfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertTrue(e.getCause().getMessage().startsWith("The output must be added as top-level on the route."));
+        } catch (RuntimeCamelException e) {
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(iae.getMessage().startsWith("The output must be added as top-level on the route."));
         }
 
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringRouteTopLevelOnCompletionMisconfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertTrue(e.getCause().getMessage().startsWith("The output must be added as top-level on the route."));
+        } catch (RuntimeCamelException e) {
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(iae.getMessage().startsWith("The output must be added as top-level on the route."));
         }
 
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringRouteTopLevelTransactedMisconfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertTrue(e.getCause().getMessage().startsWith("The output must be added as top-level on the route."));
+        } catch (RuntimeCamelException e) {
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(iae.getMessage().startsWith("The output must be added as top-level on the route."));
         }
 
 

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
@@ -19,28 +19,30 @@ package org.apache.camel.spring.processor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.RuntimeCamelException;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
 public class SpringTryCatchMisconfiguredTest extends ContextTestSupport {
 
+    @Override
     protected CamelContext createCamelContext() throws Exception {
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
-            assertEquals("This doCatch should have a doTry as its parent on DoCatch[ [class java.io.IOException] -> [To[mock:fail]]]", e.getCause().getCause().getMessage());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftce = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftce.getCause());
+            assertEquals("This doCatch should have a doTry as its parent on DoCatch[ [class java.io.IOException] -> [To[mock:fail]]]", iae.getMessage());
         }
 
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMisconfiguredFinallyTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
-            assertEquals("This doFinally should have a doTry as its parent on DoFinally[[To[mock:finally]]]", e.getCause().getCause().getMessage());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftcre.getCause());
+            assertEquals("This doFinally should have a doTry as its parent on DoFinally[[To[mock:finally]]]", iae.getMessage());
         }
 
         // return a working context instead, to let this test pass

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.spring.processor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.RuntimeCamelException;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
@@ -28,10 +29,10 @@ public class SpringTryCatchMustHaveExceptionConfiguredTest extends ContextTestSu
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (Exception e) {
-            assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
-            assertEquals("At least one Exception must be configured to catch", e.getCause().getCause().getMessage());
+        } catch (RuntimeCamelException e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftcre.getCause());
+            assertEquals("At least one Exception must be configured to catch", iae.getMessage());
         }
 
         // return a working context instead, to let this test pass

--- a/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringBootExecutionListener.java
+++ b/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringBootExecutionListener.java
@@ -33,6 +33,11 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
         LOG.info("@RunWith(CamelSpringBootJUnit4ClassRunner.class) preparing: {}", testContext.getTestClass());
 
         Class<?> testClass = testContext.getTestClass();
+        // we are customizing the Camel context with
+        // CamelAnnotationsHandler so we do not want to start it
+        // automatically, which would happen when SpringCamelContext
+        // is added to Spring ApplicationContext, so we set the flag
+        // not to start it just yet
         SpringCamelContext.setNoStart(true);
         ConfigurableApplicationContext context = (ConfigurableApplicationContext) testContext.getApplicationContext();
 
@@ -44,6 +49,8 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
         CamelAnnotationsHandler.handleUseOverridePropertiesWithPropertiesComponent(context, testClass);
         SpringCamelContext.setNoStart(false);
         CamelContext camelContext = context.getBean(CamelContext.class);
+
+        // after our customizations we should start the CamelContext
         camelContext.start();
     }
 

--- a/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringBootExecutionListener.java
+++ b/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringBootExecutionListener.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.test.spring;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.spring.SpringCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,6 +33,7 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
         LOG.info("@RunWith(CamelSpringBootJUnit4ClassRunner.class) preparing: {}", testContext.getTestClass());
 
         Class<?> testClass = testContext.getTestClass();
+        SpringCamelContext.setNoStart(true);
         ConfigurableApplicationContext context = (ConfigurableApplicationContext) testContext.getApplicationContext();
 
         // Post CamelContext(s) instantiation but pre CamelContext(s) start setup
@@ -39,6 +42,9 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
         CamelAnnotationsHandler.handleMockEndpoints(context, testClass);
         CamelAnnotationsHandler.handleMockEndpointsAndSkip(context, testClass);
         CamelAnnotationsHandler.handleUseOverridePropertiesWithPropertiesComponent(context, testClass);
+        SpringCamelContext.setNoStart(false);
+        CamelContext camelContext = context.getBean(CamelContext.class);
+        camelContext.start();
     }
 
     @Override


### PR DESCRIPTION
Submitted for review, thanks 👍 

See the discussion on the [user forum](http://camel.465427.n5.nabble.com/OnApplicationEvent-not-called-with-CamelAutoConfiguration-tt5798802.html).

This makes `CamelSpringBootApplicationController` lifecycle bean with
top priority during `ApplicationContext` close.