### PR TITLE
CAMEL-11382 - Creating IgniteComponent from Ignite Instance throws IllegalStateException

### DIFF
--- a/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/AbstractIgniteComponent.java
+++ b/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/AbstractIgniteComponent.java
@@ -17,22 +17,9 @@
 package org.apache.camel.component.ignite;
 
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Map;
-
-import org.apache.camel.Endpoint;
-import org.apache.camel.component.ignite.cache.IgniteCacheEndpoint;
-import org.apache.camel.component.ignite.compute.IgniteComputeEndpoint;
-import org.apache.camel.component.ignite.events.IgniteEventsEndpoint;
-import org.apache.camel.component.ignite.idgen.IgniteIdGenEndpoint;
-import org.apache.camel.component.ignite.messaging.IgniteMessagingEndpoint;
-import org.apache.camel.component.ignite.queue.IgniteQueueEndpoint;
-import org.apache.camel.component.ignite.set.IgniteSetEndpoint;
 import org.apache.camel.impl.DefaultComponent;
-import org.apache.camel.util.ObjectHelper;
-import org.apache.camel.util.URISupport;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
@@ -121,6 +108,7 @@ public abstract class AbstractIgniteComponent extends DefaultComponent {
      */
     public void setIgnite(Ignite ignite) {
         this.ignite = ignite;
+        lifecycleMode = IgniteLifecycleMode.USER_MANAGED;
     }
 
     /**

--- a/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
+++ b/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
@@ -38,8 +38,8 @@ public class IgniteCreationTest extends AbstractIgniteTest {
     }
 
     @Test
-    public void testCAMEL_11382() {
-       assertNotNull(ignite());
+    public void testCAMEL11382() {
+        assertNotNull(ignite());
     }
 
     @Override
@@ -48,8 +48,8 @@ public class IgniteCreationTest extends AbstractIgniteTest {
     }
     
     @After
-    public void stopUserManagedIgnite(){
-        if (ignite != null){
+    public void stopUserManagedIgnite() {
+        if (ignite != null) {
             Ignition.stop(ignite.name(), true);
         }
     }

--- a/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
+++ b/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ignite;
+
+import org.apache.camel.component.ignite.cache.IgniteCacheComponent;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.junit.Test;
+
+public class IgniteCreationTest extends AbstractIgniteTest {
+
+    @Override
+    protected String getScheme() {
+        return "ignite-cache";
+    }
+
+    @Override
+    protected AbstractIgniteComponent createComponent() {
+        Ignite ignite = Ignition.start(createConfiguration());
+        return IgniteCacheComponent.fromIgnite(ignite);
+    }
+
+    @Test
+    public void testCAMEL_11382() {
+       assertNotNull(ignite());
+    }
+
+    @Override
+    public boolean isCreateCamelContextPerClass() {
+        return true;
+    }
+
+}

--- a/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
+++ b/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCreationTest.java
@@ -19,9 +19,12 @@ package org.apache.camel.component.ignite;
 import org.apache.camel.component.ignite.cache.IgniteCacheComponent;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.Ignition;
+import org.junit.After;
 import org.junit.Test;
 
 public class IgniteCreationTest extends AbstractIgniteTest {
+    
+    private Ignite ignite;
 
     @Override
     protected String getScheme() {
@@ -30,7 +33,7 @@ public class IgniteCreationTest extends AbstractIgniteTest {
 
     @Override
     protected AbstractIgniteComponent createComponent() {
-        Ignite ignite = Ignition.start(createConfiguration());
+        ignite = Ignition.start(createConfiguration());
         return IgniteCacheComponent.fromIgnite(ignite);
     }
 
@@ -42,6 +45,13 @@ public class IgniteCreationTest extends AbstractIgniteTest {
     @Override
     public boolean isCreateCamelContextPerClass() {
         return true;
+    }
+    
+    @After
+    public void stopUserManagedIgnite(){
+        if (ignite != null){
+            Ignition.stop(ignite.name(), true);
+        }
     }
 
 }


### PR DESCRIPTION
Creating an IgniteComponent from configuration works fine, but when I try and create one from an existing Ignite instance it throws an IllegalStateException when starting the component: "No configuration resource or IgniteConfiguration was provided to the Ignite component."

Looking at the code it appears the lifecycleMode is ignored as it is only set to COMPONENT_MANAGED and cannot be altered outside of the class.