### PR TITLE
CAMEL-11896: set CamelLogDebugBodyMaxChars when 0 or negative

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -140,9 +140,7 @@ public class CamelAutoConfiguration {
         camelContext.getShutdownStrategy().setShutdownRoutesInReverseOrder(config.isShutdownRoutesInReverseOrder());
         camelContext.getShutdownStrategy().setLogInflightExchangesOnTimeout(config.isShutdownLogInflightExchangesOnTimeout());
 
-        if (config.getLogDebugMaxChars() > 0) {
-            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "" + config.getLogDebugMaxChars());
-        }
+        camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "" + config.getLogDebugMaxChars());
 
         // stream caching
         camelContext.setStreamCaching(config.isStreamCachingEnabled());


### PR DESCRIPTION
[CAMEL-11896](https://issues.apache.org/jira/browse/CAMEL-11896): set CamelLogDebugBodyMaxChars when 0 or negative