### PR TITLE
CAMEL-11845: Migrate easymock and powermock to mockito

### DIFF
--- a/camel-core/pom.xml
+++ b/camel-core/pom.xml
@@ -191,12 +191,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/camel-core/src/test/java/org/apache/camel/component/rest/RestProducerBindingProcessorTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/rest/RestProducerBindingProcessorTest.java
@@ -28,20 +28,16 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.apache.camel.impl.DefaultMessage;
 import org.apache.camel.spi.DataFormat;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.same;
-import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RestProducerBindingProcessorTest {
 
@@ -74,27 +70,22 @@ public class RestProducerBindingProcessorTest {
         input.setBody(request);
         exchange.setIn(input);
 
-        jsonDataFormat.marshal(same(exchange), same(request), anyObject(OutputStream.class));
-        expectLastCall().andVoid();
-
         final ResponsePojo response = new ResponsePojo();
-        expect(outJsonDataFormat.unmarshal(same(exchange), anyObject(InputStream.class))).andReturn(response);
+        when(outJsonDataFormat.unmarshal(same(exchange), any(InputStream.class))).thenReturn(response);
 
-        final Capture<AsyncCallback> bindingCallback = EasyMock.newCapture();
+        final ArgumentCaptor<AsyncCallback> bindingCallback = ArgumentCaptor.forClass(AsyncCallback.class);
 
-        expect(processor.process(same(exchange), capture(bindingCallback))).andReturn(false);
-
-        replay(jsonDataFormat, outJsonDataFormat, processor);
+        when(processor.process(same(exchange), bindingCallback.capture())).thenReturn(false);
 
         bindingProcessor.process(exchange, callback);
 
-        assertTrue(bindingCallback.hasCaptured());
+        verify(jsonDataFormat).marshal(same(exchange), same(request), any(OutputStream.class));
+
+        assertNotNull(bindingCallback.getValue());
 
         final AsyncCallback that = bindingCallback.getValue();
 
         that.done(false);
-
-        verify(jsonDataFormat, outJsonDataFormat, processor);
 
         Assert.assertSame(response, exchange.getOut().getBody());
     }
@@ -113,27 +104,22 @@ public class RestProducerBindingProcessorTest {
         input.setBody(request);
         exchange.setIn(input);
 
-        xmlDataFormat.marshal(same(exchange), same(request), anyObject(OutputStream.class));
-        expectLastCall().andVoid();
-
         final ResponsePojo response = new ResponsePojo();
-        expect(outXmlDataFormat.unmarshal(same(exchange), anyObject(InputStream.class))).andReturn(response);
+        when(outXmlDataFormat.unmarshal(same(exchange), any(InputStream.class))).thenReturn(response);
 
-        final Capture<AsyncCallback> bindingCallback = EasyMock.newCapture();
+        final ArgumentCaptor<AsyncCallback> bindingCallback = ArgumentCaptor.forClass(AsyncCallback.class);
 
-        expect(processor.process(same(exchange), capture(bindingCallback))).andReturn(false);
-
-        replay(xmlDataFormat, outXmlDataFormat, processor);
+        when(processor.process(same(exchange), bindingCallback.capture())).thenReturn(false);
 
         bindingProcessor.process(exchange, callback);
 
-        assertTrue(bindingCallback.hasCaptured());
+        verify(xmlDataFormat).marshal(same(exchange), same(request), any(OutputStream.class));
+
+        assertNotNull(bindingCallback.getValue());
 
         final AsyncCallback that = bindingCallback.getValue();
 
         that.done(false);
-
-        verify(xmlDataFormat, outXmlDataFormat, processor);
 
         Assert.assertSame(response, exchange.getOut().getBody());
     }
@@ -152,20 +138,16 @@ public class RestProducerBindingProcessorTest {
         input.setBody(request);
         exchange.setIn(input);
 
-        final Capture<AsyncCallback> bindingCallback = EasyMock.newCapture();
+        final ArgumentCaptor<AsyncCallback> bindingCallback = ArgumentCaptor.forClass(AsyncCallback.class);
 
-        expect(processor.process(same(exchange), capture(bindingCallback))).andReturn(false);
-
-        replay(processor);
+        when(processor.process(same(exchange), bindingCallback.capture())).thenReturn(false);
 
         bindingProcessor.process(exchange, callback);
 
-        assertTrue(bindingCallback.hasCaptured());
+        assertNotNull(bindingCallback.getValue());
 
         final AsyncCallback that = bindingCallback.getValue();
 
         that.done(false);
-
-        verify(processor);
     }
 }

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultFactoryFinderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultFactoryFinderTest.java
@@ -26,11 +26,6 @@ import org.apache.camel.spi.ClassResolver;
 import org.apache.camel.spi.Injector;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -38,6 +33,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DefaultFactoryFinderTest {
 
@@ -60,12 +58,10 @@ public class DefaultFactoryFinderTest {
 
         final String properties = "class=" + TestImplA.class.getName();
 
-        expect(classResolver.loadResourceAsStream("/org/apache/camel/impl/TestImplA"))
-                .andReturn(new ByteArrayInputStream(properties.getBytes()));
+        when(classResolver.loadResourceAsStream("/org/apache/camel/impl/TestImplA"))
+                .thenReturn(new ByteArrayInputStream(properties.getBytes()));
 
-        expect(classResolver.resolveClass(TestImplA.class.getName())).andReturn(null);
-
-        replay(classResolver);
+        when(classResolver.resolveClass(TestImplA.class.getName())).thenReturn(null);
 
         final DefaultFactoryFinder factoryFinder = new DefaultFactoryFinder(classResolver, TEST_RESOURCE_PATH);
 
@@ -73,7 +69,6 @@ public class DefaultFactoryFinderTest {
             factoryFinder.findClass("TestImplA", null);
             fail("Should have thrown ClassNotFoundException");
         } catch (final ClassNotFoundException e) {
-            verify(classResolver);
             assertEquals(TestImplA.class.getName(), e.getMessage());
         }
 
@@ -81,12 +76,10 @@ public class DefaultFactoryFinderTest {
 
     @Test
     public void shouldComplainIfInstanceTypeIsNotAsExpected() throws ClassNotFoundException, IOException {
-        final Injector injector = createMock(Injector.class);
+        final Injector injector = mock(Injector.class);
 
         final TestImplA expected = new TestImplA();
-        expect(injector.newInstance(TestImplA.class)).andReturn(expected);
-
-        replay(injector);
+        when(injector.newInstance(TestImplA.class)).thenReturn(expected);
 
         try {
             factoryFinder.newInstances("TestImplA", injector, TestImplB.class);
@@ -128,12 +121,10 @@ public class DefaultFactoryFinderTest {
 
     @Test
     public void shouldCreateNewInstancesWithInjector() throws ClassNotFoundException, IOException {
-        final Injector injector = createMock(Injector.class);
+        final Injector injector = mock(Injector.class);
 
         final TestImplA expected = new TestImplA();
-        expect(injector.newInstance(TestImplA.class)).andReturn(expected);
-
-        replay(injector);
+        when(injector.newInstance(TestImplA.class)).thenReturn(expected);
 
         final List<TestType> instances = factoryFinder.newInstances("TestImplA", injector, TestType.class);
 

--- a/camel-core/src/test/java/org/apache/camel/management/DefaultManagementAgentMockTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/DefaultManagementAgentMockTest.java
@@ -26,13 +26,11 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.ManagementAgent;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createStrictMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests proper behavior of DefaultManagementAgent when
@@ -43,8 +41,8 @@ public class DefaultManagementAgentMockTest {
 
     @Test
     public void testObjectNameModification() throws JMException {
-        MBeanServer mbeanServer = createStrictMock(MBeanServer.class);
-        ObjectInstance instance = createStrictMock(ObjectInstance.class);
+        MBeanServer mbeanServer = mock(MBeanServer.class);
+        ObjectInstance instance = mock(ObjectInstance.class);
 
         ManagementAgent agent = new DefaultManagementAgent();
         agent.setMBeanServer(mbeanServer);
@@ -54,28 +52,24 @@ public class DefaultManagementAgentMockTest {
         ObjectName registeredObjectName = new ObjectName("domain", "key", "otherValue");
 
         // Register MBean and return different ObjectName
-        expect(mbeanServer.isRegistered(sourceObjectName)).andReturn(false);
-        expect(mbeanServer.registerMBean(object, sourceObjectName)).andReturn(instance);
-        expect(instance.getObjectName()).andReturn(registeredObjectName);
-        expect(mbeanServer.isRegistered(registeredObjectName)).andReturn(true);
-        replay(mbeanServer, instance);
+        when(mbeanServer.isRegistered(sourceObjectName)).thenReturn(false);
+        when(mbeanServer.registerMBean(object, sourceObjectName)).thenReturn(instance);
+        when(instance.getObjectName()).thenReturn(registeredObjectName);
+        when(mbeanServer.isRegistered(registeredObjectName)).thenReturn(true);
 
         agent.register(object, sourceObjectName);
 
         assertTrue(agent.isRegistered(sourceObjectName));
-        verify(mbeanServer, instance);
         reset(mbeanServer, instance);
 
         // ... and unregister it again
-        expect(mbeanServer.isRegistered(registeredObjectName)).andReturn(true);
+        when(mbeanServer.isRegistered(registeredObjectName)).thenReturn(true);
         mbeanServer.unregisterMBean(registeredObjectName);
-        expect(mbeanServer.isRegistered(sourceObjectName)).andReturn(false);
-        replay(mbeanServer);
+        when(mbeanServer.isRegistered(sourceObjectName)).thenReturn(false);
 
         agent.unregister(sourceObjectName);
 
         assertFalse(agent.isRegistered(sourceObjectName));
-        verify(mbeanServer);
     }
 
     @Test

--- a/components/camel-cxf-transport/pom.xml
+++ b/components/camel-cxf-transport/pom.xml
@@ -149,8 +149,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/message/DefaultCxfMessageMapperTest.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/message/DefaultCxfMessageMapperTest.java
@@ -29,9 +29,11 @@ import org.apache.cxf.common.security.SimplePrincipal;
 import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.security.SecurityContext;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DefaultCxfMessageMapperTest extends Assert {
 
@@ -44,7 +46,7 @@ public class DefaultCxfMessageMapperTest extends Assert {
 
         Exchange camelExchange = setupCamelExchange(requestURI, requestPath, null);
         Message cxfMessage = mapper.createCxfMessageFromCamelExchange(
-            camelExchange, EasyMock.createMock(HeaderFilterStrategy.class));
+            camelExchange, mock(HeaderFilterStrategy.class));
 
         assertEquals(requestURI, cxfMessage.get(Message.REQUEST_URI).toString());
         assertEquals(requestPath, cxfMessage.get(Message.BASE_PATH).toString());
@@ -54,18 +56,14 @@ public class DefaultCxfMessageMapperTest extends Assert {
     public void testSecurityContext() {
         DefaultCxfMessageMapper mapper = new DefaultCxfMessageMapper();
 
-        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
-        request.getUserPrincipal();
-        EasyMock.expectLastCall().andReturn(new SimplePrincipal("barry"));
-        request.isUserInRole("role1");
-        EasyMock.expectLastCall().andReturn(true);
-        request.isUserInRole("role2");
-        EasyMock.expectLastCall().andReturn(false);
-        EasyMock.replay(request);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getUserPrincipal()).thenReturn(new SimplePrincipal("barry"));
+        when(request.isUserInRole("role1")).thenReturn(true);
+        when(request.isUserInRole("role2")).thenReturn(false);
         Exchange camelExchange = setupCamelExchange("/", "/", request);
         
         Message cxfMessage = mapper.createCxfMessageFromCamelExchange(
-            camelExchange, EasyMock.createMock(HeaderFilterStrategy.class));
+            camelExchange, mock(HeaderFilterStrategy.class));
         SecurityContext sc = cxfMessage.get(SecurityContext.class);
         assertNotNull(sc);
         assertEquals("barry", sc.getUserPrincipal().getName());
@@ -74,45 +72,25 @@ public class DefaultCxfMessageMapperTest extends Assert {
     }
 
     private Exchange setupCamelExchange(String requestURI, String requestPath, HttpServletRequest request) {
-        org.apache.camel.Message camelMessage = EasyMock
-            .createMock(org.apache.camel.Message.class);
-        Exchange camelExchange = EasyMock.createMock(Exchange.class);
-        camelExchange.getProperty(CamelTransportConstants.CXF_EXCHANGE,
-            org.apache.cxf.message.Exchange.class);
-        EasyMock.expectLastCall().andReturn(new ExchangeImpl());
-        camelExchange.hasOut();
-        EasyMock.expectLastCall().andReturn(false);
-        camelExchange.getIn();
-        EasyMock.expectLastCall().andReturn(camelMessage).times(3);
-        camelMessage.getHeaders();
-        EasyMock.expectLastCall().andReturn(Collections.emptyMap()).times(2);
-        camelMessage.getHeader(Exchange.CONTENT_TYPE, String.class);
-        EasyMock.expectLastCall().andReturn(null);
-        camelMessage.getHeader("Accept", String.class);
-        EasyMock.expectLastCall().andReturn(null);
-        camelMessage.getHeader(Exchange.HTTP_CHARACTER_ENCODING, String.class);
-        EasyMock.expectLastCall().andReturn(null);
-        camelMessage.getHeader(Exchange.CHARSET_NAME, String.class);
-        EasyMock.expectLastCall().andReturn(null);
-        camelMessage.getHeader(Exchange.HTTP_URI, String.class);
-        EasyMock.expectLastCall().andReturn(requestURI);
-        camelMessage.getHeader(Exchange.HTTP_PATH, String.class);
-        EasyMock.expectLastCall().andReturn(requestPath);
-        camelMessage.getHeader(Exchange.HTTP_BASE_URI, String.class);
-        EasyMock.expectLastCall().andReturn(requestPath);
-        camelMessage.getHeader(Exchange.HTTP_METHOD, String.class);
-        EasyMock.expectLastCall().andReturn("GET");
-        camelMessage.getHeader(Exchange.HTTP_QUERY, String.class);
-        EasyMock.expectLastCall().andReturn("");
-        camelMessage.getHeader(Exchange.HTTP_SERVLET_REQUEST);
-        EasyMock.expectLastCall().andReturn(request);
-        camelMessage.getHeader(Exchange.HTTP_SERVLET_RESPONSE);
-        EasyMock.expectLastCall().andReturn(null);
-
-        camelMessage.getBody(InputStream.class);
-        EasyMock.expectLastCall().andReturn(
-            new ByteArrayInputStream("".getBytes()));
-        EasyMock.replay(camelExchange, camelMessage);
+        org.apache.camel.Message camelMessage = mock(org.apache.camel.Message.class);
+        Exchange camelExchange = mock(Exchange.class);
+        when(camelExchange.getProperty(CamelTransportConstants.CXF_EXCHANGE,
+            org.apache.cxf.message.Exchange.class)).thenReturn(new ExchangeImpl());
+        when(camelExchange.hasOut()).thenReturn(false);
+        when(camelExchange.getIn()).thenReturn(camelMessage);
+        when(camelMessage.getHeaders()).thenReturn(Collections.emptyMap());
+        when(camelMessage.getHeader(Exchange.CONTENT_TYPE, String.class)).thenReturn(null);
+        when(camelMessage.getHeader("Accept", String.class)).thenReturn(null);
+        when(camelMessage.getHeader(Exchange.HTTP_CHARACTER_ENCODING, String.class)).thenReturn(null);
+        when(camelMessage.getHeader(Exchange.CHARSET_NAME, String.class)).thenReturn(null);
+        when(camelMessage.getHeader(Exchange.HTTP_URI, String.class)).thenReturn(requestURI);
+        when(camelMessage.getHeader(Exchange.HTTP_PATH, String.class)).thenReturn(requestPath);
+        when(camelMessage.getHeader(Exchange.HTTP_BASE_URI, String.class)).thenReturn(requestPath);
+        when(camelMessage.getHeader(Exchange.HTTP_METHOD, String.class)).thenReturn("GET");
+        when(camelMessage.getHeader(Exchange.HTTP_QUERY, String.class)).thenReturn("");
+        when(camelMessage.getHeader(Exchange.HTTP_SERVLET_REQUEST)).thenReturn(request);
+        when(camelMessage.getHeader(Exchange.HTTP_SERVLET_RESPONSE)).thenReturn(null);
+        when(camelMessage.getBody(InputStream.class)).thenReturn(new ByteArrayInputStream("".getBytes()));
         return camelExchange;
     }
 }

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
@@ -47,8 +47,11 @@ import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.ConduitInitiator;
 import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.MessageObserver;
-import org.easymock.EasyMock;
 import org.junit.Test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
 
 public class CamelDestinationTest extends CamelTransportTestSupport {
     private Message destMessage;
@@ -89,7 +92,7 @@ public class CamelDestinationTest extends CamelTransportTestSupport {
     }
 
     public CamelDestination setupCamelDestination(EndpointInfo endpointInfo, boolean send) throws IOException {
-        ConduitInitiator conduitInitiator = EasyMock.createMock(ConduitInitiator.class);
+        ConduitInitiator conduitInitiator = mock(ConduitInitiator.class);
         CamelDestination camelDestination = new CamelDestination(context, bus, conduitInitiator, endpointInfo);
         if (send) {
             // setMessageObserver
@@ -258,10 +261,8 @@ public class CamelDestinationTest extends CamelTransportTestSupport {
         final RuntimeException expectedException = new RuntimeException("We simulate an exception in CXF processing");
         
         DefaultCamelContext camelContext = new DefaultCamelContext();
-        CamelDestination dest = EasyMock.createMock(CamelDestination.class);
-        dest.incoming(EasyMock.isA(org.apache.camel.Exchange.class));
-        EasyMock.expectLastCall().andThrow(expectedException);
-        EasyMock.replay(dest);
+        CamelDestination dest = mock(CamelDestination.class);
+        doThrow(expectedException).when(dest).incoming(isA(org.apache.camel.Exchange.class));
         ConsumerProcessor consumerProcessor = dest.new ConsumerProcessor();
         
         // Send our dummy exchange and check that the exception that occurred on incoming is set
@@ -270,7 +271,6 @@ public class CamelDestinationTest extends CamelTransportTestSupport {
         Exception exc = exchange.getException();
         assertNotNull(exc);
         assertEquals(expectedException, exc);
-        EasyMock.verify(dest);
     }
     
     @Test

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelTransportTestSupport.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelTransportTestSupport.java
@@ -31,9 +31,9 @@ import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.MessageObserver;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 
 public abstract class CamelTransportTestSupport extends CamelTestSupport {
 
@@ -70,7 +70,7 @@ public abstract class CamelTransportTestSupport extends CamelTestSupport {
         if (decoupled) {
             // setup the reference type
         } else {
-            target = EasyMock.createMock(EndpointReferenceType.class);
+            target = Mockito.mock(EndpointReferenceType.class);
         }
 
         CamelConduit camelConduit = new CamelConduit(context, bus, endpointInfo, target);

--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -319,8 +319,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfEndpointTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfEndpointTest.java
@@ -29,10 +29,14 @@ import org.apache.cxf.bus.extension.ExtensionManagerBus;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.frontend.AbstractWSDLBasedEndpointFactory;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 /**
  * A unit test for spring configured cxf endpoint.
@@ -98,31 +102,23 @@ public class CxfEndpointTest extends Assert {
     @Test
     public void testCxfEndpointConfigurer() throws Exception {
         SimpleRegistry registry = new SimpleRegistry();
-        CxfEndpointConfigurer configurer = EasyMock.createMock(CxfEndpointConfigurer.class);
-        Processor processor = EasyMock.createMock(Processor.class);
+        CxfEndpointConfigurer configurer = mock(CxfEndpointConfigurer.class);
+        Processor processor = mock(Processor.class);
         registry.put("myConfigurer", configurer);
         CamelContext camelContext = new DefaultCamelContext(registry);
         CxfComponent cxfComponent = new CxfComponent(camelContext);
         CxfEndpoint endpoint = (CxfEndpoint)cxfComponent.createEndpoint(routerEndpointURI + "&cxfEndpointConfigurer=#myConfigurer");
 
-        configurer.configure(EasyMock.isA(AbstractWSDLBasedEndpointFactory.class));
-        EasyMock.expectLastCall();
-        configurer.configureServer(EasyMock.isA(Server.class));
-        EasyMock.expectLastCall();
-        EasyMock.replay(configurer);
         endpoint.createConsumer(processor);
-        EasyMock.verify(configurer);
-
-        EasyMock.reset(configurer);
-        configurer.configure(EasyMock.isA(AbstractWSDLBasedEndpointFactory.class));
-        EasyMock.expectLastCall();
-        configurer.configureClient(EasyMock.isA(Client.class));
-        EasyMock.expectLastCall();
-        EasyMock.replay(configurer);
+        verify(configurer).configure(isA(AbstractWSDLBasedEndpointFactory.class));
+        verify(configurer).configureServer(isA(Server.class));
+        
+        reset(configurer);
         Producer producer = endpoint.createProducer();
         producer.start();
-        EasyMock.verify(configurer);
-
+        
+        verify(configurer).configure(isA(AbstractWSDLBasedEndpointFactory.class));
+        verify(configurer).configureClient(isA(Client.class));
     }
 
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/DefaultCxfBindingTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/DefaultCxfBindingTest.java
@@ -52,10 +52,11 @@ import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.message.Attachment;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * 
@@ -274,15 +275,12 @@ public class DefaultCxfBindingTest extends Assert {
         exchange.getOut().addAttachment("att-1", new DataHandler(new FileDataSource("pom.xml")));
         exchange.getOut().getAttachmentObject("att-1").setHeader("attachment-header", "value 1");
         
-        IMocksControl control = EasyMock.createNiceControl();
-        
-        Endpoint endpoint = control.createMock(Endpoint.class);
-        Binding binding = control.createMock(Binding.class);
-        EasyMock.expect(endpoint.getBinding()).andReturn(binding);
+        Endpoint endpoint = mock(Endpoint.class);
+        Binding binding = mock(Binding.class);
+        when(endpoint.getBinding()).thenReturn(binding);
         org.apache.cxf.message.Message cxfMessage = new org.apache.cxf.message.MessageImpl();
-        EasyMock.expect(binding.createMessage()).andReturn(cxfMessage);
+        when(binding.createMessage()).thenReturn(cxfMessage);
         cxfExchange.put(Endpoint.class, endpoint);
-        control.replay();
         
         cxfBinding.populateCxfResponseFromExchange(exchange, cxfExchange);
         

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/converter/ConverterTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/converter/ConverterTest.java
@@ -35,10 +35,12 @@ import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.apache.cxf.message.MessageContentsList;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 public class ConverterTest extends Assert {
     
@@ -58,24 +60,18 @@ public class ConverterTest extends Assert {
         CamelContext context = new DefaultCamelContext();
         Exchange exchange = new DefaultExchange(context);
         
-        Response response = EasyMock.createMock(Response.class);
-        InputStream is = EasyMock.createMock(InputStream.class);
+        Response response = mock(Response.class);
+        InputStream is = mock(InputStream.class);
         
-        response.getEntity();
-        EasyMock.expectLastCall().andReturn(is);
+        when(response.getEntity()).thenReturn(is);
         
-        EasyMock.replay(response);
         InputStream result = CxfConverter.toInputStream(response, exchange);
         assertEquals("We should get the inputStream here ", is, result);
-        EasyMock.verify(response);
         
-        EasyMock.reset(response);
-        response.getEntity();
-        EasyMock.expectLastCall().andReturn("Hello World");
-        EasyMock.replay(response);
+        reset(response);
+        when(response.getEntity()).thenReturn("Hello World");
         result = CxfConverter.toInputStream(response, exchange);
         assertTrue("We should get the inputStream here ", result instanceof ByteArrayInputStream);
-        EasyMock.verify(response);
     }
     
     @Test


### PR DESCRIPTION
Migrate camel-cxf-transport from easymock to mockito.