### PR TITLE
Upgrade commons-net to version 3.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -157,7 +157,7 @@
     <commons-logging-version>1.2</commons-logging-version>
     <commons-math-version>2.2</commons-math-version>
     <commons-math3-version>3.6.1</commons-math3-version>
-    <commons-net-version>3.3</commons-net-version>
+    <commons-net-version>3.6</commons-net-version>
     <commons-pool-version>1.6</commons-pool-version>
     <commons-pool2-version>2.4.2</commons-pool2-version>
     <commons-vfs2-version>2.0</commons-vfs2-version>


### PR DESCRIPTION
Main usages seem to be camel-ftp and camel-cxf (tests). The unit tests of both components are green after this update.

Commons-net is also used by camel-hbase, camel-hdfs and camel-hdfs2. The unit test of camel-hdfs are green after this update. I was not able to run the unit test of camel-hbase and camel-hdfs2 did not run on my machine before the update.