### PR TITLE
clearing salesforce session when bayeux client receive 403 

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -137,6 +137,14 @@ public class SubscriptionHelper extends ServiceSupport {
                                     LOG.error("Error renewing OAuth token on 401 error: " + e.getMessage(), e);
                                 }
                             }
+                            if (handshakeError.startsWith("403::")) {
+                                try {
+                                    LOG.info("Cleaning Session from SalesforceSession before restarting client");
+                                    session.logout();
+                                } catch (SalesforceException e) {
+                                    LOG.error("Error while cleaning session : " + e.getMessage(), e);
+                                }
+                            }
                         }
 
                         // restart if handshake fails for any reason


### PR DESCRIPTION
clearing salesforce session when bayeux client receive 403 
https://issues.apache.org/jira/browse/CAMEL-11980