### PR TITLE
update commons-csv to 1.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -142,7 +142,7 @@
     <commons-compress-version>1.14</commons-compress-version>
     <commons-configuration-version>1.9</commons-configuration-version>
     <commons-configuration-bundle-version>1.9_1</commons-configuration-bundle-version>
-    <commons-csv-version>1.4</commons-csv-version>
+    <commons-csv-version>1.5</commons-csv-version>
     <commons-cli-version>1.3.1</commons-cli-version>
     <commons-daemon-version>1.0.15</commons-daemon-version>
     <commons-dbcp-version>1.4</commons-dbcp-version>


### PR DESCRIPTION
camel-csv test pass

`git grep commons-csv` found this match:

`platforms/karaf/features/src/main/resources/bundles.properties:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-csv/${commons-csv-bundle-version}/jar`

I not sure if this is correct, as their is no other match for `commons-csv-bundle-version` (and commons-csv should already be an osgi bundle).