### PR TITLE
CAMEL-11845: Migrate easymock and powermock to mockito

### DIFF
--- a/components/camel-mina/pom.xml
+++ b/components/camel-mina/pom.xml
@@ -86,8 +86,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-mina/src/test/java/org/apache/camel/component/mina/MinaProducerShutdownMockTest.java
+++ b/components/camel-mina/src/test/java/org/apache/camel/component/mina/MinaProducerShutdownMockTest.java
@@ -26,9 +26,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.mina.transport.socket.nio.SocketConnector;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit testing for using a MinaProducer that it can shutdown properly (CAMEL-395)
@@ -40,10 +39,7 @@ public class MinaProducerShutdownMockTest extends BaseMinaTest {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
 
-        // create our mock and record expected behavior = that worker timeout should be set to 0
-        SocketConnector mockConnector = createMock(SocketConnector.class);
-        mockConnector.setWorkerTimeout(0);
-        replay(mockConnector);
+        SocketConnector mockConnector = mock(SocketConnector.class);
 
         // normal camel code to get a producer
         Endpoint endpoint = context.getEndpoint("mina:tcp://localhost:{{port}}?textline=true&sync=false");
@@ -63,7 +59,7 @@ public class MinaProducerShutdownMockTest extends BaseMinaTest {
         // stop using our mock
         producer.stop();
 
-        verify(mockConnector);
+        verify(mockConnector).setWorkerTimeout(0);
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-mina2/pom.xml
+++ b/components/camel-mina2/pom.xml
@@ -82,8 +82,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-mina2/src/test/java/org/apache/camel/component/mina2/Mina2ProducerShutdownMockTest.java
+++ b/components/camel-mina2/src/test/java/org/apache/camel/component/mina2/Mina2ProducerShutdownMockTest.java
@@ -27,10 +27,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.mina.transport.socket.SocketConnector;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit testing for using a MinaProducer that it can shutdown properly (CAMEL-395)
@@ -42,10 +40,7 @@ public class Mina2ProducerShutdownMockTest extends BaseMina2Test {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
 
-        // create our mock and record expected behavior = that worker timeout should be set to 0
-        SocketConnector mockConnector = createMock(SocketConnector.class);
-        mockConnector.dispose(true);
-        replay(mockConnector);
+        SocketConnector mockConnector = mock(SocketConnector.class);
 
         // normal camel code to get a producer
         Endpoint endpoint = context.getEndpoint(String.format("mina2:tcp://localhost:%1$s?textline=true&sync=false", getPort()));
@@ -70,7 +65,7 @@ public class Mina2ProducerShutdownMockTest extends BaseMina2Test {
         // stop using our mock
         producer.stop();
 
-        verify(mockConnector);
+        verify(mockConnector).dispose(true);
 
         assertMockEndpointsSatisfied();
     }


### PR DESCRIPTION
Migrate camel-mina and camel-mina2 from easymock to mockito.

Test still pass.