### PR TITLE
Include wrap to camel-leveldb

### DIFF
--- a/platforms/karaf/features/pom.xml
+++ b/platforms/karaf/features/pom.xml
@@ -185,8 +185,7 @@
                 <!-- camel-cxf uses blueprint but its feature name is different in karaf 3.x vs 4.x -->
                 <!-- camel-ignite requires to install apache ignite first -->
                 <!-- camel-guice does not work in OSGi currently -->
-                <!-- camel-leveldb uses some wrap magic to install which validator fails but it works -->
-                <feature>camel|camel-(?!(blueprint|cdi|cxf|ignite|guice|leveldb))*</feature>
+                <feature>camel|camel-(?!(blueprint|cdi|cxf|ignite|guice))*</feature>
               </features>
 			        <configuration>file://${project.build.directory}/classes/config.properties</configuration>
             </configuration>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1397,6 +1397,7 @@
     <bundle>mvn:org.apache.camel/camel-linkedin/${project.version}</bundle>
   </feature>
   <feature name='camel-leveldb' version='${project.version}' resolver='(obr)' start-level='50'>
+    <feature prerequisite="true">wrap</feature>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>wrap:mvn:org.fusesource.leveldbjni/leveldbjni-all/${leveldbjni-version}$Bundle-Version=${leveldbjni-version}&amp;Export-Package=*;-noimport:=true;version="${leveldbjni-version}"</bundle>
     <bundle dependency='true'>mvn:org.fusesource.hawtbuf/hawtbuf/${hawtbuf-version}</bundle>


### PR DESCRIPTION
This pull request is continuation of following one: https://github.com/apache/camel/pull/2062 but for branch master.

To make pax exam integration tests works for everyone, wrap prerequisite should be added to camel-leveldb and/or other packages.

@davsclaus idea is to add wrap to camel-core which probably would solve problems with pax exam.

@oscerd @davsclaus What do you think? 