### PR TITLE
CAMEL-11511: Proposal to enhance the `BeanInfo` introspection in 2 cases

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -304,43 +304,41 @@ public class BeanInfo {
      * @param clazz the class
      */
     private void introspect(Class<?> clazz) {
-        // get the target clazz as it could potentially have been enhanced by CGLIB etc.
-        clazz = getTargetClass(clazz);
-        ObjectHelper.notNull(clazz, "clazz", this);
-
-        LOG.trace("Introspecting class: {}", clazz);
 
         // does the class have any public constructors?
         publicConstructors = clazz.getConstructors().length > 0;
 
-        // favor declared methods, and then filter out duplicate interface methods
-        List<Method> methods;
-        if (Modifier.isPublic(clazz.getModifiers())) {
-            LOG.trace("Preferring class methods as class: {} is public accessible", clazz);
-            methods = new ArrayList<Method>(Arrays.asList(clazz.getDeclaredMethods()));
-        } else {
-            LOG.trace("Preferring interface methods as class: {} is not public accessible", clazz);
-            methods = getInterfaceMethods(clazz);
-            // and then we must add its declared methods as well
-            List<Method> extraMethods = Arrays.asList(clazz.getDeclaredMethods());
-            methods.addAll(extraMethods);
-        }
+        MethodsFilter methods = new MethodsFilter(getType());
+        introspect(clazz, methods);
 
         // now introspect the methods and filter non valid methods
-        for (Method method : methods) {
+        for (Method method : methods.asReadOnlyList()) {
             boolean valid = isValidMethod(clazz, method);
             LOG.trace("Method: {} is valid: {}", method, valid);
             if (valid) {
                 introspect(clazz, method);
             }
         }
+    }
+
+    private void introspect(Class<?> clazz, MethodsFilter filteredMethods) {
+        // get the target clazz as it could potentially have been enhanced by
+        // CGLIB etc.
+        clazz = getTargetClass(clazz);
+        ObjectHelper.notNull(clazz, "clazz", this);
+
+        LOG.trace("Introspecting class: {}", clazz);
+
+        for (Method m : Arrays.asList(clazz.getDeclaredMethods())) {
+            filteredMethods.filterMethod(m);
+        }
 
         Class<?> superClass = clazz.getSuperclass();
         if (superClass != null && !superClass.equals(Object.class)) {
-            introspect(superClass);
+            introspect(superClass, filteredMethods);
         }
         for (Class<?> superInterface : clazz.getInterfaces()) {
-            introspect(superInterface);
+            introspect(superInterface, filteredMethods);
         }
     }
 
@@ -1005,19 +1003,6 @@ public class BeanInfo {
         }
 
         return null;
-    }
-    
-    private static List<Method> getInterfaceMethods(Class<?> clazz) {
-        final List<Method> answer = new ArrayList<Method>();
-
-        while (clazz != null && !clazz.equals(Object.class)) {
-            for (Class<?> interfaceClazz : clazz.getInterfaces()) {
-                Collections.addAll(answer, interfaceClazz.getDeclaredMethods());
-            }
-            clazz = clazz.getSuperclass();
-        }
-
-        return answer;
     }
 
     private static void removeAllSetterOrGetterMethods(List<MethodInfo> methods) {

--- a/camel-core/src/main/java/org/apache/camel/component/bean/MethodsFilter.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/MethodsFilter.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * This class aims at retaining the right methods while parsing a given
+ * {@link java.lang.Class}.
+ */
+class MethodsFilter {
+
+    private final List<Method> methods = new ArrayList<Method>();
+    private final Class<?> inheritingClass;
+
+    /**
+     * Creates a <code>MethodsFilter</code> for a given {@link java.lang.Class}.
+     *
+     * @param clazz The {@link java.lang.Class} whose methods are to be
+     *            filtered.
+     */
+    public MethodsFilter(Class<?> clazz) {
+        this.inheritingClass = clazz;
+    }
+
+    /**
+     * Retains methods, preferring those from public classes in case of
+     * overrides.
+     *
+     * @param proposedMethod The method proposed to the filter.
+     */
+    void filterMethod(Method proposedMethod) {
+        if (proposedMethod.isBridge()) {
+            return;
+        }
+
+        for (int i = 0; i < methods.size(); i++) {
+            Method alreadyRegistered = methods.get(i);
+
+            if (Modifier.isPublic(proposedMethod.getDeclaringClass().getModifiers())) {
+                boolean overridden = ObjectHelper.isOverridingMethod(inheritingClass, proposedMethod, alreadyRegistered, false);
+                boolean overridding = ObjectHelper.isOverridingMethod(inheritingClass, alreadyRegistered, proposedMethod, false);
+
+                boolean registeredMethodIsPublic = Modifier.isPublic(alreadyRegistered.getDeclaringClass().getModifiers());
+
+                if (overridden && !registeredMethodIsPublic) {
+                    // Retain the overridden method from a public class
+                    methods.set(i, proposedMethod);
+                    return;
+                } else if (overridding) {
+                    // Retain the override from a public class
+                    methods.set(i, proposedMethod);
+                    return;
+                }
+            }
+        }
+
+        methods.add(proposedMethod);
+    }
+
+    List<Method> asReadOnlyList() {
+        return Collections.unmodifiableList(methods);
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -1438,7 +1438,7 @@ public final class ObjectHelper {
 
         if (source.equals(target)) {
             return true;
-        } else if (source.getDeclaringClass() == target.getDeclaringClass()) {
+        } else if (target.getDeclaringClass().isAssignableFrom(source.getDeclaringClass())) {
             return false;
         } else if (!source.getDeclaringClass().isAssignableFrom(inheritingClass) || !target.getDeclaringClass().isAssignableFrom(inheritingClass)) {
             return false;

--- a/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.bean;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -26,11 +27,12 @@ import org.apache.camel.InOnly;
 import org.apache.camel.InOut;
 import org.apache.camel.Pattern;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @version 
+ * @version
  */
 public class BeanInfoTest extends TestCase {
     private static final Logger LOG = LoggerFactory.getLogger(BeanInfoTest.class);
@@ -112,6 +114,30 @@ public class BeanInfoTest extends TestCase {
         assertMethodPattern(info, "inOutMethod", ExchangePattern.InOut);
     }
 
+    public void testImplementLevel2InterfaceMethodInPackagePrivateClass() {
+        BeanInfo info = createBeanInfo(PackagePrivateClassImplementingLevel2InterfaceMethod.class);
+        List<MethodInfo> mis = info.getMethods();
+        Assert.assertNotNull(mis);
+        Assert.assertEquals(1, mis.size());
+        MethodInfo mi = mis.get(0);
+        Assert.assertNotNull(mi);
+        Method m = mi.getMethod();
+        Assert.assertEquals("method", m.getName());
+        Assert.assertTrue(Modifier.isPublic(m.getDeclaringClass().getModifiers()));
+    }
+
+    public void testPublicClassImplementingInterfaceMethodBySuperPackagePrivateClass() {
+        BeanInfo info = createBeanInfo(PublicClassImplementingBySuperPackagePrivateClass.class);
+        List<MethodInfo> mis = info.getMethods();
+        Assert.assertNotNull(mis);
+        Assert.assertEquals(1, mis.size());
+        MethodInfo mi = mis.get(0);
+        Assert.assertNotNull(mi);
+        Method m = mi.getMethod();
+        Assert.assertEquals("method", m.getName());
+        Assert.assertTrue(Modifier.isPublic(m.getDeclaringClass().getModifiers()));
+    }
+
     protected BeanInfo createBeanInfo(Class<?> type) {
         BeanInfo info = new BeanInfo(camelContext, type);
         return info;
@@ -183,6 +209,33 @@ public class BeanInfoTest extends TestCase {
         public Object inOutMethod() {
             return null;
         }
+    }
+
+    public interface ILevel2Interface {
+        String method();
+    }
+
+    public interface ILevel1Interface extends ILevel2Interface {
+    }
+
+    class PackagePrivateClassImplementingLevel2InterfaceMethod implements ILevel1Interface {
+        @Override
+        public String method() {
+            return "PackagePrivateClassImplementingLevel2InterfaceMethod.method() has been called";
+        }
+    }
+
+    public interface IMethodInterface {
+        String method();
+    }
+
+    class PackagePrivateClassDefiningMethod {
+        public String method() {
+            return "PackagePrivateClassDefiningMethod.method() has been called";
+        }
+    }
+
+    public class PublicClassImplementingBySuperPackagePrivateClass extends PackagePrivateClassDefiningMethod implements IMethodInterface {
     }
 
 }


### PR DESCRIPTION
Proposal to enhance the `BeanInfo` introspection in 2 cases:
- A package private class implementing a 2 hop interface method
- A public class implementing an interface method by an override from a package private class

More info in [CAMEL-11511](https://issues.apache.org/jira/browse/CAMEL-11511).
