### PR TITLE
CAMEL-11559: Work around a NPE in milo 0.1.3

### DIFF
--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
@@ -174,7 +174,12 @@ public class SubscriptionManager {
                 } else {
                     final NodeId nodeId = s.getPartialNodeId().toNodeId(namespaceIndex);
                     final ReadValueId itemId = new ReadValueId(nodeId, AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE);
-                    final MonitoringParameters parameters = new MonitoringParameters(entry.getKey(), s.getSamplingInterval(), null, null, null);
+                    Double samplingInterval = s.getSamplingInterval();
+                    if (samplingInterval == null) {
+                        // work around a bug (NPE) in Eclipse Milo 0.1.3
+                        samplingInterval = 0.0;
+                    }
+                    final MonitoringParameters parameters = new MonitoringParameters(entry.getKey(), samplingInterval, null, null, null);
                     items.add(new MonitoredItemCreateRequest(itemId, MonitoringMode.Reporting, parameters));
                 }
             }


### PR DESCRIPTION
When the sampling interval is unset in the Camel component, then it is passed to milo as `null`. Which is acceptable to the milo API, however internally milo automatically unboxes the value from `Double` to `double` and may run into a NPE by doing so.

This patch assures that, although theoretically acceptable, `null` is never passed in to the Milo API.

Signed-off-by: Jens Reimann <jreimann@redhat.com>