### PR TITLE
CAMEL-11149 Maps JMH benchmarks: add complex cases for various header…

### DIFF
--- a/tests/camel-jmh/pom.xml
+++ b/tests/camel-jmh/pom.xml
@@ -63,6 +63,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3-version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/tests/camel-jmh/src/test/java/org/apache/camel/itest/jmh/SimpleMockTest.java
+++ b/tests/camel-jmh/src/test/java/org/apache/camel/itest/jmh/SimpleMockTest.java
@@ -105,6 +105,6 @@ public class SimpleMockTest {
     public void simpleMockTest(BenchmarkState state, Blackhole bh) {
         ProducerTemplate template = state.producer;
         template.sendBody("direct:start", "Hello World");
-   }
+    }
 
 }


### PR DESCRIPTION
… maps impl, tweak jmh config to produce readable results, fix checkstyle issue in SimpleMockTest.

I've tweak JMH config a bit to get more readable results. It is ok, to use only one _mode_(SampleTime)_ in this case. Here are my results:

```
Benchmark                                                                         Mode  Cnt     Score    Error  Units
CaseInsensitiveMapTest.camelMapComplexCase                                      sample   15  1974.678 ± 31.294  ms/op
CaseInsensitiveMapTest.camelMapSimpleCase                                       sample  236   107.242 ±  1.821  ms/op
CaseInsensitiveMapTest.cedarsoftMapComplexCase                                  sample   20  1400.898 ± 23.216  ms/op
CaseInsensitiveMapTest.cedarsoftMapSimpleCase                                   sample  221   113.891 ±  0.585  ms/op
CaseInsensitiveMapTest.hashMapComplexCase                                       sample   55   495.986 ±  2.844  ms/op
CaseInsensitiveMapTest.hashMapSimpleCase                                        sample  910    27.537 ±  0.156  ms/op

```