### PR TITLE
Fix the problem of instanceof test always return true.

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/SObjectTree.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/SObjectTree.java
@@ -247,7 +247,7 @@ public final class SObjectTree implements Serializable {
         if (Objects.equals(attributesReferenceId, referenceId)) {
             final Object object = node.getObject();
 
-            if (object instanceof AbstractSObjectBase) {
+            if (object != null) {
                 return updateBaseObjectId(id, (AbstractSObjectBase) object);
             } else {
                 return updateGeneralObjectId(id, object);


### PR DESCRIPTION
This instanceof test will always return true because AbstractSObjectBase is the return type of method node.getObject().
 The return value of method node.getObject() might be null, it would be better to do a null test rather than an instanceof test.
http://findbugs.sourceforge.net/bugDescriptions.html#BC_VACUOUS_INSTANCEOF