### PR TITLE
CAMEL-11808: log4j2 2.9 upgrade causes errors in camel build

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
@@ -246,9 +246,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.5</version>
         <configuration>
-          <goalPrefix>camel-salesforce</goalPrefix>
-          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>camel-salesforce</goalPrefix>         
         </configuration>
         <executions>
           <execution>
@@ -256,12 +256,14 @@
             <goals>
               <goal>descriptor</goal>
             </goals>
+            <phase>process-classes</phase>
           </execution>
           <execution>
             <id>help-goal</id>
             <goals>
               <goal>helpmojo</goal>
             </goals>
+            <phase>process-classes</phase>
           </execution>
         </executions>
       </plugin>

--- a/components/camel-servicenow/camel-servicenow-maven-plugin/pom.xml
+++ b/components/camel-servicenow/camel-servicenow-maven-plugin/pom.xml
@@ -223,9 +223,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.5</version>
         <configuration>
-          <goalPrefix>camel-servicenow</goalPrefix>
-          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>camel-servicenow</goalPrefix>          
         </configuration>
         <executions>
           <execution>
@@ -233,12 +233,14 @@
             <goals>
               <goal>descriptor</goal>
             </goals>
+            <phase>process-classes</phase>
           </execution>
           <execution>
             <id>help-goal</id>
             <goals>
               <goal>helpmojo</goal>
             </goals>
+            <phase>process-classes</phase>
           </execution>
         </executions>
       </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -444,7 +444,7 @@
     <!-- virtual dependency only used by Eclipse m2e -->
     <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
     <log4j-version>1.2.17</log4j-version>
-    <log4j2-version>2.8.2</log4j2-version>
+    <log4j2-version>2.9.0</log4j2-version>
     <log4j2-25-version>2.5</log4j2-25-version>
     <logback-version>1.2.0</logback-version>
     <lucene3-bundle-version>3.6.0_1</lucene3-bundle-version>


### PR DESCRIPTION
Fix for issue: https://issues.apache.org/jira/browse/CAMEL-11808

The 'maven-plugin-plugin' was failing. There's a little bit of tweaking involved here as I am not sure how log4j 2.9 transitively affects this plugin, but, there were some existing issues with this plugin as the below, which we haven't made changes in camel,
https://issues.apache.org/jira/browse/MPLUGIN-238
http://maven.apache.org/plugin-tools/maven-plugin-plugin/examples/using-annotations.html

The 'HelpMojo' goal was affected. 
I am not sure if the version 3.4 of the plugin contains the fix, because it does not work! Upgrading the version after making the suggested changes has no issues with the build. 

camel-servicenow and camel-salesforce maven plugins failed in the build and now the build is working fine along-with the iTests. 