### PR TITLE
Fix the problem of using '+' and '+=' operators to concatenate strings in a loop.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/MappedEndpointConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MappedEndpointConfiguration.java
@@ -130,10 +130,10 @@ public final class MappedEndpointConfiguration extends DefaultEndpointConfigurat
         }
 
         queryParams.sort(null);
-        String q = "";
+        StringBuilder q = new StringBuilder();
         for (String entry : queryParams) {
-            q += q.length() == 0 ? "" : "&";
-            q += entry;
+            q.append(q.length() == 0 ? "" : "&");
+            q.append(entry);
         }
 
         StringBuilder u = new StringBuilder(64);

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
@@ -125,11 +125,11 @@ public class IrcConfiguration implements Cloneable {
      * Return space separated list of channel names without pwd
      */
     public String getListOfChannels() {
-        String retval = "";
+        StringBuilder retval = new StringBuilder();
         for (IrcChannel channel : channels) {
-            retval += (retval.isEmpty() ? "" : " ") + channel.getName();
+            retval.append(retval.length() == 0 ? "" : " ").append(channel.getName());
         }
-        return retval;
+        return retval.toString();
     }
 
     public void configure(String uriStr) throws URISyntaxException, UnsupportedEncodingException  {

--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/stored/template/generated/ParseException.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/stored/template/generated/ParseException.java
@@ -102,29 +102,29 @@ public class ParseException extends Exception {
             }
             expected.append(eol).append("    ");
         }
-        String retval = "Encountered \"";
+        StringBuilder retval = new StringBuilder("Encountered \"");
         Token tok = currentToken.next;
         for (int i = 0; i < maxSize; i++) {
-            if (i != 0) retval += " ";
+            if (i != 0) retval.append(" ");
             if (tok.kind == 0) {
-                retval += tokenImage[0];
+                retval.append(tokenImage[0]);
                 break;
             }
-            retval += " " + tokenImage[tok.kind];
-            retval += " \"";
-            retval += add_escapes(tok.image);
-            retval += " \"";
+            retval.append(" ").append(tokenImage[tok.kind]);
+            retval.append(" \"");
+            retval.append(add_escapes(tok.image));
+            retval.append(" \"");
             tok = tok.next;
         }
-        retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
-        retval += "." + eol;
+        retval.append("\" at line ").append(currentToken.next.beginLine).append(", column ").append(currentToken.next.beginColumn);
+        retval.append(".").append(eol);
         if (expectedTokenSequences.length == 1) {
-            retval += "Was expecting:" + eol + "    ";
+            retval.append("Was expecting:").append(eol).append("    ");
         } else {
-            retval += "Was expecting one of:" + eol + "    ";
+            retval.append("Was expecting one of:").append(eol).append("    ");
         }
-        retval += expected.toString();
-        return retval;
+        retval.append(expected.toString());
+        return retval.toString();
     }
 
     /**


### PR DESCRIPTION

The method is building a String using concatenation in a loop.
In each iteration, the String is converted to a StringBuilder, appended to, and converted back to a String.
This can lead to a cost quadratic in the number of iterations, as the growing string is recopied in each iteration.
Better performance can be obtained by using a StringBuilder explicitly.
http://findbugs.sourceforge.net/bugDescriptions.html#SBSC_USE_STRINGBUFFER_CONCATENATION