### PR TITLE
CAMEL-11845: Migrated camel-bonita from powermock to mockito

### DIFF
--- a/components/camel-azure/pom.xml
+++ b/components/camel-azure/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <azure-storage-java-sdk-version>5.0.0</azure-storage-java-sdk-version>
-        <powermock-easymock-version>1.6.6</powermock-easymock-version>
         <camel.osgi.export.pkg>org.apache.camel.component.azure.*</camel.osgi.export.pkg>
         <camel.osgi.export.service>
         </camel.osgi.export.service>
@@ -60,12 +59,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock-version}</version>
             <scope>test</scope>
         </dependency>
      </dependencies>

--- a/components/camel-bonita/pom.xml
+++ b/components/camel-bonita/pom.xml
@@ -63,15 +63,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock-version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -97,25 +90,4 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <!-- TODO: See https://github.com/powermock/powermock/issues/783 for more information. -->
-                <exclude>**/**.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterAlreadyConnectedTest.java
+++ b/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterAlreadyConnectedTest.java
@@ -27,12 +27,10 @@ import org.apache.camel.component.bonita.api.filter.BonitaAuthFilter;
 import org.apache.camel.component.bonita.api.util.BonitaAPIConfig;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(PowerMockRunner.class)
 public class BonitaAuthFilterAlreadyConnectedTest {
 
     @Mock
@@ -40,6 +38,7 @@ public class BonitaAuthFilterAlreadyConnectedTest {
 
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         Map<String, Cookie> resultCookies = new HashMap<>();
         resultCookies.put("JSESSIONID", new Cookie("JSESSIONID", "something"));
         Mockito.when(requestContext.getCookies()).thenReturn(resultCookies);

--- a/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterConnectionTest.java
+++ b/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterConnectionTest.java
@@ -29,11 +29,9 @@ import org.apache.camel.component.bonita.api.util.BonitaAPIConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockitoAnnotations;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -42,8 +40,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*", "javax.management.*"})
 public class BonitaAuthFilterConnectionTest {
 
     @Rule
@@ -54,6 +50,7 @@ public class BonitaAuthFilterConnectionTest {
 
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         Mockito.when(requestContext.getCookies()).thenReturn(new HashMap<String, Cookie>());
         Mockito.when(requestContext.getHeaders()).thenReturn(new MultivaluedHashMap());
     }

--- a/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterTest.java
+++ b/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAuthFilterTest.java
@@ -27,14 +27,10 @@ import org.apache.camel.component.bonita.api.filter.BonitaAuthFilter;
 import org.apache.camel.component.bonita.api.util.BonitaAPIConfig;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
 public class BonitaAuthFilterTest {
 
     @Mock
@@ -42,6 +38,7 @@ public class BonitaAuthFilterTest {
 
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         Map<String, Cookie> resultCookies = new HashMap<>();
         Mockito.when(requestContext.getCookies()).thenReturn(resultCookies);
 

--- a/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/util/BonitaAPIUtilPrepareInputsTest.java
+++ b/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/util/BonitaAPIUtilPrepareInputsTest.java
@@ -30,14 +30,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(BonitaAPIUtil.class)
 public class BonitaAPIUtilPrepareInputsTest {
 
     @Mock
@@ -47,6 +44,7 @@ public class BonitaAPIUtilPrepareInputsTest {
 
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         bonitaApiUtil = BonitaAPIUtil
                 .getInstance(new BonitaAPIConfig("hostname", "port", "username", "password"));
         Mockito.when(processDefinition.getName()).thenReturn("processName");

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -557,7 +557,6 @@
     <pax-logging-version>1.8.6</pax-logging-version>
     <pdfbox-version>1.8.13</pdfbox-version>
     <pgjdbc-ng-driver-version>0.7.1</pgjdbc-ng-driver-version>
-    <powermock-version>1.6.6</powermock-version>
     <protobuf-version>3.3.0</protobuf-version>
     <protobuf-guava-version>20.0</protobuf-guava-version>
     <protobuf-maven-plugin-version>0.5.0</protobuf-maven-plugin-version>


### PR DESCRIPTION
Migrated camel-bonita from powermock to mockito.
Removed an unused property from camel-azure as well.

More details in [CAMEL-11845](https://issues.apache.org/jira/browse/CAMEL-11845).