### PR TITLE
CAMEL-11869: Adopted mockito-core 2.10.0 except for camel-core

### DIFF
--- a/camel-core/pom.xml
+++ b/camel-core/pom.xml
@@ -193,7 +193,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/camel-core/pom.xml
+++ b/camel-core/pom.xml
@@ -193,6 +193,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
@@ -26,12 +26,12 @@ import org.apache.camel.ContextTestSupport;
 import org.slf4j.Logger;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 
 /**

--- a/camel-core/src/test/java/org/apache/camel/processor/ThroughPutLoggerTest.java
+++ b/camel-core/src/test/java/org/apache/camel/processor/ThroughPutLoggerTest.java
@@ -24,10 +24,10 @@ import org.apache.camel.util.CamelLogger;
 import org.slf4j.Logger;
 
 import static org.hamcrest.Matchers.startsWith;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 public class ThroughPutLoggerTest extends TestCase {
 

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -150,6 +150,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-beanstalk/pom.xml
+++ b/components/camel-beanstalk/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-caffeine/pom.xml
+++ b/components/camel-caffeine/pom.xml
@@ -79,18 +79,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>${hamcrest-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${metrics-version}</version>

--- a/components/camel-chronicle/pom.xml
+++ b/components/camel-chronicle/pom.xml
@@ -76,18 +76,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>${hamcrest-version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   
   <profiles>

--- a/components/camel-cometd/pom.xml
+++ b/components/camel-cometd/pom.xml
@@ -92,10 +92,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/components/camel-consul/pom.xml
+++ b/components/camel-consul/pom.xml
@@ -94,18 +94,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>${hamcrest-version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 

--- a/components/camel-core-xml/src/test/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBeanTest.java
+++ b/components/camel-core-xml/src/test/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBeanTest.java
@@ -83,7 +83,7 @@ public class AbstractCamelContextFactoryBeanTest {
 
         // program the property resolution in context mock
         when(context.resolvePropertyPlaceholders(anyString())).thenAnswer(invocation -> {
-            final String placeholder = invocation.getArgumentAt(0, String.class);
+            final String placeholder = invocation.getArgument(0);
 
             // we receive the argument and check if the method should return a
             // value that can be converted to boolean

--- a/components/camel-couchdb/pom.xml
+++ b/components/camel-couchdb/pom.xml
@@ -62,6 +62,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/components/camel-digitalocean/pom.xml
+++ b/components/camel-digitalocean/pom.xml
@@ -75,11 +75,6 @@
       <artifactId>camel-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/components/camel-ehcache/pom.xml
+++ b/components/camel-ehcache/pom.xml
@@ -78,18 +78,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>${hamcrest-version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/components/camel-gora/pom.xml
+++ b/components/camel-gora/pom.xml
@@ -72,8 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -151,12 +151,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <!-- unit testing requires java 8 -->

--- a/components/camel-irc/pom.xml
+++ b/components/camel-irc/pom.xml
@@ -74,8 +74,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/components/camel-jaxb/pom.xml
+++ b/components/camel-jaxb/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-jcache/pom.xml
+++ b/components/camel-jcache/pom.xml
@@ -96,12 +96,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>${hamcrest-version}</version>

--- a/components/camel-jgroups/pom.xml
+++ b/components/camel-jgroups/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-metrics/pom.xml
+++ b/components/camel-metrics/pom.xml
@@ -86,6 +86,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -84,8 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-openstack/pom.xml
+++ b/components/camel-openstack/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
 

--- a/components/camel-printer/pom.xml
+++ b/components/camel-printer/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>   

--- a/components/camel-reactive-streams/pom.xml
+++ b/components/camel-reactive-streams/pom.xml
@@ -94,12 +94,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-reactor/pom.xml
+++ b/components/camel-reactor/pom.xml
@@ -86,12 +86,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-servicenow/camel-servicenow-component/pom.xml
+++ b/components/camel-servicenow/camel-servicenow-component/pom.xml
@@ -148,18 +148,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>${hamcrest-version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/components/camel-spark-rest/pom.xml
+++ b/components/camel-spark-rest/pom.xml
@@ -104,8 +104,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/components/camel-telegram/pom.xml
+++ b/components/camel-telegram/pom.xml
@@ -83,8 +83,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>  
     <dependency>

--- a/components/camel-websocket/pom.xml
+++ b/components/camel-websocket/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -499,7 +499,7 @@
     <minimal-json-version>0.9.4</minimal-json-version>
     <mock-javamail-version>1.9</mock-javamail-version>
     <mockwebserver-version>0.0.15</mockwebserver-version>
-    <mockito-version>1.10.19</mockito-version>
+    <mockito-version>2.10.0</mockito-version>
     <mongo-java-driver-version>3.5.0</mongo-java-driver-version>
     <mongo-java-driver32-version>3.2.2</mongo-java-driver32-version>
     <mongo-hadoop-version>1.5.0</mongo-hadoop-version>


### PR DESCRIPTION
I've moved forward all components but not camel-core yet as its build seems to be broken.

Please check [CAMEL-11869](https://issues.apache.org/jira/browse/CAMEL-11869) out for more details.