### PR TITLE
CAMEL-11424 Fix potential endless wait in camel-olingo2 and camel-olingo4

### DIFF
--- a/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
+++ b/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
@@ -332,10 +332,10 @@ public final class Olingo2AppImpl implements Olingo2App {
     private <T> void readContent(UriInfoWithType uriInfo, InputStream content, Olingo2ResponseHandler<T> responseHandler) {
         try {
             responseHandler.onResponse(this.<T>readContent(uriInfo, content));
-        } catch (EntityProviderException e) {
+        } catch (Exception e) {
             responseHandler.onException(e);
-        } catch (ODataApplicationException e) {
-            responseHandler.onException(e);
+        } catch (Error e) {
+            responseHandler.onException(new ODataApplicationException("Runtime Error Occurred", Locale.ENGLISH, e));
         }
     }
 
@@ -593,14 +593,10 @@ public final class Olingo2AppImpl implements Olingo2App {
                     }
                 }
             });
-        } catch (ODataException e) {
+        } catch (Exception e) {
             responseHandler.onException(e);
-        } catch (URISyntaxException e) {
-            responseHandler.onException(e);
-        } catch (UnsupportedEncodingException e) {
-            responseHandler.onException(e);
-        } catch (IOException e) {
-            responseHandler.onException(e);
+        } catch (Error e) {
+            responseHandler.onException(new ODataApplicationException("Runtime Error Occurred", Locale.ENGLISH, e));
         }
     }
 

--- a/components/camel-olingo4/camel-olingo4-api/src/main/java/org/apache/camel/component/olingo4/api/impl/Olingo4AppImpl.java
+++ b/components/camel-olingo4/camel-olingo4-api/src/main/java/org/apache/camel/component/olingo4/api/impl/Olingo4AppImpl.java
@@ -340,8 +340,10 @@ public final class Olingo4AppImpl implements Olingo4App {
     private <T> void readContent(UriInfo uriInfo, InputStream content, Olingo4ResponseHandler<T> responseHandler) {
         try {
             responseHandler.onResponse(this.<T> readContent(uriInfo, content));
-        } catch (ODataException e) {
+        } catch (Exception e) {
             responseHandler.onException(e);
+        } catch (Error e) {
+            responseHandler.onException(new ODataException("Runtime Error Occurred", e));
         }
     }
 
@@ -493,8 +495,10 @@ public final class Olingo4AppImpl implements Olingo4App {
                 }
             });
 
-        } catch (ODataException e) {
+        } catch (Exception e) {
             responseHandler.onException(e);
+        } catch (Error e) {
+            responseHandler.onException(new ODataException("Runtime Error Occurred", e));
         }
     }
 


### PR DESCRIPTION
This fixes and issue where unhandled exceptions and runtime errors would cause responseHandler to never be triggered causing the routes to hang forever.