### PR TITLE
CAMEL-11398: Google components should throw more friendly exception when the required credentials lack

### DIFF
--- a/components/camel-google-calendar/pom.xml
+++ b/components/camel-google-calendar/pom.xml
@@ -261,7 +261,7 @@
               <childDelegation>false</childDelegation>
               <useFile>true</useFile>
               <forkCount>1</forkCount>
-	      <reuseForks>true</reuseForks>
+              <reuseForks>true</reuseForks>
               <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
               <excludes>
                 <exclude>**/*XXXTest.java</exclude>

--- a/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/BatchGoogleCalendarClientFactory.java
+++ b/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/BatchGoogleCalendarClientFactory.java
@@ -26,6 +26,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.calendar.Calendar;
+import org.apache.camel.RuntimeCamelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,18 @@ public class BatchGoogleCalendarClientFactory implements GoogleCalendarClientFac
     public Calendar makeClient(String clientId, String clientSecret,
                                Collection<String> scopes, String applicationName, String refreshToken,
                                String accessToken, String emailAddress, String p12FileName, String user) {
+        boolean serviceAccount = false;
+        // if emailAddress and p12FileName values are present, assume Google Service Account
+        if (null != emailAddress && !"".equals(emailAddress) && null != p12FileName && !"".equals(p12FileName)) {
+            serviceAccount = true;
+        }
+        if (!serviceAccount && (clientId == null || clientSecret == null)) {
+            throw new IllegalArgumentException("clientId and clientSecret are required to create Google Calendar client.");
+        }
 
-        Credential credential;
         try {
-            // if emailAddress and p12FileName values are present, assume Google Service Account
-            if (null != emailAddress && !"".equals(emailAddress) && null != p12FileName && !"".equals(p12FileName)) {
+            Credential credential;
+            if (serviceAccount) {
                 credential = authorizeServiceAccount(emailAddress, p12FileName, scopes, user);
             } else {
                 credential = authorize(clientId, clientSecret, scopes);
@@ -61,9 +69,8 @@ public class BatchGoogleCalendarClientFactory implements GoogleCalendarClientFac
             }
             return new Calendar.Builder(transport, jsonFactory, credential).setApplicationName(applicationName).build();
         } catch (Exception e) {
-            LOG.error("Could not create Google Drive client.", e);
+            throw new RuntimeCamelException("Could not create Google Calendar client.", e);
         }
-        return null;
     }
 
     // Authorizes the installed application to access user's protected data.

--- a/components/camel-google-drive/pom.xml
+++ b/components/camel-google-drive/pom.xml
@@ -286,7 +286,7 @@
               <childDelegation>false</childDelegation>
               <useFile>true</useFile>
               <forkCount>1</forkCount>
-	      <reuseForks>true</reuseForks>
+              <reuseForks>true</reuseForks>
               <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
               <excludes>
                 <exclude>**/*XXXTest.java</exclude>

--- a/components/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/BatchGoogleDriveClientFactory.java
+++ b/components/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/BatchGoogleDriveClientFactory.java
@@ -24,6 +24,7 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.drive.Drive;
 
+import org.apache.camel.RuntimeCamelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +40,11 @@ public class BatchGoogleDriveClientFactory implements GoogleDriveClientFactory {
 
     @Override
     public Drive makeClient(String clientId, String clientSecret, Collection<String> scopes, String applicationName, String refreshToken, String accessToken) {
-        Credential credential;
+        if (clientId == null || clientSecret == null) {
+            throw new IllegalArgumentException("clientId and clientSecret are required to create Google Drive client.");
+        }
         try {
-            credential = authorize(clientId, clientSecret, scopes);
+            Credential credential = authorize(clientId, clientSecret, scopes);
 
             if (refreshToken != null && !"".equals(refreshToken)) {
                 credential.setRefreshToken(refreshToken);
@@ -51,9 +54,8 @@ public class BatchGoogleDriveClientFactory implements GoogleDriveClientFactory {
             }
             return new Drive.Builder(transport, jsonFactory, credential).setApplicationName(applicationName).build();
         } catch (Exception e) {
-            LOG.error("Could not create Google Drive client.", e);            
+            throw new RuntimeCamelException("Could not create Google Drive client.", e);
         }
-        return null;
     }
     
     // Authorizes the installed application to access user's protected data.

--- a/components/camel-google-mail/pom.xml
+++ b/components/camel-google-mail/pom.xml
@@ -298,7 +298,7 @@
               <childDelegation>false</childDelegation>
               <useFile>true</useFile>
               <forkCount>1</forkCount>
-          <reuseForks>true</reuseForks>
+              <reuseForks>true</reuseForks>
               <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
               <excludes>
                 <exclude>**/*XXXTest.java</exclude>

--- a/components/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/BatchGoogleMailClientFactory.java
+++ b/components/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/BatchGoogleMailClientFactory.java
@@ -24,6 +24,7 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.gmail.Gmail;
 
+import org.apache.camel.RuntimeCamelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +40,11 @@ public class BatchGoogleMailClientFactory implements GoogleMailClientFactory {
 
     @Override
     public Gmail makeClient(String clientId, String clientSecret, Collection<String> scopes, String applicationName, String refreshToken, String accessToken) {
-        Credential credential;
+        if (clientId == null || clientSecret == null) {
+            throw new IllegalArgumentException("clientId and clientSecret are required to create Gmail client.");
+        }
         try {
-            credential = authorize(clientId, clientSecret, scopes);
+            Credential credential = authorize(clientId, clientSecret, scopes);
 
             if (refreshToken != null && !"".equals(refreshToken)) {
                 credential.setRefreshToken(refreshToken);
@@ -51,9 +54,8 @@ public class BatchGoogleMailClientFactory implements GoogleMailClientFactory {
             }
             return new Gmail.Builder(transport, jsonFactory, credential).setApplicationName(applicationName).build();
         } catch (Exception e) {
-            LOG.error("Could not create Google Drive client.", e);
+            throw new RuntimeCamelException("Could not create Gmail client.", e);
         }
-        return null;
     }
 
     // Authorizes the installed application to access user's protected data.

--- a/components/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/GmailConfigurationTest.java
+++ b/components/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/GmailConfigurationTest.java
@@ -26,8 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test class for {@link com.google.api.services.gmail.Gmail$Users$Messages}
- * APIs.
+ * Test class for {@link GoogleMailConfiguration}.
  */
 public class GmailConfigurationTest extends AbstractGoogleMailTestSupport {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-11398