### PR TITLE
CAMEL-11509 - check for semicolon added to call ContentType.create

### DIFF
--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
@@ -505,7 +505,7 @@ public class HttpProducer extends DefaultProducer {
                     //it removes "boundary" from Content-Type; I have to use contentType.create method.
                     if (contentTypeString != null) {
                         // using ContentType.parser for charset
-                        if (contentTypeString.indexOf("charset") > 0) {
+                        if (contentTypeString.indexOf("charset") > 0 || contentTypeString.indexOf(";") > 0) {
                             contentType = ContentType.parse(contentTypeString);
                         } else {
                             contentType = ContentType.create(contentTypeString);

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpProducerContentTypeWithSemiColomnTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpProducerContentTypeWithSemiColomnTest.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.component.http4;
+
+import java.io.IOException;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpProducerContentTypeWithSemiColomnTest extends BaseHttpTest {
+
+    private static final String CONTENT_TYPE = "multipart/form-data;boundary=---------------------------j2radvtrk";
+    
+    private HttpServer localServer;
+    
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        localServer = ServerBootstrap.bootstrap().
+                setHttpProcessor(getBasicHttpProcessor()).
+                setConnectionReuseStrategy(getConnectionReuseStrategy()).
+                setResponseFactory(getHttpResponseFactory()).
+                setExpectationVerifier(getHttpExpectationVerifier()).
+                setSslContext(getSSLContext()).
+                registerHandler("/content", new HttpRequestHandler() {
+                    @Override
+                    public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+                        String contentType = request.getFirstHeader(Exchange.CONTENT_TYPE).getValue();
+                        
+                        assertEquals(CONTENT_TYPE.replace(";", "; "), contentType);
+
+                        response.setEntity(new StringEntity(contentType, "ASCII"));
+                        response.setStatusCode(HttpStatus.SC_OK);
+                    }
+                }).create();
+        localServer.start();
+
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        if (localServer != null) {
+            localServer.stop();
+        }
+    }
+    
+    @Test
+    public void testContentTypeWithBoundary() throws Exception {
+        Exchange out = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/content", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.CONTENT_TYPE, CONTENT_TYPE);
+                exchange.getIn().setBody("This is content");
+            }
+            
+        });
+
+        assertNotNull(out);
+        assertFalse("Should not fail", out.isFailed());
+        assertEquals(CONTENT_TYPE.replace(";", "; "), out.getOut().getBody(String.class));
+        
+    }
+    
+    @Test
+    public void testContentTypeWithBoundaryWithIgnoreResponseBody() throws Exception {
+        Exchange out = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/content?ignoreResponseBody=true", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.CONTENT_TYPE, CONTENT_TYPE);
+                exchange.getIn().setBody("This is content");
+            }
+            
+        });
+
+        assertNotNull(out);
+        assertFalse("Should not fail", out.isFailed());
+        assertNull(out.getOut().getBody());
+        
+    }
+}


### PR DESCRIPTION
As mentioned in the issue when ContentType.create is called for such cases, it breaks HttpProducerContentTypeTest.java.
if not, the issue is up.

As a workaround issue, simple check is added.
We may need to check why ContentType.create fails whereas ContentType.parse not as @WillemJiang commented on https://issues.apache.org/jira/browse/CAMEL-7886
and fixed in the issue like 

```
//Check the contentType is valid or not, If not it throws an exception.
//When ContentType.parse parse method parse "multipart/form-data;boundary=---------------------------j2radvtrk",
//it removes "boundary" from Content-Type; I have to use contentType.create method.
if (contentTypeString != null) {
    // using ContentType.parser for charset
    if (contentTypeString.indexOf("charset") > 0) {
        contentType = ContentType.parse(contentTypeString);
    } else {
        contentType = ContentType.create(contentTypeString);
    }
}
```

I will also try to catch up with httpcomponents and revisit the issue.
