### PR TITLE
CAMEL-11977: MongoDB Tailable cursor consumer fails to stop on shutdown

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailingProcess.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbTailingProcess.java
@@ -180,6 +180,8 @@ public class MongoDbTailingProcess implements Runnable {
             if (keepRunning) {
                 LOG.debug("Cursor not found exception from MongoDB, will regenerate cursor. This is normal behaviour with tailable cursors.", e);
             }
+        } catch (IllegalStateException e) {
+            // do nothing
         }
 
         // the loop finished, persist the lastValue just in case we are shutting down


### PR DESCRIPTION
Is it still possible to include this fix into v2.20.1. It would be very good if so.