### PR TITLE
CAMEL-11244: camel-hazelcast: use string/enum instead of numeric operation type

### DIFF
--- a/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
@@ -45,7 +45,7 @@ with the following path and query parameters:
 |=======================================================================
 | Name | Description | Default | Type
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
-| **defaultOperation** (producer) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (producer) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (producer) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (producer) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
@@ -82,7 +82,7 @@ Java DSL:
 [source,java]
 -----------------------------------------------------------------------------------------
 from("direct:set")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.SETVALUE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
 .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
 -----------------------------------------------------------------------------------------
 
@@ -110,7 +110,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
 .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
 ------------------------------------------------------------------------------------
 
@@ -138,7 +138,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------------
 from("direct:increment")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.INCREMENT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
 .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
 ------------------------------------------------------------------------------------------
 
@@ -166,7 +166,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------------
 from("direct:decrement")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DECREMENT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
 .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
 ------------------------------------------------------------------------------------------
 
@@ -194,7 +194,7 @@ Java DSL:
 [source,java]
 ----------------------------------------------------------------------------------------
 from("direct:destroy")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DESTROY_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
 .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
 ----------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
@@ -45,7 +45,7 @@ with the following path and query parameters:
 | Name | Description | Default | Type
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
 | **bridgeErrorHandler** (consumer) | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored. | false | boolean
-| **defaultOperation** (consumer) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (consumer) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (consumer) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (consumer) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **exceptionHandler** (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler

--- a/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
@@ -39,7 +39,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -71,7 +71,7 @@ The list producer provides 7 operations:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:add")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD))
 .toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 ------------------------------------------------------------------------------------
 
@@ -80,7 +80,7 @@ from("direct:add")
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
 .toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX)
 .to("seda:out");
 ------------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ from("direct:get")
 [source,java]
 -----------------------------------------------------------------------------------------
 from("direct:set")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.SETVALUE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
 .toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 -----------------------------------------------------------------------------------------
 
@@ -99,7 +99,7 @@ from("direct:set")
 [source,java]
 --------------------------------------------------------------------------------------------
 from("direct:removevalue")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
 .toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 --------------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
@@ -40,7 +40,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -79,7 +79,7 @@ The map cache producer provides follow operations specified by *CamelHazelcastOp
 * evictAll
 
 All operations are provide the inside the "hazelcast.operation.type" header variable. In Java
-DSL you can use the constants from `org.apache.camel.component.hazelcast.HazelcastConstants`.
+DSL you can use the constants from `org.apache.camel.component.hazelcast.HazelcastOperation`.
 
 Header Variables for the request message:
 
@@ -115,7 +115,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ------------------------------------------------------------------------------------
 
@@ -140,7 +140,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
 .setHeader(HazelcastConstants.TTL_VALUE, constant(Long.valueOf(1)))
 .setHeader(HazelcastConstants.TTL_UNIT, constant(TimeUnit.MINUTES))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
@@ -174,7 +174,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX)
 .to("seda:out");
 ------------------------------------------------------------------------------------
@@ -201,7 +201,7 @@ Java DSL:
 [source,java]
 ---------------------------------------------------------------------------------------
 from("direct:update")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.UPDATE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.UPDATE))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ---------------------------------------------------------------------------------------
 
@@ -226,7 +226,7 @@ Java DSL:
 [source,java]
 ---------------------------------------------------------------------------------------
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ---------------------------------------------------------------------------------------
 
@@ -251,7 +251,7 @@ Java DSL:
 [source,java]
 --------------------------------------------------------------------------------------
 from("direct:query")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.QUERY_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.QUERY))
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX)
 .to("seda:out");
 --------------------------------------------------------------------------------------

--- a/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
@@ -41,7 +41,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -81,7 +81,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
 .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 ------------------------------------------------------------------------------------
 
@@ -107,7 +107,7 @@ Java DSL:
 [source,java]
 --------------------------------------------------------------------------------------------
 from("direct:removevalue")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
 .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
 --------------------------------------------------------------------------------------------
 
@@ -138,7 +138,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
 .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX)
 .to("seda:out");
 ------------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ Java DSL:
 [source,java]
 ---------------------------------------------------------------------------------------
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
 .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
 ---------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
@@ -40,7 +40,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -71,7 +71,7 @@ The queue producer provides 6 operations:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:add")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD))
 .toF("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX);
 ------------------------------------------------------------------------------------
 
@@ -80,7 +80,7 @@ from("direct:add")
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
 .toF("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX);
 ------------------------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ from("direct:put")
 [source,java]
 -------------------------------------------------------------------------------------
 from("direct:poll")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.POLL_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.POLL))
 .toF("hazelcast:%sbar", HazelcastConstants.QUEUE_PREFIX);
 -------------------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ from("direct:poll")
 [source,java]
 -------------------------------------------------------------------------------------
 from("direct:peek")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PEEK_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PEEK))
 .toF("hazelcast:%sbar", HazelcastConstants.QUEUE_PREFIX);
 -------------------------------------------------------------------------------------
 
@@ -107,7 +107,7 @@ from("direct:peek")
 [source,java]
 --------------------------------------------------------------------------------------
 from("direct:offer")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.OFFER_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.OFFER))
 .toF("hazelcast:%sbar", HazelcastConstants.QUEUE_PREFIX);
 --------------------------------------------------------------------------------------
 
@@ -116,7 +116,7 @@ from("direct:offer")
 [source,java]
 --------------------------------------------------------------------------------------------
 from("direct:removevalue")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
 .toF("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX);
 --------------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
@@ -41,7 +41,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -84,7 +84,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
 .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
 ------------------------------------------------------------------------------------
 
@@ -110,7 +110,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
 .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX)
 .to("seda:out");
 ------------------------------------------------------------------------------------
@@ -138,7 +138,7 @@ Java DSL:
 [source,java]
 ---------------------------------------------------------------------------------------
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
 .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX);
 ---------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
@@ -44,7 +44,7 @@ with the following path and query parameters:
 |=======================================================================
 | Name | Description | Default | Type
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
-| **defaultOperation** (producer) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (producer) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (producer) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (producer) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **synchronous** (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
@@ -84,7 +84,7 @@ Java DSL:
 [source,java]
 ------------------------------------------------------------------------------------
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD))
 .to(String.format("hazelcast-%sbar", HazelcastConstants.RINGBUFFER_PREFIX));
 ------------------------------------------------------------------------------------
 
@@ -110,7 +110,7 @@ Java DSL:
 [source,java]
 -----------------------------------------------------------------------------------------------
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.READ_ONCE_HEAD_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.READ_ONCE_HEAD))
 .toF("hazelcast-%sbar", HazelcastConstants.RINGBUFFER_PREFIX)
 .to("seda:out");
 -----------------------------------------------------------------------------------------------

--- a/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
@@ -41,7 +41,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
@@ -40,7 +40,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean

--- a/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
@@ -40,7 +40,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |=======================================================================
 | Name | Description | Default | Type
-| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | String
+| **defaultOperation** (common) | To specify a default operation to use if no operation header has been provided. |  | HazelcastOperation
 | **hazelcastInstance** (common) | The hazelcast instance reference which can be used for hazelcast endpoint. |  | HazelcastInstance
 | **hazelcastInstanceName** (common) | The hazelcast instance reference name which can be used for hazelcast endpoint. If you don't specify the instance reference camel use the default hazelcast instance from the camel-hazelcast instance. |  | String
 | **reliable** (common) | Define if the endpoint will use a reliable Topic struct or not. | false | boolean
@@ -66,7 +66,7 @@ The topic producer provides only one operation (publish).
 [source,java]
 ----------------------------------------------------------------------------------------
 from("direct:add")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUBLISH_OPERATION))
+.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUBLISH))
 .toF("hazelcast-%sbar", HazelcastConstants.PUBLISH_OPERATION);
 ----------------------------------------------------------------------------------------
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastComponentHelper.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastComponentHelper.java
@@ -17,62 +17,12 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.util.ObjectHelper;
 
 public final class HazelcastComponentHelper {
-
-    private static final HashMap<String, Integer> MAPPING;
-
-    static {
-        MAPPING = new HashMap<>();
-        addMapping(MAPPING, "put", HazelcastConstants.PUT_OPERATION);
-        addMapping(MAPPING, "delete", HazelcastConstants.DELETE_OPERATION);
-        addMapping(MAPPING, "get", HazelcastConstants.GET_OPERATION);
-        addMapping(MAPPING, "update", HazelcastConstants.UPDATE_OPERATION);
-        addMapping(MAPPING, "query", HazelcastConstants.QUERY_OPERATION);
-        addMapping(MAPPING, "getAll", HazelcastConstants.GET_ALL_OPERATION);
-        addMapping(MAPPING, "clear", HazelcastConstants.CLEAR_OPERATION);
-        addMapping(MAPPING, "evict", HazelcastConstants.EVICT_OPERATION);
-        addMapping(MAPPING, "evictAll", HazelcastConstants.EVICT_ALL_OPERATION);
-        addMapping(MAPPING, "putIfAbsent", HazelcastConstants.PUT_IF_ABSENT_OPERATION);
-        addMapping(MAPPING, "addAll", HazelcastConstants.ADD_ALL_OPERATION);
-        addMapping(MAPPING, "removeAll", HazelcastConstants.REMOVE_ALL_OPERATION);
-        addMapping(MAPPING, "retainAll", HazelcastConstants.RETAIN_ALL_OPERATION);
-        addMapping(MAPPING, "valueCount", HazelcastConstants.VALUE_COUNT_OPERATION);
-        addMapping(MAPPING, "containsKey", HazelcastConstants.CONTAINS_KEY_OPERATION);
-        addMapping(MAPPING, "containsValue", HazelcastConstants.CONTAINS_VALUE_OPERATION);
-        addMapping(MAPPING, "keySet", HazelcastConstants.GET_KEYS_OPERATION);
-
-        // multimap
-        addMapping(MAPPING, "removevalue", HazelcastConstants.REMOVEVALUE_OPERATION);
-
-        // atomic numbers
-        addMapping(MAPPING, "increment", HazelcastConstants.INCREMENT_OPERATION);
-        addMapping(MAPPING, "decrement", HazelcastConstants.DECREMENT_OPERATION);
-        addMapping(MAPPING, "setvalue", HazelcastConstants.SETVALUE_OPERATION);
-        addMapping(MAPPING, "destroy", HazelcastConstants.DESTROY_OPERATION);
-        addMapping(MAPPING, "compareAndSet", HazelcastConstants.COMPARE_AND_SET_OPERATION);
-        addMapping(MAPPING, "getAndAdd", HazelcastConstants.GET_AND_ADD_OPERATION);
-
-        // queue
-        addMapping(MAPPING, "add", HazelcastConstants.ADD_OPERATION);
-        addMapping(MAPPING, "offer", HazelcastConstants.OFFER_OPERATION);
-        addMapping(MAPPING, "peek", HazelcastConstants.PEEK_OPERATION);
-        addMapping(MAPPING, "poll", HazelcastConstants.POLL_OPERATION);
-        addMapping(MAPPING, "remainingCapacity", HazelcastConstants.REMAINING_CAPACITY_OPERATION);
-        addMapping(MAPPING, "drainTo", HazelcastConstants.DRAIN_TO_OPERATION);
-
-        // topic
-        addMapping(MAPPING, "publish", HazelcastConstants.PUBLISH_OPERATION);
-
-        // ringbuffer
-        addMapping(MAPPING, "capacity", HazelcastConstants.GET_CAPACITY_OPERATION);
-        addMapping(MAPPING, "readonceHead", HazelcastConstants.READ_ONCE_HEAD_OPERATION);
-        addMapping(MAPPING, "readonceTail", HazelcastConstants.READ_ONCE_TAIL_OPERATION);
-    }
 
     private HazelcastComponentHelper() {
     }
@@ -81,7 +31,7 @@ public final class HazelcastComponentHelper {
         // get in headers
         Map<String, Object> headers = ex.getIn().getHeaders();
 
-        // delete item id
+        // DELETE item id
         if (headers.containsKey(HazelcastConstants.OBJECT_ID)) {
             headers.remove(HazelcastConstants.OBJECT_ID);
         }
@@ -107,33 +57,11 @@ public final class HazelcastComponentHelper {
         ex.getIn().setHeader(HazelcastConstants.LISTENER_TIME, new Date().getTime());
     }
 
-    public static int lookupOperationNumber(Exchange exchange, int defaultOperation) {
-        return extractOperationNumber(exchange.getIn().getHeader(HazelcastConstants.OPERATION), defaultOperation);
+    public static HazelcastOperation lookupOperation(Exchange exchange, HazelcastOperation defaultOperation) {
+
+        String operationName = exchange.getIn().getHeader(HazelcastConstants.OPERATION, String.class);
+        return ObjectHelper.isEmpty(operationName) ? defaultOperation : HazelcastOperation.getHazelcastOperation(operationName);
     }
 
-    public static int extractOperationNumber(Object value, int defaultOperation) {
-        int operation = defaultOperation;
-        if (value instanceof String) {
-            operation = mapToOperationNumber((String) value);
-        } else if (value instanceof Integer) {
-            operation = (Integer)value;
-        }
-        return operation;
-    }
 
-    /**
-     * Allows the use of speaking operation names (e.g. for usage in Spring DSL)
-     */
-    private static int mapToOperationNumber(String operationName) {
-        if (MAPPING.containsKey(operationName)) {
-            return MAPPING.get(operationName);
-        } else {
-            throw new IllegalArgumentException(String.format("Operation '%s' is not supported by this component.", operationName));
-        }
-    }
-
-    private static void addMapping(HashMap<String, Integer> mapping, String operationName, int operationNumber) {
-        mapping.put(operationName, operationNumber);
-        mapping.put(String.valueOf(operationNumber), operationNumber);
-    }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastConstants.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastConstants.java
@@ -56,52 +56,217 @@ public final class HazelcastConstants {
     public static final String CACHE_NAME = "CamelHazelcastCacheName";
     public static final String CACHE_TYPE = "CamelHazelcastCacheType";
 
-    // actions (put, delete, get, getAll, update, clear)
+    // actions (PUT, DELETE, GET, GET_ALL, UPDATE, CLEAR)
     public static final String OPERATION = "CamelHazelcastOperationType";
-    public static final int PUT_OPERATION = 1;
-    public static final int DELETE_OPERATION = 2;
-    public static final int GET_OPERATION = 3;
-    public static final int UPDATE_OPERATION = 4;
-    public static final int QUERY_OPERATION = 5;
-    public static final int GET_ALL_OPERATION = 6;
-    public static final int CLEAR_OPERATION = 7;
-    public static final int PUT_IF_ABSENT_OPERATION = 8;
-    public static final int ADD_ALL_OPERATION = 9;
-    public static final int REMOVE_ALL_OPERATION = 10;
-    public static final int RETAIN_ALL_OPERATION = 11;
-    public static final int EVICT_OPERATION = 12;
-    public static final int EVICT_ALL_OPERATION = 13;
-    public static final int VALUE_COUNT_OPERATION = 14;
-    public static final int CONTAINS_KEY_OPERATION = 15;
-    public static final int CONTAINS_VALUE_OPERATION = 16;
-    public static final int GET_KEYS_OPERATION = 41;
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#PUT}
+     */
+    public static final String PUT_OPERATION = "put";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#DELETE}
+     */
+    public static final String DELETE_OPERATION = "delete";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#GET}
+     */
+    public static final String GET_OPERATION = "get";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#UPDATE}
+     */
+    public static final String UPDATE_OPERATION = "update";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#QUERY}
+     */
+    public static final String QUERY_OPERATION = "query";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#GET_ALL}
+     */
+    public static final String GET_ALL_OPERATION = "getAll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#CLEAR}
+     */
+    public static final String CLEAR_OPERATION = "clear";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#PUT_IF_ABSENT}
+     */
+    public static final String PUT_IF_ABSENT_OPERATION = "putIfAbsent";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#ADD_ALL}
+     */
+    public static final String ADD_ALL_OPERATION = "addAll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#REMOVE_ALL}
+     */
+    public static final String REMOVE_ALL_OPERATION = "removeAll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#RETAIN_ALL}
+     */
+    public static final String RETAIN_ALL_OPERATION = "retailAll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#EVICT}
+     */
+    public static final String EVICT_OPERATION = "evict";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#EVICT_ALL}
+     */
+    public static final String EVICT_ALL_OPERATION = "evictAll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#VALUE_COUNT}
+     */
+    public static final String VALUE_COUNT_OPERATION = "valueCount";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#CONTAINS_KEY}
+     */
+    public static final String CONTAINS_KEY_OPERATION = "containsKey";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#CONTAINS_VALUE}
+     */
+    public static final String CONTAINS_VALUE_OPERATION = "containsValue";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#GET_KEYS}
+     */
+    public static final String GET_KEYS_OPERATION = "keySet";
     
     // multimap
-    public static final int REMOVEVALUE_OPERATION = 17;
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#REMOVE_VALUE}
+     */
+    public static final String REMOVEVALUE_OPERATION = "removevalue";
 
     // atomic numbers
-    public static final int INCREMENT_OPERATION = 20;
-    public static final int DECREMENT_OPERATION = 21;
-    public static final int SETVALUE_OPERATION = 22;
-    public static final int DESTROY_OPERATION = 23;
-    public static final int COMPARE_AND_SET_OPERATION = 24;
-    public static final int GET_AND_ADD_OPERATION = 25;
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#INCREMENT}
+     */
+    public static final String INCREMENT_OPERATION = "increment";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#DECREMENT}
+     */
+    public static final String DECREMENT_OPERATION = "decrement";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#SET_VALUE}
+     */
+    public static final String SETVALUE_OPERATION = "setvalue";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#DESTROY}
+     */
+    public static final String DESTROY_OPERATION = "destroy";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#COMPARE_AND_SET}
+     */
+    public static final String COMPARE_AND_SET_OPERATION = "compareAndSet";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#GET_AND_ADD}
+     */
+    public static final String GET_AND_ADD_OPERATION = "getAndAdd";
 
     // queue
-    public static final int ADD_OPERATION = 31;
-    public static final int OFFER_OPERATION = 32;
-    public static final int PEEK_OPERATION = 33;
-    public static final int POLL_OPERATION = 34;
-    public static final int REMAINING_CAPACITY_OPERATION = 35;
-    public static final int DRAIN_TO_OPERATION = 36;
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#ADD}
+     */
+    public static final String ADD_OPERATION = "add";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#OFFER}
+     */
+    public static final String OFFER_OPERATION = "offer";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#PEEK}
+     */
+    public static final String PEEK_OPERATION = "peek";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#POLL}
+     */
+    public static final String POLL_OPERATION = "poll";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#REMAINING_CAPACITY}
+     */
+    public static final String REMAINING_CAPACITY_OPERATION = "remainingCapacity";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#DRAIN_TO}
+     */
+    public static final String DRAIN_TO_OPERATION = "drainTo";
 
     // topic
-    public static final int PUBLISH_OPERATION = 37;
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#PUBLISH}
+     */
+    public static final String PUBLISH_OPERATION = "publish";
     
     // ring_buffer
-    public static final int READ_ONCE_HEAD_OPERATION = 38;
-    public static final int READ_ONCE_TAIL_OPERATION = 39;
-    public static final int GET_CAPACITY_OPERATION = 40;
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#READ_ONCE_HEAD}
+     */
+    public static final String READ_ONCE_HEAD_OPERATION = "readOnceHead";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#READ_ONCE_TAIL}
+     */
+    public static final String READ_ONCE_TAIL_OPERATION = "readOnceTail";
+
+    /**
+     * @deprecated
+     * use {@link HazelcastOperation#CAPACITY}
+     */
+    public static final String GET_CAPACITY_OPERATION = "capacity";
 
     /*
      * header values

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
@@ -79,7 +79,10 @@ public abstract class HazelcastDefaultComponent extends DefaultComponent {
         }
 
         HazelcastDefaultEndpoint endpoint = doCreateEndpoint(uri, remaining, parameters, hzInstance);
-        endpoint.setDefaultOperation(defaultOperation);
+        if (defaultOperation != null) {
+            endpoint.setDefaultOperation(HazelcastOperation.getHazelcastOperation(defaultOperation));
+        }
+
         return endpoint;
     }
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultEndpoint.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultEndpoint.java
@@ -25,7 +25,6 @@ import org.apache.camel.component.hazelcast.seda.HazelcastSedaConfiguration;
 import org.apache.camel.component.hazelcast.topic.HazelcastTopicConfiguration;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.spi.Metadata;
-import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 
@@ -41,9 +40,8 @@ public abstract class HazelcastDefaultEndpoint extends DefaultEndpoint {
     protected HazelcastInstance hazelcastInstance;
     @UriParam
     protected String hazelcastInstanceName;
-    @UriParam(enums = "put,delete,get,update,query,getAll,clear,evict,evictAll,putIfAbsent,addAll,removeAll,retainAll,valueCount,containsKey,containsValue,keySet,removevalue,increment"
-        + ",decrement,setvalue,destroy,compareAndSet,getAndAdd,add,offer,peek,poll,remainingCapacity,drainTo,publish,capacity,readonceHead,readonceTail")
-    private String defaultOperation;
+    @UriParam
+    private HazelcastOperation defaultOperation;
     @UriParam
     private HazelcastSedaConfiguration hazelcastSedaConfiguration; // to include component schema docs
     @UriParam
@@ -115,11 +113,11 @@ public abstract class HazelcastDefaultEndpoint extends DefaultEndpoint {
     /**
      * To specify a default operation to use, if no operation header has been provided.
      */
-    public void setDefaultOperation(String defaultOperation) {
+    public void setDefaultOperation(HazelcastOperation defaultOperation) {
         this.defaultOperation = defaultOperation;
     }
 
-    public String getDefaultOperation() {
+    public HazelcastOperation getDefaultOperation() {
         return defaultOperation;
     }
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultProducer.java
@@ -30,12 +30,9 @@ public abstract class HazelcastDefaultProducer extends DefaultProducer {
         return (HazelcastDefaultEndpoint)super.getEndpoint();
     }
 
-    protected int lookupOperationNumber(Exchange exchange) {
-        int defaultNumber = -1;
-        // if there is a default operation we need to convert that first to a number
-        if (getEndpoint().getDefaultOperation() != null) {
-            defaultNumber = HazelcastComponentHelper.extractOperationNumber(getEndpoint().getDefaultOperation(), -1);
-        }
-        return HazelcastComponentHelper.lookupOperationNumber(exchange, defaultNumber);
+    protected HazelcastOperation lookupOperation(Exchange exchange) {
+
+        return HazelcastComponentHelper.lookupOperation(exchange, getEndpoint().getDefaultOperation());
+
     }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastOperation.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastOperation.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hazelcast;
+
+public enum HazelcastOperation {
+
+    // actions
+    PUT("put"),
+    DELETE("delete"),
+    GET("get"),
+    UPDATE("update"),
+    QUERY("query"),
+    GET_ALL("getAll"),
+    CLEAR("clear"),
+    PUT_IF_ABSENT("putIfAbsent"),
+    ADD_ALL("allAll"),
+    REMOVE_ALL("removeAll"),
+    RETAIN_ALL("retainAll"),
+    EVICT("evict"),
+    EVICT_ALL("evictAll"),
+    VALUE_COUNT("valueCount"),
+    CONTAINS_KEY("containsKey"),
+    CONTAINS_VALUE("containsValue"),
+    GET_KEYS("keySet"),
+
+    // multimap
+    REMOVE_VALUE("removevalue"),
+
+    // atomic numbers
+    INCREMENT("increment"),
+    DECREMENT("decrement"),
+    SET_VALUE("setvalue"),
+    DESTROY("destroy"),
+    COMPARE_AND_SET("compareAndSet"),
+    GET_AND_ADD("getAndAdd"),
+
+    // queue
+    ADD("add"),
+    OFFER("offer"),
+    PEEK("peek"),
+    POLL("poll"),
+    REMAINING_CAPACITY("remainingCapacity"),
+    DRAIN_TO("drainTo"),
+
+    // topic
+    PUBLISH("publish"),
+
+    // ring_buffer
+    READ_ONCE_HEAD("readOnceHeal"),
+    READ_ONCE_TAIL("readOnceTail"),
+    CAPACITY("capacity");
+
+
+    private static HazelcastOperation[] values = values();
+    private final String operation;
+
+    HazelcastOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public static HazelcastOperation getHazelcastOperation(String name) {
+        if (name == null) {
+            return null;
+        }
+        for (HazelcastOperation hazelcastOperation : values) {
+            if (hazelcastOperation.toString().equalsIgnoreCase(name) || hazelcastOperation.name().equalsIgnoreCase(name)) {
+                return hazelcastOperation;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Operation '%s' is not supported by this component.", name));
+    }
+
+    public String toString() {
+        return operation;
+    }
+
+}

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 import org.apache.camel.util.ObjectHelper;
 
 public class HazelcastAtomicnumberProducer extends HazelcastDefaultProducer {
@@ -47,35 +48,35 @@ public class HazelcastAtomicnumberProducer extends HazelcastDefaultProducer {
             expectedValue = (long) headers.get(HazelcastConstants.EXPECTED_VALUE);
         }
         
-        int operation = lookupOperationNumber(exchange);
+        HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
 
-        case HazelcastConstants.INCREMENT_OPERATION:
+        case INCREMENT:
             this.increment(exchange);
             break;
 
-        case HazelcastConstants.DECREMENT_OPERATION:
+        case DECREMENT:
             this.decrement(exchange);
             break;
             
-        case HazelcastConstants.COMPARE_AND_SET_OPERATION:
+        case COMPARE_AND_SET:
             this.compare(expectedValue, exchange);
             break;
             
-        case HazelcastConstants.GET_AND_ADD_OPERATION:
+        case GET_AND_ADD:
             this.getAndAdd(exchange);
             break;
 
-        case HazelcastConstants.SETVALUE_OPERATION:
+        case SET_VALUE:
             this.set(exchange);
             break;
 
-        case HazelcastConstants.GET_OPERATION:
+        case GET:
             this.get(exchange);
             break;
 
-        case HazelcastConstants.DESTROY_OPERATION:
+        case DESTROY:
             this.destroy();
             break;
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 /**
  * Implementation of Hazelcast List {@link Producer}.
@@ -45,7 +46,7 @@ public class HazelcastListProducer extends HazelcastDefaultProducer {
 
         Map<String, Object> headers = exchange.getIn().getHeaders();
 
-        // get header parameters
+        // GET header parameters
         Integer pos = null;
 
         if (headers.containsKey(HazelcastConstants.OBJECT_POS)) {
@@ -55,39 +56,39 @@ public class HazelcastListProducer extends HazelcastDefaultProducer {
             pos = (Integer) headers.get(HazelcastConstants.OBJECT_POS);
         }
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
 
-        case HazelcastConstants.ADD_OPERATION:
+        case ADD:
             this.add(pos, exchange);
             break;
 
-        case HazelcastConstants.GET_OPERATION:
+        case GET:
             this.get(pos, exchange);
             break;
 
-        case HazelcastConstants.SETVALUE_OPERATION:
+        case SET_VALUE:
             this.set(pos, exchange);
             break;
 
-        case HazelcastConstants.REMOVEVALUE_OPERATION:
+        case REMOVE_VALUE:
             this.remove(pos, exchange);
             break;
             
-        case HazelcastConstants.CLEAR_OPERATION:
+        case CLEAR:
             this.clear();
             break;
             
-        case HazelcastConstants.ADD_ALL_OPERATION:
+        case ADD_ALL:
             this.addAll(pos, exchange);
             break;
             
-        case HazelcastConstants.REMOVE_ALL_OPERATION:
+        case REMOVE_ALL:
             this.removeAll(exchange);
             break;
 
-        case HazelcastConstants.RETAIN_ALL_OPERATION:
+        case RETAIN_ALL:
             this.retainAll(exchange);
             break;
             
@@ -102,10 +103,10 @@ public class HazelcastListProducer extends HazelcastDefaultProducer {
     private void add(Integer pos, Exchange exchange) {
         final Object body = exchange.getIn().getBody();
         if (null == pos) {
-            // add the specified element to the end of the list
+            // ADD the specified element to the end of the list
             list.add(body);
         } else {
-            // add the specified element at the specified position
+            // ADD the specified element at the specified position
             list.add(pos, body);
         }
     }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
@@ -29,6 +29,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 import org.apache.camel.util.ObjectHelper;
 
 public class HazelcastMapProducer extends HazelcastDefaultProducer {
@@ -44,7 +45,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
 
         Map<String, Object> headers = exchange.getIn().getHeaders();
 
-        // get header parameters
+        // GET header parameters
         Object oid = null;
         Object ovalue = null;
         Object ttl = null;
@@ -71,10 +72,10 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
             query = (String) headers.get(HazelcastConstants.QUERY);
         }
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
         switch (operation) {
 
-        case HazelcastConstants.PUT_OPERATION:
+        case PUT:
             if (ObjectHelper.isEmpty(ttl) && ObjectHelper.isEmpty(ttlUnit)) {
                 this.put(oid, exchange);
             } else {
@@ -82,7 +83,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
             }
             break;
             
-        case HazelcastConstants.PUT_IF_ABSENT_OPERATION:
+        case PUT_IF_ABSENT:
             if (ObjectHelper.isEmpty(ttl) && ObjectHelper.isEmpty(ttlUnit)) {
                 this.putIfAbsent(oid, exchange);
             } else {
@@ -90,31 +91,31 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
             }
             break;
 
-        case HazelcastConstants.GET_OPERATION:
+        case GET:
             this.get(oid, exchange);
             break;
             
-        case HazelcastConstants.GET_ALL_OPERATION:
+        case GET_ALL:
             this.getAll(oid, exchange);
             break;
 
-        case HazelcastConstants.GET_KEYS_OPERATION:
+        case GET_KEYS:
             this.getKeys(exchange);
             break;
 
-        case HazelcastConstants.CONTAINS_KEY_OPERATION:
+        case CONTAINS_KEY:
             this.containsKey(oid, exchange);
             break;
             
-        case HazelcastConstants.CONTAINS_VALUE_OPERATION:
+        case CONTAINS_VALUE:
             this.containsValue(exchange);
             break;
 
-        case HazelcastConstants.DELETE_OPERATION:
+        case DELETE:
             this.delete(oid);
             break;
 
-        case HazelcastConstants.UPDATE_OPERATION:
+        case UPDATE:
             if (ObjectHelper.isEmpty(ovalue)) {
                 this.update(oid, exchange);
             } else {
@@ -122,19 +123,19 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
             }
             break;
 
-        case HazelcastConstants.QUERY_OPERATION:
+        case QUERY:
             this.query(query, exchange);
             break;
             
-        case HazelcastConstants.CLEAR_OPERATION:
+        case CLEAR:
             this.clear(exchange);
             break;
             
-        case HazelcastConstants.EVICT_OPERATION:
+        case EVICT:
             this.evict(oid);
             break;
 
-        case HazelcastConstants.EVICT_ALL_OPERATION:
+        case EVICT_ALL:
             this.evictAll();
             break;
             
@@ -147,7 +148,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     }
 
     /**
-     * query map with a sql like syntax (see http://www.hazelcast.com/)
+     * QUERY map with a sql like syntax (see http://www.hazelcast.com/)
      */
     private void query(String query, Exchange exchange) {
         Collection<Object> result;
@@ -160,7 +161,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     }
 
     /**
-     * update an object in your cache (the whole object will be replaced)
+     * UPDATE an object in your cache (the whole object will be replaced)
      */
     private void update(Object oid, Exchange exchange) {
         Object body = exchange.getIn().getBody();
@@ -195,14 +196,14 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     
     
     /**
-     * get All objects and give it back
+     * GET All objects and give it back
      */
     private void getAll(Object oid, Exchange exchange) {
         exchange.getOut().setBody(this.cache.getAll((Set<Object>) oid));
     }
 
     /**
-     * put a new object into the cache
+     * PUT a new object into the cache
      */
     private void put(Object oid, Exchange exchange) {
         Object body = exchange.getIn().getBody();
@@ -210,7 +211,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     }
     
     /**
-     * put a new object into the cache with a specific time to live
+     * PUT a new object into the cache with a specific time to live
      */
     private void put(Object oid, Object ttl, Object ttlUnit, Exchange exchange) {
         Object body = exchange.getIn().getBody();
@@ -270,7 +271,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     }
 
     /**
-    * get keys set of objects and give it back
+    * GET keys set of objects and give it back
     */
     private void getKeys(Exchange exchange) {
         exchange.getOut().setBody(this.cache.keySet());

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 public class HazelcastMultimapProducer extends HazelcastDefaultProducer {
 
@@ -40,45 +41,45 @@ public class HazelcastMultimapProducer extends HazelcastDefaultProducer {
 
         Map<String, Object> headers = exchange.getIn().getHeaders();
 
-        // get header parameters
+        // GET header parameters
         Object oid = null;
 
         if (headers.containsKey(HazelcastConstants.OBJECT_ID)) {
             oid = headers.get(HazelcastConstants.OBJECT_ID);
         }
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
-        case HazelcastConstants.PUT_OPERATION:
+        case PUT:
             this.put(oid, exchange);
             break;
 
-        case HazelcastConstants.GET_OPERATION:
+        case GET:
             this.get(oid, exchange);
             break;
 
-        case HazelcastConstants.DELETE_OPERATION:
+        case DELETE:
             this.delete(oid);
             break;
 
-        case HazelcastConstants.REMOVEVALUE_OPERATION:
+        case REMOVE_VALUE:
             this.removevalue(oid, exchange);
             break;
             
-        case HazelcastConstants.CONTAINS_KEY_OPERATION:
+        case CONTAINS_KEY:
             this.containsKey(oid, exchange);
             break;
             
-        case HazelcastConstants.CONTAINS_VALUE_OPERATION:
+        case CONTAINS_VALUE:
             this.containsValue(exchange);
             break;
 
-        case HazelcastConstants.CLEAR_OPERATION:
+        case CLEAR:
             this.clear(exchange);
             break;
             
-        case HazelcastConstants.VALUE_COUNT_OPERATION:
+        case VALUE_COUNT:
             this.valuecount(oid, exchange);
             break;
             

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueEndpoint.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueEndpoint.java
@@ -23,6 +23,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.component.hazelcast.HazelcastCommand;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 import org.apache.camel.spi.UriEndpoint;
 
 /**
@@ -34,6 +35,7 @@ public class HazelcastQueueEndpoint extends HazelcastDefaultEndpoint {
     public HazelcastQueueEndpoint(HazelcastInstance hazelcastInstance, String endpointUri, Component component, String cacheName) {
         super(hazelcastInstance, endpointUri, component, cacheName);
         setCommand(HazelcastCommand.queue);
+        setDefaultOperation(HazelcastOperation.ADD);
     }
 
     @Override

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.hazelcast.queue;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IQueue;
@@ -27,7 +28,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
-import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 /**
  *
@@ -52,43 +53,42 @@ public class HazelcastQueueProducer extends HazelcastDefaultProducer {
             drainToCollection = headers.get(HazelcastConstants.DRAIN_TO_COLLECTION);
         }
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
 
-        case -1:
-            //If no operation is specified use ADD.
-        case HazelcastConstants.ADD_OPERATION:
+        case ADD:
             this.add(exchange);
             break;
 
-        case HazelcastConstants.PUT_OPERATION:
+        case PUT:
             this.put(exchange);
             break;
 
-        case HazelcastConstants.POLL_OPERATION:
+        case POLL:
             this.poll(exchange);
             break;
 
-        case HazelcastConstants.PEEK_OPERATION:
+        case PEEK:
             this.peek(exchange);
             break;
 
-        case HazelcastConstants.OFFER_OPERATION:
+        case OFFER:
             this.offer(exchange);
             break;
 
-        case HazelcastConstants.REMOVEVALUE_OPERATION:
+        case REMOVE_VALUE:
             this.remove(exchange);
             break;
 
-        case HazelcastConstants.REMAINING_CAPACITY_OPERATION:
+        case REMAINING_CAPACITY:
             this.remainingCapacity(exchange);
             break;
             
-        case HazelcastConstants.DRAIN_TO_OPERATION:
+        case DRAIN_TO:
             this.drainTo((Collection) drainToCollection, exchange);
             break;
+
         default:
             throw new IllegalArgumentException(String.format("The value '%s' is not allowed for parameter '%s' on the QUEUE cache.", operation, HazelcastConstants.OPERATION));
         }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapProducer.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 public class HazelcastReplicatedmapProducer extends HazelcastDefaultProducer {
 
@@ -40,37 +41,37 @@ public class HazelcastReplicatedmapProducer extends HazelcastDefaultProducer {
 
         Map<String, Object> headers = exchange.getIn().getHeaders();
 
-        // get header parameters
+        // GET header parameters
         Object oid = null;
 
         if (headers.containsKey(HazelcastConstants.OBJECT_ID)) {
             oid = headers.get(HazelcastConstants.OBJECT_ID);
         }
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
-        case HazelcastConstants.PUT_OPERATION:
+        case PUT:
             this.put(oid, exchange);
             break;
 
-        case HazelcastConstants.GET_OPERATION:
+        case GET:
             this.get(oid, exchange);
             break;
 
-        case HazelcastConstants.DELETE_OPERATION:
+        case DELETE:
             this.delete(oid);
             break;
 
-        case HazelcastConstants.CLEAR_OPERATION:
+        case CLEAR:
             this.clear(exchange);
             break;
             
-        case HazelcastConstants.CONTAINS_KEY_OPERATION:
+        case CONTAINS_KEY:
             this.containsKey(oid, exchange);
             break;
             
-        case HazelcastConstants.CONTAINS_VALUE_OPERATION:
+        case CONTAINS_VALUE:
             this.containsValue(exchange);
             break;
             

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/HazelcastRingbufferProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/HazelcastRingbufferProducer.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.hazelcast.ringbuffer;
 
-import java.util.Map;
-
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.ringbuffer.Ringbuffer;
 
@@ -26,6 +24,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 public class HazelcastRingbufferProducer extends HazelcastDefaultProducer {
 
@@ -38,29 +37,27 @@ public class HazelcastRingbufferProducer extends HazelcastDefaultProducer {
 
     public void process(Exchange exchange) throws Exception {
 
-        Map<String, Object> headers = exchange.getIn().getHeaders();
-        
-        int operation = lookupOperationNumber(exchange);
+        HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
 
-        case HazelcastConstants.READ_ONCE_HEAD_OPERATION:
+        case READ_ONCE_HEAD:
             this.readOnceHead(exchange);
             break;
             
-        case HazelcastConstants.READ_ONCE_TAIL_OPERATION:
+        case READ_ONCE_TAIL:
             this.readOnceTail(exchange);
             break;
             
-        case HazelcastConstants.GET_CAPACITY_OPERATION:
+        case CAPACITY:
             this.getCapacity(exchange);
             break;
             
-        case HazelcastConstants.REMAINING_CAPACITY_OPERATION:
+        case REMAINING_CAPACITY:
             this.getRemainingCapacity(exchange);
             break;
             
-        case HazelcastConstants.ADD_OPERATION:
+        case ADD:
             this.add(exchange);
             break;
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
@@ -27,6 +27,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 /**
  * Implementation of Hazelcast Set {@link Producer}.
@@ -42,31 +43,31 @@ public class HazelcastSetProducer extends HazelcastDefaultProducer {
 
     public void process(Exchange exchange) throws Exception {
 
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
 
-        case HazelcastConstants.ADD_OPERATION:
+        case ADD:
             this.add(exchange);
             break;
 
-        case HazelcastConstants.REMOVEVALUE_OPERATION:
+        case REMOVE_VALUE:
             this.remove(exchange);
             break;
             
-        case HazelcastConstants.CLEAR_OPERATION:
+        case CLEAR:
             this.clear();
             break;
             
-        case HazelcastConstants.ADD_ALL_OPERATION:
+        case ADD_ALL:
             this.addAll(exchange);
             break;
             
-        case HazelcastConstants.REMOVE_ALL_OPERATION:
+        case REMOVE_ALL:
             this.removeAll(exchange);
             break;
 
-        case HazelcastConstants.RETAIN_ALL_OPERATION:
+        case RETAIN_ALL:
             this.retainAll(exchange);
             break;
             

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicEndpoint.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicEndpoint.java
@@ -24,6 +24,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.component.hazelcast.HazelcastCommand;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 import org.apache.camel.spi.UriEndpoint;
 
 /**
@@ -38,6 +39,7 @@ public class HazelcastTopicEndpoint extends HazelcastDefaultEndpoint implements 
         super(hazelcastInstance, endpointUri, component, cacheName);
         this.configuration = configuration;
         setCommand(HazelcastCommand.topic);
+        setDefaultOperation(HazelcastOperation.PUBLISH);
     }
 
     @Override

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicProducer.java
@@ -23,6 +23,7 @@ import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultEndpoint;
 import org.apache.camel.component.hazelcast.HazelcastDefaultProducer;
+import org.apache.camel.component.hazelcast.HazelcastOperation;
 
 /**
  *
@@ -41,19 +42,18 @@ public class HazelcastTopicProducer extends HazelcastDefaultProducer {
     }
 
     public void process(Exchange exchange) throws Exception {
-        final int operation = lookupOperationNumber(exchange);
+        final HazelcastOperation operation = lookupOperation(exchange);
 
         switch (operation) {
-        case -1:
-            // default operation to publish
-        case HazelcastConstants.PUBLISH_OPERATION:
+
+        case PUBLISH:
             this.publish(exchange);
             break;
         default:
             throw new IllegalArgumentException(String.format("The value '%s' is not allowed for parameter '%s' on the TOPIC cache.", operation, HazelcastConstants.OPERATION));
         }
 
-        // finally copy headers
+         // finally copy headers
         HazelcastComponentHelper.copyHeaders(exchange);
     }
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * Hazelcast settings are given to an end-user and can be controlled with repositoryName and persistentRespositoryName,
  * both are {@link com.hazelcast.core.IMap} &lt;String, Exchange&gt;. However HazelcastAggregationRepository
  * can run it's own Hazelcast instance, but obviously no benefits of Hazelcast clustering are gained this way.
- * If the {@link HazelcastAggregationRepository} uses it's own local {@link HazelcastInstance} it will destroy this
+ * If the {@link HazelcastAggregationRepository} uses it's own local {@link HazelcastInstance} it will DESTROY this
  * instance on {@link #doStop()}. You should control {@link HazelcastInstance} lifecycle yourself whenever you instantiate
  * {@link HazelcastAggregationRepository} passing a reference to the instance.
  *

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
@@ -136,27 +136,27 @@ public class HazelcastAtomicnumberProducerTest extends HazelcastCamelTestSupport
                 from("direct:setInvalid").setHeader(HazelcastConstants.OPERATION, constant("invalid"))
                         .to(String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:set").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.SETVALUE_OPERATION))
+                from("direct:set").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
                         .to(String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
+                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET)).to(String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:increment").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.INCREMENT_OPERATION)).to(
+                from("direct:increment").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:decrement").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DECREMENT_OPERATION)).to(
+                from("direct:decrement").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:destroy").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DESTROY_OPERATION)).to(
+                from("direct:destroy").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
                 
-                from("direct:compareAndSet").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.COMPARE_AND_SET_OPERATION)).to(
+                from("direct:compareAndSet").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.COMPARE_AND_SET)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
               
-                from("direct:getAndAdd").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_AND_ADD_OPERATION)).to(
+                from("direct:getAndAdd").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET_AND_ADD)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX));
 
-                from("direct:setWithOperationNumber").toF("hazelcast-%sfoo?operation=%s", HazelcastConstants.ATOMICNUMBER_PREFIX, HazelcastConstants.SETVALUE_OPERATION);
+                from("direct:setWithOperationNumber").toF("hazelcast-%sfoo?operation=%s", HazelcastConstants.ATOMICNUMBER_PREFIX, HazelcastOperation.SET_VALUE);
                 from("direct:setWithOperationName").toF("hazelcast-%sfoo?operation=setvalue", HazelcastConstants.ATOMICNUMBER_PREFIX);
 
             }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
@@ -75,7 +75,7 @@ public class HazelcastListProducerTest extends HazelcastCamelTestSupport {
 
     @Test
     public void removeValue() throws InterruptedException {
-        template.sendBody("direct:removevalue", "foo2");
+        template.sendBody("direct:removeValue", "foo2");
         verify(list).remove("foo2");
     }
 
@@ -95,13 +95,13 @@ public class HazelcastListProducerTest extends HazelcastCamelTestSupport {
 
     @Test
     public void removeValueWithIdx() {
-        template.sendBodyAndHeader("direct:removevalue", null, HazelcastConstants.OBJECT_POS, 1);
+        template.sendBodyAndHeader("direct:removeValue", null, HazelcastConstants.OBJECT_POS, 1);
         verify(list).remove(1);
     }
 
     @Test
     public void removeValueWithoutIdx() {
-        template.sendBody("direct:removevalue", "foo1");
+        template.sendBody("direct:removeValue", "foo1");
         verify(list).remove("foo1");
     }
     
@@ -116,7 +116,7 @@ public class HazelcastListProducerTest extends HazelcastCamelTestSupport {
         Collection t = new ArrayList();
         t.add("test1");
         t.add("test2");
-        template.sendBody("direct:addAll", t);
+        template.sendBody("direct:addall", t);
         verify(list).addAll(t);
     }
     
@@ -134,7 +134,7 @@ public class HazelcastListProducerTest extends HazelcastCamelTestSupport {
         Collection t = new ArrayList();
         t.add("test1");
         t.add("test2");
-        template.sendBody("direct:retainAll", t);
+        template.sendBody("direct:RETAIN_ALL", t);
         verify(list).retainAll(t);
     }
 
@@ -146,29 +146,29 @@ public class HazelcastListProducerTest extends HazelcastCamelTestSupport {
 
                 from("direct:addInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 
-                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
+                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 
-                from("direct:set").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.SETVALUE_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
+                from("direct:set").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 
-                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX)
+                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX)
                         .to("seda:out");
 
-                from("direct:removevalue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION)).to(
+                from("direct:removeValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX));
-                
-                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CLEAR_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
 
-                from("direct:addAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_ALL_OPERATION)).to(
+                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CLEAR)).toF("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX);
+
+                from("direct:addall").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX));
-                
-                from("direct:removeAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVE_ALL_OPERATION)).to(
+
+                from("direct:removeAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX));
-                
-                from("direct:retainAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.RETAIN_ALL_OPERATION)).to(
+
+                from("direct:RETAIN_ALL").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.RETAIN_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.LIST_PREFIX));
-                
-                from("direct:addWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.LIST_PREFIX, HazelcastConstants.ADD_OPERATION);
-                from("direct:addWithOperationName").toF("hazelcast-%sbar?operation=add", HazelcastConstants.LIST_PREFIX);
+
+                from("direct:addWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.LIST_PREFIX, HazelcastOperation.ADD);
+                from("direct:addWithOperationName").toF("hazelcast-%sbar?operation=ADD", HazelcastConstants.LIST_PREFIX);
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerTest.java
@@ -149,7 +149,7 @@ public class HazelcastMapProducerTest extends HazelcastCamelTestSupport implemen
         String sql = "bar > 1000";
 
         when(map.values(any(SqlPredicate.class))).thenReturn(Arrays.<Object>asList(new Dummy("beta", 2000), new Dummy("gamma", 3000)));
-        template.sendBodyAndHeader("direct:query", null, HazelcastConstants.QUERY, sql);
+        template.sendBodyAndHeader("direct:queue", null, HazelcastConstants.QUERY, sql);
         verify(map).values(any(SqlPredicate.class));
 
         Collection<?> b1 = consumer.receiveBody("seda:out", 5000, Collection.class);
@@ -161,7 +161,7 @@ public class HazelcastMapProducerTest extends HazelcastCamelTestSupport implemen
     @Test
     public void testEmptyQuery() {
         when(map.values()).thenReturn(Arrays.<Object>asList(new Dummy("beta", 2000), new Dummy("gamma", 3000), new Dummy("delta", 4000)));
-        template.sendBody("direct:query", null);
+        template.sendBody("direct:queue", null);
         verify(map).values();
 
         Collection<?> b1 = consumer.receiveBody("seda:out", 5000, Collection.class);
@@ -256,42 +256,42 @@ public class HazelcastMapProducerTest extends HazelcastCamelTestSupport implemen
 
                 from("direct:putInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
 
-                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
-                
-                from("direct:putIfAbsent").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_IF_ABSENT_OPERATION))
+                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
+
+                from("direct:putIfAbsent").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT_IF_ABSENT))
                          .to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
 
-                from("direct:update").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.UPDATE_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
+                from("direct:update").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.UPDATE)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
 
-                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
+                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
 
-                from("direct:getAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_ALL_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
-                        .to("seda:out");
-                
-                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
-
-                from("direct:query").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.QUERY_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
+                from("direct:getAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET_ALL)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
 
-                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CLEAR_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
- 
-                from("direct:evict").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.EVICT_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
+                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
+
+                from("direct:queue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.QUERY)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
 
-                from("direct:evictAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.EVICT_ALL_OPERATION)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
+                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CLEAR)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX));
+
+                from("direct:evict").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.EVICT)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
-                
-                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_KEY_OPERATION))
+
+                from("direct:evictAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.EVICT_ALL)).to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
+                        .to("seda:out");
+
+                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_KEY))
                         .to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
-                
-                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_VALUE_OPERATION))
+
+                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_VALUE))
                         .to(String.format("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX))
                         .to("seda:out");
-                
-                from("direct:putWithOperationNumber").toF("hazelcast-%sfoo?operation=%s", HazelcastConstants.MAP_PREFIX, HazelcastConstants.PUT_OPERATION);
-                from("direct:putWithOperationName").toF("hazelcast-%sfoo?operation=put", HazelcastConstants.MAP_PREFIX);
+
+                from("direct:putWithOperationNumber").toF("hazelcast-%sfoo?operation=%s", HazelcastConstants.MAP_PREFIX, HazelcastOperation.PUT);
+                from("direct:putWithOperationName").toF("hazelcast-%sfoo?operation=PUT", HazelcastConstants.MAP_PREFIX);
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerTest.java
@@ -75,7 +75,7 @@ public class HazelcastMultimapProducerTest extends HazelcastCamelTestSupport {
 
     @Test
     public void testRemoveValue() {
-        template.sendBodyAndHeader("direct:removevalue", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
+        template.sendBodyAndHeader("direct:removeValue", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
         verify(map).remove("4711", "my-foo");
     }
 
@@ -142,31 +142,31 @@ public class HazelcastMultimapProducerTest extends HazelcastCamelTestSupport {
 
                 from("direct:putInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 
-                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
+                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 
-                from("direct:removevalue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION)).to(
+                from("direct:removeValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 
-                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX))
+                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX))
                         .to("seda:out");
 
-                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
+                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 
-                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CLEAR_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
+                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CLEAR)).to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
                 
-                from("direct:valueCount").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.VALUE_COUNT_OPERATION))
+                from("direct:valueCount").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.VALUE_COUNT))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
                 
-                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_KEY_OPERATION))
+                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_KEY))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX))
                         .to("seda:out");
                 
-                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_VALUE_OPERATION))
+                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_VALUE))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX))
                         .to("seda:out");
                 
-                from("direct:putWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.MULTIMAP_PREFIX, HazelcastConstants.PUT_OPERATION);
-                from("direct:putWithOperationName").toF("hazelcast-%sbar?operation=put", HazelcastConstants.MULTIMAP_PREFIX);
+                from("direct:putWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.MULTIMAP_PREFIX, HazelcastOperation.PUT);
+                from("direct:putWithOperationName").toF("hazelcast-%sbar?operation=PUT", HazelcastConstants.MULTIMAP_PREFIX);
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
@@ -95,13 +95,13 @@ public class HazelcastQueueProducerTest extends HazelcastCamelTestSupport {
 
     @Test
     public void removeSpecifiedValue() throws InterruptedException {
-        template.sendBody("direct:removevalue", "foo2");
+        template.sendBody("direct:removeValue", "foo2");
         verify(queue).remove("foo2");
     }
 
     @Test
     public void removeValue() {
-        template.sendBody("direct:removevalue", null);
+        template.sendBody("direct:removeValue", null);
         verify(queue).remove();
     }
 
@@ -124,7 +124,7 @@ public class HazelcastQueueProducerTest extends HazelcastCamelTestSupport {
     @Test
     public void remainingCapacity() throws InterruptedException {
         when(queue.remainingCapacity()).thenReturn(10);
-        int answer = template.requestBody("direct:remainingCapacity", null, Integer.class);
+        int answer = template.requestBody("direct:REMAINING_CAPACITY", null, Integer.class);
         verify(queue).remainingCapacity();
         assertEquals(10, answer);
     }
@@ -149,28 +149,28 @@ public class HazelcastQueueProducerTest extends HazelcastCamelTestSupport {
 
                 from("direct:putInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:offer").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.OFFER_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:offer").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.OFFER)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:poll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.POLL_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:poll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.POLL)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:peek").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PEEK_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:peek").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PEEK)).to(String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:removevalue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION)).to(
+                from("direct:removeValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
 
-                from("direct:remainingCapacity").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMAINING_CAPACITY_OPERATION)).to(
-                        String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
-                
-                from("direct:drainTo").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DRAIN_TO_OPERATION)).to(
+                from("direct:REMAINING_CAPACITY").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMAINING_CAPACITY)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
                 
-                from("direct:putWithOperationNumber").toF(String.format("hazelcast-%sbar?operation=%s", HazelcastConstants.QUEUE_PREFIX, HazelcastConstants.PUT_OPERATION));
+                from("direct:drainTo").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DRAIN_TO)).to(
+                        String.format("hazelcast-%sbar", HazelcastConstants.QUEUE_PREFIX));
+                
+                from("direct:putWithOperationNumber").toF(String.format("hazelcast-%sbar?operation=%s", HazelcastConstants.QUEUE_PREFIX, HazelcastOperation.PUT));
 
-                from("direct:putWithOperationName").toF(String.format("hazelcast-%sbar?operation=put", HazelcastConstants.QUEUE_PREFIX));
+                from("direct:putWithOperationName").toF(String.format("hazelcast-%sbar?operation=PUT", HazelcastConstants.QUEUE_PREFIX));
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicProducerTest.java
@@ -72,7 +72,7 @@ public class HazelcastReliableTopicProducerTest extends HazelcastCamelTestSuppor
 
                 from("direct:publishInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sbar?reliable=true", HazelcastConstants.TOPIC_PREFIX));
 
-                from("direct:publish").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUBLISH_OPERATION)).to(String.format("hazelcast-%sbar?reliable=true", 
+                from("direct:publish").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUBLISH)).to(String.format("hazelcast-%sbar?reliable=true",
                     HazelcastConstants.TOPIC_PREFIX));
             }
         };

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerTest.java
@@ -130,27 +130,27 @@ public class HazelcastReplicatedmapProducerTest extends HazelcastCamelTestSuppor
 
                 from("direct:putInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
 
-                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUT_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
+                from("direct:put").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT)).to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
 
-                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX))
+                from("direct:get").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET)).to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX))
                         .to("seda:out");
 
-                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.DELETE_OPERATION))
+                from("direct:delete").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
 
-                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CLEAR_OPERATION))
+                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CLEAR))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
                 
-                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_KEY_OPERATION))
+                from("direct:containsKey").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_KEY))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX))
                         .to("seda:out");
         
-                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CONTAINS_VALUE_OPERATION))
+                from("direct:containsValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CONTAINS_VALUE))
                         .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX))
                         .to("seda:out");
                 
-                from("direct:putWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.REPLICATEDMAP_PREFIX, HazelcastConstants.PUT_OPERATION);
-                from("direct:putWithOperationName").toF("hazelcast-%sbar?operation=put", HazelcastConstants.REPLICATEDMAP_PREFIX);
+                from("direct:putWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.REPLICATEDMAP_PREFIX, HazelcastOperation.PUT);
+                from("direct:putWithOperationName").toF("hazelcast-%sbar?operation=PUT", HazelcastConstants.REPLICATEDMAP_PREFIX);
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastRingbufferProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastRingbufferProducerTest.java
@@ -46,14 +46,14 @@ public class HazelcastRingbufferProducerTest extends HazelcastCamelTestSupport {
     @Test
     public void testReadHead() throws InterruptedException {
         when(ringbuffer.readOne(Matchers.anyLong())).thenReturn("pippo");
-        Object result = template.requestBody("direct:readonceHead", 12L, String.class);
+        Object result = template.requestBody("direct:READ_ONCE_HEAD", 12L, String.class);
         assertEquals("pippo", result);
     }
     
     @Test
     public void testReadTail() throws InterruptedException {
         when(ringbuffer.readOne(Matchers.anyLong())).thenReturn("pippo");
-        Object result = template.requestBody("direct:readonceTail", 12L, String.class);
+        Object result = template.requestBody("direct:READ_ONCE_TAIL", 12L, String.class);
         assertEquals("pippo", result);
     }
     
@@ -74,7 +74,7 @@ public class HazelcastRingbufferProducerTest extends HazelcastCamelTestSupport {
     @Test
     public void testRemainingCapacity() throws InterruptedException {
         when(ringbuffer.remainingCapacity()).thenReturn(2L);
-        Object result = template.requestBody("direct:remainingCapacity", "", Long.class);
+        Object result = template.requestBody("direct:REMAINING_CAPACITY", "", Long.class);
         assertEquals(2L, result);
     }
 
@@ -84,19 +84,19 @@ public class HazelcastRingbufferProducerTest extends HazelcastCamelTestSupport {
             @Override
             public void configure() throws Exception {
               
-                from("direct:readonceHead").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.READ_ONCE_HEAD_OPERATION)).to(
+                from("direct:READ_ONCE_HEAD").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.READ_ONCE_HEAD)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.RINGBUFFER_PREFIX));
                 
-                from("direct:readonceTail").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.READ_ONCE_TAIL_OPERATION)).to(
+                from("direct:READ_ONCE_TAIL").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.READ_ONCE_TAIL)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.RINGBUFFER_PREFIX));
                 
-                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION)).to(
+                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.RINGBUFFER_PREFIX));
                 
-                from("direct:capacity").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.GET_CAPACITY_OPERATION)).to(
+                from("direct:capacity").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CAPACITY)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.RINGBUFFER_PREFIX));
                 
-                from("direct:remainingCapacity").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMAINING_CAPACITY_OPERATION)).to(
+                from("direct:REMAINING_CAPACITY").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMAINING_CAPACITY)).to(
                         String.format("hazelcast-%sfoo", HazelcastConstants.RINGBUFFER_PREFIX));
 
             }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
@@ -75,7 +75,7 @@ public class HazelcastSetProducerTest extends HazelcastCamelTestSupport {
 
     @Test
     public void removeValue() throws InterruptedException {
-        template.sendBody("direct:removevalue", "foo2");
+        template.sendBody("direct:removeValue", "foo2");
         verify(set).remove("foo2");
     }
     
@@ -90,7 +90,7 @@ public class HazelcastSetProducerTest extends HazelcastCamelTestSupport {
         Collection t = new ArrayList();
         t.add("test1");
         t.add("test2");
-        template.sendBody("direct:addAll", t);
+        template.sendBody("direct:addall", t);
         verify(set).addAll(t);
     }
     
@@ -108,7 +108,7 @@ public class HazelcastSetProducerTest extends HazelcastCamelTestSupport {
         Collection t = new ArrayList();
         t.add("test1");
         t.add("test2");
-        template.sendBody("direct:retainAll", t);
+        template.sendBody("direct:RETAIN_ALL", t);
         verify(set).retainAll(t);
     }
 
@@ -120,24 +120,24 @@ public class HazelcastSetProducerTest extends HazelcastCamelTestSupport {
 
                 from("direct:addInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).toF("hazelcast-%sbar", HazelcastConstants.SET_PREFIX);
 
-                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.SET_PREFIX);
+                from("direct:add").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD)).toF("hazelcast-%sbar", HazelcastConstants.SET_PREFIX);
 
-                from("direct:removevalue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVEVALUE_OPERATION)).to(
+                from("direct:removeValue").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.SET_PREFIX));
                 
-                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.CLEAR_OPERATION)).toF("hazelcast-%sbar", HazelcastConstants.SET_PREFIX);
+                from("direct:clear").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.CLEAR)).toF("hazelcast-%sbar", HazelcastConstants.SET_PREFIX);
 
-                from("direct:addAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.ADD_ALL_OPERATION)).to(
+                from("direct:addall").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.SET_PREFIX));
                 
-                from("direct:removeAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.REMOVE_ALL_OPERATION)).to(
+                from("direct:removeAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.SET_PREFIX));
                 
-                from("direct:retainAll").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.RETAIN_ALL_OPERATION)).to(
+                from("direct:RETAIN_ALL").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.RETAIN_ALL)).to(
                         String.format("hazelcast-%sbar", HazelcastConstants.SET_PREFIX));
                 
-                from("direct:addWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.SET_PREFIX, HazelcastConstants.ADD_OPERATION);
-                from("direct:addWithOperationName").toF("hazelcast-%sbar?operation=add", HazelcastConstants.SET_PREFIX);
+                from("direct:addWithOperationNumber").toF("hazelcast-%sbar?operation=%s", HazelcastConstants.SET_PREFIX, HazelcastOperation.ADD);
+                from("direct:addWithOperationName").toF("hazelcast-%sbar?operation=ADD", HazelcastConstants.SET_PREFIX);
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicProducerTest.java
@@ -72,7 +72,7 @@ public class HazelcastTopicProducerTest extends HazelcastCamelTestSupport {
 
                 from("direct:publishInvalid").setHeader(HazelcastConstants.OPERATION, constant("bogus")).to(String.format("hazelcast-%sbar", HazelcastConstants.TOPIC_PREFIX));
 
-                from("direct:publish").setHeader(HazelcastConstants.OPERATION, constant(HazelcastConstants.PUBLISH_OPERATION)).to(String.format("hazelcast-%sbar", HazelcastConstants.TOPIC_PREFIX));
+                from("direct:publish").setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUBLISH)).to(String.format("hazelcast-%sbar", HazelcastConstants.TOPIC_PREFIX));
             }
         };
     }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicyMain.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicyMain.java
@@ -37,7 +37,7 @@ public final class HazelcastRoutePolicyMain {
                 policy.setLockValue(args[1]);
                 policy.setTryLockTimeout(5, TimeUnit.SECONDS);
 
-                from("file:///tmp/camel?delete=true")
+                from("file:///tmp/camel?DELETE=true")
                     .routeId(args[1])
                     .routePolicy(policy)
                     .setHeader("HazelcastRouteID", constant(args[1]))

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
@@ -51,22 +51,22 @@ public class HazelcastIdempotentRepositoryTest extends CamelTestSupport {
 
     @Test
     public void testAdd() throws Exception {
-        // add first key
+        // ADD first key
         assertTrue(repo.add(key01));
         assertTrue(cache.containsKey(key01));
 
-        // try to add the same key again
+        // try to ADD the same key again
         assertFalse(repo.add(key01));
         assertEquals(1, cache.size());
 
-        // try to add an other one
+        // try to ADD an other one
         assertTrue(repo.add(key02));
         assertEquals(2, cache.size());
     }
 
     @Test
     public void testConfirm() throws Exception {
-        // add first key and confirm
+        // ADD first key and confirm
         assertTrue(repo.add(key01));
         assertTrue(repo.confirm(key01));
 
@@ -78,7 +78,7 @@ public class HazelcastIdempotentRepositoryTest extends CamelTestSupport {
     public void testContains() throws Exception {
         assertFalse(repo.contains(key01));
 
-        // add key and check again
+        // ADD key and check again
         assertTrue(repo.add(key01));
         assertTrue(repo.contains(key01));
 
@@ -86,19 +86,19 @@ public class HazelcastIdempotentRepositoryTest extends CamelTestSupport {
 
     @Test
     public void testRemove() throws Exception {
-        // add key to remove
+        // ADD key to remove
         assertTrue(repo.add(key01));
         assertTrue(repo.add(key02));
         assertEquals(2, cache.size());
 
-        // clear repo
+        // CLEAR repo
         repo.clear();
         assertEquals(0, cache.size());
     }
     
     @Test
     public void testClear() throws Exception {
-        // add key to remove
+        // ADD key to remove
         assertTrue(repo.add(key01));
         assertEquals(1, cache.size());
 


### PR DESCRIPTION
I've kept operations current names in order to have backward compatibility especially with Spring/XML DSL. However, entries in HazelcastConstants have been declared as deprecated.

