### PR TITLE
CAMEL-11445 Declare JEE namespace in beans.xml

### DIFF
--- a/components/camel-cdi/src/main/resources/META-INF/beans.xml
+++ b/components/camel-cdi/src/main/resources/META-INF/beans.xml
@@ -17,7 +17,12 @@
     limitations under the License.
 
 -->
-<beans version="1.0" bean-discovery-mode="all">
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee 
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+    version="1.0" bean-discovery-mode="all">
 
     <scan>
         <exclude name="org.apache.camel.cdi.Main"/>


### PR DESCRIPTION
This adds XML namespace declaration to `beans.xml`.

@astefanutti would you mind having a look, I'm not up to date with CDI spec, I think there is a newer version but I'm not sure what namespace it uses.