### PR TITLE
Upgrade Java Mail to version 1.6.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -335,7 +335,7 @@
     <javax.el-api-version>2.2.5</javax.el-api-version>
     <javax.el-version>2.2.5</javax.el-version>
     <javax-inject-bundle-version>1_2</javax-inject-bundle-version>
-    <javax-mail-version>1.5.5</javax-mail-version>
+    <javax-mail-version>1.6.0</javax-mail-version>
     <javax.servlet-api-version>3.1.0</javax.servlet-api-version>
     <javax.ws.rs-api-version>2.0.1</javax.ws.rs-api-version>
     <jaxb-bundle-version>2.2.11_1</jaxb-bundle-version>


### PR DESCRIPTION
Java Mail 1.6.0 should be binary compatible to 1.5.x according to https://javaee.github.io/javamail/docs/COMPAT.txt

Camel-mail tests pass.