### PR TITLE
CAMEL-11469 Use remainder of uri to parse config

### DIFF
--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatComponent.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatComponent.java
@@ -53,15 +53,13 @@ public class HipchatComponent extends UriEndpointComponent {
         if (endpoint.getConfiguration().getAuthToken() == null) {
             throw new HipchatException("OAuth 2 auth token must be specified");
         }
-        parseUri(uri, endpoint);
+        parseUri(remaining, endpoint);
         LOG.debug("Using Hipchat API URL: {}", endpoint.getConfiguration().hipChatUrl());
         return endpoint;
     }
 
-    private void parseUri(String uri, HipchatEndpoint endpoint) throws Exception {
-        // strip scheme
-        uri = ObjectHelper.after(uri, ":");
-        uri = URISupport.normalizeUri(uri);
+    private void parseUri(String remaining, HipchatEndpoint endpoint) throws Exception {
+        String uri = URISupport.normalizeUri(remaining);
 
         URI hipChatUri = new URI(uri);
         if (hipChatUri.getHost() != null) {

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatXmlDefinedComponentProducerTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/HipchatXmlDefinedComponentProducerTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hipchat;
+
+import java.io.InputStream;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.model.ModelHelper;
+import org.apache.camel.model.RoutesDefinition;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+
+import static org.hamcrest.core.Is.is;
+
+public class HipchatXmlDefinedComponentProducerTest extends CamelTestSupport {
+
+    @EndpointInject(uri = "hipchat:https:foobar.com:443?authToken=abc123")
+    protected Endpoint endpoint;
+
+    @Test
+    public void shouldConfigureEndpointCorrectlyViaXml() throws Exception {
+        assertIsInstanceOf(HipchatEndpoint.class, endpoint);
+        HipchatEndpoint hipchatEndpoint = (HipchatEndpoint) endpoint;
+        HipchatConfiguration configuration = hipchatEndpoint.getConfiguration();
+        assertThat(configuration.getAuthToken(), is("abc123"));
+        assertThat(configuration.getHost(), is("foobar.com"));
+        assertThat(configuration.getProtocol(), is("https"));
+        assertThat(configuration.getPort(), is(443));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        final CamelContext context = super.createCamelContext();
+        HipchatComponent component = new HipchatComponent(context) {
+            @Override
+            protected HipchatEndpoint getHipchatEndpoint(String uri) {
+                return new HipchatEPSuccessTestSupport(uri, this, null, null);
+            }
+        };
+        context.addComponent("hipchat", component);
+
+        // This test is all about ensuring the endpoint is configured correctly when using the XML DSL so this
+        try (InputStream routes = getClass().getResourceAsStream("HipchatXmlDefinedComponentProducerTest-route.xml")) {
+            RoutesDefinition routesDefinition = ModelHelper.loadRoutesDefinition(context, routes);
+            context.addRouteDefinition(routesDefinition.getRoutes().get(0));
+        }
+
+        return context;
+    }
+}

--- a/components/camel-hipchat/src/test/resources/org/apache/camel/component/hipchat/HipchatXmlDefinedComponentProducerTest-route.xml
+++ b/components/camel-hipchat/src/test/resources/org/apache/camel/component/hipchat/HipchatXmlDefinedComponentProducerTest-route.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<routes xmlns="http://camel.apache.org/schema/spring"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <route id="hipchatTest">
+        <from uri="direct://foo"/>
+        <to id="hipchat" uri="hipchat:https:foobar.com:443?authToken=abc123"/>
+    </route>
+
+</routes>


### PR DESCRIPTION
The configuration now uses the remainder of the uri to parse out the properties. This can now cope with a '//' or not and stops further string manipulation where it isn't needed.

CAMEL-9495 was fixing parsing logic and seemed to knock it out. I'm not super familiar with camel core but it looks like the 'remaining' URI is already being passed in so it seems silly to attempt this again?

Also I had to work hard a bit not to introduce a dependency on spring in order to reproduce this. My work around is to manually load in the route from XML. It's quite clunky the way I've done it. If there's a smoother way, please advise.