### PR TITLE
Replace the Number.valueOf method with the Number.parseXXX method.

### DIFF
--- a/components/camel-sip/src/main/java/org/apache/camel/component/sip/SipConfiguration.java
+++ b/components/camel-sip/src/main/java/org/apache/camel/component/sip/SipConfiguration.java
@@ -173,7 +173,7 @@ public class SipConfiguration {
             setTransport((String) settings.get("transport"));
         } 
         if (settings.containsKey("maxMessageSize")) {
-            setMaxMessageSize(Integer.valueOf((String) settings.get("maxMessageSize")));
+            setMaxMessageSize(Integer.parseInt((String) settings.get("maxMessageSize")));
         } 
         if (settings.containsKey("cacheConnections")) {
             setCacheConnections(Boolean.valueOf((String) settings.get("cacheConnections")));
@@ -185,10 +185,10 @@ public class SipConfiguration {
             setContentSubType((String) settings.get("contentSubType"));
         }
         if (settings.containsKey("maxForwards")) {
-            setMaxForwards(Integer.valueOf((String) settings.get("maxForwards")));
+            setMaxForwards(Integer.parseInt((String) settings.get("maxForwards")));
         }
         if (settings.containsKey("receiveTimeoutMillis")) {
-            setReceiveTimeoutMillis(Long.valueOf((String) settings.get("receiveTimeoutMillis")));
+            setReceiveTimeoutMillis(Long.parseLong((String) settings.get("receiveTimeoutMillis")));
         }
         if (settings.containsKey("eventHeaderName")) {
             setEventHeaderName((String) settings.get("eventHeaderName"));
@@ -200,7 +200,7 @@ public class SipConfiguration {
             setUseRouterForAllUris(Boolean.valueOf((String) settings.get("useRouterForAllUris")));
         }
         if (settings.containsKey("msgExpiration")) {
-            setMsgExpiration(Integer.valueOf((String) settings.get("msgExpiration")));
+            setMsgExpiration(Integer.parseInt((String) settings.get("msgExpiration")));
         }
         if (settings.containsKey("presenceAgent")) {
             setPresenceAgent(Boolean.valueOf((String) settings.get("presenceAgent")));
@@ -214,7 +214,7 @@ public class SipConfiguration {
                 setFromHost((String) settings.get("fromHost"));
             } 
             if (settings.containsKey("fromPort")) {
-                setFromPort(Integer.valueOf((String) settings.get("fromPort")));
+                setFromPort(Integer.parseInt((String) settings.get("fromPort")));
             } 
             setToUser(uri.getUserInfo());
             setToHost(uri.getHost());
@@ -231,7 +231,7 @@ public class SipConfiguration {
                     setToHost((String) settings.get("toHost"));
                 } 
                 if (settings.containsKey("toPort")) {
-                    setToPort(Integer.valueOf((String) settings.get("toPort")));
+                    setToPort(Integer.parseInt((String) settings.get("toPort")));
                 } 
             }
         }


### PR DESCRIPTION
It is more efficient to use the static parseXXX method to extract unboxed primitive value from a String.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_BOXED_PRIMITIVE_FOR_PARSING