### PR TITLE
DefaultFactoryFinderTest#shouldCreateNewInstancesWithInjector: remove…

### DIFF
--- a/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
@@ -28,9 +28,6 @@ import org.slf4j.Logger;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -102,10 +99,6 @@ public class XPathTransformTest extends ContextTestSupport {
         NodeList list = XPathBuilder.xpath("//*", NodeList.class).evaluate(context, doc, NodeList.class);
         assertNotNull(list);
 
-        // optional trace and debug logging
-        verify(l, atLeast(0)).trace(anyString());
-        verify(l, atLeast(0)).debug(anyString());
-        verify(l, atLeastOnce()).info(anyString(), any(Object.class));
         verify(l, never()).info(argThat(containsString("Namespaces discovered in message")), any(Object.class));
     }
 

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultFactoryFinderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultFactoryFinderTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultFactoryFinderTest {
@@ -127,8 +126,6 @@ public class DefaultFactoryFinderTest {
         when(injector.newInstance(TestImplA.class)).thenReturn(expected);
 
         final List<TestType> instances = factoryFinder.newInstances("TestImplA", injector, TestType.class);
-
-        verify(injector);
 
         assertEquals(1, instances.size());
         assertThat(instances, hasItem(expected));

--- a/camel-core/src/test/java/org/apache/camel/management/DefaultManagementAgentMockTest.java
+++ b/camel-core/src/test/java/org/apache/camel/management/DefaultManagementAgentMockTest.java
@@ -24,7 +24,6 @@ import javax.management.ObjectName;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.ManagementAgent;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -38,7 +37,6 @@ import static org.mockito.Mockito.when;
  * {@link MBeanServer#registerMBean(Object, ObjectName)} returns an
  * {@link ObjectInstance} with a different ObjectName
  */
-@Ignore("Is flaky with mockito")
 public class DefaultManagementAgentMockTest {
 
     @Test


### PR DESCRIPTION
… incorrect Mockito#verfiy call which caused subsequent DefaultManagementAgentMockTest tests to be flaky

DefaultManagementAgentMockTest: re-enable

Sorry about that. :( I did not notice my mistake, because the error only manifest when I run all camel-core test.

Edit: There was also problem with XPathTransformTest#testXPathNamespaceLoggingDisabledJavaDSL when all camel-core tests are run. I added another commit to fix it.