### PR TITLE
Adds note to asyncDelayedRedelivery about the Async Components

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/DefaultErrorHandlerBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/DefaultErrorHandlerBuilder.java
@@ -226,7 +226,8 @@ public class DefaultErrorHandlerBuilder extends ErrorHandlerBuilderSupport {
     }
 
     /**
-     * Will allow asynchronous delayed redeliveries.
+     * Will allow asynchronous delayed redeliveries. The route, in particular the consumer's component,
+     * must support the Asynchronous Routing Engine (e.g. seda)
      *
      * @see org.apache.camel.processor.RedeliveryPolicy#setAsyncDelayedRedelivery(boolean)
      * @return the builder

--- a/camel-core/src/main/java/org/apache/camel/model/RedeliveryPolicyDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RedeliveryPolicyDefinition.java
@@ -185,7 +185,8 @@ public class RedeliveryPolicyDefinition {
     //-------------------------------------------------------------------------
 
     /**
-     * Allow synchronous delayed redelivery.
+     * Allow synchronous delayed redelivery. The route, in particular the consumer's component,
+     * must support the Asynchronous Routing Engine (e.g. seda).
      *
      * @return the builder
      */


### PR DESCRIPTION
Tiny javadoc note about the hypothesis about asyncDelayedRedelivery in redelivery policies.

Nothing really ground breaking but a small hint that would have helped me to understand what my route expected. The current doc/code could let imagine that the onException/errorHandler automatically becomes async even if he's in a direct route.