### PR TITLE
HazelcastSedaConsumer stopped unexpectedly

### DIFF
--- a/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
@@ -39,7 +39,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (9 parameters):
+#### Query Parameters (10 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -50,6 +50,7 @@ with the following path and query parameters:
 | **hazelcastInstanceName** (producer) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
@@ -38,7 +38,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -52,6 +52,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
@@ -34,7 +34,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -48,6 +48,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
@@ -35,7 +35,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -49,6 +49,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
@@ -36,7 +36,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -50,6 +50,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
@@ -35,7 +35,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -49,6 +49,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
@@ -36,7 +36,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -50,6 +50,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
@@ -38,7 +38,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (9 parameters):
+#### Query Parameters (10 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -49,6 +49,7 @@ with the following path and query parameters:
 | **hazelcastInstanceName** (producer) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
@@ -36,7 +36,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -50,6 +50,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
@@ -35,7 +35,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -49,6 +49,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
@@ -35,7 +35,7 @@ with the following path and query parameters:
 | **cacheName** | *Required* The name of the cache |  | String
 |=======================================================================
 
-#### Query Parameters (12 parameters):
+#### Query Parameters (13 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
@@ -49,6 +49,7 @@ with the following path and query parameters:
 | **exchangePattern** (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | **concurrentConsumers** (seda) | To use concurrent consumers polling from the SEDA queue. | 1 | int
+| **onErrorDelay** (seda) | Milliseconds before consumer continues polling after an error has occurred. | 1000 | int
 | **pollTimeout** (seda) | The timeout used when consuming from the SEDA queue. When a timeout occurs the consumer can check whether it is allowed to continue running. Setting a lower value allows the consumer to react more quickly upon shutdown. | 1000 | int
 | **transacted** (seda) | If set to true then the consumer runs in transaction mode where the messages in the seda queue will only be removed if the transaction commits which happens when the processing is complete. | false | boolean
 | **transferExchange** (seda) | If set to true the whole Exchange will be transfered. If header or body contains not serializable objects they will be skipped. | false | boolean

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConfiguration.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConfiguration.java
@@ -32,6 +32,8 @@ public class HazelcastSedaConfiguration {
     private int concurrentConsumers = 1;
     @UriParam(label = "seda", defaultValue = "1000")
     private int pollTimeout = 1000;
+    @UriParam(label = "seda", defaultValue = "1000")
+    private int onErrorDelay = 1000;
     @UriParam(label = "seda")
     private boolean transferExchange;
     @UriParam(label = "seda")
@@ -89,6 +91,20 @@ public class HazelcastSedaConfiguration {
 
     public boolean isTransferExchange() {
         return transferExchange;
+    }
+
+    /**
+     * Milliseconds before consumer continues polling after an error has occurred.
+     */
+    public void setOnErrorDelay(int onErrorDelay) {
+        if (onErrorDelay < 0) {
+            throw new IllegalArgumentException("Property onErrorDelay must be a positive number, was " + onErrorDelay);
+        }
+        this.onErrorDelay = onErrorDelay;
+    }
+
+    public int getOnErrorDelay() {
+        return onErrorDelay;
     }
 
     /**

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
@@ -142,7 +142,7 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
                 }
                 getExceptionHandler().handleException("Error processing exchange", exchange, e);
                 try {
-                    Thread.sleep(100);
+                    Thread.sleep(endpoint.getConfiguration().getOnErrorDelay());
                 } catch (InterruptedException ignore) {
                 }
             }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
@@ -77,16 +77,17 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
             final Exchange exchange = this.getEndpoint().createExchange();
 
             TransactionContext transactionCtx = null;
-            if (endpoint.getConfiguration().isTransacted()) {
-                // Get and begin transaction if exist
-                transactionCtx = endpoint.getHazelcastInstance().newTransactionContext();
-
-                if (transactionCtx != null) {
-                    log.trace("Begin transaction: {}", transactionCtx.getTxnId());
-                    transactionCtx.beginTransaction();
-                }
-            }
             try {
+                if (endpoint.getConfiguration().isTransacted()) {
+                    // Get and begin transaction if exist
+                    transactionCtx = endpoint.getHazelcastInstance().newTransactionContext();
+
+                    if (transactionCtx != null) {
+                        log.trace("Begin transaction: {}", transactionCtx.getTxnId());
+                        transactionCtx.beginTransaction();
+                    }
+                }
+
                 final Object body = queue.poll(endpoint.getConfiguration().getPollTimeout(), TimeUnit.MILLISECONDS);
 
                 if (body != null) {
@@ -134,9 +135,16 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
                 // Rollback
                 if (transactionCtx != null) {
                     log.trace("Rollback transaction: {}", transactionCtx.getTxnId());
-                    transactionCtx.rollbackTransaction();
+                    try {
+                        transactionCtx.rollbackTransaction();
+                    } catch (Throwable ignore) {
+                    }
                 }
                 getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignore) {
+                }
             }
         }
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaConfigurationTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaConfigurationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.component.hazelcast.seda.HazelcastSedaEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
@@ -42,6 +43,7 @@ public class HazelcastSedaConfigurationTest extends CamelTestSupport {
         assertEquals("Invalid queue name", "foo", hzlqEndpoint.getConfiguration().getQueueName());
         assertEquals("Default value of concurrent consumers is invalid", 1, hzlqEndpoint.getConfiguration().getConcurrentConsumers());
         assertEquals("Default value of pool timeout is invalid", 1000, hzlqEndpoint.getConfiguration().getPollTimeout());
+        assertEquals("Default value of on error delay is invalid", 1000, hzlqEndpoint.getConfiguration().getOnErrorDelay());
     }
 
     @Test
@@ -51,6 +53,7 @@ public class HazelcastSedaConfigurationTest extends CamelTestSupport {
         assertEquals("Invalid queue name", "foo", hzlqEndpoint.getConfiguration().getQueueName());
         assertEquals("Value of concurrent consumers is invalid", 4, hzlqEndpoint.getConfiguration().getConcurrentConsumers());
         assertEquals("Default value of pool timeout is invalid", 1000, hzlqEndpoint.getConfiguration().getPollTimeout());
+        assertEquals("Default value of on error delay is invalid", 1000, hzlqEndpoint.getConfiguration().getOnErrorDelay());
     }
 
     @Test
@@ -60,6 +63,27 @@ public class HazelcastSedaConfigurationTest extends CamelTestSupport {
         assertEquals("Invalid queue name", "foo", hzlqEndpoint.getConfiguration().getQueueName());
         assertEquals("Default value of concurrent consumers is invalid", 1, hzlqEndpoint.getConfiguration().getConcurrentConsumers());
         assertEquals("Invalid pool timeout", 4000, hzlqEndpoint.getConfiguration().getPollTimeout());
+        assertEquals("Default value of on error delay is invalid", 1000, hzlqEndpoint.getConfiguration().getOnErrorDelay());
+    }
+
+    @Test
+    public void createEndpointWithOnErrorDelayParam() throws Exception {
+        HazelcastSedaEndpoint hzlqEndpoint = (HazelcastSedaEndpoint) context.getEndpoint("hazelcast-seda:foo?onErrorDelay=5000");
+
+        assertEquals("Invalid queue name", "foo", hzlqEndpoint.getConfiguration().getQueueName());
+        assertEquals("Default value of concurrent consumers is invalid", 1, hzlqEndpoint.getConfiguration().getConcurrentConsumers());
+        assertEquals("Default value of pool timeout is invalid", 1000, hzlqEndpoint.getConfiguration().getPollTimeout());
+        assertEquals("Value of on error delay is invalid", 5000, hzlqEndpoint.getConfiguration().getOnErrorDelay());
+    }
+
+    @Test
+    public void createEndpointWithIllegalOnErrorDelayParam() throws Exception {
+        try {
+            context.getEndpoint("hazelcast-seda:foo?onErrorDelay=-1");
+            fail("Should have thrown exception");
+        } catch (ResolveEndpointFailedException e) {
+            assertTrue(e.getCause().getMessage().contains("onErrorDelay must be a positive number, was -1"));
+        }
     }
 
 }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerNewTransactionTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerNewTransactionTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hazelcast;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.transaction.TransactionContext;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+public class HazelcastSedaRecoverableConsumerNewTransactionTest extends HazelcastSedaRecoverableConsumerTest {
+
+    protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        TransactionContext transactionContext = Mockito.mock(TransactionContext.class);
+        when(hazelcastInstance.newTransactionContext())
+                .thenThrow(new HazelcastException("Could not obtain Connection!!!"))
+                .thenReturn(transactionContext);
+        when(hazelcastInstance.getQueue("foo")).thenReturn(queue);
+    }
+
+    protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        verify(hazelcastInstance).getQueue("foo");
+        verify(hazelcastInstance, atLeastOnce()).newTransactionContext();
+    }
+
+}

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerRollbackTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerRollbackTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hazelcast;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.transaction.TransactionContext;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+
+public class HazelcastSedaRecoverableConsumerRollbackTest extends HazelcastSedaRecoverableConsumerTest {
+
+    protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        TransactionContext transactionContext = Mockito.mock(TransactionContext.class);
+        HazelcastException hazelcastException = new HazelcastException("Could not obtain Connection!!!");
+        doThrow(hazelcastException)
+                .doNothing()
+                .when(transactionContext).beginTransaction();
+        doThrow(hazelcastException)
+                .doNothing()
+                .when(transactionContext).rollbackTransaction();
+        when(hazelcastInstance.newTransactionContext()).thenReturn(transactionContext);
+        when(hazelcastInstance.getQueue("foo")).thenReturn(queue);
+    }
+
+    protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        verify(hazelcastInstance).getQueue("foo");
+        verify(hazelcastInstance, atLeastOnce()).newTransactionContext();
+    }
+
+}

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hazelcast;
+
+import com.hazelcast.core.IQueue;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public abstract class HazelcastSedaRecoverableConsumerTest extends HazelcastCamelTestSupport {
+
+    @Mock
+    protected IQueue<Object> queue;
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint mock;
+
+    @Test
+    public void testRecovery() throws InterruptedException {
+        when(queue.poll(any(Long.class), any(TimeUnit.class)))
+                .thenReturn("bar")
+                .thenReturn(null);
+
+        mock.expectedMessageCount(1);
+
+        assertMockEndpointsSatisfied(5000, TimeUnit.MILLISECONDS);
+    }
+
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("hazelcast-seda:foo?transacted=true").to("mock:result");
+            }
+        };
+    }
+
+    @After
+    public final void stopContext() throws Exception {
+        context.stop();
+    }
+
+}

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import java.util.concurrent.TimeUnit;
+
 import com.hazelcast.core.IQueue;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,8 +25,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
@@ -54,7 +54,7 @@ public abstract class HazelcastSedaRecoverableConsumerTest extends HazelcastCame
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("hazelcast-seda:foo?transacted=true").to("mock:result");
+                from("hazelcast-seda:foo?transacted=true&onErrorDelay=5").to("mock:result");
             }
         };
     }


### PR DESCRIPTION
Move all Hazelcast instance interaction inside try-catch, and sleep 100 ms when exception occurred to avoid spamming log with errors e.g. when Hazelcast instance is unreachable for a period of time.