### PR TITLE
CAMEL-11275 FileWatcherReloadStrategy watches sub directories as well if isRecursive is true

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/FileWatcherReloadStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/FileWatcherReloadStrategy.java
@@ -19,11 +19,17 @@ package org.apache.camel.impl;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -49,23 +55,41 @@ import org.apache.camel.util.ObjectHelper;
 public class FileWatcherReloadStrategy extends ReloadStrategySupport {
 
     private String folder;
+    private boolean isRecursive;
     private ExecutorService executorService;
     private WatchFileChangesTask task;
+    private Map<WatchKey, Path> folderKeys;
 
     public FileWatcherReloadStrategy() {
+        setRecursive(false);
     }
 
     public FileWatcherReloadStrategy(String directory) {
         setFolder(directory);
+        setRecursive(false);
+    }
+    
+    public FileWatcherReloadStrategy(String directory, boolean isRecursive) {
+        setFolder(directory);
+        setRecursive(isRecursive);
     }
 
     public void setFolder(String folder) {
         this.folder = folder;
     }
+    
+    public void setRecursive(boolean isRecursive) {
+        this.isRecursive = isRecursive;
+    }
 
     @ManagedAttribute(description = "Folder being watched")
     public String getFolder() {
         return folder;
+    }
+    
+    @ManagedAttribute(description = "Whether the reload strategy watches directory recursively")
+    public boolean isRecursive() {
+        return isRecursive;
     }
 
     @ManagedAttribute(description = "Whether the watcher is running")
@@ -113,11 +137,12 @@ public class FileWatcherReloadStrategy extends ReloadStrategySupport {
                 Path path = dir.toPath();
                 WatchService watcher = path.getFileSystem().newWatchService();
                 // we cannot support deleting files as we don't know which routes that would be
-                if (modifier != null) {
-                    path.register(watcher, new WatchEvent.Kind<?>[]{ENTRY_CREATE, ENTRY_MODIFY}, modifier);
+                if (isRecursive) {
+                    this.folderKeys = new HashMap<WatchKey, Path>();
+                    registerRecursive(watcher, path, modifier);
                 } else {
-                    path.register(watcher, ENTRY_CREATE, ENTRY_MODIFY);
-                }
+                    registerPathToWatcher(modifier, path, watcher);
+                }                
 
                 task = new WatchFileChangesTask(watcher, path);
 
@@ -127,6 +152,27 @@ public class FileWatcherReloadStrategy extends ReloadStrategySupport {
                 throw ObjectHelper.wrapRuntimeCamelException(e);
             }
         }
+    }
+
+    private WatchKey registerPathToWatcher(WatchEvent.Modifier modifier, Path path, WatchService watcher) throws IOException {
+        WatchKey key;
+        if (modifier != null) {
+            key = path.register(watcher, new WatchEvent.Kind<?>[]{ENTRY_CREATE, ENTRY_MODIFY}, modifier);
+        } else {
+            key = path.register(watcher, ENTRY_CREATE, ENTRY_MODIFY);
+        }
+        return key;
+    }
+    
+    private void registerRecursive(final WatchService watcher, final Path root, final WatchEvent.Modifier modifier) throws IOException {
+        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                WatchKey key = registerPathToWatcher(modifier, dir, watcher);
+                folderKeys.put(key, dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     @Override
@@ -174,10 +220,17 @@ public class FileWatcherReloadStrategy extends ReloadStrategySupport {
                 }
 
                 if (key != null) {
+                    Path pathToReload = null;
+                    if (isRecursive) {
+                        pathToReload = folderKeys.get(key);
+                    } else {
+                        pathToReload = folder;
+                    }
+                    
                     for (WatchEvent<?> event : key.pollEvents()) {
                         WatchEvent<Path> we = (WatchEvent<Path>) event;
                         Path path = we.context();
-                        String name = folder.resolve(path).toAbsolutePath().toFile().getAbsolutePath();
+                        String name = pathToReload.resolve(path).toAbsolutePath().toFile().getAbsolutePath();
                         log.trace("Modified/Created file: {}", name);
 
                         // must be an .xml file

--- a/camel-core/src/main/java/org/apache/camel/main/MainSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/main/MainSupport.java
@@ -63,6 +63,7 @@ public abstract class MainSupport extends ServiceSupport {
     protected List<RouteBuilder> routeBuilders = new ArrayList<RouteBuilder>();
     protected String routeBuilderClasses;
     protected String fileWatchDirectory;
+    protected boolean fileWatchDirectoryRecursively;
     protected final List<CamelContext> camelContexts = new ArrayList<CamelContext>();
     protected ProducerTemplate camelTemplate;
     protected boolean hangupInterceptorEnabled = true;
@@ -411,6 +412,19 @@ public abstract class MainSupport extends ServiceSupport {
     public void setFileWatchDirectory(String fileWatchDirectory) {
         this.fileWatchDirectory = fileWatchDirectory;
     }
+    
+    public boolean isFileWatchDirectoryRecursively() {
+        return fileWatchDirectoryRecursively;
+    }
+    
+    /**
+     * Sets the flag to watch directory of XML file changes recursively to trigger live reload of Camel routes.
+     * <p/>
+     * Notice you cannot set this value and a custom {@link ReloadStrategy} as well.
+     */
+    public void setFileWatchDirectoryRecursively(boolean fileWatchDirectoryRecursively) {
+        this.fileWatchDirectoryRecursively = fileWatchDirectoryRecursively;
+    }
 
     public String getRouteBuilderClasses() {
         return routeBuilderClasses;
@@ -553,7 +567,7 @@ public abstract class MainSupport extends ServiceSupport {
             camelContext.setTracing(true);
         }
         if (fileWatchDirectory != null) {
-            ReloadStrategy reload = new FileWatcherReloadStrategy(fileWatchDirectory);
+            ReloadStrategy reload = new FileWatcherReloadStrategy(fileWatchDirectory, fileWatchDirectoryRecursively);
             camelContext.setReloadStrategy(reload);
             // ensure reload is added as service and started
             camelContext.addService(reload);

--- a/examples/camel-example-reload/src/main/java/org/apache/camel/example/reload/CamelReloadRecursivelyMain.java
+++ b/examples/camel-example-reload/src/main/java/org/apache/camel/example/reload/CamelReloadRecursivelyMain.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.reload;
+
+import org.apache.camel.spring.Main;
+
+/**
+ * A main class to run the example from your editor.
+ */
+public final class CamelReloadRecursivelyMain {
+
+    private CamelReloadRecursivelyMain() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Main makes it easier to run a Spring application
+        Main main = new Main();
+        // configure the location of the Spring XML file
+        main.setApplicationContextUri("META-INF/spring/camel-context.xml");
+        // turn on reload when the XML file is updated in the source code
+        main.setFileWatchDirectory("src/main/resources/META-INF/spring");
+        main.setFileWatchDirectoryRecursively(true);
+        // run and block until Camel is stopped (or JVM terminated)
+        main.run();
+    }
+}

--- a/examples/camel-example-reload/src/main/resources/META-INF/spring/bar/barContext.xml
+++ b/examples/camel-example-reload/src/main/resources/META-INF/spring/bar/barContext.xml
@@ -1,0 +1,19 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+ 
+    <!-- this is an included XML file where we only the the routeContext -->
+    <routeContext id="barContext" xmlns="http://camel.apache.org/schema/spring">
+        <route id="bar">
+        	<from uri="direct:bar"/>
+        	<transform>
+		        <!-- and I can be changed too -->
+		        <constant>Hello Bar!</constant>
+		    </transform>
+    	</route>
+    </routeContext>
+ 
+</beans>

--- a/examples/camel-example-reload/src/main/resources/META-INF/spring/camel-context.xml
+++ b/examples/camel-example-reload/src/main/resources/META-INF/spring/camel-context.xml
@@ -26,20 +26,31 @@
   <!-- notice Camel will only update the routes that has been changed, so you can edit either either route or both
        and save the file, and Camel will update only what is required -->
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring">
+  <import resource="bar/barContext.xml"/>
 
-    <route id="timer">
+  <camelContext xmlns="http://camel.apache.org/schema/spring">
+  
+  	<routeContextRef ref="barContext"/>
+
+    <route id="timerFoo">
       <from uri="timer:foo"/>
       <to uri="direct:foo"/>
       <!-- you can try changing me -->
-      <log message="You said: ${body}"/>
+      <log message="Foo said: ${body}"/>
+    </route>
+    
+    <route id="timerBar">
+      <from uri="timer:bar"/>
+      <to uri="direct:bar"/>
+      <!-- you can try changing me -->
+      <log message="Bar said: ${body}"/>
     </route>
 
     <route id="foo">
       <from uri="direct:foo"/>
       <transform>
         <!-- and I can be changed too -->
-        <constant>Hello World</constant>
+        <constant>Hello Foo!</constant>
       </transform>
     </route>
 


### PR DESCRIPTION
FileWatcherReloadStrategy will watch sub-directories for a given path. This implementation will help if you have xml based routes configuration and for a given camelContext and if you have routeContexts imported and those imported xml routes are part of subdirectory of the camelContext. (see camel-example-reload)

isRecursive flag is defaulted to be false to avoid potential Shutdown problems if you have multiple xml route configurations and none are imported and somehow they are nested under the same path.