### PR TITLE
CAMEL-11894: camel-karaf-commands deployment failed on karaf 4.0

### DIFF
--- a/platforms/karaf/commands/pom.xml
+++ b/platforms/karaf/commands/pom.xml
@@ -84,8 +84,7 @@
           <instructions>
             <Import-Package>
               !org.apache.felix.utils.properties,
-              org.apache.karaf.shell.api.action;version="[4,5)",
-              org.apache.karaf.shell.support.completers;version="[4,5)",
+              org.apache.karaf.shell.*;version="[4,5)",
               org.slf4j.*;version="[1.6,2)",
               *
             </Import-Package>


### PR DESCRIPTION
Fix OSGi's version range for the missing package