### PR TITLE
Remove the useless condition.

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConfiguration.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConfiguration.java
@@ -167,7 +167,7 @@ public class MailConfiguration implements Cloneable {
         int port = uri.getPort();
         if (port > 0) {
             setPort(port);
-        } else if (port <= 0 && this.port <= 0) {
+        } else if (this.port <= 0) {
             // resolve default port if no port number was provided, and not already configured with a port number
             setPort(MailUtils.getDefaultPortForProtocol(uri.getScheme()));
         }

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/impl/MllpSocketUtil.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/impl/MllpSocketUtil.java
@@ -218,7 +218,7 @@ public final class MllpSocketUtil {
         if (payload != null && length >= 0) {
             for (int i = Math.min(length, payload.length) - 1; i > 0; --i) {
                 if (payload[i] == END_OF_DATA) {
-                    if (i > 0 && payload[i - 1] == END_OF_BLOCK) {
+                    if (payload[i - 1] == END_OF_BLOCK) {
                         return i - 1;
                     }
                 }


### PR DESCRIPTION
The two conditional expressions always return true in their current control flow.
They are useless.