### PR TITLE
Jdk9 ga

### DIFF
--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -498,7 +498,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <!--ignore tests until CXF-7270 is resolved and released-->
+                <!--ignore tests until CXF-7520 is resolved and released-->
                 <exclude>**/**</exclude>
               </excludes>
             </configuration>

--- a/components/camel-elsql/pom.xml
+++ b/components/camel-elsql/pom.xml
@@ -116,26 +116,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <forkedProcessTimeoutInSeconds>3000</forkedProcessTimeoutInSeconds>
-              <argLine>--add-modules java.sql,java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
-              <!--https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-              <reuseForks>true</reuseForks>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-jcr/pom.xml
+++ b/components/camel-jcr/pom.xml
@@ -110,26 +110,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <!--TODO: See https://issues.apache.org/jira/browse/JCR-4131 for more information. -->
-                <exclude>**/**.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -150,7 +150,7 @@
         <configuration>
           <argLine>
             -javaagent:${opentracing-agent.lib}/opentracing-agent.jar
-            -Dorg.jboss.byteman.verbose
+            -Dorg.jboss.byteman.verbose ${camel.surefire.fork.vmargs}
           </argLine>
         </configuration>
         <executions>
@@ -175,40 +175,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>run-integration-tests</id>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-                <configuration>
-                  <excludes>
-                    <!--TODO: https://github.com/opentracing-contrib/java-agent/issues/18-->
-                    <exclude>**/**.java</exclude>
-                  </excludes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-script/pom.xml
+++ b/components/camel-script/pom.xml
@@ -146,28 +146,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>jdk9-build</id>
-            <activation>
-                <jdk>9</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- TODO: Let's wait until Groovy and Ruby are supported on Java 9-->
-                                <exclude>**/**Groovy**.java</exclude>
-                                <exclude>**/**Ruby**.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-    
 </project>

--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -292,14 +292,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>--add-modules java.xml.bind,java.xml.ws --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                            <!--https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-                            <reuseForks>true</reuseForks>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/components/camel-spring-cloud-netflix/pom.xml
+++ b/components/camel-spring-cloud-netflix/pom.xml
@@ -135,25 +135,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-              <!--https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-              <reuseForks>true</reuseForks>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-spring-cloud/pom.xml
+++ b/components/camel-spring-cloud/pom.xml
@@ -131,25 +131,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-              <!--https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-              <reuseForks>true</reuseForks>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-sql/pom.xml
+++ b/components/camel-sql/pom.xml
@@ -137,26 +137,4 @@
 
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <forkedProcessTimeoutInSeconds>3000</forkedProcessTimeoutInSeconds>
-              <argLine>--add-modules java.sql,java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
-              <!--https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-              <reuseForks>true</reuseForks>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/examples/camel-example-cdi-xml/pom.xml
+++ b/examples/camel-example-cdi-xml/pom.xml
@@ -122,26 +122,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <!-- need older version of surefire to make test work -->
-            <version>2.19.1</version>
-            <configuration>
-              <argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/examples/camel-example-cxf/pom.xml
+++ b/examples/camel-example-cxf/pom.xml
@@ -255,7 +255,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <!--ignore tests until CXF-7270 is resolved and released-->
+                <!--ignore tests until CXF-7520 is resolved and released-->
                 <exclude>**/**</exclude>
               </excludes>
             </configuration>

--- a/examples/camel-example-reportincident-wssecurity/pom.xml
+++ b/examples/camel-example-reportincident-wssecurity/pom.xml
@@ -236,7 +236,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <!--ignore tests until CXF-7270 is resolved and released-->
+                <!--ignore tests until CXF-7520 is resolved and released-->
                 <exclude>**/**</exclude>
               </excludes>
             </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5521,8 +5521,6 @@
               <artifactId>maven-surefire-plugin</artifactId>
               <!--lets avoid polluting every pom.xml as these settings are almost always needed-->
               <configuration>
-                <!--https://issues.apache.org/jira/browse/SUREFIRE-1265-->
-                <reuseForks>true</reuseForks>
                 <argLine>${camel.surefire.fork.vmargs}</argLine>
               </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <compiler.fork>false</compiler.fork>
 
     <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
-    <maven-surefire-plugin-version>2.20</maven-surefire-plugin-version>
+    <maven-surefire-plugin-version>2.20.1</maven-surefire-plugin-version>
 
     <!-- eclipse plugin need the jaxb in this pom.xml file -->
     <!-- Make sure to keep JAXB version up to date in parent/pom.xml in the bottom of the file -->

--- a/tests/camel-blueprint-cxf-test/pom.xml
+++ b/tests/camel-blueprint-cxf-test/pom.xml
@@ -204,7 +204,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <!--ignore tests until CXF-7270 is resolved and released-->
+                <!--ignore tests until CXF-7520 is resolved and released-->
                 <exclude>**/**</exclude>
               </excludes>
             </configuration>


### PR DESCRIPTION
Enable more tests on JDK9 GA and upgrade maven-surefire-plugin to 2.20.1.

Some tests are still skipped on JDK9 GA due to:

[CXF-7520](https://issues.apache.org/jira/browse/CXF-7520)
[BOON-376](https://github.com/boonproject/boon/issues/376)
[groovy-eclipse-265](https://github.com/groovy/groovy-eclipse/issues/265)
[TOMEE-2038](https://issues.apache.org/jira/browse/TOMEE-2038)

Thanks!
