### PR TITLE
CAMEL-11845: Remove powermock from camel-docker

### DIFF
--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -97,39 +97,10 @@
       <artifactId>camel-test</artifactId>
       <scope>test</scope>
     </dependency>
-       <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock-version}</version>
-      <scope>test</scope>
-   </dependency>
-   <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock-version}</version>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
    </dependency>
   </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk9-build</id>
-            <activation>
-                <jdk>9</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!--TODO: See https://github.com/powermock/powermock/issues/783 for more details-->
-                                <exclude>**/**.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/consumer/DockerEventsConsumerTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/consumer/DockerEventsConsumerTest.java
@@ -30,14 +30,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * Consumer test for events on Docker Platform
  */
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class DockerEventsConsumerTest extends CamelTestSupport {
     private String host = "localhost";
     private Integer port = 2375;

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/consumer/DockerStatsConsumerTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/consumer/DockerStatsConsumerTest.java
@@ -30,14 +30,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * Consumer test for statistics on Docker Platform
  */
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class DockerStatsConsumerTest extends CamelTestSupport {
     private String host = "localhost";
     private Integer port = 2375;

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/BaseDockerHeaderTest.java
@@ -32,12 +32,9 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
+@RunWith(MockitoJUnitRunner.class)
 public abstract class BaseDockerHeaderTest<T> extends CamelTestSupport {
 
     @Mock


### PR DESCRIPTION
Since I was already working in this area. This is a start towards https://issues.apache.org/jira/browse/CAMEL-11845.