### PR TITLE
CAMEL-11446: Use awaitility in camel-core for testing where we otherw…

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/component/file/NewFileConsumerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/NewFileConsumerTest.java
@@ -47,9 +47,7 @@ public class NewFileConsumerTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesMockWaitTime();
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> myFile.isPost());
-
-        assertTrue("Should have invoked postPollCheck", myFile.isPost());
+        await("postPollCheck invocation").atMost(1, TimeUnit.SECONDS).until(myFile::isPost);
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/impl/CamelPostProcessorHelperTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/CamelPostProcessorHelperTest.java
@@ -133,9 +133,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // give UoW a bit of time
-        await().atMost(1, TimeUnit.SECONDS).until(() -> mySynchronization.isOnDone());
-
-        assertTrue("Should have invoked onDone", mySynchronization.isOnDone());
+        await("onDone invokation").atMost(1, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
     }
 
     public void testProduceSynchronization() throws Exception {
@@ -153,9 +151,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // give UoW a bit of time
-        await().atMost(1, TimeUnit.SECONDS).until(() -> mySynchronization.isOnDone());
-
-        assertTrue("Should have invoked onDone", mySynchronization.isOnDone());
+        await("onDone invocation").atMost(1, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
     }
 
     public void testEndpointInjectProducerTemplate() throws Exception {

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateTest.java
@@ -124,12 +124,9 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello");
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             Object foo = consumer.receiveBodyNoWait("seda:foo");
-            if (foo != null) {
-                assertEquals("Hello", foo);
-            }
-            return foo != null;
+            assertEquals("Hello", foo);
         });
     }
 
@@ -158,12 +155,9 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello");
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             String foo = consumer.receiveBodyNoWait("seda:foo", String.class);
-            if (foo != null) {
-                assertEquals("Hello", foo);
-            }
-            return foo != null;
+            assertEquals("Hello", foo);
         });
     }
 
@@ -261,12 +255,9 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello");
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             String foo = consumer.receiveBodyNoWait(endpoint, String.class);
-            if (foo != null) {
-                assertEquals("Hello", foo);
-            }
-            return foo != null;
+            assertEquals("Hello", foo);
         });
     }
 
@@ -279,12 +270,9 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello");
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             Object foo = consumer.receiveBodyNoWait(endpoint);
-            if (foo != null) {
-                assertEquals("Hello", foo);
-            }
-            return foo != null;
+            assertEquals("Hello", foo);
         });
     }
 

--- a/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyFactoryTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyFactoryTest.java
@@ -34,13 +34,10 @@ public class DurationRoutePolicyFactoryTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // need a little time to stop async
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            boolean started = context.getRouteStatus("foo").isStarted();
-            boolean stopped = context.getRouteStatus("foo").isStopped();
-            return !started && stopped;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFalse(context.getRouteStatus("foo").isStarted());
+            assertTrue(context.getRouteStatus("foo").isStopped());
         });
-        assertFalse(context.getRouteStatus("foo").isStarted());
-        assertTrue(context.getRouteStatus("foo").isStopped());
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyMaxMessagesTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyMaxMessagesTest.java
@@ -34,13 +34,10 @@ public class DurationRoutePolicyMaxMessagesTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // need a little time to stop async
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            boolean started = context.getRouteStatus("foo").isStarted();
-            boolean stopped = context.getRouteStatus("foo").isStopped();
-            return !started && stopped;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFalse(context.getRouteStatus("foo").isStarted());
+            assertTrue(context.getRouteStatus("foo").isStopped());
         });
-        assertFalse(context.getRouteStatus("foo").isStarted());
-        assertTrue(context.getRouteStatus("foo").isStopped());
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyMaxSecondsTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DurationRoutePolicyMaxSecondsTest.java
@@ -34,14 +34,10 @@ public class DurationRoutePolicyMaxSecondsTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // need a little time to stop async
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            boolean started = context.getRouteStatus("foo").isStarted();
-            boolean stopped = context.getRouteStatus("foo").isStopped();
-            return !started && stopped;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFalse(context.getRouteStatus("foo").isStarted());
+            assertTrue(context.getRouteStatus("foo").isStopped());
         });
-
-        assertFalse(context.getRouteStatus("foo").isStarted());
-        assertTrue(context.getRouteStatus("foo").isStopped());
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/management/JmxInstrumentationUsingDefaultsTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/JmxInstrumentationUsingDefaultsTest.java
@@ -180,13 +180,9 @@ public class JmxInstrumentationUsingDefaultsTest extends ContextTestSupport {
         releaseMBeanServers();
         super.setUp();
 
-        await().atMost(3, TimeUnit.SECONDS).until(() -> {
-            try {
-                mbsc = getMBeanConnection();
-                return true;
-            } catch (Throwable e) {
-                return false;
-            }
+        await().atMost(3, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
+            mbsc = getMBeanConnection();
+            return true;
         });
     }
 

--- a/camel-core/src/test/java/org/apache/camel/processor/resequencer/ResequencerEngineTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/resequencer/ResequencerEngineTest.java
@@ -153,7 +153,7 @@ public class ResequencerEngineTest extends TestSupport {
         runner.start();
 
         // wait for runner to run
-        await().atMost(1, TimeUnit.SECONDS).until(() -> runner.isRunning());
+        await().atMost(1, TimeUnit.SECONDS).until(runner::isRunning);
     }
     
 }


### PR DESCRIPTION
…ise use thread sleep which can be speeded up.

Great to see this getting done. :+1: 

While looking at the code I noticed some places where is is possible to slightly reduce code by using additional awaitility features.