### PR TITLE
update log4j2 to 2.9.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -449,8 +449,7 @@
     <!-- virtual dependency only used by Eclipse m2e -->
     <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
     <log4j-version>1.2.17</log4j-version>
-    <!-- 2.9.1 causes problems with powermock testing -->
-    <log4j2-version>2.9.0</log4j2-version>
+    <log4j2-version>2.9.1</log4j2-version>
     <log4j2-25-version>2.5</log4j2-25-version>
     <logback-version>1.2.0</logback-version>
     <lucene3-bundle-version>3.6.0_1</lucene3-bundle-version>


### PR DESCRIPTION
Camel does not use powermock anymore, so this should be safe.