### PR TITLE
CAMEL-11394: REUSE_ADDRESSES options is set using the value for TCP_NO_DELAY intea…

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -367,7 +367,7 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
         if (reuseAddresses != null && !optionMap.contains(Options.REUSE_ADDRESSES)) {
             // rebuild map
             OptionMap.Builder builder = OptionMap.builder();
-            builder.addAll(optionMap).set(Options.REUSE_ADDRESSES, tcpNoDelay);
+            builder.addAll(optionMap).set(Options.REUSE_ADDRESSES, reuseAddresses);
             optionMap = builder.getMap();
         }
     }


### PR DESCRIPTION
The undertow endpoint configuration for the REUSE_ADDRESS option is set using the option value for TCP_NO_DELAY instead of the value for REUSE_ADDRESS.

This makes it impossible to configure it separately from value for the tcpNoDelay.