### PR TITLE
CAMEL-11793: Update Box Java SDK to version 2.8.1

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxFilesManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxFilesManager.java
@@ -214,10 +214,10 @@ public class BoxFilesManager {
             BoxFile file = new BoxFile(boxConnection, fileId);
 
             if (modified != null) {
-                if (fileSize != null && listener != null) {
+                if (fileSize != null) {
                     file.uploadVersion(fileContent, modified, fileSize, listener);
                 } else {
-                    file.uploadVersion(fileContent, modified);
+                    file.uploadVersion(fileContent, modified, 0, listener);
                 }
             } else {
                 file.uploadVersion(fileContent);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,7 +96,7 @@
     <boon-version>0.34</boon-version>
     <bouncycastle-version>1.57</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
-    <box-java-sdk-version>2.1.1</box-java-sdk-version>
+    <box-java-sdk-version>2.8.1</box-java-sdk-version>
     <braintree-gateway-version>2.63.0</braintree-gateway-version>
     <brave-zipkin-version>4.5.2</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>


### PR DESCRIPTION
This is in order to be able to set timeouts properly for the Box client to avoid hanging threads due to network issues.

See https://github.com/box/box-java-sdk/issues/466