### PR TITLE
CAMEL-11188:Use Files.newFileInputStream instead of new FileInputStream

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -247,7 +247,7 @@ public class MethodInfo {
     public MethodInvocation createMethodInvocation(final Object pojo, boolean hasParameters, final Exchange exchange) {
         final Object[] arguments;
         if (hasParameters) {
-             arguments = parametersExpression.evaluate(exchange, Object[].class);
+            arguments = parametersExpression.evaluate(exchange, Object[].class);
         } else {
             arguments = null;
         }

--- a/camel-core/src/test/java/org/apache/camel/builder/xml/XsltBuilderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/xml/XsltBuilderTest.java
@@ -17,8 +17,9 @@
 package org.apache.camel.builder.xml;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
@@ -104,7 +105,7 @@ public class XsltBuilderTest extends ContextTestSupport {
     public void testXsltInputStream() throws Exception {
         File styleSheet = new File("src/test/resources/org/apache/camel/builder/xml/example.xsl");
 
-        XsltBuilder builder = XsltBuilder.xslt(new FileInputStream(styleSheet));
+        XsltBuilder builder = XsltBuilder.xslt(Files.newInputStream(Paths.get(styleSheet.getAbsolutePath())));
 
         Exchange exchange = new DefaultExchange(context);
         exchange.getIn().setBody("<hello>world!</hello>");
@@ -118,7 +119,7 @@ public class XsltBuilderTest extends ContextTestSupport {
         File styleSheet = new File("src/test/resources/org/apache/camel/builder/xml/example.xsl");
 
         XsltBuilder builder = new XsltBuilder();
-        builder.setTransformerInputStream(new FileInputStream(styleSheet));
+        builder.setTransformerInputStream(Files.newInputStream(Paths.get(styleSheet.getAbsolutePath())));
 
         Exchange exchange = new DefaultExchange(context);
         exchange.getIn().setBody("<hello>world!</hello>");
@@ -130,7 +131,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
     public void testXsltSource() throws Exception {
         File file = new File("src/test/resources/org/apache/camel/builder/xml/example.xsl");
-        Source styleSheet = new SAXSource(new InputSource(new FileInputStream(file)));
+        Source styleSheet = new SAXSource(new InputSource(Files.newInputStream(Paths.get(file.getAbsolutePath()))));
 
         XsltBuilder builder = XsltBuilder.xslt(styleSheet);
 
@@ -144,7 +145,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
     public void testXsltTemplates() throws Exception {
         File file = new File("src/test/resources/org/apache/camel/builder/xml/example.xsl");
-        Source source = new SAXSource(new InputSource(new FileInputStream(file)));
+        Source source = new SAXSource(new InputSource(Files.newInputStream(Paths.get(file.getAbsolutePath()))));
 
         XmlConverter converter = new XmlConverter();
         Templates styleSheet = converter.getTransformerFactory().newTemplates(source);

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
@@ -20,7 +20,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -48,7 +51,7 @@ public class FileProducerCharsetUTFOptimizedTest extends ContextTestSupport {
         }
 
         // write the byte array to a file using plain API
-        FileOutputStream fos = new FileOutputStream("target/charset/input/input.txt");
+        OutputStream fos = Files.newOutputStream(Paths.get("target/charset/input/input.txt"));
         fos.write(utf);
         fos.close();
 
@@ -61,7 +64,7 @@ public class FileProducerCharsetUTFOptimizedTest extends ContextTestSupport {
         File file = new File("target/charset/output.txt");
         assertTrue("File should exist", file.exists());
 
-        InputStream fis = IOHelper.buffered(new FileInputStream(file));
+        InputStream fis = Files.newInputStream(Paths.get(file.getAbsolutePath()));
         byte[] buffer = new byte[100];
 
         int len = fis.read(buffer);

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
@@ -17,14 +17,14 @@
 package org.apache.camel.component.file;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.util.IOHelper;
 
 /**
  *
@@ -54,7 +54,7 @@ public class FileProducerCharsetUTFtoISOConfiguredTest extends ContextTestSuppor
         }
 
         // write the byte array to a file using plain API
-        FileOutputStream fos = new FileOutputStream("target/charset/input/input.txt");
+        OutputStream fos = Files.newOutputStream(Paths.get("target/charset/input/input.txt"));
         fos.write(utf);
         fos.close();
 
@@ -67,7 +67,7 @@ public class FileProducerCharsetUTFtoISOConfiguredTest extends ContextTestSuppor
         File file = new File("target/charset/output.txt");
         assertTrue("File should exist", file.exists());
 
-        InputStream fis = IOHelper.buffered(new FileInputStream(file));
+        InputStream fis = Files.newInputStream(Paths.get(file.getAbsolutePath()));
         byte[] buffer = new byte[100];
 
         int len = fis.read(buffer);

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
@@ -20,7 +20,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -55,7 +58,7 @@ public class FileProducerCharsetUTFtoISOConvertBodyToTest extends ContextTestSup
         }
 
         // write the byte array to a file using plain API
-        FileOutputStream fos = new FileOutputStream("target/charset/input/input.txt");
+        OutputStream fos = Files.newOutputStream(Paths.get("target/charset/input/input.txt"));
         fos.write(utf);
         fos.close();
 
@@ -68,7 +71,7 @@ public class FileProducerCharsetUTFtoISOConvertBodyToTest extends ContextTestSup
         File file = new File("target/charset/output.txt");
         assertTrue("File should exist", file.exists());
 
-        InputStream fis = IOHelper.buffered(new FileInputStream(file));
+        InputStream fis = Files.newInputStream(Paths.get(file.getAbsolutePath()));
         byte[] buffer = new byte[100];
 
         int len = fis.read(buffer);

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOTest.java
@@ -20,7 +20,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -54,7 +57,7 @@ public class FileProducerCharsetUTFtoISOTest extends ContextTestSupport {
         }
 
         // write the byte array to a file using plain API
-        FileOutputStream fos = new FileOutputStream("target/charset/input/input.txt");
+        OutputStream fos = Files.newOutputStream(Paths.get("target/charset/input/input.txt"));
         fos.write(utf);
         fos.close();
 
@@ -67,7 +70,7 @@ public class FileProducerCharsetUTFtoISOTest extends ContextTestSupport {
         File file = new File("target/charset/output.txt");
         assertTrue("File should exist", file.exists());
 
-        InputStream fis = IOHelper.buffered(new FileInputStream(file));
+        InputStream fis = Files.newInputStream(Paths.get(file.getAbsolutePath()));
         byte[] buffer = new byte[100];
 
         int len = fis.read(buffer);

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
@@ -17,14 +17,14 @@
 package org.apache.camel.component.file;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.util.IOHelper;
 
 /**
  *
@@ -48,7 +48,7 @@ public class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
         }
 
         // write the byte array to a file using plain API
-        FileOutputStream fos = new FileOutputStream("target/charset/input/input.txt");
+        OutputStream fos = Files.newOutputStream(Paths.get("target/charset/input/input.txt"));
         fos.write(utf);
         fos.close();
 
@@ -61,7 +61,7 @@ public class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
         File file = new File("target/charset/output.txt");
         assertTrue("File should exist", file.exists());
 
-        InputStream fis = IOHelper.buffered(new FileInputStream(file));
+        InputStream fis = Files.newInputStream(Paths.get(file.getAbsolutePath()));
         byte[] buffer = new byte[100];
 
         int len = fis.read(buffer);

--- a/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorBeanCallTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorBeanCallTest.java
@@ -18,7 +18,10 @@ package org.apache.camel.component.validator;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -71,8 +74,8 @@ public class ValidatorBeanCallTest extends ContextTestSupport {
 
     public static class MyValidatorBean {
 
-        public InputStream loadFile() throws FileNotFoundException {
-            return new FileInputStream("src/test/resources/report.xsd");
+        public InputStream loadFile() throws Exception {
+            return Files.newInputStream(Paths.get("src/test/resources/report.xsd"));
         }
 
     }

--- a/camel-core/src/test/java/org/apache/camel/converter/IOConverterCharsetTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/IOConverterCharsetTest.java
@@ -18,11 +18,12 @@ package org.apache.camel.converter;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 
 import org.apache.camel.ContextTestSupport;
@@ -35,7 +36,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
         File file = new File("src/test/resources/org/apache/camel/converter/german.utf-8.txt");
         try (InputStream in = IOConverter.toInputStream(file, "UTF-8");
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8)); 
-        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(file.getAbsolutePath())), StandardCharsets.UTF_8))) {
             String line = reader.readLine();
             String naiveLine = naiveReader.readLine();
             assertEquals(naiveLine, line);
@@ -48,7 +49,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
         File file = new File("src/test/resources/org/apache/camel/converter/german.utf-8.txt");
         try (InputStream in = IOConverter.toInputStream(file, "UTF-8");
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.ISO_8859_1));
-        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(file.getAbsolutePath())), StandardCharsets.UTF_8))) {
             String line = reader.readLine();
             String naiveLine = naiveReader.readLine();
             assertEquals(naiveLine, line);
@@ -61,7 +62,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
         File file = new File("src/test/resources/org/apache/camel/converter/german.iso-8859-1.txt");
         try (InputStream in = IOConverter.toInputStream(file, "ISO-8859-1");
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
-        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "ISO-8859-1"))) {
+        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(file.getAbsolutePath())), "ISO-8859-1"))) {
             String line = reader.readLine();
             String naiveLine = naiveReader.readLine();
             assertEquals(naiveLine, line);
@@ -73,7 +74,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
         switchToDefaultCharset(StandardCharsets.UTF_8);
         File file = new File("src/test/resources/org/apache/camel/converter/german.iso-8859-1.txt");
         try (InputStream in = IOConverter.toInputStream(file, "ISO-8859-1");
-        InputStream naiveIn = new FileInputStream(file)) {
+        InputStream naiveIn = Files.newInputStream(Paths.get(file.getAbsolutePath()))) {
             byte[] bytes = new byte[8192];
             in.read(bytes);
             byte[] naiveBytes = new byte[8192];
@@ -85,7 +86,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
     public void testToReaderFileWithCharsetUTF8() throws Exception {
         File file = new File("src/test/resources/org/apache/camel/converter/german.utf-8.txt");
         try (BufferedReader reader = IOConverter.toReader(file, "UTF-8");
-        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(file.getAbsolutePath())), StandardCharsets.UTF_8))) {
             String line = reader.readLine();
             String naiveLine = naiveReader.readLine();
             assertEquals(naiveLine, line);
@@ -96,7 +97,7 @@ public class IOConverterCharsetTest extends ContextTestSupport {
     public void testToReaderFileWithCharsetLatin1() throws Exception {
         File file = new File("src/test/resources/org/apache/camel/converter/german.iso-8859-1.txt");
         try (BufferedReader reader = IOConverter.toReader(file, "ISO-8859-1");
-        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "ISO-8859-1"))) {
+        BufferedReader naiveReader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(file.getAbsolutePath())), "ISO-8859-1"))) {
             String line = reader.readLine();
             String naiveLine = naiveReader.readLine();
             assertEquals(naiveLine, line);

--- a/camel-core/src/test/java/org/apache/camel/converter/IOConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/IOConverterTest.java
@@ -30,6 +30,8 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.apache.camel.ContextTestSupport;
@@ -47,7 +49,7 @@ public class IOConverterTest extends ContextTestSupport {
 
     public void testToBytes() throws Exception {
         File file = new File("src/test/resources/org/apache/camel/converter/dummy.txt");
-        byte[] data = IOConverter.toBytes(new FileInputStream(file));
+        byte[] data = IOConverter.toBytes(Files.newInputStream(Paths.get(file.getAbsolutePath())));
         assertEquals("get the wrong byte size", file.length(), data.length);
         assertEquals('#', (char) data[0]);
 

--- a/camel-core/src/test/java/org/apache/camel/util/IOHelperTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/IOHelperTest.java
@@ -19,14 +19,15 @@ package org.apache.camel.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import junit.framework.TestCase;
-import org.apache.camel.CamelContext;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
@@ -90,7 +91,7 @@ public class IOHelperTest extends TestCase {
     private void assertReadAsWritten(String testname, String text, String compareText) throws Exception {
         File file = tempFile(testname);
         write(file, text);
-        String loadText = IOHelper.loadText(new FileInputStream(file));
+        String loadText = IOHelper.loadText(Files.newInputStream(Paths.get(file.getAbsolutePath())));
         assertEquals(compareText, loadText);
     }
 

--- a/camel-core/src/test/java/org/apache/camel/util/XmlLineNumberParserTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/XmlLineNumberParserTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.util;
 
-import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -27,7 +29,7 @@ import junit.framework.TestCase;
 public class XmlLineNumberParserTest extends TestCase {
 
     public void testParse() throws Exception {
-        FileInputStream fis = new FileInputStream("src/test/resources/org/apache/camel/util/camel-context.xml");
+        InputStream fis = Files.newInputStream(Paths.get("src/test/resources/org/apache/camel/util/camel-context.xml"));
         Document dom = XmlLineNumberParser.parseXml(fis);
         assertNotNull(dom);
 
@@ -43,7 +45,7 @@ public class XmlLineNumberParserTest extends TestCase {
     }
 
     public void testParseCamelContext() throws Exception {
-        FileInputStream fis = new FileInputStream("src/test/resources/org/apache/camel/util/camel-context.xml");
+        InputStream fis = Files.newInputStream(Paths.get("src/test/resources/org/apache/camel/util/camel-context.xml"));
         Document dom = XmlLineNumberParser.parseXml(fis, null, "camelContext", null);
         assertNotNull(dom);
 
@@ -59,7 +61,7 @@ public class XmlLineNumberParserTest extends TestCase {
     }
 
     public void testParseCamelContextForceNamespace() throws Exception {
-        FileInputStream fis = new FileInputStream("src/test/resources/org/apache/camel/util/camel-context.xml");
+        InputStream fis = Files.newInputStream(Paths.get("src/test/resources/org/apache/camel/util/camel-context.xml"));
         Document dom = XmlLineNumberParser.parseXml(fis, null, "camelContext", "http://camel.apache.org/schema/spring");
         assertNotNull(dom);
 


### PR DESCRIPTION
[CAMEL-11188]  Updated To Files.newFileInputStream from new FileInputStream  for all Test classes