### PR TITLE
CAMEL-11814: makes NO_START a ThreadLocal, and ...

### DIFF
--- a/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.spring;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.bean.BeanProcessor;
 import org.apache.camel.component.event.EventComponent;
@@ -62,7 +60,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
         ApplicationListener<ApplicationEvent>, Ordered {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringCamelContext.class);
-    private static final AtomicBoolean NO_START = new AtomicBoolean();
+    private static final ThreadLocal<Boolean> NO_START = new ThreadLocal<>();
     private ApplicationContext applicationContext;
     private EventComponent eventComponent;
     private boolean shutdownEager = true;
@@ -75,7 +73,11 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
     }
 
     public static void setNoStart(boolean b) {
-        NO_START.set(b);
+        if (b) {
+            NO_START.set(true);
+        } else {
+            NO_START.set(null);
+        }
     }
 
     /**


### PR DESCRIPTION
...changes the way CamelMainRunController is started

We need to change NO_START flag back to ThreadLocal as there is a use
case when it's used from a single classloader outside of the tests in
wildfly-camel.

CamelMainRunController would atempt to start CamelContext from a thread
that does not have the NO_START flag defined (it's a ThreadLocal), so
it can only run when CamelContext is started. It's main purpose is to
prevent the SpringBoot application JVM from terminating so having it
run when the CamelContext is started doesn't prevent that.