### PR TITLE
CAMEL-11751: Upgraded dropbox-core SDK to 3.0.4

### DIFF
--- a/components/camel-dropbox/src/main/docs/dropbox-component.adoc
+++ b/components/camel-dropbox/src/main/docs/dropbox-component.adoc
@@ -91,7 +91,7 @@ with the following path and query parameters:
 |===
 | Name | Description | Default | Type
 | *accessToken* (common) | *Required* The access token to make API requests for a specific Dropbox user |  | String
-| *client* (common) | To use an existing DbxClient instance as DropBox client. |  | DbxClient
+| *client* (common) | To use an existing DbxClient instance as DropBox client. |  | DbxClientV2
 | *clientIdentifier* (common) | *Required* Name of the app registered to make API requests |  | String
 | *localPath* (common) | Optional folder or file to upload on Dropbox from the local filesystem. If this option has not been configured then the message body is used as the content to upload. |  | String
 | *newRemotePath* (common) | Destination file or folder |  | String

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/DropboxConfiguration.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/DropboxConfiguration.java
@@ -18,8 +18,8 @@ package org.apache.camel.component.dropbox;
 
 import java.util.Locale;
 
-import com.dropbox.core.DbxClient;
 import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.v2.DbxClientV2;
 import org.apache.camel.component.dropbox.util.DropboxOperation;
 import org.apache.camel.component.dropbox.util.DropboxUploadMode;
 import org.apache.camel.spi.Metadata;
@@ -56,16 +56,16 @@ public class DropboxConfiguration {
     private String clientIdentifier;
     //reference to dropbox client
     @UriParam
-    private DbxClient client;
+    private DbxClientV2 client;
 
     /**
      * To use an existing DbxClient instance as DropBox client.
      */
-    public void setClient(DbxClient client) {
+    public void setClient(DbxClientV2 client) {
         this.client = client;
     }
 
-    public DbxClient getClient() {
+    public DbxClientV2 getClient() {
         return client;
     }
 
@@ -74,7 +74,7 @@ public class DropboxConfiguration {
      */
     public void createClient() {
         DbxRequestConfig config = new DbxRequestConfig(clientIdentifier, Locale.getDefault().toString());
-        this.client = new DbxClient(config, accessToken);
+        this.client = new DbxClientV2(config, accessToken);
     }
 
     public String getAccessToken() {

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
@@ -25,13 +25,21 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.dropbox.core.DbxClient;
-import com.dropbox.core.DbxEntry;
+import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
-import com.dropbox.core.DbxWriteMode;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.FileMetadata;
+import com.dropbox.core.v2.files.ListFolderErrorException;
+import com.dropbox.core.v2.files.ListFolderResult;
+import com.dropbox.core.v2.files.Metadata;
+import com.dropbox.core.v2.files.SearchMatch;
+import com.dropbox.core.v2.files.SearchResult;
+import com.dropbox.core.v2.files.UploadUploader;
+import com.dropbox.core.v2.files.WriteMode;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.dropbox.dto.DropboxDelResult;
 import org.apache.camel.component.dropbox.dto.DropboxFileDownloadResult;
@@ -54,7 +62,7 @@ public final class DropboxAPIFacade {
 
     private static final Logger LOG = LoggerFactory.getLogger(DropboxAPIFacade.class);
 
-    private final DbxClient client;
+    private final DbxClientV2 client;
 
     private final Exchange exchange;
 
@@ -62,29 +70,31 @@ public final class DropboxAPIFacade {
      * @param client the DbxClient performing dropbox low level operations
      * @param exchange the current Exchange
      */
-    public DropboxAPIFacade(DbxClient client, Exchange exchange) {
+    public DropboxAPIFacade(DbxClientV2 client, Exchange exchange) {
         this.client = client;
         this.exchange = exchange;
     }
 
     /**
      * Put or upload a new file or an entire directory to dropbox
-     * @param localPath  the file path or the dir path on the local filesystem
+     *
+     * @param localPath the file path or the dir path on the local filesystem
      * @param remotePath the remote path destination on dropbox
-     * @param mode how a file should be saved on dropbox;
-     *             in case of "add" the new file will be renamed in case
-     *             a file with the same name already exists on dropbox.
-     *             in case of "force" the file already existing with the same name will be overridden.
-     * @return a result object reporting for each remote path the result of the operation.
+     * @param mode how a file should be saved on dropbox; in case of "add" the
+     *            new file will be renamed in case a file with the same name
+     *            already exists on dropbox. in case of "force" the file already
+     *            existing with the same name will be overridden.
+     * @return a result object reporting for each remote path the result of the
+     *         operation.
      * @throws DropboxException
      */
     public DropboxFileUploadResult put(String localPath, String remotePath, DropboxUploadMode mode) throws DropboxException {
-        //in case the remote path is not specified, the remotePath = localPath
+        // in case the remote path is not specified, the remotePath = localPath
         String dropboxPath = remotePath == null ? localPath : remotePath;
 
-        DbxEntry entry;
+        UploadUploader entry;
         try {
-            entry = client.getMetadata(dropboxPath);
+            entry = client.files().upload(dropboxPath);
         } catch (DbxException e) {
             throw new DropboxException(dropboxPath + " does not exist or can't obtain metadata");
         }
@@ -96,15 +106,16 @@ public final class DropboxAPIFacade {
         }
     }
 
-    private DropboxFileUploadResult putFile(String localPath, DropboxUploadMode mode, String dropboxPath, DbxEntry entry) throws DropboxException {
+    private DropboxFileUploadResult putFile(String localPath, DropboxUploadMode mode, String dropboxPath, UploadUploader entry) throws DropboxException {
         File fileLocalPath = new File(localPath);
-        //verify uploading of a single file
+        // verify uploading of a single file
         if (fileLocalPath.isFile()) {
-            //check if dropbox file exists
-            if (entry != null && !entry.isFile()) {
+            // check if dropbox file exists
+            if (entry != null) {
                 throw new DropboxException(dropboxPath + " exists on dropbox and is not a file!");
             }
-            //in case the entry not exists on dropbox check if the filename should be appended
+            // in case the entry not exists on dropbox check if the filename
+            // should be appended
             if (entry == null) {
                 if (dropboxPath.endsWith(DropboxConstants.DROPBOX_FILE_SEPARATOR)) {
                     dropboxPath = dropboxPath + fileLocalPath.getName();
@@ -114,7 +125,7 @@ public final class DropboxAPIFacade {
             LOG.debug("Uploading: {},{}", fileLocalPath, dropboxPath);
             DropboxFileUploadResult result;
             try {
-                DbxEntry.File uploadedFile = putSingleFile(fileLocalPath, dropboxPath, mode);
+                FileMetadata uploadedFile = putSingleFile(fileLocalPath, dropboxPath, mode);
                 if (uploadedFile == null) {
                     result = new DropboxFileUploadResult(dropboxPath, DropboxResultCode.KO);
                 } else {
@@ -125,18 +136,18 @@ public final class DropboxAPIFacade {
             }
             return result;
         } else if (fileLocalPath.isDirectory()) {
-            //verify uploading of a list of files inside a dir
+            // verify uploading of a list of files inside a dir
             LOG.debug("Uploading a dir...");
-            //check if dropbox folder exists
-            if (entry != null && !entry.isFolder()) {
+            // check if dropbox folder exists
+            if (entry != null) {
                 throw new DropboxException(dropboxPath + " exists on dropbox and is not a folder!");
             }
             if (!dropboxPath.endsWith(DropboxConstants.DROPBOX_FILE_SEPARATOR)) {
                 dropboxPath = dropboxPath + DropboxConstants.DROPBOX_FILE_SEPARATOR;
             }
-            //revert to old path
+            // revert to old path
             String oldDropboxPath = dropboxPath;
-            //list all files in a dir
+            // list all files in a dir
             Collection<File> listFiles = FileUtils.listFiles(fileLocalPath, null, true);
             if (listFiles.isEmpty()) {
                 throw new DropboxException(localPath + " doesn't contain any files");
@@ -153,7 +164,7 @@ public final class DropboxAPIFacade {
                 dropboxPath = dropboxPath + remainingPath;
                 try {
                     LOG.debug("Uploading: {},{}", fileLocalPath, dropboxPath);
-                    DbxEntry.File uploadedFile = putSingleFile(file, dropboxPath, mode);
+                    FileMetadata uploadedFile = putSingleFile(file, dropboxPath, mode);
                     if (uploadedFile == null) {
                         resultMap.put(dropboxPath, DropboxResultCode.KO);
                     } else {
@@ -170,7 +181,7 @@ public final class DropboxAPIFacade {
         }
     }
 
-    private DropboxFileUploadResult putBody(Exchange exchange, DropboxUploadMode mode, String dropboxPath, DbxEntry entry) throws DropboxException {
+    private DropboxFileUploadResult putBody(Exchange exchange, DropboxUploadMode mode, String dropboxPath, UploadUploader entry) throws DropboxException {
         String name = exchange.getIn().getHeader(HEADER_PUT_FILE_NAME, String.class);
         if (name == null) {
             // fallback to use CamelFileName
@@ -181,7 +192,8 @@ public final class DropboxAPIFacade {
             name = exchange.getIn().getMessageId();
         }
 
-        //in case the entry not exists on dropbox check if the filename should be appended
+        // in case the entry not exists on dropbox check if the filename should
+        // be appended
         if (entry == null) {
             if (dropboxPath.endsWith(DropboxConstants.DROPBOX_FILE_SEPARATOR)) {
                 dropboxPath = dropboxPath + name;
@@ -192,7 +204,7 @@ public final class DropboxAPIFacade {
 
         DropboxFileUploadResult result;
         try {
-            DbxEntry.File uploadedFile = putSingleBody(exchange, dropboxPath, mode);
+            FileMetadata uploadedFile = putSingleBody(exchange, dropboxPath, mode);
             if (uploadedFile == null) {
                 result = new DropboxFileUploadResult(dropboxPath, DropboxResultCode.KO);
             } else {
@@ -204,35 +216,35 @@ public final class DropboxAPIFacade {
         return result;
     }
 
-    private DbxEntry.File putSingleFile(File inputFile, String dropboxPath, DropboxUploadMode mode) throws Exception {
+    private FileMetadata putSingleFile(File inputFile, String dropboxPath, DropboxUploadMode mode) throws Exception {
         FileInputStream inputStream = new FileInputStream(inputFile);
-        DbxEntry.File uploadedFile;
+        FileMetadata uploadedFile;
         try {
-            DbxWriteMode uploadMode;
+            WriteMode uploadMode;
             if (mode == DropboxUploadMode.force) {
-                uploadMode = DbxWriteMode.force();
+                uploadMode = WriteMode.OVERWRITE;
             } else {
-                uploadMode = DbxWriteMode.add();
+                uploadMode = WriteMode.ADD;
             }
-            uploadedFile = client.uploadFile(dropboxPath, uploadMode, inputFile.length(), inputStream);
+            uploadedFile = client.files().uploadBuilder(dropboxPath).withMode(uploadMode).uploadAndFinish(inputStream, inputFile.length());
             return uploadedFile;
         } finally {
             IOHelper.close(inputStream);
         }
     }
 
-    private DbxEntry.File putSingleBody(Exchange exchange, String dropboxPath, DropboxUploadMode mode) throws Exception {
+    private FileMetadata putSingleBody(Exchange exchange, String dropboxPath, DropboxUploadMode mode) throws Exception {
         byte[] data = exchange.getIn().getMandatoryBody(byte[].class);
         InputStream is = new ByteArrayInputStream(data);
         try {
-            DbxEntry.File uploadedFile;
-            DbxWriteMode uploadMode;
+            FileMetadata uploadedFile;
+            WriteMode uploadMode;
             if (mode == DropboxUploadMode.force) {
-                uploadMode = DbxWriteMode.force();
+                uploadMode = WriteMode.OVERWRITE;
             } else {
-                uploadMode = DbxWriteMode.add();
+                uploadMode = WriteMode.ADD;
             }
-            uploadedFile = client.uploadFile(dropboxPath, uploadMode, data.length, is);
+            uploadedFile = client.files().uploadBuilder(dropboxPath).withMode(uploadMode).uploadAndFinish(is, data.length);
             return uploadedFile;
         } finally {
             IOHelper.close(is);
@@ -240,28 +252,33 @@ public final class DropboxAPIFacade {
     }
 
     /**
-     * Search inside a remote path including its sub directories.
-     * The query param can be null.
-     * @param remotePath  the remote path where starting the search from
-     * @param query a space-separated list of substrings to search for. A file matches only if it contains all the substrings
+     * Search inside a remote path including its sub directories. The query
+     * param can be null.
+     *
+     * @param remotePath the remote path where starting the search from
+     * @param query a space-separated list of substrings to search for. A file
+     *            matches only if it contains all the substrings
      * @return a result object containing all the files found.
      * @throws DropboxException
      */
     public DropboxSearchResult search(String remotePath, String query) throws DropboxException {
-        DbxEntry.WithChildren listing;
+        SearchResult listing;
+        List<SearchMatch> searchMatches;
         if (query == null) {
             LOG.debug("Search no query");
             try {
-                listing = client.getMetadataWithChildren(remotePath);
-                return new DropboxSearchResult(listing.children);
+                listing = client.files().search(remotePath, null);
+                searchMatches = listing.getMatches();
+                return new DropboxSearchResult(searchMatches);
             } catch (DbxException e) {
                 throw new DropboxException(remotePath + " does not exist or can't obtain metadata");
             }
         } else {
             LOG.debug("Search by query: {}", query);
             try {
-                List<DbxEntry> entries = client.searchFileAndFolderNames(remotePath, query);
-                return new DropboxSearchResult(entries);
+                listing = client.files().search(remotePath, query);
+                searchMatches = listing.getMatches();
+                return new DropboxSearchResult(searchMatches);
             } catch (DbxException e) {
                 throw new DropboxException(remotePath + " does not exist or can't obtain metadata");
             }
@@ -269,15 +286,16 @@ public final class DropboxAPIFacade {
     }
 
     /**
-     * Delete every files and subdirectories inside the remote directory.
-     * In case the remotePath is a file, delete the file.
-     * @param remotePath  the remote location to delete
+     * Delete every files and subdirectories inside the remote directory. In
+     * case the remotePath is a file, delete the file.
+     *
+     * @param remotePath the remote location to delete
      * @return a result object with the result of the delete operation.
      * @throws DropboxException
      */
     public DropboxDelResult del(String remotePath) throws DropboxException {
         try {
-            client.delete(remotePath);
+            client.files().deleteV2(remotePath);
         } catch (DbxException e) {
             throw new DropboxException(remotePath + " does not exist or can't obtain metadata");
         }
@@ -286,6 +304,7 @@ public final class DropboxAPIFacade {
 
     /**
      * Rename a remote path with the new path location.
+     *
      * @param remotePath the existing remote path to be renamed
      * @param newRemotePath the new remote path substituting the old one
      * @return a result object with the result of the move operation.
@@ -293,7 +312,7 @@ public final class DropboxAPIFacade {
      */
     public DropboxMoveResult move(String remotePath, String newRemotePath) throws DropboxException {
         try {
-            client.move(remotePath, newRemotePath);
+            client.files().moveV2(remotePath, newRemotePath);
             return new DropboxMoveResult(remotePath, newRemotePath);
         } catch (DbxException e) {
             throw new DropboxException(remotePath + " does not exist or can't obtain metadata");
@@ -302,53 +321,37 @@ public final class DropboxAPIFacade {
 
     /**
      * Get the content of every file inside the remote path.
+     *
      * @param remotePath the remote path where to download from
-     * @return a result object with the content (ByteArrayOutputStream) of every files inside the remote path.
+     * @return a result object with the content (ByteArrayOutputStream) of every
+     *         files inside the remote path.
      * @throws DropboxException
      */
     public DropboxFileDownloadResult get(String remotePath) throws DropboxException {
         return new DropboxFileDownloadResult(downloadFilesInFolder(remotePath));
     }
 
-    /**
-     * @deprecated not in use
-     */
-    @Deprecated
-    public boolean isDirectory(String path) throws DropboxException {
-        try {
-            DbxEntry.WithChildren listing = client.getMetadataWithChildren(path);
-            return listing.children != null;
-        } catch (DbxException e) {
-            throw new DropboxException(path + " does not exist or can't obtain metadata");
-        }
-    }
-
-
     private Map<String, Object> downloadFilesInFolder(String path) throws DropboxException {
         try {
-            DbxEntry.WithChildren listing = client.getMetadataWithChildren(path);
-            if (listing == null) {
-                return Collections.emptyMap();
-            } else if (listing.children == null) {
-                LOG.debug("downloading a single file...");
-                Map.Entry<String, Object> entry = downloadSingleFile(path);
-                return Collections.singletonMap(entry.getKey(), entry.getValue());
+            ListFolderResult folderResult = client.files().listFolder(path.equals("/") ? "" : path);
+            Map<String, Object> returnMap = new LinkedHashMap<>();
+            for (Metadata entry : folderResult.getEntries()) {
+                returnMap.put(entry.getPathDisplay(), downloadSingleFile(entry.getPathDisplay()).getValue());
             }
-            Map<String, Object> result = new HashMap<>();
-            for (DbxEntry entry : listing.children) {
-                if (entry.isFile()) {
-                    try {
-                        Map.Entry<String, Object> singleFile = downloadSingleFile(entry.path);
-                        result.put(singleFile.getKey(), singleFile.getValue());
-                    } catch (DropboxException e) {
-                        LOG.warn("Cannot download from path={}, reason={}. This exception is ignored.", entry.path, e.getMessage());
-                    }
+            return returnMap;
+        } catch (ListFolderErrorException e) {
+            try {
+                DbxDownloader<FileMetadata> listing = client.files().download(path);
+                if (listing == null) {
+                    return Collections.emptyMap();
                 } else {
-                    Map<String, Object> filesInFolder = downloadFilesInFolder(entry.path);
-                    result.putAll(filesInFolder);
+                    LOG.debug("downloading a single file...");
+                    Map.Entry<String, Object> entry = downloadSingleFile(path);
+                    return Collections.singletonMap(entry.getKey(), entry.getValue());
                 }
+            } catch (DbxException dbxException) {
+                throw new DropboxException(dbxException);
             }
-            return result;
         } catch (DbxException e) {
             throw new DropboxException(e);
         }
@@ -357,8 +360,9 @@ public final class DropboxAPIFacade {
     private Map.Entry<String, Object> downloadSingleFile(String path) throws DropboxException {
         try {
             OutputStreamBuilder target = OutputStreamBuilder.withExchange(exchange);
-            DbxEntry.File downloadedFile = client.getFile(path, null, target);
+            DbxDownloader<FileMetadata> downloadedFile = client.files().download(path);
             if (downloadedFile != null) {
+                downloadedFile.download(target);
                 LOG.debug("downloaded path={}", path);
                 return new AbstractMap.SimpleEntry<>(path, target.build());
             } else {

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/dto/DropboxSearchResult.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/dto/DropboxSearchResult.java
@@ -20,17 +20,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.dropbox.core.DbxEntry;
+import com.dropbox.core.v2.files.SearchMatch;
 
 public class DropboxSearchResult {
 
-    private final List<DbxEntry> found;
+    private final List<SearchMatch> found;
 
-    public DropboxSearchResult(List<DbxEntry> found) {
+    public DropboxSearchResult(List<SearchMatch> found) {
         this.found = new ArrayList<>(found);
     }
 
-    public List<DbxEntry> getFound() {
+    public List<SearchMatch> getFound() {
         return Collections.unmodifiableList(found);
     }
 

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/integration/consumer/DropboxScheduledPollSearchConsumer.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/integration/consumer/DropboxScheduledPollSearchConsumer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.dropbox.integration.consumer;
 
-import com.dropbox.core.DbxEntry;
+import com.dropbox.core.v2.files.SearchMatch;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.dropbox.DropboxConfiguration;
@@ -43,8 +43,8 @@ public class DropboxScheduledPollSearchConsumer extends DropboxScheduledPollCons
                 .search(configuration.getRemotePath(), configuration.getQuery());
 
         StringBuilder fileExtracted = new StringBuilder();
-        for (DbxEntry entry : result.getFound()) {
-            fileExtracted.append(entry.name).append("-").append(entry.path).append("\n");
+        for (SearchMatch entry : result.getFound()) {
+            fileExtracted.append(entry.getMetadata().getName()).append("-").append(entry.getMetadata().getPathDisplay()).append("\n");
         }
 
         exchange.getIn().setHeader(DropboxResultHeader.FOUND_FILES.name(), fileExtracted.toString());

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/integration/producer/DropboxSearchProducer.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/integration/producer/DropboxSearchProducer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.dropbox.integration.producer;
 
-import com.dropbox.core.DbxEntry;
+import com.dropbox.core.v2.files.SearchMatch;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.dropbox.DropboxConfiguration;
 import org.apache.camel.component.dropbox.DropboxEndpoint;
@@ -43,8 +43,8 @@ public class DropboxSearchProducer extends DropboxProducer {
                 .search(remotePath, query);
 
         StringBuilder fileExtracted = new StringBuilder();
-        for (DbxEntry entry : result.getFound()) {
-            fileExtracted.append(entry.name).append("-").append(entry.path).append("\n");
+        for (SearchMatch entry : result.getFound()) {
+            fileExtracted.append(entry.getMetadata().getName()).append("-").append(entry.getMetadata().getPathDisplay()).append("\n");
         }
         exchange.getIn().setHeader(DropboxResultHeader.FOUND_FILES.name(), fileExtracted.toString());
         exchange.getIn().setBody(result.getFound());


### PR DESCRIPTION
Possible upgrade of Dropbox SDK Java Api: https://issues.apache.org/jira/browse/CAMEL-11751

Although, the latest release of Dropbox is 3.0.4,  there are hardly any new Api classes introduced in version 3.x from 2.x. Migration from 1.x to 2.x has quite a few Api changes and to the best of the understanding, i have attempted to migrate the component. However, please do suggest if there are some improvements or changes required, or more testing needs to be done/attempted. 