### PR TITLE
[CAMEL-101276] Refactored completionSize & completionTimeout expressions

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/AggregateDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/AggregateDefinition.java
@@ -754,11 +754,11 @@ public class AggregateDefinition extends ProcessorDefinition<AggregateDefinition
      * a fixed value or using an Expression which allows you to evaluate a size dynamically - will use Integer as result.
      * If both are set Camel will fallback to use the fixed value if the Expression result was null or 0.
      *
-     * @param completionSize  the completion size as an {@link org.apache.camel.Expression} which is evaluated as a {@link Integer} type
+     * @param completionSizeExpr  the completion size as an {@link org.apache.camel.Expression} which is evaluated as a {@link Integer} type
      * @return builder
      */
-    public AggregateDefinition completionSize(Expression completionSize) {
-        setCompletionSizeExpression(new ExpressionSubElementDefinition(completionSize));
+    public AggregateDefinition completionSizeExpr(Expression completionSizeExpr) {
+        setCompletionSizeExpression(new ExpressionSubElementDefinition(completionSizeExpr));
         return this;
     }
 
@@ -807,11 +807,11 @@ public class AggregateDefinition extends ProcessorDefinition<AggregateDefinition
      * The timeout is an approximation and there is no guarantee that the a timeout is triggered exactly after the timeout value.
      * It is not recommended to use very low timeout values or checker intervals.
      *
-     * @param completionTimeout  the timeout as an {@link Expression} which is evaluated as a {@link Long} type
+     * @param completionTimeoutExpr  the timeout as an {@link Expression} which is evaluated as a {@link Long} type
      * @return the builder
      */
-    public AggregateDefinition completionTimeout(Expression completionTimeout) {
-        setCompletionTimeoutExpression(new ExpressionSubElementDefinition(completionTimeout));
+    public AggregateDefinition completionTimeoutExpr(Expression completionTimeoutExpr) {
+        setCompletionTimeoutExpression(new ExpressionSubElementDefinition(completionTimeoutExpr));
         return this;
     }
 

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompletionSizeExpressionAndTimeoutTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompletionSizeExpressionAndTimeoutTest.java
@@ -40,7 +40,7 @@ public class AggregateCompletionSizeExpressionAndTimeoutTest extends ContextTest
                 from("direct:start")
                     .split(body().tokenize(","))
                         .aggregate(constant(true), new BodyInAggregatingStrategy())
-                            .completionSize(constant(2)).completionTimeout(1000)
+                            .completionSizeExpr(constant(2)).completionTimeout(1000)
                             .to("log:result", "mock:result");
             }
         };

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeFallbackTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeFallbackTest.java
@@ -49,7 +49,7 @@ public class AggregateExpressionSizeFallbackTest extends ContextTestSupport {
                 from("direct:start")
                     .aggregate(header("id"), new BodyInAggregatingStrategy())
                         // if no mySize header it will fallback to the 3 in size
-                        .completionSize(header("mySize")).completionSize(3)
+                        .completionSizeExpr(header("mySize")).completionSize(3)
                         .to("mock:aggregated");
             }
         };

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeOverrideFixedTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeOverrideFixedTest.java
@@ -51,7 +51,7 @@ public class AggregateExpressionSizeOverrideFixedTest extends ContextTestSupport
             public void configure() throws Exception {
                 from("direct:start")
                     .aggregate(header("id"), new BodyInAggregatingStrategy())
-                        .completionSize(2).completionSize(header("mySize"))
+                        .completionSize(2).completionSizeExpr(header("mySize"))
                         .to("mock:aggregated");
             }
         };

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeOverrideFixedTimeoutTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeOverrideFixedTimeoutTest.java
@@ -53,7 +53,7 @@ public class AggregateExpressionSizeOverrideFixedTimeoutTest extends ContextTest
             public void configure() throws Exception {
                 from("direct:start")
                     .aggregate(header("id"), new BodyInAggregatingStrategy())
-                        .completionSize(2).completionSize(header("mySize"))
+                        .completionSize(2).completionSizeExpr(header("mySize"))
                         .completionTimeout(1000)
                         .to("mock:aggregated");
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionSizeTest.java
@@ -53,7 +53,7 @@ public class AggregateExpressionSizeTest extends ContextTestSupport {
                     // Aggregate them using the BodyInAggregatingStrategy strategy which
                     // and the header mySize determines the number of aggregated messages should trigger the completion
                     // and send it to mock:aggregated
-                    .aggregate(header("id"), new BodyInAggregatingStrategy()).completionSize(header("mySize"))
+                    .aggregate(header("id"), new BodyInAggregatingStrategy()).completionSizeExpr(header("mySize"))
                         .to("mock:aggregated");
                 // END SNIPPET: e1
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutFallbackTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutFallbackTest.java
@@ -49,7 +49,7 @@ public class AggregateExpressionTimeoutFallbackTest extends ContextTestSupport {
                 from("direct:start")
                     .aggregate(header("id"), new BodyInAggregatingStrategy())
                         // if no timeout header it will fallback to the 2000 seconds
-                        .completionTimeout(header("timeout")).completionTimeout(2000)
+                        .completionTimeoutExpr(header("timeout")).completionTimeout(2000)
                         .to("mock:aggregated");
             }
         };

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutPerGroupTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutPerGroupTest.java
@@ -67,7 +67,7 @@ public class AggregateExpressionTimeoutPerGroupTest extends ContextTestSupport {
                     // and the timeout header contains the timeout in millis of inactivity them timeout and complete the aggregation
                     // and send it to mock:aggregated
                     .aggregate(header("id"), new BodyInAggregatingStrategy())
-                        .completionTimeout(header("timeout")).completionTimeout(1000).completionTimeoutCheckerInterval(10)
+                        .completionTimeoutExpr(header("timeout")).completionTimeout(1000).completionTimeoutCheckerInterval(10)
                         .to("mock:aggregated");
                 // END SNIPPET: e1
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateExpressionTimeoutTest.java
@@ -53,7 +53,7 @@ public class AggregateExpressionTimeoutTest extends ContextTestSupport {
                     // Aggregate them using the BodyInAggregatingStrategy strategy which
                     // and the timeout header contains the timeout in millis of inactivity them timeout and complete the aggregation
                     // and send it to mock:aggregated
-                    .aggregate(header("id"), new BodyInAggregatingStrategy()).completionTimeout(header("timeout")).completionTimeoutCheckerInterval(10)
+                    .aggregate(header("id"), new BodyInAggregatingStrategy()).completionTimeoutExpr(header("timeout")).completionTimeoutCheckerInterval(10)
                         .to("mock:aggregated");
                 // END SNIPPET: e1
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeCompletionExpressionSizeTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeCompletionExpressionSizeTest.java
@@ -44,7 +44,7 @@ public class AggregateGroupedExchangeCompletionExpressionSizeTest extends Contex
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                    .aggregate(constant(true)).completionSize(header("size"))
+                    .aggregate(constant(true)).completionSizeExpr(header("size"))
                     .groupExchanges()
                     .to("mock:result");
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizePredicateTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeSizePredicateTest.java
@@ -65,7 +65,7 @@ public class AggregateGroupedExchangeSizePredicateTest extends ContextTestSuppor
             public void configure() throws Exception {
                 from("direct:start")
                     // must use eagerCheckCompletion so we can check the groupSize header on the incoming exchange 
-                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).eagerCheckCompletion().completionSize(header("groupSize"))
+                    .aggregate(new GroupedExchangeAggregationStrategy()).constant(true).eagerCheckCompletion().completionSizeExpr(header("groupSize"))
                         .to("mock:result")
                     .end();
             }

--- a/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateSimpleExpressionIssueTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateSimpleExpressionIssueTest.java
@@ -96,7 +96,7 @@ public class AggregateSimpleExpressionIssueTest extends ContextTestSupport {
                     .log("Picked up ${file:name}")
                     .split().tokenize("\n").streaming()
                         .aggregate(constant(true), aggStrategy)
-                        .completionSize(simple("1000")).completionTimeout(simple("500"))
+                        .completionSizeExpr(simple("1000")).completionTimeoutExpr(simple("500"))
                             .bean(myBean)
                         .end()
                     .end();

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateControllerTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateControllerTest.xml
@@ -31,9 +31,9 @@
                 <correlationExpression>
                     <simple>header.id</simple>
                 </correlationExpression>
-                <completionSize>
+                <completionSizeExpr>
                     <constant>10</constant>
-                </completionSize>
+                </completionSizeExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionSizeFallbackTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionSizeFallbackTest.xml
@@ -31,10 +31,10 @@
             <aggregate strategyRef="aggregatorStrategy" completionSize="3">
                 <correlationExpression>
                     <simple>header.id</simple>
-                </correlationExpression>
-                <completionSize>
+                </correlationExpression>                
+                <completionSizeExpr>
                     <header>mySize</header>
-                </completionSize>
+                </completionSizeExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionSizeTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionSizeTest.xml
@@ -32,9 +32,9 @@
                 <correlationExpression>
                     <simple>header.id</simple>
                 </correlationExpression>
-                <completionSize>
+                <completionSizeExpr>
                     <header>mySize</header>
-                </completionSize>
+                </completionSizeExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutFallbackTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutFallbackTest.xml
@@ -32,9 +32,9 @@
                 <correlationExpression>
                     <simple>${header.id}</simple>
                 </correlationExpression>
-                <completionTimeout>
+                <completionTimeoutExpr>
                     <header>timeout</header>
-                </completionTimeout>
+                </completionTimeoutExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutPerGroupTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutPerGroupTest.xml
@@ -32,9 +32,9 @@
                 <correlationExpression>
                     <simple>${header.id}</simple>
                 </correlationExpression>
-                <completionTimeout>
+                <completionTimeoutExpr>
                     <header>timeout</header>
-                </completionTimeout>
+                </completionTimeoutExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateExpressionTimeoutTest.xml
@@ -32,9 +32,9 @@
                 <correlationExpression>
                     <simple>header.id</simple>
                 </correlationExpression>
-                <completionTimeout>
+                <completionTimeoutExpr>
                     <header>timeout</header>
-                </completionTimeout>
+                </completionTimeoutExpr>
                 <to uri="mock:aggregated"/>
             </aggregate>
         </route>

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateGroupedExchangeCompletionExpressionSizeTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator/SpringAggregateGroupedExchangeCompletionExpressionSizeTest.xml
@@ -31,9 +31,9 @@
                 <correlationExpression>
                     <constant>true</constant>
                 </correlationExpression>
-                <completionSize>
+                <completionSizeExpr>
                     <header>size</header>
-                </completionSize>
+                </completionSizeExpr>
                 <to uri="mock:result"/>
             </aggregate>
         </route>


### PR DESCRIPTION

completionTimeout & completionSize attributes and expression usages are confusing in xml dsl, so if we have to change the names, we need to change the names in camel-spring.xsd and camel-blueprint.xsd files.
 
With the below respective changes, 

- camel-spring.xsd

 <xs:element name="completionTimeoutExpr" type="tns:expressionSubElementDefinition" minOccurs="0"/>
          <xs:element name="completionSizeExpr" type="tns:expressionSubElementDefinition" minOccurs="0"/>
          
          
- camel-blueprint.xsd          

          <xs:element minOccurs="0" name="completionTimeoutExpr" type="tns:expressionSubElementDefinition"/>
          <xs:element minOccurs="0" name="completionSizeExpr" type="tns:expressionSubElementDefinition"/>
          
I tested the committed code with the above xsd changes and i am able to refactor code with 'completionTimeoutExpr' and 'completionSizeExpr' for the use in expressions. I can't commit or have access to camel-spring.xsd and camel-blueprint.xsd, because everytime, i build the camel-spring and camel-blueprint, the xsd changes. 
          