### PR TITLE
Unable to change DataFormat.contentTypeHeader value to false

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/DataFormatDefinition.java
@@ -106,12 +106,11 @@ public class DataFormatDefinition extends IdentifiedType implements OtherAttribu
                 dataFormat = createDataFormat(routeContext);
                 if (dataFormat != null) {
                     // is enabled by default so assume true if null
-                    if (contentTypeHeader == null || contentTypeHeader) {
-                        try {
-                            setProperty(routeContext.getCamelContext(), dataFormat, "contentTypeHeader", Boolean.TRUE);
-                        } catch (Exception e) {
-                            // ignore as this option is optional and not all data formats support this
-                        }
+                    final boolean contentTypeHeader = this.contentTypeHeader == null || this.contentTypeHeader;
+                    try {
+                        setProperty(routeContext.getCamelContext(), dataFormat, "contentTypeHeader", contentTypeHeader);
+                    } catch (Exception e) {
+                        // ignore as this option is optional and not all data formats support this
                     }
                     // configure the rest of the options
                     configureDataFormat(dataFormat, routeContext.getCamelContext());

--- a/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbTest.java
@@ -114,6 +114,19 @@ public class CamelJaxbTest extends CamelTestSupport {
     }
 
     @Test
+    public void testMarshalWithoutContentType() throws Exception {
+        PersonType person = new PersonType();
+        person.setFirstName("foo");
+        person.setLastName("bar");
+
+        MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, null);
+        template.sendBody("direct:marshalWithoutContentType", person);
+        resultEndpoint.assertIsSatisfied();
+    }
+
+    @Test
     public void testCustomXmlStreamWriter() throws InterruptedException {
         PersonType person = new PersonType();
         person.setFirstName("foo");
@@ -179,6 +192,10 @@ public class CamelJaxbTest extends CamelTestSupport {
                 dataFormat.setSchemaLocation("person.xsd");
                 dataFormat.setIgnoreJAXBElement(false);
 
+                JaxbDataFormat dataFormatWithoutContentType = new JaxbDataFormat("org.apache.camel.foo.bar");
+                dataFormat.setIgnoreJAXBElement(false);
+                dataFormatWithoutContentType.setContentTypeHeader(false);
+
                 JaxbDataFormat filterEnabledFormat = new JaxbDataFormat("org.apache.camel.foo.bar");
                 filterEnabledFormat.setFilterNonXmlChars(true);
 
@@ -203,6 +220,10 @@ public class CamelJaxbTest extends CamelTestSupport {
 
                 from("direct:marshal")
                     .marshal(dataFormat)
+                    .to("mock:result");
+
+                from("direct:marshalWithoutContentType")
+                    .marshal(dataFormatWithoutContentType)
                     .to("mock:result");
 
                 from("direct:marshalFilteringEnabled")

--- a/components/camel-jaxb/src/test/resources/org/apache/camel/jaxb/CamelJaxbTest.xml
+++ b/components/camel-jaxb/src/test/resources/org/apache/camel/jaxb/CamelJaxbTest.xml
@@ -50,6 +50,13 @@
       <to uri="mock:result"/>
     </route>
     <route>
+      <from uri="direct:marshalWithoutContentType"/>
+      <marshal>
+        <jaxb contextPath="org.apache.camel.foo.bar" contentTypeHeader="false"/>
+      </marshal>
+      <to uri="mock:result"/>
+    </route>
+    <route>
       <from uri="direct:unmarshalFilteringEnabled"/>
       <unmarshal>
         <jaxb filterNonXmlChars="true" contextPath="org.apache.camel.foo.bar"/>


### PR DESCRIPTION
`JaxbDataFormat` has a `contentTypeHeader` property with default value of `TRUE`. It should be able to change `contentTypeHeader` to `FALSE`.