### PR TITLE
Fix camel-jpa on JDK9 GA

### DIFF
--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -263,6 +263,19 @@
           </plugin>
         </plugins>
       </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.openjpa</groupId>
+          <artifactId>openjpa-persistence-jdbc</artifactId>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.geronimo.specs</groupId>
+              <artifactId>geronimo-jpa_2.0_spec</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
With this, `mvn clean install` builds successfully on entire Apache Camel project with JDK9 GA.

Thanks!