### PR TITLE
Set org.apache.core as the jkd9 automatic module name for camel-core

### DIFF
--- a/camel-core/pom.xml
+++ b/camel-core/pom.xml
@@ -115,6 +115,7 @@
     </camel.osgi.activator>
     <!-- do not skip any tests by default -->
     <platform.skip.tests/>
+    <camel.automatic.module.name>org.apache.camel</camel.automatic.module.name>
   </properties>
 
   <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5174,6 +5174,7 @@
             <Karaf-Info>Camel;${project.artifactId}=${project.version}</Karaf-Info>
             <_versionpolicy>${camel.osgi.import.default.version}</_versionpolicy>
             <_failok>${camel.osgi.failok}</_failok>
+            <Automatic-Module-Name>${camel.automatic.module.name}</Automatic-Module-Name>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
This will be useful for people wanting to use Java 9's module system with camel-core. 

From Mark Reinhold's recommendation and common adoption, the module name should correspond to the principal exported API package:

> Strongly recommend that all modules be named according to the reverse
    Internet domain-name convention.  A module's name should correspond
    to the name of its principal exported API package, which should also
    follow that convention.  If a module does not have such a package, or
    if for legacy reasons it must have a name that does not correspond to
    one of its exported packages, then its name should at least start
    with the reversed form of an Internet domain with which the author is
    associated.

Thanks!