### PR TITLE
CAMEL-11392: String to ByteBuffer conversion causes overflow due to multibyte chars

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/converter/NIOConverter.java
+++ b/camel-core/src/main/java/org/apache/camel/converter/NIOConverter.java
@@ -84,7 +84,6 @@ public final class NIOConverter {
 
     @Converter
     public static ByteBuffer toByteBuffer(String value, Exchange exchange) {
-        ByteBuffer buf = ByteBuffer.allocate(value.length());
         byte[] bytes = null;
         if (exchange != null) {
             String charsetName = exchange.getProperty(Exchange.CHARSET_NAME, String.class);
@@ -99,9 +98,7 @@ public final class NIOConverter {
         if (bytes == null) {
             bytes = value.getBytes();
         }
-        buf.put(bytes);
-        buf.flip();
-        return buf;
+        return ByteBuffer.wrap(bytes);
     }
 
     @Converter


### PR DESCRIPTION
The NIOConverter uses String.length() to allocate a ByteBuffer which may not match the actual encoded byte length if the String contains multibyte chars.
