### PR TITLE
CAMEL-11369: camel-spring-boot-starter generator paste incorrect default value

### DIFF
--- a/platforms/spring-boot/components-starter/camel-base64-starter/src/main/java/org/apache/camel/dataformat/base64/springboot/Base64DataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-base64-starter/src/main/java/org/apache/camel/dataformat/base64/springboot/Base64DataFormatConfiguration.java
@@ -39,7 +39,7 @@ public class Base64DataFormatConfiguration
     /**
      * The line separators to use. By default \r\n is used.
      */
-    private String lineSeparator;
+    private String lineSeparator = "\\r\\n";
     /**
      * Instead of emitting '' and '/' we emit '-' and '_' respectively. urlSafe
      * is only applied to encode operations. Decoding seamlessly handles both

--- a/platforms/spring-boot/components-starter/camel-castor-starter/src/main/java/org/apache/camel/dataformat/castor/springboot/CastorDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-castor-starter/src/main/java/org/apache/camel/dataformat/castor/springboot/CastorDataFormatConfiguration.java
@@ -42,7 +42,7 @@ public class CastorDataFormatConfiguration
     /**
      * Encoding to use when marshalling an Object to XML. Is by default UTF-8
      */
-    private String encoding;
+    private String encoding = "UTF-8";
     /**
      * Add additional packages to Castor XmlContext
      */

--- a/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/CryptoDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-crypto-starter/src/main/java/org/apache/camel/converter/crypto/springboot/CryptoDataFormatConfiguration.java
@@ -35,7 +35,7 @@ public class CryptoDataFormatConfiguration
      * The JCE algorithm name indicating the cryptographic algorithm that will
      * be used. Is by default DES/CBC/PKCS5Padding.
      */
-    private String algorithm;
+    private String algorithm = "DES/CBC/PKCS5Padding";
     /**
      * The name of the JCE Security Provider that should be used.
      */
@@ -62,7 +62,7 @@ public class CryptoDataFormatConfiguration
     /**
      * The JCE algorithm name indicating the Message Authentication algorithm.
      */
-    private String macAlgorithm;
+    private String macAlgorithm = "HmacSHA1";
     /**
      * Flag indicating that a Message Authentication Code should be calculated
      * and appended to the encrypted data.

--- a/platforms/spring-boot/components-starter/camel-flatpack-starter/src/main/java/org/apache/camel/dataformat/flatpack/springboot/FlatpackDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-flatpack-starter/src/main/java/org/apache/camel/dataformat/flatpack/springboot/FlatpackDataFormatConfiguration.java
@@ -52,11 +52,11 @@ public class FlatpackDataFormatConfiguration
     /**
      * If the text is qualified with a char such as "
      */
-    private String textQualifier;
+    private String textQualifier = "\"";
     /**
      * The delimiter char (could be ; or similar)
      */
-    private String delimiter;
+    private String delimiter = ",";
     /**
      * Allows for lines to be shorter than expected and ignores the extra
      * characters

--- a/platforms/spring-boot/components-starter/camel-mail-starter/src/main/java/org/apache/camel/dataformat/mime/multipart/springboot/MimeMultipartDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-mail-starter/src/main/java/org/apache/camel/dataformat/mime/multipart/springboot/MimeMultipartDataFormatConfiguration.java
@@ -34,7 +34,7 @@ public class MimeMultipartDataFormatConfiguration
     /**
      * Specify the subtype of the MIME Multipart. Default is mixed.
      */
-    private String multipartSubType;
+    private String multipartSubType = "mixed";
     /**
      * Defines whether a message without attachment is also marshaled into a
      * MIME Multipart (with only one body part). Default is false.

--- a/platforms/spring-boot/components-starter/camel-protobuf-starter/src/main/java/org/apache/camel/dataformat/protobuf/springboot/ProtobufDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-protobuf-starter/src/main/java/org/apache/camel/dataformat/protobuf/springboot/ProtobufDataFormatConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.dataformat.protobuf.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.dataformat.protobuf.ProtobufDataFormat;
 import org.apache.camel.spring.boot.DataFormatConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -42,7 +41,7 @@ public class ProtobufDataFormatConfiguration
      * native or json for either native protobuf or json fields representation.
      * The default value is native.
      */
-    private String contentTypeFormat;
+    private String contentTypeFormat = "native";
     /**
      * Whether the data format should set the Content-Type header with the type
      * from the data format if the data format is capable of doing so. For

--- a/platforms/spring-boot/components-starter/camel-soap-starter/src/main/java/org/apache/camel/dataformat/soap/springboot/SoapJaxbDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-soap-starter/src/main/java/org/apache/camel/dataformat/soap/springboot/SoapJaxbDataFormatConfiguration.java
@@ -62,7 +62,7 @@ public class SoapJaxbDataFormatConfiguration
     /**
      * SOAP version should either be 1.1 or 1.2. Is by default 1.1
      */
-    private String version;
+    private String version = "1.1";
     /**
      * When marshalling using JAXB or SOAP then the JAXB implementation will
      * automatic assign namespace prefixes such as ns2 ns3 ns4 etc. To control

--- a/platforms/spring-boot/components-starter/camel-tagsoup-starter/src/main/java/org/apache/camel/dataformat/tagsoup/springboot/TidyMarkupDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-tagsoup-starter/src/main/java/org/apache/camel/dataformat/tagsoup/springboot/TidyMarkupDataFormatConfiguration.java
@@ -35,7 +35,7 @@ public class TidyMarkupDataFormatConfiguration
      * What data type to unmarshal as can either be org.w3c.dom.Node or
      * java.lang.String. Is by default org.w3c.dom.Node
      */
-    private String dataObjectType;
+    private String dataObjectType = "org.w3c.dom.Node";
     /**
      * When returning a String do we omit the XML declaration in the top.
      */

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityCsvDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityCsvDataFormatConfiguration.java
@@ -38,15 +38,15 @@ public class UniVocityCsvDataFormatConfiguration
     /**
      * The quote symbol.
      */
-    private String quote;
+    private String quote = "\"";
     /**
      * The quote escape symbol
      */
-    private String quoteEscape;
+    private String quoteEscape = "\"";
     /**
      * The delimiter of values
      */
-    private String delimiter;
+    private String delimiter = ",";
     /**
      * The string representation of a null value. The default value is null
      */
@@ -92,11 +92,11 @@ public class UniVocityCsvDataFormatConfiguration
     /**
      * The normalized line separator of the files The default value is \n
      */
-    private String normalizedLineSeparator;
+    private String normalizedLineSeparator = "\\n";
     /**
      * The comment symbol. The default value is
      */
-    private String comment;
+    private String comment = "#";
     /**
      * Whether the unmarshalling should produce an iterator that reads the lines
      * on the fly or if all the lines must be read at one. The default value is

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityFixedWidthDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityFixedWidthDataFormatConfiguration.java
@@ -89,11 +89,11 @@ public class UniVocityFixedWidthDataFormatConfiguration
     /**
      * The normalized line separator of the files The default value is \n
      */
-    private String normalizedLineSeparator;
+    private String normalizedLineSeparator = "\\n";
     /**
      * The comment symbol. The default value is
      */
-    private String comment;
+    private String comment = "#";
     /**
      * Whether the unmarshalling should produce an iterator that reads the lines
      * on the fly or if all the lines must be read at one. The default value is

--- a/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityTsvDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-univocity-parsers-starter/src/main/java/org/apache/camel/dataformat/univocity/springboot/UniVocityTsvDataFormatConfiguration.java
@@ -34,7 +34,7 @@ public class UniVocityTsvDataFormatConfiguration
     /**
      * The escape character.
      */
-    private String escapeChar;
+    private String escapeChar = "\\";
     /**
      * The string representation of a null value. The default value is null
      */
@@ -80,11 +80,11 @@ public class UniVocityTsvDataFormatConfiguration
     /**
      * The normalized line separator of the files The default value is \n
      */
-    private String normalizedLineSeparator;
+    private String normalizedLineSeparator = "\\n";
     /**
      * The comment symbol. The default value is
      */
-    private String comment;
+    private String comment = "#";
     /**
      * Whether the unmarshalling should produce an iterator that reads the lines
      * on the fly or if all the lines must be read at one. The default value is

--- a/platforms/spring-boot/components-starter/camel-xmlsecurity-starter/src/main/java/org/apache/camel/dataformat/xmlsecurity/springboot/XMLSecurityDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xmlsecurity-starter/src/main/java/org/apache/camel/dataformat/xmlsecurity/springboot/XMLSecurityDataFormatConfiguration.java
@@ -39,7 +39,7 @@ public class XMLSecurityDataFormatConfiguration
      * XMLCipher.SEED_128 XMLCipher.CAMELLIA_128 XMLCipher.CAMELLIA_192
      * XMLCipher.CAMELLIA_256 The default value is MLCipher.TRIPLEDES
      */
-    private String xmlCipherAlgorithm;
+    private String xmlCipherAlgorithm = "TRIPLEDES";
     /**
      * A String used as passPhrase to encrypt/decrypt content. The passPhrase
      * has to be provided. If no passPhrase is specified a default passPhrase is
@@ -66,7 +66,7 @@ public class XMLSecurityDataFormatConfiguration
      * XMLCipher.RSA_OAEP XMLCipher.RSA_OAEP_11 The default value is
      * XMLCipher.RSA_OAEP
      */
-    private String keyCipherAlgorithm;
+    private String keyCipherAlgorithm = "RSA_OAEP";
     /**
      * The key alias to be used when retrieving the recipient's public or
      * private key from a KeyStore when performing asymmetric key encryption or
@@ -89,14 +89,14 @@ public class XMLSecurityDataFormatConfiguration
      * choices are: XMLCipher.SHA1 XMLCipher.SHA256 XMLCipher.SHA512 The default
      * value is XMLCipher.SHA1
      */
-    private String digestAlgorithm;
+    private String digestAlgorithm = "SHA1";
     /**
      * The MGF Algorithm to use with the RSA OAEP algorithm. The available
      * choices are: EncryptionConstants.MGF1_SHA1
      * EncryptionConstants.MGF1_SHA256 EncryptionConstants.MGF1_SHA512 The
      * default value is EncryptionConstants.MGF1_SHA1
      */
-    private String mgfAlgorithm;
+    private String mgfAlgorithm = "MGF1_SHA1";
     /**
      * Whether to add the public key used to encrypt the session key as a
      * KeyValue in the EncryptedKey structure or not.

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpringBootAutoConfigurationMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpringBootAutoConfigurationMojo.java
@@ -1054,7 +1054,7 @@ public class SpringBootAutoConfigurationMojo extends AbstractMojo {
                 prop.getField().getJavaDoc().setFullText(option.getDescription());
             }
             if (!Strings.isBlank(option.getDefaultValue())) {
-                if ("java.lang.String".equals(option.getType())) {
+                if ("java.lang.String".equals(option.getJavaType())) {
                     prop.getField().setStringInitializer(option.getDefaultValue());
                 } else if ("long".equals(option.getJavaType()) || "java.lang.Long".equals(option.getJavaType())) {
                     // the value should be a Long number
@@ -1149,7 +1149,7 @@ public class SpringBootAutoConfigurationMojo extends AbstractMojo {
                 prop.getField().getJavaDoc().setFullText(option.getDescription());
             }
             if (!Strings.isBlank(option.getDefaultValue())) {
-                if ("java.lang.String".equals(option.getType())) {
+                if ("java.lang.String".equals(option.getJavaType())) {
                     prop.getField().setStringInitializer(option.getDefaultValue());
                 } else if ("long".equals(option.getJavaType()) || "java.lang.Long".equals(option.getJavaType())) {
                     // the value should be a Long number


### PR DESCRIPTION
@davsclaus, the problem was in type comparison, not in enum processing at all
Other code looks like working fine, but need to be reviewed for better understanding, join reusable methods, common type comparison and using constants (classes) instead of string values 