### PR TITLE
CAMEL-11658: test for RestletProducer handling unencoded headers

### DIFF
--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletValidUriQueryTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletValidUriQueryTest.java
@@ -69,4 +69,17 @@ public class RestletValidUriQueryTest extends RestletTestSupport {
         });
         assertEquals(200, ex.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));   
     }
+
+    @Test
+    public void testGetBodyByRestletProducerUnencodedHeader() throws Exception {
+        Exchange ex = template.request("direct:start", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_QUERY, QUERY_STRING);
+                exchange.getIn().setHeader("username", "homer &?#%+\"<>@=,;/:"); // header with unencoded characters
+
+            }
+        });
+        assertEquals(200, ex.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
+    }
 }


### PR DESCRIPTION
This is just a unit test showing how a header with characters that are not allowed in URI path will cause a failure within RestletProducer.

CAMEL-11658: The regression is only for some characters (such as space). Other characters actually didn't work very well before (question mark "?" could cause other parts of path to become query, etc.).