### PR TITLE
camel-azure, camel-hipchat, camel-ibatis: remove unused easymock test dependency

### DIFF
--- a/components/camel-azure/pom.xml
+++ b/components/camel-azure/pom.xml
@@ -62,11 +62,5 @@
             <artifactId>camel-test-spring</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock-version}</version>
-            <scope>test</scope>
-        </dependency>
      </dependencies>
 </project>

--- a/components/camel-hipchat/pom.xml
+++ b/components/camel-hipchat/pom.xml
@@ -85,11 +85,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/components/camel-ibatis/pom.xml
+++ b/components/camel-ibatis/pom.xml
@@ -79,11 +79,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION
Test code does not use easymock. All tests of these components still pass.