### PR TITLE
CAMEL-11282 : RestletComponent changed to extend DefaultComponent and…

### DIFF
--- a/components/camel-restlet/src/main/docs/restlet-component.adoc
+++ b/components/camel-restlet/src/main/docs/restlet-component.adoc
@@ -71,6 +71,7 @@ The Restlet component supports 22 options which are listed below.
 | Name | Description | Default | Type
 | *controllerDaemon* (consumer) | Indicates if the controller thread should be a daemon (not blocking JVM exit). |  | Boolean
 | *controllerSleepTimeMs* (consumer) | Time for the controller thread to sleep between each control. |  | Integer
+| *headerFilterStrategy* (filter) | Custom org.apache.camel.spi.HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | *inboundBufferSize* (consumer) | The size of the buffer when reading messages. |  | Integer
 | *maxConnectionsPerHost* (common) | Maximum number of concurrent connections per host (IP address). |  | Integer
 | *maxThreads* (consumer) | Maximum threads that will service requests. |  | Integer
@@ -89,7 +90,6 @@ The Restlet component supports 22 options which are listed below.
 | *synchronous* (producer) | Whether to use synchronous Restlet Client for the producer. Setting this option to true can yield faster performance as it seems the Restlet synchronous Client works better. |  | Boolean
 | *enabledConverters* (advanced) | A list of converters to enable as full class name or simple class name. All the converters automatically registered are enabled if empty or null |  | List
 | *useGlobalSslContext Parameters* (security) | Enable usage of global SSL context parameters. | false | boolean
-| *headerFilterStrategy* (filter) | To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | *resolveProperty Placeholders* (advanced) | Whether the component should resolve property placeholders on itself when starting. Only properties which are of String type can use property placeholders. | true | boolean
 |===
 // component options: END

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletHeaderFilterStrategyTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestletHeaderFilterStrategyTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.restlet;
+
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultHeaderFilterStrategy;
+import org.junit.Test;
+
+/**
+ * @version 
+ */
+public class RestletHeaderFilterStrategyTest extends RestletTestSupport {
+
+    private static final String HEADER_FILTER = "filter";
+
+    @Test
+    public void testRestletProducerInFilterAllowedHeader() throws Exception {
+        String acceptedHeaderKey = "dontFilter";
+        MockEndpoint mock = getMockEndpoint("mock:out");
+        mock.expectedHeaderReceived(acceptedHeaderKey, "any value");
+        String out = template.requestBodyAndHeader("direct:start", null, acceptedHeaderKey, "any value", String.class);
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void testRestletProducerInFilterNotAllowedHeader() throws Exception {
+        String notAcceptedHeaderKey = HEADER_FILTER + "ThisHeader";
+        MockEndpoint mock = getMockEndpoint("mock:out");
+        mock.whenAnyExchangeReceived(new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                String notValidHeader = exchange.getIn().getHeader(notAcceptedHeaderKey, String.class);
+                Map<String, Object> headers = exchange.getIn().getHeaders();
+                for (String key : headers.keySet()) {
+                    assertFalse("Header should have been filtered: " + key, key.startsWith(HEADER_FILTER));
+                }
+            }
+        });
+        template.requestBodyAndHeader("direct:start", null, notAcceptedHeaderKey, "any value", String.class);
+        mock.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // force synchronous processing using restlet and add filtering
+                DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
+                strategy.setInFilterPattern(HEADER_FILTER + ".*");
+                strategy.setOutFilterPattern(HEADER_FILTER + ".*");
+
+                RestletComponent restlet = context.getComponent("restlet", RestletComponent.class);
+                restlet.setHeaderFilterStrategy(strategy);
+                restlet.setSynchronous(true);
+
+                from("direct:start").to("restlet:http://localhost:" + portNum + "/users/123/exclude").to("log:reply");
+                from("restlet:http://localhost:" + portNum + "/users/{id}/{filterExcluded}?restletMethods=GET").to("mock:out");
+            }
+        };
+    }
+}


### PR DESCRIPTION
… implement HeaderFilterStrategyAware. Testcase added to verify that HeaderFiltering.

This is a proposed fix for https://issues.apache.org/jira/browse/CAMEL-11282. Maybe HeaderFilterStrategyComponent could be changed to extend DefaultComponent in version 3.0.0, to catch all other HeaderFilterComponents.