### PR TITLE
Prevent crash when route IDs contain dollar signs

### DIFF
--- a/components/camel-metrics/src/main/java/org/apache/camel/component/metrics/routepolicy/MetricsRoutePolicy.java
+++ b/components/camel-metrics/src/main/java/org/apache/camel/component/metrics/routepolicy/MetricsRoutePolicy.java
@@ -171,7 +171,7 @@ public class MetricsRoutePolicy extends RoutePolicySupport implements NonManaged
 
         String answer = namePattern;
         answer = answer.replaceFirst("##name##", name);
-        answer = answer.replaceFirst("##routeId##", route.getId());
+        answer = answer.replaceFirst("##routeId##", java.util.regex.Matcher.quoteReplacement(route.getId()));
         answer = answer.replaceFirst("##type##", type);
         return answer;
     }


### PR DESCRIPTION
Spring Boot configured route get names like `UpdateRelationCamelRoute$$EnhancerBySpringCGLIB$$24c87b04`. The dollar signs are interpreted as group references since the `java.lang.String#replaceFirst()` method works with regular expressions. An alternative to the proposed change is to use the `java.lang.String#replace()` method, assuming users of `MetricsRoutePolicy` don't put the `##routeId##` token multiple places in the name pattern and really want to keep all but the first literal occurrence.