### PR TITLE
CAMEL-11178: default methods support in bean binding

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -328,7 +328,7 @@ public class BeanInfo {
             methods.addAll(extraMethods);
         }
 
-        Set<Method> overriddenMethods = new HashSet<Method>();
+        Set<Method> overrides = new HashSet<Method>();
 
         // do not remove duplicates form class from the Java itself as they have some "duplicates" we need
         boolean javaClass = clazz.getName().startsWith("java.") || clazz.getName().startsWith("javax.");
@@ -348,12 +348,12 @@ public class BeanInfo {
                     }
                     // skip duplicates which may be assign compatible (favor keep first added method when duplicate)
                     if (ObjectHelper.isOverridingMethod(getType(), source, target, false)) {
-                        overriddenMethods.add(target);
+                        overrides.add(target);
                     }
                 }
             }
-            methods.removeAll(overriddenMethods);
-            overriddenMethods.clear();
+            methods.removeAll(overrides);
+            overrides.clear();
         }
 
         // now introspect the methods and filter non valid methods

--- a/camel-core/src/test/java/org/apache/camel/component/bean/issues/DefaultMethodCalledFromSimpleExpressionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/issues/DefaultMethodCalledFromSimpleExpressionTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean.issues;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+
+public class DefaultMethodCalledFromSimpleExpressionTest extends ContextTestSupport {
+
+    private static final String DEFAULT_METHOD_CONTENT = "A.defaultMethod() has been called";
+
+    public void testDefaultMethodFromSimpleExpression() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived(DEFAULT_METHOD_CONTENT);
+
+        template.sendBodyAndProperty("direct:defaultMethod", "", "myObject", new B() {
+        });
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:defaultMethod").setBody(simple("${exchangeProperty.myObject.defaultMethod}")).to("mock:result");
+            }
+        };
+    }
+
+    public interface A {
+        default String defaultMethod() {
+            return DEFAULT_METHOD_CONTENT;
+        }
+    }
+
+    public interface B extends A {
+    }
+}


### PR DESCRIPTION
Actually, the management of default methods has already been added via [a previous commit](https://github.com/apache/camel/pull/1703/commits/0ddb6a7baf2e092304ec7644b655371bdac28cd5) on version 2.20.0-SNAPSHOT. I like such PR solving more than one ticket :)

Please, check [CAMEL-11178](https://issues.apache.org/jira/browse/CAMEL-11178) out for more details.