### PR TITLE
CAMEL-11144: Make the unit tests use dynamic ports

### DIFF
--- a/components/camel-milo/pom.xml
+++ b/components/camel-milo/pom.xml
@@ -99,10 +99,6 @@
         <configuration>
           <!-- required due to issue eclipse/milo#23 -->
           <reuseForks>false</reuseForks>
-          <!-- TODO: CAMEL-11144 -->
-          <excludes>
-            <exclude>**Test.java</exclude>
-          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
@@ -28,6 +28,32 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 
 public abstract class AbstractMiloServerTest extends CamelTestSupport {
 
+    private int serverPort;
+
+    @Override
+    protected void doPreSetup() throws Exception {
+        super.doPreSetup();
+        this.serverPort = Ports.pickServerPort();
+    }
+
+    public int getServerPort() {
+        return this.serverPort;
+    }
+
+    /**
+     * Replace the port placeholder with the dynamic server port
+     * 
+     * @param uri the URI to process
+     * @return the result, may be {@code null} if the input is {@code null}
+     */
+    protected String resolve(String uri) {
+        if (uri == null) {
+            return uri;
+        }
+
+        return uri.replace("@@port@@", Integer.toString(this.serverPort));
+    }
+
     public static void testBody(final AssertionClause clause, final Consumer<DataValue> valueConsumer) {
         testBody(clause, DataValue.class, valueConsumer);
     }
@@ -63,7 +89,7 @@ public abstract class AbstractMiloServerTest extends CamelTestSupport {
 
     protected void configureMiloServer(final MiloServerComponent server) throws Exception {
         server.setBindAddresses("localhost");
-        server.setBindPort(12685);
+        server.setBindPort(this.serverPort);
         server.setUserAuthenticationCredentials("foo:bar,foo2:bar2");
     }
 

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemMultiConnectionsCertTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemMultiConnectionsCertTest.java
@@ -41,16 +41,16 @@ public class MonitorItemMultiConnectionsCertTest extends AbstractMiloServerTest 
     private static final String MILO_SERVER_ITEM_1 = "milo-server:myitem1";
 
     // with key
-    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1")
                                                         + "&keyStoreUrl=file:src/test/resources/cert/cert.p12&keyStorePassword=pwd1&keyPassword=pwd1";
 
     // with wrong password
-    private static final String MILO_CLIENT_ITEM_C2_1 = "milo-client:tcp://foo:bar2@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C2_1 = "milo-client:tcp://foo:bar2@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
     // without key, clientId=1
-    private static final String MILO_CLIENT_ITEM_C3_1 = "milo-client:tcp://foo:bar@localhost:12685?clientId=1&node="
+    private static final String MILO_CLIENT_ITEM_C3_1 = "milo-client:tcp://foo:bar@localhost:@@port@@?clientId=1&node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
     private static final String MOCK_TEST_1 = "mock:test1";
@@ -90,9 +90,9 @@ public class MonitorItemMultiConnectionsCertTest extends AbstractMiloServerTest 
             public void configure() throws Exception {
                 from(DIRECT_START_1).to(MILO_SERVER_ITEM_1);
 
-                from(MILO_CLIENT_ITEM_C1_1).to(MOCK_TEST_1);
-                from(MILO_CLIENT_ITEM_C2_1).to(MOCK_TEST_2);
-                from(MILO_CLIENT_ITEM_C3_1).to(MOCK_TEST_3);
+                from(resolve(MILO_CLIENT_ITEM_C1_1)).to(MOCK_TEST_1);
+                from(resolve(MILO_CLIENT_ITEM_C2_1)).to(MOCK_TEST_2);
+                from(resolve(MILO_CLIENT_ITEM_C3_1)).to(MOCK_TEST_3);
             }
         };
     }
@@ -102,8 +102,6 @@ public class MonitorItemMultiConnectionsCertTest extends AbstractMiloServerTest 
      */
     @Test
     public void testMonitorItem1() throws Exception {
-        // set server value
-        this.producer1.sendBody("Foo");
 
         // item 1 ... only this one receives
         this.test1Endpoint.setExpectedCount(1);
@@ -116,6 +114,9 @@ public class MonitorItemMultiConnectionsCertTest extends AbstractMiloServerTest 
         // item 3
         this.test3Endpoint.setExpectedCount(0);
         this.test3Endpoint.setSleepForEmptyTest(5_000);
+
+        // set server value
+        this.producer1.sendBody("Foo");
 
         // assert
         this.assertMockEndpointsSatisfied();

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemMultiConnectionsTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemMultiConnectionsTest.java
@@ -34,13 +34,13 @@ public class MonitorItemMultiConnectionsTest extends AbstractMiloServerTest {
 
     private static final String MILO_SERVER_ITEM_1 = "milo-server:myitem1";
 
-    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
-    private static final String MILO_CLIENT_ITEM_C2_1 = "milo-client:tcp://foo:bar2@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C2_1 = "milo-client:tcp://foo:bar2@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
-    private static final String MILO_CLIENT_ITEM_C3_1 = "milo-client:tcp://foo2:bar@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C3_1 = "milo-client:tcp://foo2:bar@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
     private static final String MOCK_TEST_1 = "mock:test1";
@@ -66,9 +66,9 @@ public class MonitorItemMultiConnectionsTest extends AbstractMiloServerTest {
             public void configure() throws Exception {
                 from(DIRECT_START_1).to(MILO_SERVER_ITEM_1);
 
-                from(MILO_CLIENT_ITEM_C1_1).to(MOCK_TEST_1);
-                from(MILO_CLIENT_ITEM_C2_1).to(MOCK_TEST_2);
-                from(MILO_CLIENT_ITEM_C3_1).to(MOCK_TEST_3);
+                from(resolve(MILO_CLIENT_ITEM_C1_1)).to(MOCK_TEST_1);
+                from(resolve(MILO_CLIENT_ITEM_C2_1)).to(MOCK_TEST_2);
+                from(resolve(MILO_CLIENT_ITEM_C3_1)).to(MOCK_TEST_3);
             }
         };
     }
@@ -78,9 +78,6 @@ public class MonitorItemMultiConnectionsTest extends AbstractMiloServerTest {
      */
     @Test
     public void testMonitorItem1() throws Exception {
-        // set server value
-        this.producer1.sendBody("Foo");
-
         // item 1 ... only this one receives
         this.test1Endpoint.setExpectedCount(1);
         this.test1Endpoint.setSleepForEmptyTest(5_000);
@@ -92,6 +89,9 @@ public class MonitorItemMultiConnectionsTest extends AbstractMiloServerTest {
         // item 3
         this.test3Endpoint.setExpectedCount(0);
         this.test3Endpoint.setSleepForEmptyTest(5_000);
+
+        // set server value
+        this.producer1.sendBody("Foo");
 
         // assert
         this.assertMockEndpointsSatisfied();

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/MonitorItemTest.java
@@ -34,7 +34,7 @@ public class MonitorItemTest extends AbstractMiloServerTest {
 
     private static final String MILO_SERVER_ITEM_1 = "milo-server:myitem1";
 
-    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:12685?node="
+    private static final String MILO_CLIENT_ITEM_C1_1 = "milo-client:tcp://foo:bar@localhost:@@port@@?node="
                                                         + NodeIds.nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
 
     private static final String MOCK_TEST_1 = "mock:test1";
@@ -52,7 +52,7 @@ public class MonitorItemTest extends AbstractMiloServerTest {
             public void configure() throws Exception {
                 from(DIRECT_START_1).to(MILO_SERVER_ITEM_1);
 
-                from(MILO_CLIENT_ITEM_C1_1).to(MOCK_TEST_1);
+                from(resolve(MILO_CLIENT_ITEM_C1_1)).to(MOCK_TEST_1);
             }
         };
     }

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/NodeIdTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/NodeIdTest.java
@@ -35,25 +35,25 @@ public class NodeIdTest extends AbstractMiloServerTest {
     @Test
     public void testFull1() {
         final String s = String.format("nsu=%s;s=%s", DEFAULT_NAMESPACE_URI, "item-1");
-        testUri("milo-client:tcp://foo:bar@localhost:12685?samplingInterval=1000&node=RAW(" + s + ")", DEFAULT_NAMESPACE_URI, "item-1");
+        testUri("milo-client:tcp://foo:bar@localhost:@@port@@?samplingInterval=1000&node=RAW(" + s + ")", DEFAULT_NAMESPACE_URI, "item-1");
     }
 
     @Test
     public void testFull2() {
         final String s = String.format("ns=%s;s=%s", 1, "item-1");
-        testUri("milo-client:tcp://foo:bar@localhost:12685?samplingInterval=1000&node=RAW(" + s + ")", ushort(1), "item-1");
+        testUri("milo-client:tcp://foo:bar@localhost:@@port@@?samplingInterval=1000&node=RAW(" + s + ")", ushort(1), "item-1");
     }
 
     @Test
     public void testFull3() {
         final String s = String.format("ns=%s;i=%s", 1, 2);
-        testUri("milo-client:tcp://foo:bar@localhost:12685?samplingInterval=1000&node=RAW(" + s + ")", ushort(1), uint(2));
+        testUri("milo-client:tcp://foo:bar@localhost:@@port@@?samplingInterval=1000&node=RAW(" + s + ")", ushort(1), uint(2));
     }
 
     @Test
     public void testFull1NonRaw() {
         final String s = String.format("ns=%s;i=%s", 1, 2);
-        testUri("milo-client:tcp://foo:bar@localhost:12685?samplingInterval=1000&node=" + urlFormParameterEscaper().escape(s), ushort(1), uint(2));
+        testUri("milo-client:tcp://foo:bar@localhost:@@port@@?samplingInterval=1000&node=" + urlFormParameterEscaper().escape(s), ushort(1), uint(2));
     }
 
     @Test
@@ -64,11 +64,11 @@ public class NodeIdTest extends AbstractMiloServerTest {
     @Test(expected = ResolveEndpointFailedException.class)
     public void testMixed() {
         // This must fail since "node" is incomplete
-        testUri("milo-client:tcp://foo:bar@localhost:12685?node=foo&namespaceUri=" + DEFAULT_NAMESPACE_URI, null, null);
+        testUri("milo-client:tcp://foo:bar@localhost:@@port@@?node=foo&namespaceUri=" + DEFAULT_NAMESPACE_URI, null, null);
     }
 
     private void testUri(final String uri, final Serializable namespace, final Serializable partialNodeId) {
-        assertNodeId(getMandatoryEndpoint(uri, MiloClientEndpoint.class), namespace, partialNodeId);
+        assertNodeId(getMandatoryEndpoint(resolve(uri), MiloClientEndpoint.class), namespace, partialNodeId);
     }
 
     private void assertNodeId(final MiloClientEndpoint endpoint, final Serializable namespace, final Serializable partialNodeId) {

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/Ports.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/Ports.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.milo;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public final class Ports {
+
+    private Ports() {
+    }
+
+    public static int pickServerPort() throws IOException {
+        try (final ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
@@ -41,8 +41,8 @@ public class WriteClientTest extends AbstractMiloServerTest {
     private static final String MILO_SERVER_ITEM_1 = "milo-server:myitem1";
     private static final String MILO_SERVER_ITEM_2 = "milo-server:myitem2";
 
-    private static final String MILO_CLIENT_BASE_C1 = "milo-client:tcp://foo:bar@localhost:12685";
-    private static final String MILO_CLIENT_BASE_C2 = "milo-client:tcp://foo2:bar2@localhost:12685";
+    private static final String MILO_CLIENT_BASE_C1 = "milo-client:tcp://foo:bar@localhost:@@port@@";
+    private static final String MILO_CLIENT_BASE_C2 = "milo-client:tcp://foo2:bar2@localhost:@@port@@";
 
     private static final String MILO_CLIENT_ITEM_C1_1 = MILO_CLIENT_BASE_C1 + "?node=" + nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem1");
     private static final String MILO_CLIENT_ITEM_C1_2 = MILO_CLIENT_BASE_C1 + "?node=" + nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "items-myitem2");
@@ -80,11 +80,11 @@ public class WriteClientTest extends AbstractMiloServerTest {
                 from(MILO_SERVER_ITEM_1).to(MOCK_TEST_1);
                 from(MILO_SERVER_ITEM_2).to(MOCK_TEST_2);
 
-                from(DIRECT_START_1).to(MILO_CLIENT_ITEM_C1_1);
-                from(DIRECT_START_2).to(MILO_CLIENT_ITEM_C1_2);
+                from(DIRECT_START_1).to(resolve(MILO_CLIENT_ITEM_C1_1));
+                from(DIRECT_START_2).to(resolve(MILO_CLIENT_ITEM_C1_2));
 
-                from(DIRECT_START_3).to(MILO_CLIENT_ITEM_C2_1);
-                from(DIRECT_START_4).to(MILO_CLIENT_ITEM_C2_2);
+                from(DIRECT_START_3).to(resolve(MILO_CLIENT_ITEM_C2_1));
+                from(DIRECT_START_4).to(resolve(MILO_CLIENT_ITEM_C2_2));
             }
         };
     }

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/server/ServerLocalTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/server/ServerLocalTest.java
@@ -16,13 +16,17 @@
  */
 package org.apache.camel.component.milo.server;
 
+import java.io.IOException;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.milo.Ports;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,6 +40,12 @@ public class ServerLocalTest extends CamelTestSupport {
 
     @EndpointInject(uri = MOCK_TEST)
     protected MockEndpoint testEndpoint;
+
+    @Before
+    public void pickFreePort() throws IOException {
+        final MiloServerComponent component = context().getComponent("milo-server", MiloServerComponent.class);
+        component.setBindPort(Ports.pickServerPort());
+    }
 
     @Override
     protected RoutesBuilder createRouteBuilder() throws Exception {


### PR DESCRIPTION
The unit tests for camel-milo currently use static ports, this change
implements the use of dynamic ports.

This change depends on the fix of CAMEL-11559

Signed-off-by: Jens Reimann <jreimann@redhat.com>