### PR TITLE
CAMEL-11585: Added JMX Reset counter via actuator

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
@@ -56,7 +56,7 @@ public class CamelRoutesEndpoint extends AbstractEndpoint<List<RouteEndpointInfo
     public List<RouteEndpointInfo> invoke() {
         return getRoutesInfo();
     }
-    
+
     public RouteEndpointInfo getRouteInfo(String id) {
         Route route = camelContext.getRoute(id);
         if (route != null) {
@@ -68,8 +68,8 @@ public class CamelRoutesEndpoint extends AbstractEndpoint<List<RouteEndpointInfo
 
     public List<RouteEndpointInfo> getRoutesInfo() {
         return camelContext.getRoutes().stream()
-            .map(RouteEndpointInfo::new)
-            .collect(Collectors.toList());
+                .map(RouteEndpointInfo::new)
+                .collect(Collectors.toList());
     }
 
     public RouteDetailsEndpointInfo getRouteDetailsInfo(String id) {
@@ -83,6 +83,13 @@ public class CamelRoutesEndpoint extends AbstractEndpoint<List<RouteEndpointInfo
 
     public void startRoute(String id) throws Exception {
         camelContext.getRouteController().startRoute(id);
+    }
+
+    public void resetRoute(String id) throws Exception {
+        ManagedRouteMBean managedRouteMBean = camelContext.getManagedRoute(id, ManagedRouteMBean.class);
+        if (managedRouteMBean != null) {
+            managedRouteMBean.reset(true);
+        } 
     }
 
     public void stopRoute(String id, Optional<Long> timeout, Optional<TimeUnit> timeUnit, Optional<Boolean> abortAfterTimeout) throws Exception {

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesMvcEndpoint.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesMvcEndpoint.java
@@ -44,7 +44,7 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
      * Default path
      */
     public static final String PATH = "/camel/routes";
-
+    
     private final CamelRoutesEndpoint delegate;
 
     public CamelRoutesMvcEndpoint(CamelRoutesEndpoint delegate) {
@@ -57,14 +57,14 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
     // ********************************************
     // Endpoints
     // ********************************************
-    
+
     @ResponseBody
     @GetMapping(
-        value = "/{id}/detail",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/detail",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object detail(
             @PathVariable String id) {
@@ -81,11 +81,11 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
 
     @ResponseBody
     @GetMapping(
-        value = "/{id}/info",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/info",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object info(
             @PathVariable String id) {
@@ -102,11 +102,11 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
 
     @ResponseBody
     @PostMapping(
-        value = "/{id}/stop",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/stop",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object stop(
             @PathVariable String id,
@@ -116,10 +116,10 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
         return doIfEnabled(() -> {
             try {
                 delegate.stopRoute(
-                    id,
-                    Optional.ofNullable(timeout),
-                    Optional.of(TimeUnit.SECONDS),
-                    Optional.ofNullable(abortAfterTimeout)
+                        id,
+                        Optional.ofNullable(timeout),
+                        Optional.of(TimeUnit.SECONDS),
+                        Optional.ofNullable(abortAfterTimeout)
                 );
             } catch (Exception e) {
                 throw new GenericException("Error stopping route " + id, e);
@@ -131,11 +131,11 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
 
     @ResponseBody
     @PostMapping(
-        value = "/{id}/start",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/start",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object start(
             @PathVariable String id) {
@@ -152,12 +152,28 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
     }
 
     @ResponseBody
+    @PostMapping(value = "/{id}/reset", produces = {ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public Object reset(@PathVariable String id) {
+
+        return doIfEnabled(() -> {
+            try {
+                delegate.resetRoute(id);                
+            } catch (Exception e) {
+                throw new GenericException("Error resetting route stats " + id, e);
+            }
+
+            return ResponseEntity.ok().build();
+        });
+    }
+
+
+    @ResponseBody
     @PostMapping(
-        value = "/{id}/suspend",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/suspend",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object suspend(
             @PathVariable String id,
@@ -166,9 +182,9 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
         return doIfEnabled(() -> {
             try {
                 delegate.suspendRoute(
-                    id,
-                    Optional.ofNullable(timeout),
-                    Optional.of(TimeUnit.SECONDS)
+                        id,
+                        Optional.ofNullable(timeout),
+                        Optional.of(TimeUnit.SECONDS)
                 );
             } catch (Exception e) {
                 throw new GenericException("Error suspending route " + id, e);
@@ -180,11 +196,11 @@ public class CamelRoutesMvcEndpoint extends EndpointMvcAdapter {
 
     @ResponseBody
     @PostMapping(
-        value = "/{id}/resume",
-        produces = {
-            ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
-            MediaType.APPLICATION_JSON_VALUE
-        }
+            value = "/{id}/resume",
+            produces = {
+                    ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+                    MediaType.APPLICATION_JSON_VALUE
+            }
     )
     public Object resume(
             @PathVariable String id) {


### PR DESCRIPTION
Fix for issue: https://issues.apache.org/jira/browse/CAMEL-11585.

As discussed in the previous PR's, now if the user uses an incorrect route id, we can see the below 400 error, 
2017-08-02 18:48:06.555  INFO 21505 --- [  XNIO-3 task-1] org.apache.camel.impl.RouteService       : {"headers":{},"body":"The provided route id does not exists : null","statusCode":"BAD_REQUEST","statusCodeValue":400}
2017-08-02 18:48:08.630  INFO 21505 --- [1 - timer://bar] bar                                      : From timer (bar) ...
2017-08-02 18:48:08.632  INFO 21505 --- [2 - timer://foo] foo                                      : From timer (foo) ...