### PR TITLE
CAMEL-11879: Upgraded lucene version to 7.0.0

### DIFF
--- a/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneConstants.java
+++ b/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneConstants.java
@@ -19,5 +19,5 @@ package org.apache.camel.component.lucene;
 import org.apache.lucene.util.Version;
 
 public interface LuceneConstants {
-    Version LUCENE_VERSION = Version.LUCENE_5_4_1;
+    Version LUCENE_VERSION = Version.LUCENE_7_0_0;
 }

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrEndpoint.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrEndpoint.java
@@ -108,7 +108,7 @@ public class SolrEndpoint extends DefaultEndpoint {
     private CloudSolrClient getCloudServer() {
         CloudSolrClient rVal = null;
         if (this.getZkHost() != null && this.getCollection() != null) {
-            rVal = new CloudSolrClient(zkHost);
+            rVal = new CloudSolrClient.Builder().withZkHost(zkHost).build();
             rVal.setDefaultCollection(this.getCollection());
         }
         return rVal;
@@ -123,31 +123,19 @@ public class SolrEndpoint extends DefaultEndpoint {
             ref = new SolrComponent.SolrServerReference();
             CloudSolrClient cloudServer = getCloudServer();
             if (cloudServer == null) {
-                HttpSolrClient solrServer = new HttpSolrClient(url);
-                ConcurrentUpdateSolrClient solrStreamingServer = new ConcurrentUpdateSolrClient(url, streamingQueueSize, streamingThreadCount);
-
-                // set the properties on the solr server
-                if (maxRetries != null) {
-                    solrServer.setMaxRetries(maxRetries);
-                }
+                HttpSolrClient solrServer = new HttpSolrClient.Builder(url).build();                
+                ConcurrentUpdateSolrClient solrStreamingServer = new ConcurrentUpdateSolrClient.Builder(url).withQueueSize(streamingQueueSize).withThreadCount(streamingThreadCount).build();
+                
+                // set the properties on the solr server               
                 if (soTimeout != null) {
                     solrServer.setSoTimeout(soTimeout);
                 }
                 if (connectionTimeout != null) {
                     solrServer.setConnectionTimeout(connectionTimeout);
-                }
-                if (defaultMaxConnectionsPerHost != null) {
-                    solrServer.setDefaultMaxConnectionsPerHost(defaultMaxConnectionsPerHost);
-                }
-                if (maxTotalConnections != null) {
-                    solrServer.setMaxTotalConnections(maxTotalConnections);
-                }
+                }                
                 if (followRedirects != null) {
                     solrServer.setFollowRedirects(followRedirects);
-                }
-                if (allowCompression != null) {
-                    solrServer.setAllowCompression(allowCompression);
-                }
+                }                
                 ref.setSolrServer(solrServer);
                 ref.setUpdateSolrServer(solrStreamingServer);
             }

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/JettySolrFactory.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/JettySolrFactory.java
@@ -29,6 +29,7 @@ import javax.net.ssl.X509TrustManager;
 
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.solr.client.solrj.embedded.JettyConfig;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.embedded.SSLConfig;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -106,8 +107,8 @@ public final class JettySolrFactory {
         SSLConfig sslConfig = buildSSLConfig(ssl, false);
 
         context = context == null ? "/solr" : context;
-        JettySolrRunner jetty = new JettySolrRunner(solrHome, context, 0, configFile, schemaFile,
-                                                    stopAtShutdown, extraServlets, sslConfig);
+        JettyConfig jettyConfig = new JettyConfig.Builder().setContext(context).setPort(0).stopAtShutdown(false).withServlets(extraServlets).withSSLConfig(sslConfig).build();              
+        JettySolrRunner jetty = new JettySolrRunner(solrHome, jettyConfig);
 
         jetty.start();
         

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrCloudFixture.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrCloudFixture.java
@@ -79,8 +79,8 @@ public class SolrCloudFixture {
                 log.info("JETTY RUNNING AT " + jetty.getBaseUrl() + " PORT " + jetty.getLocalPort());
             }
         }
-
-        solrClient = new CloudSolrClient(zkAddr, true);
+        
+        solrClient = new CloudSolrClient.Builder().withZkHost(zkAddr).build();
         solrClient.connect();
 
         createCollection(solrClient, "collection1", 1, 1, "conf1");

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrFixtures.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrFixtures.java
@@ -23,7 +23,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+
 
 
 public class SolrFixtures {
@@ -59,11 +59,12 @@ public class SolrFixtures {
             return "solr://localhost:" + port + "/solr";
         }
     }
+        
 
     SolrClient getServer() {
         if (serverType == TestServerType.USE_HTTPS) {
             return solrHttpsServer;
-        } else if (serverType == TestServerType.USE_CLOUD) {
+        } else if (serverType == TestServerType.USE_CLOUD) {            
             return cloudFixture.solrClient;
         } else {
             return solrServer;
@@ -73,14 +74,14 @@ public class SolrFixtures {
     static void createSolrFixtures() throws Exception {
         solrHttpsRunner = JettySolrFactory.createJettyTestFixture(true);
         httpsPort = solrHttpsRunner.getLocalPort();
-        log.info("Started Https Test Server: " + solrHttpsRunner.getBaseUrl());
-        solrHttpsServer = new HttpSolrServer("https://localhost:" + httpsPort + "/solr");
+        log.info("Started Https Test Server: " + solrHttpsRunner.getBaseUrl());        
+        solrHttpsServer = new HttpSolrClient.Builder("https://localhost: + httpsPort + /solr").build();
         solrHttpsServer.setConnectionTimeout(60000);
 
         solrRunner = JettySolrFactory.createJettyTestFixture(false);
         port = solrRunner.getLocalPort();
-
-        solrServer = new HttpSolrServer("http://localhost:" + port + "/solr");
+        
+        solrServer = new HttpSolrClient.Builder("http://localhost: + port + /solr").build();
 
         log.info("Started Test Server: " + solrRunner.getBaseUrl());
         cloudFixture = new SolrCloudFixture("src/test/resources/solr");
@@ -109,7 +110,7 @@ public class SolrFixtures {
             solrHttpsServer.commit();
         }
         if (cloudFixture != null) {
-            cloudFixture.solrClient.deleteByQuery("*:*");
+            cloudFixture.solrClient.deleteByQuery("*:*");            
             cloudFixture.solrClient.commit();
         }
     }

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrUpdateTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrUpdateTest.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.camel.Exchange;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
@@ -51,7 +51,7 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
     public void testInsertSolrInputDocumentAsXMLWithoutAddRoot() throws Exception {
 
         SolrInputDocument doc = new SolrInputDocument();
-        doc.addField("id", "MA147LL/A", 1.0f);
+        doc.addField("id", "MA147LL/A");        
         String docAsXml = ClientUtils.toXML(doc);
         template.sendBodyAndHeader("direct:start", docAsXml, SolrConstants.OPERATION, SolrConstants.OPERATION_INSERT);
         solrCommit();
@@ -65,7 +65,7 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
     public void testInsertSolrInputDocumentAsXMLWithAddRoot() throws Exception {
 
         SolrInputDocument doc = new SolrInputDocument();
-        doc.addField("id", "MA147LL/A", 1.0f);
+        doc.addField("id", "MA147LL/A");
         String docAsXml = "<add>" + ClientUtils.toXML(doc) + "</add>";
         template.sendBodyAndHeader("direct:start", docAsXml, SolrConstants.OPERATION, SolrConstants.OPERATION_INSERT);
         solrCommit();
@@ -79,7 +79,7 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
     public void testInsertSolrInputDocument() throws Exception {
 
         SolrInputDocument doc = new SolrInputDocument();
-        doc.addField("id", "MA147LL/A", 1.0f);
+        doc.addField("id", "MA147LL/A");
         template.sendBodyAndHeader("direct:start", doc, SolrConstants.OPERATION, SolrConstants.OPERATION_INSERT);
 
         solrCommit();
@@ -94,11 +94,11 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
         List<SolrInputDocument> docList = new ArrayList<SolrInputDocument>(2);
 
         SolrInputDocument doc = new SolrInputDocument();
-        doc.addField("id", "MA147LL/A", 1.0f);
+        doc.addField("id", "MA147LL/A");
         docList.add(doc);
 
         doc = new SolrInputDocument();
-        doc.addField("id", "KP147LL/A", 1.0f);
+        doc.addField("id", "KP147LL/A");
         docList.add(doc);
 
         template.sendBodyAndHeader("direct:start", docList, SolrConstants.OPERATION, SolrConstants.OPERATION_INSERT);
@@ -160,7 +160,7 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
         template.send("direct:start", exchange);
 
         //noinspection ThrowableResultOfMethodCallIgnored
-        assertEquals(HttpSolrServer.RemoteSolrException.class, exchange.getException().getClass());
+        assertEquals(HttpSolrClient.RemoteSolrException.class, exchange.getException().getClass());
     }
 
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -455,10 +455,10 @@
     <logback-version>1.2.0</logback-version>
     <lucene3-bundle-version>3.6.0_1</lucene3-bundle-version>
     <lucene3-version>3.6.0</lucene3-version>
-    <lucene-bundle-version>5.5.2_1</lucene-bundle-version>
+    <lucene-bundle-version>6.6.0_2</lucene-bundle-version>
     <!-- lucene aligned with elasticsearch version of lucene in use -->
-    <lucene-version>5.5.2</lucene-version>
-    <lucene-version-range>[5,6)</lucene-version-range>
+    <lucene-version>7.0.0</lucene-version>
+    <lucene-version-range>[5,7)</lucene-version-range>
     <lightcouch-version>0.1.8</lightcouch-version>
     <lightcouch-gson-version>2.4</lightcouch-gson-version>
     <lightcouch-bundle-version>0.1.8_2</lightcouch-bundle-version>
@@ -620,8 +620,8 @@
     <snmp4j-version>2.3.4_1</snmp4j-version>
     <solr-bundle-version>5.5.2_1</solr-bundle-version>
     <!-- solr version aligned with lucene -->
-    <solr-version>5.5.2</solr-version>
-    <solr-version-range>[5,6)</solr-version-range>
+    <solr-version>7.0.0</solr-version>
+    <solr-version-range>[5,7)</solr-version-range>
     <spark-version>1.6.1</spark-version>
     <spark-rest-version>2.6.0</spark-rest-version>
     <spark-rest-bundle-version>2.6.0_1</spark-rest-bundle-version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-11879
Upgraded Lucene to latest version 7.0.0. 

Passed the iTests for Karaf and OSGi without issues, including the camel-lucene component tests. 