### PR TITLE
Update CMISSessionFacade.java

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -182,8 +182,9 @@ public class CMISSessionFacade {
 
     public InputStream getContentStreamFor(QueryResult item) {
         Document document = getDocument(item);
-        if (document != null && document.getContentStream() != null) {
-            return document.getContentStream().getStream();
+        ContentStream contentStream = document.getContentStream();
+        if (document != null && contentStream != null) {
+            return contentStream.getStream();
         }
         return null;
     }

--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISSessionFacade.java
@@ -182,9 +182,11 @@ public class CMISSessionFacade {
 
     public InputStream getContentStreamFor(QueryResult item) {
         Document document = getDocument(item);
-        ContentStream contentStream = document.getContentStream();
-        if (document != null && contentStream != null) {
-            return contentStream.getStream();
+        if(document != null) {
+            ContentStream contentStream = document.getContentStream();
+            if (contentStream != null) {
+                return contentStream.getStream();
+            }
         }
         return null;
     }


### PR DESCRIPTION
Hi, this piece of code causes two calls in a row for content stream. Result of document.getContentStream() has to be stored and used where is needed, not to call document.getContentStream() in condition and than again in return statement.