### PR TITLE
CAMEL-11607: Fix npe in MBeanInfoAssembler when debug is enabled.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/management/MBeanInfoAssembler.java
+++ b/camel-core/src/main/java/org/apache/camel/management/MBeanInfoAssembler.java
@@ -74,10 +74,10 @@ public class MBeanInfoAssembler implements Service {
 
     @Override
     public void stop() throws Exception {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Clearing cache[size={}, hits={}, misses={}, evicted={}]", new Object[]{cache.size(), cache.getHits(), cache.getMisses(), cache.getEvicted()});
-        }
         if (cache != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Clearing cache[size={}, hits={}, misses={}, evicted={}]", new Object[]{cache.size(), cache.getHits(), cache.getMisses(), cache.getEvicted()});
+            }
             cache.clear();
         }
     }


### PR DESCRIPTION
If debug is enabled and cache is not initialised an npe is thrown
when stopping the component.