### PR TITLE
CAMEL-11586: added default camel route path

### DIFF
--- a/components/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/components/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,7 +3,8 @@
     {
       "name": "endpoints.camelroutes.path",
       "type": "java.lang.String",
-      "description": "Endpoint URL path."
+      "description": "Endpoint URL path.",
+      "defaultValue": "/camel/routes"
     },
     {
       "name": "endpoints.camelroutes.enabled",


### PR DESCRIPTION
Possible Fix for https://issues.apache.org/jira/browse/CAMEL-11586. 