### PR TITLE
CAMEL-11298: Fix, allowing usage of absolute and relative paths with chmodDirectory option

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -81,7 +81,7 @@ public class FileOperations implements GenericFileOperations<File> {
         return file.exists();
     }
 
-    protected boolean buildDirectory(File dir, Set<PosixFilePermission> permissions) {
+    protected boolean buildDirectory(File dir, Set<PosixFilePermission> permissions, boolean absolute) {
         if (dir.exists()) {
             return true;
         }
@@ -93,7 +93,15 @@ public class FileOperations implements GenericFileOperations<File> {
         // create directory one part of a time and set permissions
         try {
             String[] parts = dir.getPath().split("\\" + File.separatorChar);
-            File base = new File("");
+
+            File base;
+            // reusing absolute flag to handle relative and absolute paths
+            if (absolute) {
+                base = new File("");
+            } else {
+                base = new File(".");
+            }
+
             for (String part : parts) {
                 File subDir = new File(base, part);
                 if (!subDir.exists()) {
@@ -121,7 +129,7 @@ public class FileOperations implements GenericFileOperations<File> {
         // always create endpoint defined directory
         if (endpoint.isAutoCreate() && !endpoint.getFile().exists()) {
             LOG.trace("Building starting directory: {}", endpoint.getFile());
-            buildDirectory(endpoint.getFile(), endpoint.getDirectoryPermissions());
+            buildDirectory(endpoint.getFile(), endpoint.getDirectoryPermissions(), absolute);
         }
 
         if (ObjectHelper.isEmpty(directory)) {
@@ -158,7 +166,7 @@ public class FileOperations implements GenericFileOperations<File> {
                 return true;
             } else {
                 LOG.trace("Building directory: {}", path);
-                return buildDirectory(path, endpoint.getDirectoryPermissions());
+                return buildDirectory(path, endpoint.getDirectoryPermissions(), absolute);
             }
         }
     }

--- a/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -16,6 +16,24 @@
  */
 package org.apache.camel.component.file;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.WrappedFile;
@@ -25,16 +43,6 @@ import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 
 /**
  * File operations for {@link java.io.File}.

--- a/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -16,24 +16,6 @@
  */
 package org.apache.camel.component.file;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.RandomAccessFile;
-import java.io.Reader;
-import java.io.Writer;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.WrappedFile;
@@ -43,6 +25,16 @@ import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 /**
  * File operations for {@link java.io.File}.
@@ -101,7 +93,7 @@ public class FileOperations implements GenericFileOperations<File> {
         // create directory one part of a time and set permissions
         try {
             String[] parts = dir.getPath().split("\\" + File.separatorChar);
-            File base = new File(".");
+            File base = new File("");
             for (String part : parts) {
                 File subDir = new File(base, part);
                 if (!subDir.exists()) {


### PR DESCRIPTION
Reused the absolute boolean flag to handle absolute paths when using chmodDirectory option. Previously using absolute paths produced an exception.