### PR TITLE
CAMEL-11977: MongoDB Tailable cursor consumer fails to stop on shutdown

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailingProcess.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailingProcess.java
@@ -158,8 +158,8 @@ public class MongoDbTailingProcess implements Runnable {
         boolean persistRegularly = persistRecords > 0;
         // while the cursor has more values, keepRunning is true and the cursorId is not 0, which symbolizes that the cursor is dead
         try {
-            while (cursor.hasNext() && keepRunning) { //cursor.getCursorId() != 0 &&
-                DBObject dbObj = cursor.next();
+            DBObject dbObj = null;
+            while ((dbObj = cursor.tryNext()) != null && keepRunning) { //cursor.getCursorId() != 0 &&
                 Exchange exchange = endpoint.createMongoDbExchange(dbObj);
                 try {
                     if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
cursor.hasNaxt() locks thread and waits for new object. Camel mongodb component uses loop to get new cursor objects, so we can just try if next is present without waiting for new object. tryNext() is what we need in this casre.

According to mongoBD documentation:
http://api.mongodb.com/java/current/com/mongodb/client/MongoCursor.html
tryNext() A special next() case that returns the next element in the iteration if available or null.

So after exit hook injection. when java will call MongoDbTailingProcess.stop(), there will be no lock at  MongoDbTailingProcess.run(). so MongoDbTailingProcess instance will be stopped.