### PR TITLE
CAMEL-11540: Fixed issue with turning off ProducerCache

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/LRUCache.java
+++ b/camel-core/src/main/java/org/apache/camel/util/LRUCache.java
@@ -75,7 +75,8 @@ public class LRUCache<K, V> implements Map<K, V>, RemovalListener<K, V>, Seriali
      * @throws IllegalArgumentException if the initial capacity is negative
      */
     public LRUCache(int initialCapacity, int maximumCacheSize) {
-        this(initialCapacity, maximumCacheSize, true);
+        //Do not stop service if ConcurrentLinkedHashMap try to evict entry when its max capacity is zero.
+        this(initialCapacity, maximumCacheSize, maximumCacheSize>0);
     }
 
     /**


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/CAMEL-11540.

ConcurrentLinkedHashMap attempts to evict entries when the max capacity is zero, eventually the service is stopped. This results in camel-rabbitmq, camel-netty4, camel-netty and camel-jms producers not possible to disable ProducerCache.

Thanks,
Saravanakumar