### PR TITLE
CAMEL-11520 URL-encode hipchat room names

### DIFF
--- a/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatProducer.java
+++ b/components/camel-hipchat/src/main/java/org/apache/camel/component/hipchat/HipchatProducer.java
@@ -27,6 +27,7 @@ import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.camel.util.URISupport;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -36,6 +37,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.camel.util.UnsafeUriCharactersEncoder.encodeHttpURI;
 
 /**
  * The Hipchat producer to send message to a user and/or a room.
@@ -71,7 +74,7 @@ public class HipchatProducer extends DefaultProducer {
             jsonParam.put(HipchatApiConstants.API_MESSAGE_COLOR, backGroundColor);
         }
         LOG.info("Sending message to room: " + room + ", " + MAPPER.writeValueAsString(jsonParam));
-        StatusLine statusLine = post(urlPath, jsonParam);
+        StatusLine statusLine = post(encodeHttpURI(urlPath), jsonParam);
         LOG.debug("Response status for send room message: " + statusLine);
         return statusLine;
     }

--- a/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatProducerIntegrationTest.java
+++ b/components/camel-hipchat/src/test/java/org/apache/camel/component/hipchat/integration/HipchatProducerIntegrationTest.java
@@ -72,6 +72,23 @@ public class HipchatProducerIntegrationTest extends CamelTestSupport {
 
     }
 
+    @Test
+    public void sendToUriUnsafeRoomName() throws Exception {
+        result.expectedMessageCount(1);
+
+        Exchange exchange1 = template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(HipchatConstants.TO_ROOM, "Camel Test");
+                exchange.getIn().setHeader(HipchatConstants.TO_USER, "@ShreyasPurohit");
+                exchange.getIn().setBody("A room with spaces");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+
+        assertResponseMessage(exchange1.getIn());
+    }
+
     private void assertResponseMessage(Message message) {
         assertEquals(204, message.getHeader(HipchatConstants.TO_ROOM_RESPONSE_STATUS, StatusLine.class).getStatusCode());
         assertEquals(204, message.getHeader(HipchatConstants.TO_USER_RESPONSE_STATUS, StatusLine.class).getStatusCode());


### PR DESCRIPTION
This allows messages to be sent to room names containing spaces or other URL-unsafe characters.