### PR TITLE
CAMEL-11235: Proposal to fix an issue where a method inherited from a superclass overrides a superinterface method

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -434,7 +434,7 @@ public class BeanInfo {
         if (answer == null) {
             // maybe the method overrides, and the method map keeps info of the source override we can use
             for (Method source : methodMap.keySet()) {
-                if (ObjectHelper.isOverridingMethod(source, method, false)) {
+                if (ObjectHelper.isOverridingMethod(getType(), source, method, false)) {
                     answer = methodMap.get(source);
                     break;
                 }

--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -328,7 +328,7 @@ public class BeanInfo {
             methods.addAll(extraMethods);
         }
 
-        Set<Method> overrides = new HashSet<Method>();
+        Set<Method> overriddenMethods = new HashSet<Method>();
 
         // do not remove duplicates form class from the Java itself as they have some "duplicates" we need
         boolean javaClass = clazz.getName().startsWith("java.") || clazz.getName().startsWith("javax.");
@@ -343,38 +343,17 @@ public class BeanInfo {
 
                 for (Method target : methods) {
                     // skip ourselves
-                    if (ObjectHelper.isOverridingMethod(source, target, true)) {
+                    if (ObjectHelper.isOverridingMethod(getType(), source, target, true)) {
                         continue;
                     }
                     // skip duplicates which may be assign compatible (favor keep first added method when duplicate)
-                    if (ObjectHelper.isOverridingMethod(source, target, false)) {
-                        overrides.add(target);
+                    if (ObjectHelper.isOverridingMethod(getType(), source, target, false)) {
+                        overriddenMethods.add(target);
                     }
                 }
             }
-            methods.removeAll(overrides);
-            overrides.clear();
-        }
-
-        // if we are a public class, then add non duplicate interface classes also
-        if (Modifier.isPublic(clazz.getModifiers())) {
-            // add additional interface methods
-            List<Method> extraMethods = getInterfaceMethods(clazz);
-            for (Method source : extraMethods) {
-                for (Method target : methods) {
-                    if (ObjectHelper.isOverridingMethod(source, target, false)) {
-                        overrides.add(source);
-                    }
-                }
-                for (Method target : methodMap.keySet()) {
-                    if (ObjectHelper.isOverridingMethod(source, target, false)) {
-                        overrides.add(source);
-                    }
-                }
-            }
-            // remove all the overrides methods
-            extraMethods.removeAll(overrides);
-            methods.addAll(extraMethods);
+            methods.removeAll(overriddenMethods);
+            overriddenMethods.clear();
         }
 
         // now introspect the methods and filter non valid methods
@@ -386,9 +365,12 @@ public class BeanInfo {
             }
         }
 
-        Class<?> superclass = clazz.getSuperclass();
-        if (superclass != null && !superclass.equals(Object.class)) {
-            introspect(superclass);
+        Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null && !superClass.equals(Object.class)) {
+            introspect(superClass);
+        }
+        for (Class<?> superInterface : clazz.getInterfaces()) {
+            introspect(superInterface);
         }
     }
 
@@ -917,9 +899,9 @@ public class BeanInfo {
             Method alreadyRegisteredMethod = alreadyRegisteredMethodInfo.getMethod();
             Method proposedMethod = proposedMethodInfo.getMethod();
 
-            if (ObjectHelper.isOverridingMethod(proposedMethod, alreadyRegisteredMethod, false)) {
+            if (ObjectHelper.isOverridingMethod(getType(), proposedMethod, alreadyRegisteredMethod, false)) {
                 return alreadyRegisteredMethodInfo;
-            } else if (ObjectHelper.isOverridingMethod(alreadyRegisteredMethod, proposedMethod, false)) {
+            } else if (ObjectHelper.isOverridingMethod(getType(), alreadyRegisteredMethod, proposedMethod, false)) {
                 return proposedMethodInfo;
             }
         }

--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -1380,12 +1380,30 @@ public final class ObjectHelper {
      * @return <tt>true</tt> if it override, <tt>false</tt> otherwise
      */
     public static boolean isOverridingMethod(Method source, Method target, boolean exact) {
+        return isOverridingMethod(target.getDeclaringClass(), source, target, exact);
+    }
+
+    /**
+     * Tests whether the target method overrides the source method from the
+     * inheriting class.
+     * <p/>
+     * Tests whether they have the same name, return type, and parameter list.
+     *
+     * @param inheritingClass the class inheriting the target method overriding
+     *            the source method
+     * @param source the source method
+     * @param target the target method
+     * @param exact <tt>true</tt> if the override must be exact same types,
+     *            <tt>false</tt> if the types should be assignable
+     * @return <tt>true</tt> if it override, <tt>false</tt> otherwise
+     */
+    public static boolean isOverridingMethod(Class<?> inheritingClass, Method source, Method target, boolean exact) {
 
         if (source.equals(target)) {
             return true;
         } else if (source.getDeclaringClass() == target.getDeclaringClass()) {
             return false;
-        } else if (!source.getDeclaringClass().isAssignableFrom(target.getDeclaringClass())) {
+        } else if (!source.getDeclaringClass().isAssignableFrom(inheritingClass) || !target.getDeclaringClass().isAssignableFrom(inheritingClass)) {
             return false;
         }
 

--- a/camel-core/src/test/java/org/apache/camel/component/bean/MyOtherFooBean.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/MyOtherFooBean.java
@@ -33,4 +33,21 @@ public class MyOtherFooBean {
     public String toString(String input) {
         return "toString(String) was called";
     }
+
+    public interface InterfaceSize {
+        int size();
+    }
+
+    public abstract static class AbstractClassSize {
+        public abstract int size();
+    }
+
+    public static class SuperClazz extends AbstractClassSize implements InterfaceSize {
+        public int size() {
+            return 1;
+        }
+    }
+
+    public static class Clazz extends SuperClazz {
+    }
 }

--- a/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
@@ -38,6 +38,9 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.bean.MyOtherFooBean;
+import org.apache.camel.component.bean.MyOtherFooBean.AbstractClassSize;
+import org.apache.camel.component.bean.MyOtherFooBean.Clazz;
+import org.apache.camel.component.bean.MyOtherFooBean.InterfaceSize;
 import org.apache.camel.component.bean.MyStaticClass;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultMessage;
@@ -889,5 +892,17 @@ public class ObjectHelperTest extends TestCase {
         Method m1 = Double.class.getMethod("intValue");
         Method m2 = Number.class.getMethod("intValue");
         assertTrue(ObjectHelper.isOverridingMethod(m2, m1, false));
+    }
+
+    public void testInheritedMethodCanOverrideInterfaceMethod() throws Exception {
+        Method m1 = AbstractClassSize.class.getMethod("size");
+        Method m2 = InterfaceSize.class.getMethod("size");
+        assertTrue(ObjectHelper.isOverridingMethod(Clazz.class, m2, m1, false));
+    }
+
+    public void testNonInheritedMethodCantOverrideInterfaceMethod() throws Exception {
+        Method m1 = AbstractClassSize.class.getMethod("size");
+        Method m2 = InterfaceSize.class.getMethod("size");
+        assertFalse(ObjectHelper.isOverridingMethod(InterfaceSize.class, m2, m1, false));
     }
 }


### PR DESCRIPTION
This PR proposes a fix for [CAMEL-11235](https://issues.apache.org/jira/browse/CAMEL-11235).

Basically, the `BeanInfo` introspection mechanism traverses the single rooted class hierarchy collecting overrides first, and then proceed with interfaces.
I've also created a new overload of `ObjectHelper.isOverridingMethod(...)` to deal with the case where a method inherited from a class [overrides a superinterface method](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.8.1).