### PR TITLE
camel-bom: fix relative path to parent pom

### DIFF
--- a/bom/camel-bom/pom.xml
+++ b/bom/camel-bom/pom.xml
@@ -23,6 +23,7 @@
     <groupId>org.apache.camel</groupId>
     <artifactId>camel</artifactId>
     <version>2.20.0-SNAPSHOT</version>
+    <relativePath>../../apache-camel</relativePath>
   </parent>
   <artifactId>camel-bom</artifactId>
   <packaging>pom</packaging>

--- a/bom/target-template-pom.xml
+++ b/bom/target-template-pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache.camel</groupId>
     <artifactId>camel</artifactId>
     <version>${project.version}</version>
+    <relativePath>../../apache-camel</relativePath>
   </parent>
 
   <artifactId>camel-bom</artifactId>


### PR DESCRIPTION
This should fix the build failures on build.apache.org, e.g.:

https://builds.apache.org/view/C/view/Apache%20Camel/job/Camel.trunk.notest/3740/console

which failed with:

```
[WARNING] 'parent.relativePath' points at org.apache.camel:bom-generator instead of org.apache.camel:camel, please verify your project structure @ line 22, column 11
[FATAL] Non-resolvable parent POM: Could not find artifact org.apache.camel:camel:pom:2.20.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 22, column 11
```