### PR TITLE
CAMEL-11682: Add sasl.jaas.config setting

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -285,7 +285,10 @@ public class KafkaConfiguration implements Cloneable {
     private Double kerberosRenewWindowFactor = SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR;
     @UriParam(label = "common,security", defaultValue = "DEFAULT")
     //sasl.kerberos.principal.to.local.rules
-    private String kerberosPrincipalToLocalRules;
+    private String kerberosPrincipalToLocalRules; 
+    @UriParam(label = "common,security", secret = true)
+    //sasl.jaas.config
+    private String saslJaasConfig;   
 
     public KafkaConfiguration() {
     }
@@ -355,6 +358,7 @@ public class KafkaConfiguration implements Cloneable {
         addPropertyIfNotNull(props, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, getKerberosRenewWindowFactor());
         addListPropertyIfNotNull(props, SaslConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES, getKerberosPrincipalToLocalRules());
         addPropertyIfNotNull(props, SaslConfigs.SASL_MECHANISM, getSaslMechanism());
+        addPropertyIfNotNull(props, SaslConfigs.SASL_JAAS_CONFIG, getSaslJaasConfig());
 
         return props;
     }
@@ -414,6 +418,7 @@ public class KafkaConfiguration implements Cloneable {
         addPropertyIfNotNull(props, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, getKerberosRenewWindowFactor());
         addListPropertyIfNotNull(props, SaslConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES, getKerberosPrincipalToLocalRules());
         addPropertyIfNotNull(props, SaslConfigs.SASL_MECHANISM, getSaslMechanism());
+        addPropertyIfNotNull(props, SaslConfigs.SASL_JAAS_CONFIG, getSaslJaasConfig());
         return props;
     }
 
@@ -984,6 +989,20 @@ public class KafkaConfiguration implements Cloneable {
      */
     public void setSaslMechanism(String saslMechanism) {
         this.saslMechanism = saslMechanism;
+    }
+    
+    public String getSaslJaasConfig() {
+        return saslJaasConfig;
+    }
+
+    /**
+     * Expose the kafka sasl.jaas.config parameter
+     * 
+     * Example:
+     * org.apache.kafka.common.security.plain.PlainLoginModule required username=\"USERNAME\" password=\"PASSWORD\";
+     */
+    public void setSaslJaasConfig(String saslMechanism) {
+        this.saslJaasConfig = saslMechanism;
     }
 
     public String getSecurityProtocol() {


### PR DESCRIPTION
I have tested the PR against IBM MessageHub and it worked with the following routes:

```
final String brokers = "kafka04-prod01.messagehub.services.eu-de.bluemix.net:9093,kafka05-prod01.messagehub.services.eu-de.bluemix.net:9093";

final String saslJaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"USERNAME\" password=\"PASSWORD\";";
					
from("direct:in")
.to("kafka:test?" 
    + "brokers=" + brokers
    + "&saslMechanism=PLAIN"  
    + "&securityProtocol=SASL_SSL"
    + "&sslProtocol=TLSv1.2"
    + "&sslEnabledProtocols=TLSv1.2" 
    + "&sslEndpointAlgorithm=HTTPS"
    + "&saslJaasConfig=" + saslJaasConfig );
```
and KafkaConsumer

```
final String brokers = "kafka04-prod01.messagehub.services.eu-de.bluemix.net:9093,kafka05-prod01.messagehub.services.eu-de.bluemix.net:9093";

final String saslJaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"USERNAME\" password=\"PASSWORD\";";
					
from("kafka:test?" 
    + "brokers=" + brokers
    + "&saslMechanism=PLAIN"  
    + "&securityProtocol=SASL_SSL"
    + "&sslProtocol=TLSv1.2"
    + "&sslEnabledProtocols=TLSv1.2" 
    + "&sslEndpointAlgorithm=HTTPS"
    + "&saslJaasConfig=" + saslJaasConfig
    + "&groupId=mygroup")
.to("stream:out");
```

The camel-kafka tests were failing on master before I made my changes.  The failures were:

```
[ERROR] Failures:
[ERROR] org.apache.camel.component.kafka.KafkaConsumerOffsetRepositoryEmptyTest.shouldStartFromBeginningWithEmptyOffsetRepository(org.apache.camel.component.kafka.KafkaConsumerOffsetRepositoryEmptyTest)
[ERROR]   Run 1: KafkaConsumerOffsetRepositoryEmptyTest.shouldStartFromBeginningWithEmptyOffsetRepository:74 mock://result Received message count. Expected: <10> but was: <0>
[ERROR]   Run 2: KafkaConsumerOffsetRepositoryEmptyTest.shouldStartFromBeginningWithEmptyOffsetRepository:74 mock://result Received message count. Expected: <10> but was: <0>
[ERROR]   Run 3: KafkaConsumerOffsetRepositoryEmptyTest.shouldStartFromBeginningWithEmptyOffsetRepository:74 mock://result Received message count. Expected: <10> but was: <0>
[INFO]
[ERROR] org.apache.camel.component.kafka.KafkaConsumerOffsetRepositoryResumeTest.shouldResumeFromAnyParticularOffset(org.apache.camel.component.kafka.KafkaConsumerOffsetRepositoryResumeTest)
[ERROR]   Run 1: KafkaConsumerOffsetRepositoryResumeTest.shouldResumeFromAnyParticularOffset:75 mock://result Received message count. Expected: <3> but was: <0>
[ERROR]   Run 2: KafkaConsumerOffsetRepositoryResumeTest.shouldResumeFromAnyParticularOffset:75 mock://result Received message count. Expected: <3> but was: <0>
[ERROR]   Run 3: KafkaConsumerOffsetRepositoryResumeTest.shouldResumeFromAnyParticularOffset:75 mock://result Received message count. Expected: <3> but was: <0>
[INFO]
[INFO]
[ERROR] Tests run: 43, Failures: 2, Errors: 0, Skipped: 2
```