### PR TITLE
Fix tests in camel-cdi

### DIFF
--- a/components/camel-cdi/src/test/resources/camel-context-errorHandler.xml
+++ b/components/camel-cdi/src/test/resources/camel-context-errorHandler.xml
@@ -25,7 +25,7 @@
     <errorHandler id="error-handler"
                   type="DeadLetterChannel"
                   deadLetterUri="mock:exception"
-                  onPrepareFailureRef="processor"/>
+                  onPrepareFailureRef="processor" xmlns="http://camel.apache.org/schema/spring"/>
 
     <camelContext id="test" errorHandlerRef="error-handler"
                   xmlns="http://camel.apache.org/schema/spring">

--- a/components/camel-cdi/src/test/resources/camel-context-routeContextRef-import.xml
+++ b/components/camel-cdi/src/test/resources/camel-context-routeContextRef-import.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <import resource="imported-route-context.xml"/>
+    <import resource="imported-route-context.xml" xmlns="http://camel.apache.org/schema/spring"/>
 
     <camelContext id="test" xmlns="http://camel.apache.org/schema/spring">
 


### PR DESCRIPTION
This was caused by [CAMEL-11822](https://issues.apache.org/jira/browse/CAMEL-11822). Looks like jaxb 2.3.0 is stricter with namespace declarations. Tested on Java 9 GA as well.