### PR TITLE
fix using MasterComponent

### DIFF
--- a/components/camel-zookeeper-master/src/main/java/org/apache/camel/component/zookeepermaster/MasterConsumer.java
+++ b/components/camel-zookeeper-master/src/main/java/org/apache/camel/component/zookeepermaster/MasterConsumer.java
@@ -90,6 +90,10 @@ public class MasterConsumer extends DefaultConsumer {
         String path = endpoint.getComponent().getCamelClusterPath(endpoint.getGroupName());
         this.groupListener = new ZookeeperGroupListenerSupport(path, endpoint, onLockOwned(), onDisconnected());
         this.groupListener.setCamelContext(endpoint.getCamelContext());
+        this.groupListener.setZooKeeperUrl(endpoint.getComponent().getZooKeeperUrl());
+        this.groupListener.setZooKeeperPassword(endpoint.getComponent().getZooKeeperPassword());
+        this.groupListener.setCurator(endpoint.getComponent().getCurator());
+        this.groupListener.setMaximumConnectionTimeout(endpoint.getComponent().getMaximumConnectionTimeout());
         ServiceHelper.startService(groupListener);
 
         LOG.info("Attempting to become master for endpoint: " + endpoint + " in " + endpoint.getCamelContext() + " with singletonID: " + endpoint.getGroupName());


### PR DESCRIPTION
MasterComponent has a problem when you use remote zookeeper server. When consumer is created on endpoint it has no information about remote zookeeper server and try to initiating client connection to localhost:2181. I added to MasterConsumer code like in MasterRoutePolicy and it started to work correctly.
I hope you confirm this problem and add fix to the next release.