### PR TITLE
CAMEL-11764: Verified connector/component scheme clashing

### DIFF
--- a/connectors/camel-connector-maven-plugin/pom.xml
+++ b/connectors/camel-connector-maven-plugin/pom.xml
@@ -33,6 +33,11 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-catalog</artifactId>
+    </dependency>
+
     <!-- we extend this existing maven plugin -->
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
My proposal breaks the `maven prepare-package` phase of the `twitter-search-connector` project (it's expected).
If this behavior is ok, I would merely change the scheme of the twitter-search-connector in a separate commit. Please, let me know.

See [CAMEL-11764](https://issues.apache.org/jira/browse/CAMEL-11764) for details about the context.