### PR TITLE
CAMEL-11875: Add support for BoxGroup.updateInfo in camel-box

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
@@ -143,6 +143,34 @@ public class BoxGroupsManager {
     }
 
     /**
+     * Update group information.
+     *
+     * @param groupId
+     *            - the id of group to update.
+     * @param groupInfo
+     *            - the updated information
+     * @return The updated group.
+     */
+    public BoxGroup updateGroupInfo(String groupId, BoxGroup.Info groupInfo) {
+        try {
+            LOG.debug("Updating info for group(id=" + groupId + ")");
+            if (groupId == null) {
+                throw new IllegalArgumentException("Parameter 'groupId' can not be null");
+            }
+            if (groupInfo == null) {
+                throw new IllegalArgumentException("Parameter 'groupInfo' can not be null");
+            }
+
+            BoxGroup group = new BoxGroup(boxConnection, groupId);
+            group.updateInfo(groupInfo);
+            return group;
+        } catch (BoxAPIException e) {
+            throw new RuntimeException(
+                    String.format("Box API returned the error code %d\n\n%s", e.getResponseCode(), e.getResponse()), e);
+        }
+    }
+
+    /**
      * Get information about all of the group memberships for this group.
      * 
      * @param groupId

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -502,6 +502,8 @@ follows:
 
 |getGroupInfo |info |groupId |com.box.sdk.BoxGroup.Info
 
+|updateGroupInfo |updateInfo |groupId, groupInfo |com.box.sdk.BoxGroup
+
 |addGroupMembership |addMembership |groupId, userId, role |com.box.sdk.BoxGroupMembership
 
 |deleteGroupMembership |deleteMembership |groupMembershipId |

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxGroupsManagerIntegrationTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxGroupsManagerIntegrationTest.java
@@ -44,6 +44,7 @@ public class BoxGroupsManagerIntegrationTest extends AbstractBoxTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(BoxGroupsManagerIntegrationTest.class);
     private static final String PATH_PREFIX = BoxApiCollection.getCollection()
             .getApiName(BoxGroupsManagerApiMethod.class).getName();
+    private static final String CAMEL_TEST_GROUP_DESCRIPTION = "CamelTestGroupDescription";
     private static final String CAMEL_TEST_GROUP_NAME = "CamelTestGroup";
     private static final String CAMEL_TEST_CREATE_GROUP_NAME = "CamelTestCreateGroup";
 
@@ -129,6 +130,27 @@ public class BoxGroupsManagerIntegrationTest extends AbstractBoxTestSupport {
 
         assertNotNull("getGroupInfo result", result);
         LOG.debug("getGroupInfo: " + result);
+    }
+
+    @Test
+    public void testUpdateGroupInfo() throws Exception {
+        BoxGroup.Info info = testGroup.getInfo();
+	info.setDescription(CAMEL_TEST_GROUP_DESCRIPTION);
+
+        try {
+            final Map<String, Object> headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelBox.groupId", testGroup.getID());
+            // parameter type is com.box.sdk.BoxGroup.Info
+            headers.put("CamelBox.groupInfo", info);
+            final com.box.sdk.BoxGroup result = requestBodyAndHeaders("direct://UPDATEGROUPINFO", null, headers);
+            assertNotNull("updateGroupInfo result", result);
+            LOG.debug("updateGroupInfo: " + result);
+        } finally {
+            info = testGroup.getInfo();
+            info.setDescription("");
+            testGroup.updateInfo(info);
+        }
     }
 
     @Test


### PR DESCRIPTION
Add support for BoxGroup.updateInfo currently missing in camel-box to be able to set description on groups.