### PR TITLE
Replace the inefficient Double constructor with static Double.valueOf() method.

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConsumer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConsumer.java
@@ -160,7 +160,7 @@ public class SqsConsumer extends ScheduledBatchPollingConsumer {
             if (this.scheduledExecutor != null && visibilityTimeout != null && (visibilityTimeout.intValue() / 2) > 0) {
                 int delay = visibilityTimeout.intValue() / 2;
                 int period = visibilityTimeout.intValue();
-                int repeatSeconds = new Double(visibilityTimeout.doubleValue() * 1.5).intValue();
+                int repeatSeconds = Double.valueOf(visibilityTimeout.doubleValue() * 1.5).intValue();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Scheduled TimeoutExtender task to start after {} delay, and run with {}/{} period/repeat (seconds), to extend exchangeId: {}",
                             new Object[]{delay, period, repeatSeconds, exchange.getExchangeId()});


### PR DESCRIPTION

Using new Double(double) is guaranteed to always result in a new object whereas Double.valueOf(double) allows caching of values to be done by the compiler, class library, or JVM.
Using of cached values avoids object allocation and the code will be faster.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_FP_NUMBER_CTOR