### PR TITLE
fuse-doc-1972 - fixed three broken links in header's table

### DIFF
--- a/components/camel-pdf/src/main/docs/pdf-component.adoc
+++ b/components/camel-pdf/src/main/docs/pdf-component.adoc
@@ -81,15 +81,15 @@ with the following path and query parameters:
 
 |`pdf-document` |*Mandatory* header for `append` operation and ignored in all other
 operations. Expected type is
-https://pdfbox.apache.org/docs/1.8.9/javadocs/org/apache/pdfbox/pdmodel/PDDocument.html[PDDocument].
+https://pdfbox.apache.org/docs/1.8.10/javadocs/org/apache/pdfbox/pdmodel/PDDocument.html[PDDocument].
 Stores PDF document which will be used for append operation.
 
 |`protection-policy` |Expected type
-ishttps://pdfbox.apache.org/docs/1.8.9/javadocs/org/apache/pdfbox/pdmodel/encryption/ProtectionPolicy.html[ProtectionPolicy].
+ishttps://pdfbox.apache.org/docs/1.8.10/javadocs/org/apache/pdfbox/pdmodel/encryption/ProtectionPolicy.html[ProtectionPolicy].
 If specified then PDF document will be encrypted with it.
 
 |`decryption-material` |Expected type
-ishttps://pdfbox.apache.org/docs/1.8.9/javadocs/org/apache/pdfbox/pdmodel/encryption/DecryptionMaterial.html[DecryptionMaterial].
+ishttps://pdfbox.apache.org/docs/1.8.10/javadocs/org/apache/pdfbox/pdmodel/encryption/DecryptionMaterial.html[DecryptionMaterial].
 *Mandatory* header if PDF document is encrypted.
 |=======================================================================
 


### PR DESCRIPTION
Hi - I'm contributing another fix to the asciidoc documentation. Can you please review it?
Specifically, I updated three broken links by changing 1.8.9 to 1.8.10. 