### PR TITLE
CAMEL-11343: gRPC component cannot load service class

### DIFF
--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
@@ -85,7 +85,7 @@ public class GrpcConsumer extends DefaultConsumer {
         ServerInterceptor headerInterceptor = new GrpcHeaderInterceptor();
         MethodHandler methodHandler = new GrpcMethodHandler(endpoint, this);
         
-        serviceProxy.setSuperclass(GrpcUtils.constructGrpcImplBaseClass(configuration.getServicePackage(), configuration.getServiceName()));
+        serviceProxy.setSuperclass(GrpcUtils.constructGrpcImplBaseClass(configuration.getServicePackage(), configuration.getServiceName(), endpoint.getCamelContext()));
         try {
             bindableService = (BindableService)serviceProxy.create(new Class<?>[0], new Object[0], methodHandler);
         } catch (NoSuchMethodException | IllegalArgumentException | InstantiationException | IllegalAccessException | InvocationTargetException e) {

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcProducer.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcProducer.java
@@ -73,10 +73,10 @@ public class GrpcProducer extends DefaultProducer implements AsyncProcessor {
             initializeChannel();
             if (endpoint.isSynchronous()) {
                 LOG.info("Getting synchronous method stub from channel");
-                grpcStub = GrpcUtils.constructGrpcBlockingStub(configuration.getServicePackage(), configuration.getServiceName(), channel);
+                grpcStub = GrpcUtils.constructGrpcBlockingStub(configuration.getServicePackage(), configuration.getServiceName(), channel, endpoint.getCamelContext());
             } else {
                 LOG.info("Getting asynchronous method stub from channel");
-                grpcStub = GrpcUtils.constructGrpcAsyncStub(configuration.getServicePackage(), configuration.getServiceName(), channel);
+                grpcStub = GrpcUtils.constructGrpcAsyncStub(configuration.getServicePackage(), configuration.getServiceName(), channel, endpoint.getCamelContext());
             }
         }
     }


### PR DESCRIPTION
Changing from Class.forName to context.getClassResolver().resolveMandatoryClass which is working in modular environments (OSGi, JavaEE, etc)