### PR TITLE
Replace the keySet iterator with an entrySet iterator.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -401,9 +401,10 @@ public class BeanInfo {
         MethodInfo answer = methodMap.get(method);
         if (answer == null) {
             // maybe the method overrides, and the method map keeps info of the source override we can use
-            for (Method source : methodMap.keySet()) {
+            for (Map.Entry<Method, MethodInfo> methodEntry : methodMap.entrySet()) {
+                Method source = methodEntry.getKey();
                 if (ObjectHelper.isOverridingMethod(getType(), source, method, false)) {
-                    answer = methodMap.get(source);
+                    answer = methodEntry.getValue();
                     break;
                 }
             }


### PR DESCRIPTION
The current source code accesses the value of a Map entry of methodMap, using a key that is retrieved from a keySet iterator.
It is more efficient to use an iterator on the entrySet of the methodMap, to avoid the Map.get(key) lookup.
http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR