### PR TITLE
CAMEL-11880: Use full version of BoxGroup.createGroup

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
@@ -78,20 +78,35 @@ public class BoxGroupsManager {
     }
 
     /**
-     * Create a new group with a specified name.
+     * Create a new group with a specified name and optional additional parameters.
+     * Optional parameters may be null.
      * 
      * @param name
      *            - the name of the new group.
+     * @param provenance
+     *            - the provenance of the new group.
+     * @param externalSyncIdentifier
+     *            - the external_sync_identifier of the new group.
+     * @param description
+     *            - the description of the new group.
+     * @param invitabilityLevel
+     *            - the invitibility_level of the new group.
+     * @param memberViewabilityLevel
+     *            - the member_viewability_level of the new group.
      * @return The newly created group.
      */
-    public BoxGroup createGroup(String name) {
+    public BoxGroup createGroup(String name, String provenance,
+        String externalSyncIdentifier, String description,
+        String invitabilityLevel, String memberViewabilityLevel) {
+
         try {
             LOG.debug("Creating group name=" + name);
             if (name == null) {
                 throw new IllegalArgumentException("Parameter 'name' can not be null");
             }
 
-            return BoxGroup.createGroup(boxConnection, name).getResource();
+            return BoxGroup.createGroup(boxConnection, name, provenance, externalSyncIdentifier, description,
+                invitabilityLevel, memberViewabilityLevel).getResource();
         } catch (BoxAPIException e) {
             throw new RuntimeException(
                     String.format("Box API returned the error code %d\n\n%s", e.getResponseCode(), e.getResponse()), e);

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -492,7 +492,7 @@ follows:
 |=======================================================================
 |Endpoint |Shorthand Alias |Options |Result Body Type
 
-|createGroup |create |name |com.box.sdk.BoxGroup 
+|createGroup |create |name, [provenance, externalSyncIdentifier, description, invitabilityLevel, memberViewabilityLevel] |com.box.sdk.BoxGroup 
 
 |addGroupMembership |createMembership |groupId, userId, role |com.box.sdk.BoxGroupMembership
 


### PR DESCRIPTION
I need the full version of BoxGroup.createGroup to use all the additional options, in particular 
external_sync_identifier which cannot be set any other way.