### PR TITLE
CAMEL-11781: Support for BoxUser.moveFolderToUser in camel-box.

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxUsersManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxUsersManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.box.sdk.BoxAPIConnection;
 import com.box.sdk.BoxAPIException;
+import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxUser;
 import com.box.sdk.CreateUserParams;
 import com.box.sdk.EmailAlias;
@@ -330,4 +331,30 @@ public class BoxUsersManager {
         }
     }
 
+    /**
+     * Move root folder for specified user to current user.
+     *
+     * @param userId
+     *            - the id of user.
+     * @param sourceUserId
+     *            - the user id of the user whose files will be the source for this operation.
+     */
+    public BoxFolder.Info moveFolderToUser(String userId, String sourceUserId) {
+        try {
+            LOG.debug("Moving root folder for user(id=" + sourceUserId + ") to user(id=" + userId + ")");
+            if (userId == null) {
+                throw new IllegalArgumentException("Parameter 'userId' can not be null");
+            }
+            if (sourceUserId == null) {
+                throw new IllegalArgumentException("Parameter 'sourceUserId' can not be null");
+            }
+
+            BoxUser user = new BoxUser(boxConnection, userId);
+
+            return user.moveFolderToUser(sourceUserId);
+        } catch (BoxAPIException e) {
+            throw new RuntimeException(
+                    String.format("Box API returned the error code %d\n\n%s", e.getResponseCode(), e.getResponse()), e);
+        }
+    }
 }

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -652,6 +652,8 @@ follows:
 |getUserInfo |info  | userId |com.box.sdk.BoxUser.Info
 
 |updateUserInfo |updateInfo |userId, info |com.box.sdk.BoxUser
+
+|moveFolderToUser |- |userId, sourceUserId |com.box.sdk.BoxFolder.Info
 |=======================================================================
 
 URI Options for _users_

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxUsersManagerIntegrationTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxUsersManagerIntegrationTest.java
@@ -51,6 +51,8 @@ public class BoxUsersManagerIntegrationTest extends AbstractBoxTestSupport {
     private static final String CAMEL_TEST_CREATE_APP_USER_NAME = "Wilma";
     private static final String CAMEL_TEST_CREATE_ENTERPRISE_USER_NAME = "fred";
     private static final String CAMEL_TEST_CREATE_ENTERPRISE_USER_LOGIN = "fred@example.com";
+    private static final String CAMEL_TEST_CREATE_ENTERPRISE_USER2_NAME = "gregory";
+    private static final String CAMEL_TEST_CREATE_ENTERPRISE_USER2_LOGIN = "gregory@example.com";
 
     private BoxUser testUser;
 
@@ -240,6 +242,22 @@ public class BoxUsersManagerIntegrationTest extends AbstractBoxTestSupport {
         }
     }
 
+    @Test
+    public void testmMoveFolderToUser() throws Exception {
+        BoxUser.Info user1 = BoxUser.createEnterpriseUser(getConnection(),
+                CAMEL_TEST_CREATE_ENTERPRISE_USER_LOGIN, CAMEL_TEST_CREATE_ENTERPRISE_USER_NAME);
+        BoxUser.Info user2 = BoxUser.createEnterpriseUser(getConnection(),
+                CAMEL_TEST_CREATE_ENTERPRISE_USER2_LOGIN, CAMEL_TEST_CREATE_ENTERPRISE_USER2_NAME);
+
+        final Map<String, Object> headers = new HashMap<String, Object>();
+        // parameter type is String
+        headers.put("CamelBox.userId", user1.getID());
+        headers.put("CamelBox.sourceUserId", user2.getID());
+
+        final com.box.sdk.BoxFolder.Info result = requestBodyAndHeaders("direct://MOVEFOLDERTOUSER", null, headers);
+        assertNotNull("moveFolderToUser result", result);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -275,6 +293,8 @@ public class BoxUsersManagerIntegrationTest extends AbstractBoxTestSupport {
                 // test route for updateUserInfo
                 from("direct://UPDATEUSERINFO").to("box://" + PATH_PREFIX + "/updateUserInfo");
 
+                // test route for moveFolderToUser
+                from("direct://MOVEFOLDERTOUSER").to("box://" + PATH_PREFIX + "/moveFolderToUser");
             }
         };
     }


### PR DESCRIPTION
Add support for BoxUser.moveFolderToUser in order to be able to move data from a user account into another before deleting an enterprise user as in the Box user interface.