### PR TITLE
CAMEL-11777: Use transaction aware queue in hazelcast:seda component

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.component.hazelcast.seda;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.core.BaseQueue;
 import com.hazelcast.transaction.TransactionContext;
 
 import org.apache.camel.AsyncCallback;
@@ -71,7 +71,7 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
     }
 
     public void run() {
-        final BlockingQueue<?> queue = endpoint.getQueue();
+        BaseQueue<?> queue = endpoint.getHazelcastInstance().getQueue(endpoint.getConfiguration().getQueueName());
 
         while (queue != null && isRunAllowed()) {
             final Exchange exchange = this.getEndpoint().createExchange();
@@ -85,6 +85,7 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
                     if (transactionCtx != null) {
                         log.trace("Begin transaction: {}", transactionCtx.getTxnId());
                         transactionCtx.beginTransaction();
+                        queue = transactionCtx.getQueue(endpoint.getConfiguration().getQueueName());
                     }
                 }
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerNewTransactionTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerNewTransactionTest.java
@@ -31,10 +31,11 @@ public class HazelcastSedaRecoverableConsumerNewTransactionTest extends Hazelcas
                 .thenThrow(new HazelcastException("Could not obtain Connection!!!"))
                 .thenReturn(transactionContext);
         when(hazelcastInstance.getQueue("foo")).thenReturn(queue);
+        when(transactionContext.getQueue("foo")).thenReturn(tqueue);
     }
 
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance).getQueue("foo");
+        verify(hazelcastInstance, times(2)).getQueue("foo");
         verify(hazelcastInstance, atLeastOnce()).newTransactionContext();
     }
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerRollbackTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerRollbackTest.java
@@ -37,10 +37,11 @@ public class HazelcastSedaRecoverableConsumerRollbackTest extends HazelcastSedaR
                 .when(transactionContext).rollbackTransaction();
         when(hazelcastInstance.newTransactionContext()).thenReturn(transactionContext);
         when(hazelcastInstance.getQueue("foo")).thenReturn(queue);
+        when(transactionContext.getQueue("foo")).thenReturn(tqueue);
     }
 
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance).getQueue("foo");
+        verify(hazelcastInstance, times(2)).getQueue("foo");
         verify(hazelcastInstance, atLeastOnce()).newTransactionContext();
     }
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.hazelcast;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.IQueue;
+import com.hazelcast.core.TransactionalQueue;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -34,12 +35,19 @@ public abstract class HazelcastSedaRecoverableConsumerTest extends HazelcastCame
     @Mock
     protected IQueue<Object> queue;
 
+    @Mock
+    protected TransactionalQueue<Object> tqueue;
+
     @EndpointInject(uri = "mock:result")
     protected MockEndpoint mock;
 
     @Test
     public void testRecovery() throws InterruptedException {
         when(queue.poll(any(Long.class), any(TimeUnit.class)))
+                .thenReturn("bar")
+                .thenReturn(null);
+
+        when(tqueue.poll(any(Long.class), any(TimeUnit.class)))
                 .thenReturn("bar")
                 .thenReturn(null);
 


### PR DESCRIPTION
As mentioned in docs of hz (any version, current for example)
http://docs.hazelcast.org/docs/3.8.4/manual/html-single/index.html#creating-a-transaction-interface
Transaction do its work if queue initialized with help of transaction ctx