### PR TITLE
Support folders in path for Zip/TarFileDataFormat#marshal

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
@@ -37,6 +37,8 @@ public class TarFileDataFormat extends DataFormatDefinition {
     private Boolean usingIterator;
     @XmlAttribute
     private Boolean allowEmptyDirectory;
+    @XmlAttribute
+    private Boolean preservePathElements;
 
     public TarFileDataFormat() {
         super("tarfile");
@@ -47,6 +49,9 @@ public class TarFileDataFormat extends DataFormatDefinition {
         if (usingIterator != null) {
             setProperty(camelContext, dataFormat, "usingIterator", usingIterator);
         }
+        if (preservePathElements != null) {
+            setProperty(camelContext, dataFormat, "preservePathElements", preservePathElements);
+        }
     }
 
     public Boolean getUsingIterator() {
@@ -55,6 +60,10 @@ public class TarFileDataFormat extends DataFormatDefinition {
     
     public Boolean getAllowEmptyDirectory() {
         return allowEmptyDirectory;
+    }
+
+    public Boolean getPreservePathElements() {
+        return preservePathElements;
     }
 
     /**
@@ -71,5 +80,13 @@ public class TarFileDataFormat extends DataFormatDefinition {
      */
     public void setAllowEmptyDirectory(Boolean allowEmptyDirectory) {
         this.allowEmptyDirectory = allowEmptyDirectory;
+    }
+
+    /**
+     * If the file name contains path elements, setting this option to true, allows the path to be maintained
+     * in the tar file.
+     */
+    public void setPreservePathElements(Boolean preservePathElements) {
+        this.preservePathElements = preservePathElements;
     }
 }

--- a/camel-core/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
+++ b/camel-core/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
@@ -38,6 +38,8 @@ public class ZipFileDataFormat extends DataFormatDefinition {
     private Boolean usingIterator;
     @XmlAttribute
     private Boolean allowEmptyDirectory;
+    @XmlAttribute
+    private Boolean preservePathElements;
 
     public ZipFileDataFormat() {
         super("zipfile");
@@ -51,6 +53,9 @@ public class ZipFileDataFormat extends DataFormatDefinition {
         if (allowEmptyDirectory != null) {
             setProperty(camelContext, dataFormat, "allowEmptyDirectory", allowEmptyDirectory);
         }
+        if (preservePathElements != null) {
+            setProperty(camelContext, dataFormat, "preservePathElements", preservePathElements);
+        }
     }
 
     public Boolean getUsingIterator() {
@@ -59,6 +64,10 @@ public class ZipFileDataFormat extends DataFormatDefinition {
     
     public Boolean getAllowEmptyDirectory() {
         return allowEmptyDirectory;
+    }
+
+    public Boolean getPreservePathElements() {
+        return preservePathElements;
     }
 
     /**
@@ -75,6 +84,14 @@ public class ZipFileDataFormat extends DataFormatDefinition {
      */
     public void setAllowEmptyDirectory(Boolean allowEmptyDirectory) {
         this.allowEmptyDirectory = allowEmptyDirectory;
+    }
+
+    /**
+     * If the file name contains path elements, setting this option to true, allows the path to be maintained
+     * in the zip file.
+     */
+    public void setPreservePathElements(Boolean preservePathElements) {
+        this.preservePathElements = preservePathElements;
     }
 
 }

--- a/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
@@ -17,9 +17,12 @@
 package org.apache.camel.dataformat.tarfile;
 
 import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.converter.stream.OutputStreamBuilder;
@@ -43,6 +46,7 @@ import static org.apache.camel.Exchange.FILE_NAME;
 public class TarFileDataFormat extends ServiceSupport implements DataFormat, DataFormatName {
     private boolean usingIterator;
     private boolean allowEmptyDirectory;
+    private boolean preservePathElements;
 
     @Override
     public String getDataFormatName() {
@@ -51,13 +55,14 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
 
     @Override
     public void marshal(final Exchange exchange, final Object graph, final OutputStream stream) throws Exception {
-        String filename = exchange.getIn().getHeader(FILE_NAME, String.class);
+        String filename;
+        String filepath = exchange.getIn().getHeader(FILE_NAME, String.class);
         Long filelength = exchange.getIn().getHeader(FILE_LENGTH, Long.class);
-        if (filename == null) {
+        if (filepath == null) {
             // generate the file name as the camel file component would do
-            filename = StringHelper.sanitize(exchange.getIn().getMessageId());
+            filename = filepath = StringHelper.sanitize(exchange.getIn().getMessageId());
         } else {
-            filename = Paths.get(filename).getFileName().toString(); // remove any path elements
+            filename = Paths.get(filepath).getFileName().toString(); // remove any path elements
         }
 
         TarArchiveOutputStream tos = new TarArchiveOutputStream(stream);
@@ -69,9 +74,11 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
             filelength = (long) is.available();
         }
 
-        TarArchiveEntry entry = new TarArchiveEntry(filename);
-        entry.setSize(filelength);
-        tos.putArchiveEntry(entry);
+        if (preservePathElements) {
+            createTarEntries(tos, filepath, filelength);
+        } else {
+            createTarEntries(tos, filename, filelength);
+        }
 
         try {
             IOHelper.copy(is, tos);
@@ -115,6 +122,31 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
         }
     }
 
+    private void createTarEntries(TarArchiveOutputStream tos, String filepath, Long filelength) throws IOException {
+        Iterator<Path> elements = Paths.get(filepath).iterator();
+        StringBuilder sb = new StringBuilder();
+
+        while (elements.hasNext()) {
+            Path path = elements.next();
+            String element = path.toString();
+            Long length = filelength;
+
+            // If there are more elements to come this element is a directory
+            // The "/" at the end tells the TarEntry it is a folder
+            if (elements.hasNext()) {
+                element += "/";
+                length = 0L;
+            }
+
+            // Each entry needs the complete path, including previous created folders.
+            TarArchiveEntry entry = new TarArchiveEntry(sb + element);
+            entry.setSize(length);
+            tos.putArchiveEntry(entry);
+
+            sb.append(element);
+        }
+    }
+
     public boolean isUsingIterator() {
         return usingIterator;
     }
@@ -129,6 +161,14 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
 
     public void setAllowEmptyDirectory(boolean allowEmptyDirectory) {
         this.allowEmptyDirectory = allowEmptyDirectory;
+    }
+
+    public boolean isPreservePathElements() {
+        return preservePathElements;
+    }
+
+    public void setPreservePathElements(boolean preservePathElements) {
+        this.preservePathElements = preservePathElements;
     }
 
     @Override

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
@@ -43,6 +43,7 @@ import static org.apache.camel.Exchange.FILE_NAME;
 import static org.apache.camel.dataformat.tarfile.TarUtils.TEXT;
 import static org.apache.camel.dataformat.tarfile.TarUtils.getBytes;
 import static org.apache.camel.dataformat.tarfile.TarUtils.getTaredText;
+import static org.apache.camel.dataformat.tarfile.TarUtils.getTaredTextInFolder;
 
 /**
  * Unit tests for {@link TarFileDataFormat}.
@@ -78,6 +79,36 @@ public class TarFileDataFormatTest extends CamelTestSupport {
 
         Exchange exchange = mock.getReceivedExchanges().get(0);
         assertTrue(ObjectHelper.equalByteArray(getTaredText("poem.txt"), (byte[]) exchange.getIn().getBody()));
+    }
+
+    @Test
+    public void testTarWithPathElements() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:tar");
+        mock.expectedMessageCount(1);
+        mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
+
+        template.sendBodyAndHeader("direct:tar", TEXT, FILE_NAME, "poems/poem.txt");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange exchange = mock.getReceivedExchanges().get(0);
+        assertTrue(ObjectHelper.equalByteArray(getTaredText("poem.txt"), (byte[]) exchange.getIn().getBody()));
+    }
+
+    @Test
+    public void testTarWithPreservedPathElements() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:tar");
+        mock.expectedMessageCount(1);
+        mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
+
+        tar.setPreservePathElements(true);
+
+        template.sendBodyAndHeader("direct:tar", TEXT, FILE_NAME, "poems/poem.txt");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange exchange = mock.getReceivedExchanges().get(0);
+        assertTrue(ObjectHelper.equalByteArray(getTaredTextInFolder("poems/", "poems/poem.txt"), (byte[]) exchange.getIn().getBody()));
     }
 
     @Test

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarUtils.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarUtils.java
@@ -59,6 +59,27 @@ final class TarUtils {
         return baos.toByteArray();
     }
 
+    static byte[] getTaredTextInFolder(String folder, String file) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(TEXT.getBytes("UTF-8"));
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        TarArchiveOutputStream tos = new TarArchiveOutputStream(baos);
+        try {
+            TarArchiveEntry folderEntry = new TarArchiveEntry(folder);
+            folderEntry.setSize(0L);
+            tos.putArchiveEntry(folderEntry);
+
+            TarArchiveEntry fileEntry = new TarArchiveEntry(file);
+            fileEntry.setSize(bais.available());
+            tos.putArchiveEntry(fileEntry);
+
+            IOHelper.copy(bais, tos);
+        } finally {
+            tos.closeArchiveEntry();
+            IOHelper.close(bais, tos);
+        }
+        return baos.toByteArray();
+    }
+
     static byte[] getBytes(File file) throws IOException {
         FileInputStream fis = new FileInputStream(file);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormat.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormat.java
@@ -16,9 +16,12 @@
  */
 package org.apache.camel.dataformat.zipfile;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -40,6 +43,7 @@ import static org.apache.camel.Exchange.FILE_NAME;
 public class ZipFileDataFormat extends ServiceSupport implements DataFormat, DataFormatName {
     private boolean usingIterator;
     private boolean allowEmptyDirectory;
+    private boolean preservePathElements;
 
     @Override
     public String getDataFormatName() {
@@ -48,16 +52,22 @@ public class ZipFileDataFormat extends ServiceSupport implements DataFormat, Dat
 
     @Override
     public void marshal(final Exchange exchange, final Object graph, final OutputStream stream) throws Exception {
-        String filename = exchange.getIn().getHeader(FILE_NAME, String.class);
-        if (filename == null) {
+        String filename;
+        String filepath = exchange.getIn().getHeader(FILE_NAME, String.class);
+        if (filepath == null) {
             // generate the file name as the camel file component would do
-            filename = StringHelper.sanitize(exchange.getIn().getMessageId());
+            filename = filepath = StringHelper.sanitize(exchange.getIn().getMessageId());
         } else {
-            filename = Paths.get(filename).getFileName().toString(); // remove any path elements
+            filename = Paths.get(filepath).getFileName().toString(); // remove any path elements
         }
 
         ZipOutputStream zos = new ZipOutputStream(stream);
-        zos.putNextEntry(new ZipEntry(filename));
+
+        if (preservePathElements) {
+            createZipEntries(zos, filepath);
+        } else {
+            createZipEntries(zos, filename);
+        }
 
         InputStream is = exchange.getContext().getTypeConverter().mandatoryConvertTo(InputStream.class, exchange, graph);
 
@@ -100,6 +110,27 @@ public class ZipFileDataFormat extends ServiceSupport implements DataFormat, Dat
         }
     }
 
+    private void createZipEntries(ZipOutputStream zos, String filepath) throws IOException {
+        Iterator<Path> elements = Paths.get(filepath).iterator();
+        StringBuilder sb = new StringBuilder();
+
+        while (elements.hasNext()) {
+            Path path = elements.next();
+            String element = path.toString();
+
+            // If there are more elements to come this element is a directory
+            // The "/" at the end tells the ZipEntry it is a folder
+            if (elements.hasNext()) {
+                element += "/";
+            }
+
+            // Each entry needs the complete path, including previous created folders.
+            zos.putNextEntry(new ZipEntry(sb + element));
+
+            sb.append(element);
+        }
+    }
+
     public boolean isUsingIterator() {
         return usingIterator;
     }
@@ -114,6 +145,14 @@ public class ZipFileDataFormat extends ServiceSupport implements DataFormat, Dat
 
     public void setAllowEmptyDirectory(boolean allowEmptyDirectory) {
         this.allowEmptyDirectory = allowEmptyDirectory;
+    }
+
+    public boolean isPreservePathElements() {
+        return preservePathElements;
+    }
+
+    public void setPreservePathElements(boolean preservePathElements) {
+        this.preservePathElements = preservePathElements;
     }
 
     @Override


### PR DESCRIPTION
The `ZipFileDataFormat#marshal` now uses the full path given in the `FILE_NAME` header as the name for the `ZipEntry`. This way it will create the specified folders in the generated zip file. 

The out `FILE_NAME` header however still uses the pathless version of the in `FILE_NAME` header.