### PR TITLE
CAMEL-11316: Added support for HTTP OPTIONS in camel-restlet

### DIFF
--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/MethodBasedRouter.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/MethodBasedRouter.java
@@ -50,13 +50,15 @@ class MethodBasedRouter extends Restlet {
         LOG.debug("MethodRouter ({}) received request method: {}", uriPattern, method);
         
         Restlet target = routes.get(method);
+        if (target == null || org.restlet.data.Method.OPTIONS.equals(method)) {
+            // must include list of allowed methods
+            response.setAllowedMethods(routes.keySet());
+        }
         if (target != null) {
             target.handle(request, response);
         } else {
             LOG.debug("MethodRouter ({}) method not allowed: {}", uriPattern, method);
             response.setStatus(Status.CLIENT_ERROR_METHOD_NOT_ALLOWED);
-            // must include list of allowed methods
-            response.setAllowedMethods(routes.keySet());
         }
     }
 

--- a/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
+++ b/components/camel-restlet/src/main/java/org/apache/camel/component/restlet/RestletComponent.java
@@ -22,6 +22,7 @@ import java.security.GeneralSecurityException;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -284,13 +285,16 @@ public class RestletComponent extends HeaderFilterStrategyComponent implements R
         }
 
         for (MethodBasedRouter router : routesToRemove) {
+
+            List<Method> methods = new ArrayList<>();
+            Collections.addAll(methods, Method.OPTIONS);
             if (endpoint.getRestletMethods() != null) {
-                Method[] methods = endpoint.getRestletMethods();
-                for (Method method : methods) {
-                    router.removeRoute(method);
-                }
+                Collections.addAll(methods, endpoint.getRestletMethods());
             } else {
-                router.removeRoute(endpoint.getRestletMethod());
+                Collections.addAll(methods, endpoint.getRestletMethod());
+            }
+            for (Method method : methods) {
+                router.removeRoute(method);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -488,14 +492,14 @@ public class RestletComponent extends HeaderFilterStrategyComponent implements R
             LOG.debug("Target has been set to guard: {}", guard);
         }
 
+        List<Method> methods = new ArrayList<>();
+        Collections.addAll(methods, Method.OPTIONS);
         if (endpoint.getRestletMethods() != null) {
-            Method[] methods = endpoint.getRestletMethods();
-            for (Method method : methods) {
-                router.addRoute(method, target);
-                LOG.debug("Attached restlet uriPattern: {} method: {}", uriPattern, method);
-            }
+            Collections.addAll(methods, endpoint.getRestletMethods());
         } else {
-            Method method = endpoint.getRestletMethod();
+            Collections.addAll(methods, endpoint.getRestletMethod());
+        }
+        for (Method method : methods) {
             router.addRoute(method, target);
             LOG.debug("Attached restlet uriPattern: {} method: {}", uriPattern, method);
         }

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletHttpOptionsTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletHttpOptionsTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * @version 
  */
-@Ignore("Not supported by camel-restlet yet")
 public class RestRestletHttpOptionsTest extends RestletTestSupport {
 
     @Test
@@ -38,12 +37,12 @@ public class RestRestletHttpOptionsTest extends RestletTestSupport {
         });
 
         assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("OPTIONS,GET", exchange.getOut().getHeader("ALLOW"));
+        assertEquals("GET, OPTIONS", exchange.getOut().getHeader("ALLOW"));
         assertEquals("", exchange.getOut().getBody(String.class));
 
         exchange = fluentTemplate.to("http://localhost:" + portNum + "/users/v1/123").withHeader(Exchange.HTTP_METHOD, "OPTIONS").send();
         assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("OPTIONS,PUT", exchange.getOut().getHeader("ALLOW"));
+        assertEquals("OPTIONS, PUT", exchange.getOut().getHeader("ALLOW"));
         assertEquals("", exchange.getOut().getBody(String.class));
     }
 


### PR DESCRIPTION
Please find a proposal, adding support for HTTP OPTIONS in camel-restlet ([CAMEL-11316](https://issues.apache.org/jira/browse/CAMEL-11316)).

+ It preserves the CORS headers management from camel-core/RestBindingAdvice.java

+ I have kept the `ALLOW` header methods ordering already in use in camel-restlet for `CLIENT_ERROR_METHOD_NOT_ALLOWED`, which may diverge from other rest components.