### PR TITLE
CAMEL-11437 - probeContentType and preMove attributes causes Exchange…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/FileEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/FileEndpoint.java
@@ -140,7 +140,7 @@ public class FileEndpoint extends GenericFileEndpoint<File> {
     public Exchange createExchange(GenericFile<File> file) {
         Exchange exchange = createExchange();
         if (file != null) {
-            file.bindToExchange(exchange);
+            file.bindToExchange(exchange, probeContentType);
         }
         return exchange;
     }

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFile.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFile.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.WrappedFile;
 import org.apache.camel.util.FileUtil;
@@ -113,6 +114,19 @@ public class GenericFile<T> implements WrappedFile<T>  {
      * Bind this GenericFile to an Exchange
      */
     public void bindToExchange(Exchange exchange) {
+        GenericFileMessage<T> msg = commonBindToExchange(exchange);
+        populateHeaders(msg, false);
+    }
+    
+    /**
+     * Bind this GenericFile to an Exchange
+     */
+    public void bindToExchange(Exchange exchange, boolean isProbeContentTypeFromEndpoint) {
+        GenericFileMessage<T> msg = commonBindToExchange(exchange);
+        populateHeaders(msg, isProbeContentTypeFromEndpoint);
+    }
+
+    private GenericFileMessage<T> commonBindToExchange(Exchange exchange) {
         Map<String, Object> headers;
 
         exchange.setProperty(FileComponent.FILE_EXCHANGE_FILE, this);
@@ -131,7 +145,7 @@ public class GenericFile<T> implements WrappedFile<T>  {
             // remove any file related headers, as we will re-populate file headers
             msg.removeHeaders("CamelFile*");
         }
-        populateHeaders(msg);
+        return msg;
     }
 
     /**
@@ -139,7 +153,7 @@ public class GenericFile<T> implements WrappedFile<T>  {
      *
      * @param message the message to populate with headers
      */
-    public void populateHeaders(GenericFileMessage<T> message) {
+    public void populateHeaders(GenericFileMessage<T> message, boolean isProbeContentTypeFromEndpoint) {
         if (message != null) {
             message.setHeader(Exchange.FILE_NAME_ONLY, getFileNameOnly());
             message.setHeader(Exchange.FILE_NAME, getFileName());
@@ -151,7 +165,7 @@ public class GenericFile<T> implements WrappedFile<T>  {
                 message.setHeader("CamelFileExtendedAttributes", extendedAttributes);
             }
             
-            if (probeContentType && file instanceof File) {
+            if ((isProbeContentTypeFromEndpoint || probeContentType) && file instanceof File) {
                 File f = (File) file;
                 Path path = f.toPath();
                 try {

--- a/camel-core/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameProcessStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameProcessStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file.strategy;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.component.file.FileEndpoint;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileOperations;
@@ -42,9 +43,18 @@ public class GenericFileRenameProcessStrategy<T> extends GenericFileProcessStrat
         if (beginRenamer != null) {
             GenericFile<T> newName = beginRenamer.renameFile(exchange, file);
             GenericFile<T> to = renameFile(operations, file, newName);
-            if (to != null) {
-                to.bindToExchange(exchange);
+            FileEndpoint fe = null;
+            if (endpoint instanceof FileEndpoint) {
+                fe = (FileEndpoint)endpoint;
+                if (to != null) {
+                    to.bindToExchange(exchange, fe.isProbeContentType());
+                }
+            } else {
+                if (to != null) {
+                    to.bindToExchange(exchange);
+                }
             }
+            
         }
 
         return true;
@@ -58,7 +68,13 @@ public class GenericFileRenameProcessStrategy<T> extends GenericFileProcessStrat
             if (failureRenamer != null) {
                 // create a copy and bind the file to the exchange to be used by the renamer to evaluate the file name
                 Exchange copy = ExchangeHelper.createCopy(exchange, true);
-                file.bindToExchange(copy);
+                FileEndpoint fe = null;
+                if (endpoint instanceof FileEndpoint) {
+                    fe = (FileEndpoint)endpoint;
+                    file.bindToExchange(copy, fe.isProbeContentType());
+                } else {
+                    file.bindToExchange(copy);
+                }
                 // must preserve message id
                 copy.getIn().setMessageId(exchange.getIn().getMessageId());
                 copy.setExchangeId(exchange.getExchangeId());
@@ -80,7 +96,13 @@ public class GenericFileRenameProcessStrategy<T> extends GenericFileProcessStrat
             if (commitRenamer != null) {
                 // create a copy and bind the file to the exchange to be used by the renamer to evaluate the file name
                 Exchange copy = ExchangeHelper.createCopy(exchange, true);
-                file.bindToExchange(copy);
+                FileEndpoint fe = null;
+                if (endpoint instanceof FileEndpoint) {
+                    fe = (FileEndpoint)endpoint;
+                    file.bindToExchange(copy, fe.isProbeContentType());
+                }  else {
+                    file.bindToExchange(copy);
+                }
                 // must preserve message id
                 copy.getIn().setMessageId(exchange.getIn().getMessageId());
                 copy.setExchangeId(exchange.getExchangeId());

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveWithProbeContentTypeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveWithProbeContentTypeTest.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+/**
+ * @version 
+ */
+public class FileConsumerPreMoveWithProbeContentTypeTest extends ContextTestSupport {
+
+    @Override
+    protected void setUp() throws Exception {
+        deleteDirectory("target/premove");
+        super.setUp();
+    }
+
+    public void testContentTypeWithPremoveAndProbeContentTypeOptions() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedBodiesReceived("Hello World");
+        mock.expectedHeaderReceived(Exchange.FILE_CONTENT_TYPE, "txt");
+
+        template.sendBodyAndHeader("file://target/premove", "Hello World", Exchange.FILE_NAME, "hello.txt");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("file://target/premove?probeContentType=true&preMove=work/work-${file:name}&initialDelay=0&delay=100")
+                    .to("mock:result");
+            }
+        };
+    }
+}

--- a/camel-core/src/test/java/org/apache/camel/component/file/GenericFileMessageTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/GenericFileMessageTest.java
@@ -45,7 +45,7 @@ public class GenericFileMessageTest extends ContextTestSupport {
         file.setFileName("target");
         file.setFile(new File("target/camel-core-test.log"));
         GenericFileMessage<File> message = new GenericFileMessage<File>(camelContext, file);
-        file.populateHeaders(message);
+        file.populateHeaders(message, false);
         assertEquals("Get a wrong file content type", "txt", message.getHeader(Exchange.FILE_CONTENT_TYPE));
     }
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFile.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFile.java
@@ -35,7 +35,10 @@ public class RemoteFile<T> extends GenericFile<T> implements Cloneable {
      */
     public void populateHeaders(GenericFileMessage<T> message) {
         if (message != null) {
-            super.populateHeaders(message);
+            // because there is not probeContentType option 
+            // in other file based components, false may be passed
+            // as the second argument.
+            super.populateHeaders(message, false);
             message.setHeader("CamelFileHost", getHostname());
         }
     }


### PR DESCRIPTION
….FILE_CONTENT_TYPE to get dropped

This is a very specific fix for the issue.

Better solution would be passing endpoint where bindToExchange method call done on GenericFile. I guess the design may need such a change on GenericFile. because in populateHeaders method there are specific conditions tied to FileEndpoint properties which are not set when concrete instances of GenericFileProcessStrategy are created without the settings bound to endpoint like GenericFileRenameProcessStrategy, GenericDeleteProcessStrategy etc. (where probeContentType is lost)