### PR TITLE
CAMEL-11785: CompositeApiClient cannot handle null resposnestream

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
@@ -240,6 +240,9 @@ public class DefaultCompositeApiClient extends AbstractClientBase implements Com
     }
 
     <T> Optional<T> tryToReadResponse(final Class<T> expectedType, final InputStream responseStream) {
+        if (responseStream == null) {           
+            return Optional.empty();
+        } 
         try {
             if (format == PayloadFormat.JSON) {
                 return Optional.of(fromJson(expectedType, responseStream));


### PR DESCRIPTION
The DefaultCompositeApiClient class didnt consider null as a valid response stream and was only considering Json and XML format. But it has to also handle null responses, incase we have an update query.