### PR TITLE
CAMEL-11671 dont rebuild the request and respect url encoding of the original request

### DIFF
--- a/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcProducer.java
+++ b/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcProducer.java
@@ -51,7 +51,7 @@ public class AhcProducer extends DefaultAsyncProducer {
             // AHC supports async processing
             Request request = getEndpoint().getBinding().prepareRequest(getEndpoint(), exchange);
             log.debug("Executing request {} ", request);
-            client.prepareRequest(request).execute(new AhcAsyncHandler(exchange, callback, request.getUrl(), getEndpoint().getBufferSize()));
+            client.executeRequest(request, new AhcAsyncHandler(exchange, callback, request.getUrl(), getEndpoint().getBufferSize()));
             return false;
         } catch (Exception e) {
             exchange.setException(e);


### PR DESCRIPTION
imho it makes no sense to rebuild the request. the prepare methods are mostly used for a) prototyped requests or b) simplified requests in form of simple urls.
we however already have a prepared request (not a prototype).
