### PR TITLE
Move protobuf and salesforce component maven versions to the parent pom

### DIFF
--- a/components/camel-protobuf/pom.xml
+++ b/components/camel-protobuf/pom.xml
@@ -92,7 +92,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.1.Final</version>
+        <version>${os-maven-plugin-version}</version>
       </extension>
     </extensions>
 
@@ -139,7 +139,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>${protobuf-maven-plugin-version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/components/camel-salesforce/camel-salesforce-component/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-component/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>com.googlecode.junit-toolbox</groupId>
       <artifactId>junit-toolbox</artifactId>
-      <version>2.2</version>
+      <version>${junit-toolbox-version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
@zregvart please look at this PR, as junit-toolbox version inserted in parent pom as more than one components are using it now. Thank you.