### PR TITLE
CAMEL-11750: Camel route with multicast (parallel) generate huge CPU …

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
+++ b/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
@@ -63,7 +63,7 @@ public class SubmitOrderedCompletionService<V> implements CompletionService<V> {
 
         public long getDelay(TimeUnit unit) {
             // if the answer is 0 then this task is ready to be taken
-            return id - index.get();
+            return unit.convert(id - index.get(), TimeUnit.SECONDS);
         }
 
         @SuppressWarnings("unchecked")

--- a/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
+++ b/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
@@ -63,7 +63,7 @@ public class SubmitOrderedCompletionService<V> implements CompletionService<V> {
 
         public long getDelay(TimeUnit unit) {
             // if the answer is 0 then this task is ready to be taken
-            return unit.convert(id - index.get(), TimeUnit.SECONDS);
+            return unit.convert(id - index.get(), TimeUnit.MILLISECONDS);
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
…load

Fixed issue with huge CPU load: added 1ms delay for a task that is 2nd in the queue order, 2ms for 3rd task, 3ms for 4th taks, etc. That helps to decrease CPU load and does not broke previous logic.