### PR TITLE
CAMEL-11885: Add support for creating folder by path in camel-box

### DIFF
--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -422,6 +422,8 @@ box:folders/endpoint?[options]
 
 |createFolder |create |parentFolderId, folderName |com.box.sdk.BoxFolder
 
+|createFolder |create |parentFolderId, path |com.box.sdk.BoxFolder
+
 |copyFolder |copy |folderId, destinationfolderId, [newName] |com.box.sdk.BoxFolder 
 
 |moveFolder |move |folderId, destinationFolderId, newName |com.box.sdk.BoxFolder

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxFoldersManagerIntegrationTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxFoldersManagerIntegrationTest.java
@@ -73,6 +73,25 @@ public class BoxFoldersManagerIntegrationTest extends AbstractBoxTestSupport {
     }
 
     @Test
+    public void testCreateFolderByPath() throws Exception {
+
+        // delete folder created in test setup.
+        deleteTestFolder();
+
+        final Map<String, Object> headers = new HashMap<String, Object>();
+        // parameter type is String
+        headers.put("CamelBox.parentFolderId", "0");
+        // parameter type is String[]
+        headers.put("CamelBox.path", new String[] {CAMEL_TEST_FOLDER});
+
+        testFolder = requestBodyAndHeaders("direct://CREATEFOLDER", null, headers);
+
+        assertNotNull("createFolder result", testFolder);
+        assertEquals("createFolder folder name", CAMEL_TEST_FOLDER, testFolder.getInfo().getName());
+        LOG.debug("createFolder: " + testFolder);
+    }
+
+    @Test
     public void testDeleteFolder() throws Exception {
         // using String message body for single parameter "folderId"
         requestBody("direct://DELETEFOLDER", testFolder.getID());


### PR DESCRIPTION
Add possibility to specify folder by path as String[] when creating folders in Box, similarly to getFolder. It makes creation of nested folders in routes much easier.

Note that createFolder(String, String[]) doesn't throw exception when folders exists unlike createFolder(String, String). This can be argued, but mimics the behaviour of, e.g., mkdir on Linux.