### PR TITLE
CAMEL-11668: CompositeApiClient class in the camel-salesforces component cannot close a null InputStream

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
@@ -251,6 +251,7 @@ public class DefaultCompositeApiClient extends AbstractClientBase implements Com
             return Optional.empty();
         } finally {
             try {
+            	if (responseStream != null)
                 responseStream.close();
             } catch (final IOException ignored) {
             }


### PR DESCRIPTION
CAMEL-11668: CompositeApiClient class in the camel-salesforces component cannot close a null InputStream