### PR TITLE
CAMEL-11446: Use awaitility in camel-core for testing where we otherw…

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/impl/ConsumerCacheZeroCapacityTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/ConsumerCacheZeroCapacityTest.java
@@ -50,9 +50,8 @@ public class ConsumerCacheZeroCapacityTest extends ContextTestSupport {
         cache.releasePollingConsumer(endpoint, consumer);
 
         // takes a little to stop
-        await().atMost(1, TimeUnit.SECONDS).until(() -> ((ServiceSupport) consumer).getStatus().isStopped());
-
-        assertEquals("Stopped", ((org.apache.camel.support.ServiceSupport) consumer).getStatus().name());
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertEquals("Stopped", ((ServiceSupport) consumer).getStatus().name()));
 
         // should not be a file consumer thread
         found = Thread.getAllStackTraces().keySet().stream().anyMatch(t -> t.getName().contains("target/foo"));

--- a/camel-core/src/test/java/org/apache/camel/impl/FileWatcherReloadStrategyTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/FileWatcherReloadStrategyTest.java
@@ -66,9 +66,7 @@ public class FileWatcherReloadStrategyTest extends ContextTestSupport {
 
         // wait for that file to be processed
         // (is slow on osx, so wait up till 20 seconds)
-        await().atMost(20, TimeUnit.SECONDS).until(() -> context.getRoutes().size() > 0);
-
-        assertEquals(1, context.getRoutes().size());
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(1, context.getRoutes().size()));
 
         // and the route should work
         getMockEndpoint("mock:bar").expectedMessageCount(1);
@@ -161,9 +159,7 @@ public class FileWatcherReloadStrategyTest extends ContextTestSupport {
 
         // wait for that file to be processed
         // (is slow on osx, so wait up till 20 seconds)
-        await().atMost(20, TimeUnit.SECONDS).until(() -> context.getRoutes().size() > 0);
-
-        assertEquals(1, context.getRoutes().size());
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(1, context.getRoutes().size()));
 
         // and the route should work
         getMockEndpoint("mock:bar").expectedMessageCount(1);

--- a/camel-core/src/test/java/org/apache/camel/management/EventNotifierExchangeSentTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/EventNotifierExchangeSentTest.java
@@ -155,9 +155,7 @@ public class EventNotifierExchangeSentTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // give it time to complete
-        await().atMost(1, TimeUnit.SECONDS).until(() -> events.size() == 6);
-
-        assertEquals(6, events.size());
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(6, events.size()));
 
         // we should find log:foo which we tapped
         // which runs async so they can be in random order

--- a/camel-core/src/test/java/org/apache/camel/management/LoadTimerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/LoadTimerTest.java
@@ -42,11 +42,12 @@ public class LoadTimerTest extends ContextTestSupport {
         TestLoadAware test = new TestLoadAware();
         myTimer.addTimerListener(test);
         try {
-            await().atMost(5, TimeUnit.SECONDS).until(() -> test.counter >= SAMPLES);
-            assertTrue(test.counter >= SAMPLES);
-            assertFalse(Double.isNaN(test.load.getLoad1()));
-            assertTrue(test.load.getLoad1() > 0.0d);
-            assertTrue(test.load.getLoad1() < SAMPLES);
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(test.counter >= SAMPLES);
+                assertFalse(Double.isNaN(test.load.getLoad1()));
+                assertTrue(test.load.getLoad1() > 0.0d);
+                assertTrue(test.load.getLoad1() < SAMPLES);
+            });
         } finally {
             myTimer.removeTimerListener(test);
         }

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRouteLoadstatisticsTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRouteLoadstatisticsTest.java
@@ -94,17 +94,17 @@ public class ManagedRouteLoadstatisticsTest extends ManagementTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        await().atMost(2, TimeUnit.SECONDS).until(() -> mbeanServer.getAttribute(on, "Load01") != null);
-
-        String load01 = (String)mbeanServer.getAttribute(on, "Load01");
-        String load05 = (String)mbeanServer.getAttribute(on, "Load05");
-        String load15 = (String)mbeanServer.getAttribute(on, "Load15");
-        assertNotNull(load01);
-        assertNotNull(load05);
-        assertNotNull(load15);
-        assertTrue(Double.parseDouble(load01.replace(',', '.')) >= 0);
-        assertTrue(Double.parseDouble(load05.replace(',', '.')) >= 0);
-        assertTrue(Double.parseDouble(load15.replace(',', '.')) >= 0);
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            String load01 = (String)mbeanServer.getAttribute(on, "Load01");
+            String load05 = (String)mbeanServer.getAttribute(on, "Load05");
+            String load15 = (String)mbeanServer.getAttribute(on, "Load15");
+            assertNotNull(load01);
+            assertNotNull(load05);
+            assertNotNull(load15);
+            assertTrue(Double.parseDouble(load01.replace(',', '.')) >= 0);
+            assertTrue(Double.parseDouble(load05.replace(',', '.')) >= 0);
+            assertTrue(Double.parseDouble(load15.replace(',', '.')) >= 0);
+        });
     }
 
 }

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRouteNoAutoStartupTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRouteNoAutoStartupTest.java
@@ -76,14 +76,11 @@ public class ManagedRouteNoAutoStartupTest extends ManagementTestSupport {
         assertMockEndpointsSatisfied();
 
         // need a bit time to let JMX update
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            // should have 1 completed exchange
             Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-            return completed > 0;
+            assertEquals(1, completed.longValue());
         });
-
-        // should have 1 completed exchange
-        Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-        assertEquals(1, completed.longValue());
 
         // should be 1 consumer and 1 processor
         Set<ObjectName> set = mbeanServer.queryNames(new ObjectName("*:type=consumers,*"), null);

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRoutePerformanceCounterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRoutePerformanceCounterTest.java
@@ -55,13 +55,10 @@ public class ManagedRoutePerformanceCounterTest extends ManagementTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-            return num == 1;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
+            assertEquals(1, completed.longValue());
         });
-
-        Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-        assertEquals(1, completed.longValue());
 
         delta = (Long) mbeanServer.getAttribute(on, "DeltaProcessingTime");
         Long last = (Long) mbeanServer.getAttribute(on, "LastProcessingTime");
@@ -74,7 +71,7 @@ public class ManagedRoutePerformanceCounterTest extends ManagementTestSupport {
         // send in another message
         template.sendBody("direct:start", "Bye World");
 
-        completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
+        Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
         assertEquals(2, completed.longValue());
         delta = (Long) mbeanServer.getAttribute(on, "DeltaProcessingTime");
         last = (Long) mbeanServer.getAttribute(on, "LastProcessingTime");

--- a/camel-core/src/test/java/org/apache/camel/management/ManagedRouteStopAndStartCleanupTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/ManagedRouteStopAndStartCleanupTest.java
@@ -55,14 +55,11 @@ public class ManagedRouteStopAndStartCleanupTest extends ManagedRouteStopAndStar
         assertEquals("Should be started", ServiceStatus.Started.name(), state);
 
         // need a bit time to let JMX update
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
-            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-            return num == 1;
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            // should have 1 completed exchange
+            Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
+            assertEquals(1, completed.longValue());
         });
-
-        // should have 1 completed exchange
-        Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
-        assertEquals(1, completed.longValue());
 
         // should be 1 consumer and 2 processors
         Set<ObjectName> set = mbeanServer.queryNames(new ObjectName("*:type=consumers,*"), null);
@@ -125,7 +122,7 @@ public class ManagedRouteStopAndStartCleanupTest extends ManagedRouteStopAndStar
         });
 
         // should have 2 completed exchange
-        completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
+        Long completed = (Long) mbeanServer.getAttribute(on, "ExchangesCompleted");
         assertEquals(2, completed.longValue());
     }
 

--- a/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointCustomRoutePolicyTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointCustomRoutePolicyTest.java
@@ -84,9 +84,7 @@ public class AsyncEndpointCustomRoutePolicyTest extends ContextTestSupport {
 
         mock.assertIsSatisfied();
 
-        await().atMost(1, TimeUnit.SECONDS).until(policy::isStopped);
-
-        assertTrue("Should be stopped", policy.isStopped());
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> assertTrue("Should be stopped", policy.isStopped()));
     }
 
     @Override

--- a/camel-core/src/test/java/org/apache/camel/processor/onexception/ContextScopedOnExceptionLoadBalancerStopRouteTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/onexception/ContextScopedOnExceptionLoadBalancerStopRouteTest.java
@@ -71,8 +71,8 @@ public class ContextScopedOnExceptionLoadBalancerStopRouteTest extends ContextTe
         template.sendBody("direct:start", "World");
 
         // give time for route to stop
-        await().atMost(1, TimeUnit.SECONDS).until(() -> context.getRouteStatus("errorRoute").isStopped());
-        assertEquals(ServiceStatus.Stopped, context.getRouteStatus("errorRoute"));
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertEquals(ServiceStatus.Stopped, context.getRouteStatus("errorRoute")));
 
         template.sendBody("direct:start", "Kaboom");
 

--- a/camel-core/src/test/java/org/apache/camel/support/DefaultTimeoutMapTest.java
+++ b/camel-core/src/test/java/org/apache/camel/support/DefaultTimeoutMapTest.java
@@ -252,10 +252,9 @@ public class DefaultTimeoutMapTest extends TestCase {
         map.start();
 
         // start and wait for scheduler to purge
-        await().atMost(2, TimeUnit.SECONDS).until(() -> map.size() == 0);
-
-        // now it should be gone
-        assertEquals(0, map.size());
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            // now it should be gone
+            assertEquals(0, map.size()));
 
         map.stop();
     }


### PR DESCRIPTION
…ise use thread sleep which can be speeded up.

Use #untilAsserted instead of #until where possible to reduce code duplication.