### PR TITLE
added support for query params to spark-rest

### DIFF
--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/DefaultSparkBinding.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/DefaultSparkBinding.java
@@ -25,7 +25,6 @@ import java.net.URLDecoder;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.TypeConverter;
@@ -108,6 +107,15 @@ public class DefaultSparkBinding implements SparkBinding {
             String value = entry.getValue();
             Object decoded = shouldUrlDecodeHeader(configuration, key, value, "UTF-8");
             if (headerFilterStrategy != null
+                    && !headerFilterStrategy.applyFilterToExternalHeaders(key, decoded, exchange)) {
+                SparkHelper.appendHeader(headers, key, decoded);
+            }
+        }
+
+        for (String key : request.queryParams()) {
+            String value = request.queryParams(key);
+            Object decoded = shouldUrlDecodeHeader(configuration, key, value, "UTF-8");
+            if (headerFilterStrategy != null 
                     && !headerFilterStrategy.applyFilterToExternalHeaders(key, decoded, exchange)) {
                 SparkHelper.appendHeader(headers, key, decoded);
             }

--- a/components/camel-spark-rest/src/test/java/org/apache/camel/component/sparkrest/CamelSparkQueryParamTest.java
+++ b/components/camel-spark-rest/src/test/java/org/apache/camel/component/sparkrest/CamelSparkQueryParamTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.sparkrest;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+
+/**
+ * Test based on the {@link CamelSparkParamTest} test which adds query parameters to the request.
+ * @author <a href="jonathan.elliott@capgemini.com">Jon Elliott</a>
+ */
+public class CamelSparkQueryParamTest extends BaseSparkTest {
+
+    @Test
+    public void testSparkGet() throws Exception {
+        getMockEndpoint("mock:foo").expectedMessageCount(1);
+        getMockEndpoint("mock:foo").expectedHeaderReceived("name", "world");
+        getMockEndpoint("mock:foo").expectedHeaderReceived("surname", "universe");
+
+        String out = template.requestBody("http://localhost:" + getPort() + "/hello/world?surname=universe", null, String.class);
+        assertEquals("Bye world", out);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("spark-rest:get:/hello/:name")
+                        .to("mock:foo")
+                        .transform().simple("Bye ${header.name}");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Camel-11323 - Fix which ensures that query parameters are mapped to Camel Headers with the camel-spark-rest project. 

source check has been run. 