### PR TITLE
CAMEL-11948  NPE on DefaultMessage setBody if deprecated constructor was used

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
@@ -33,7 +33,7 @@ import org.apache.camel.spi.DataTypeAware;
  * Unless a specific provider wishes to do something particularly clever with
  * headers you probably want to just derive from {@link DefaultMessage}
  *
- * @version 
+ * @version
  */
 public abstract class MessageSupport implements Message, CamelContextAware, DataTypeAware {
     private CamelContext camelContext;
@@ -48,6 +48,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return String.format("Message[%s]", messageId == null ? "" : messageId);
     }
 
+    @Override
     public Object getBody() {
         if (body == null) {
             body = createBody();
@@ -55,10 +56,12 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return body;
     }
 
+    @Override
     public <T> T getBody(Class<T> type) {
         return getBody(type, getBody());
     }
 
+    @Override
     public Object getMandatoryBody() throws InvalidPayloadException {
         Object answer = getBody();
         if (answer == null) {
@@ -97,6 +100,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return null;
     }
 
+    @Override
     public <T> T getMandatoryBody(Class<T> type) throws InvalidPayloadException {
         // eager same instance type test to avoid the overhead of invoking the type converter
         // if already same type
@@ -116,14 +120,16 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         throw new InvalidPayloadException(e, type, this);
     }
 
+    @Override
     public void setBody(Object body) {
         this.body = body;
         // set data type if in use
-        if (body != null && camelContext.isUseDataType()) {
+        if (body != null && camelContext != null && camelContext.isUseDataType()) {
             this.dataType = new DataType(body.getClass());
         }
     }
 
+    @Override
     public <T> void setBody(Object value, Class<T> type) {
         Exchange e = getExchange();
         if (e != null) {
@@ -156,6 +162,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return dataType != null;
     }
 
+    @Override
     public Message copy() {
         Message answer = newInstance();
         // must copy over CamelContext
@@ -166,6 +173,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return answer;
     }
 
+    @Override
     public void copyFrom(Message that) {
         if (that == this) {
             // the same instance so do not need to copy
@@ -183,6 +191,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         copyFromWithNewBody(that, that.getBody());
     }
 
+    @Override
     public void copyFromWithNewBody(Message that, Object newBody) {
         if (that == this) {
             // the same instance so do not need to copy
@@ -219,6 +228,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         copyAttachments(that);
     }
 
+    @Override
     public Exchange getExchange() {
         return exchange;
     }
@@ -227,14 +237,17 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         this.exchange = exchange;
     }
 
+    @Override
     public CamelContext getCamelContext() {
         return camelContext;
     }
 
+    @Override
     public void setCamelContext(CamelContext camelContext) {
         this.camelContext = camelContext;
     }
 
+    @Override
     public void copyAttachments(Message that) {
         // the attachments may be the same instance if the end user has made some mistake
         // and set the OUT message with the same attachment instance of the IN message etc
@@ -270,6 +283,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return null;
     }
 
+    @Override
     public String getMessageId() {
         if (messageId == null) {
             messageId = createMessageId();
@@ -277,6 +291,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         return this.messageId;
     }
 
+    @Override
     public void setMessageId(String messageId) {
         this.messageId = messageId;
     }

--- a/camel-core/src/test/java/org/apache/camel/impl/DefaultMessageTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/DefaultMessageTest.java
@@ -16,14 +16,15 @@
  */
 package org.apache.camel.impl;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.camel.Attachment;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DefaultMessageTest {
 
@@ -34,6 +35,16 @@ public class DefaultMessageTest {
         Map<String, Attachment> attachments = message.createAttachments();
 
         assertThat(attachments, instanceOf(LinkedHashMap.class));
+    }
+
+    @Test
+    public void testCamelContextIsNull() {
+        @SuppressWarnings("deprecation")
+        DefaultMessage message = new DefaultMessage();
+        String body = "something";
+        message.setBody(body);
+        assertEquals(body, message.getBody());
+        assertEquals(null, message.getCamelContext());
     }
 
 }


### PR DESCRIPTION
After upgrade camel 2.20.0, some operations fail with a NullPointerException:

```
Caused by: java.lang.NullPointerException
        at org.apache.camel.impl.MessageSupport.setBody(MessageSupport.java:122)
```

The issue seems to be introduced with the change CAMEL-11380.

The issue could be easily reproduced by using the deprecated constructor, where no camelContext is set:

```
        Message message = new DefaultMessage();
        message.setBody("something");
```

To remain better backward compatibility, i would suggest a nullcheck in the setBody for cases where the CamelContext is not set.
