### PR TITLE
FUSEDOC-2074 - update contents

### DIFF
--- a/camel-core/src/main/docs/xslt-component.adoc
+++ b/camel-core/src/main/docs/xslt-component.adoc
@@ -12,44 +12,30 @@ link:templating.html[Templating] to generate respopnses for requests.
 ----
 xslt:templateName[?options]
 ----
+The URI format contains *templateName*, which can be one of the following:
 
-Where *templateName* is the classpath-local URI of the template to
-invoke; or the complete URL of the remote template. Refer to the
-http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/core/io/DefaultResourceLoader.html[Spring
-Documentation for more detail of the URI syntax]
+* the classpath-local URI of the template to invoke
 
-You can append query options to the URI in the following format,
-`?option=value&option=value&...`
+* the complete URL of the remote template. 
 
-Here are some example URIs
+You can append query options to the URI in the following format:
 
-URI
+*?option=value&option=value&...*
 
-Description
+Refer to the http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/core/io/DefaultResourceLoader.html[Spring
+Documentation] for more detail of the URI syntax.
 
-[source]
-----
-xslt:com/acme/mytransform.xsl
-----
+.Example URIs
+[options="header"]
+|=================================================================
+|URI                              |Description     
+|xslt:com/acme/mytransform.xsl|Refers to the file com/acme/mytransform.xsl on the classpath
+|xslt:file:///foo/bar.xsl |Refers to the file /foo/bar.xsl
+|xslt:http://acme.com/cheese/foo.xsl|Refers to the remote http resource
+|=================================================================
 
-refers to the file com/acme/mytransform.xsl on the classpath
-
-[source]
-----
-xslt:file:///foo/bar.xsl
-----
-
-refers to the file /foo/bar.xsl
-
-[source]
-----
-xslt:http://acme.com/cheese/foo.xsl
-----
-
-refers to the remote http resource
-
-Maven users will need to add the following dependency to their `pom.xml`
-for this component when using *Camel 2.8* or older:
+For *Camel 2.8* or older, Maven users will need to add the following dependency to their `pom.xml`
+for this component:
 
 [source,xml]
 ----
@@ -61,7 +47,7 @@ for this component when using *Camel 2.8* or older:
 </dependency>
 ----
 
-From Camel 2.9 onwards the link:xslt.html[XSLT] component is provided
+From *Camel 2.9* onwards the link:xslt.html[XSLT] component is provided
 directly in the camel-core.
 
 === Options
@@ -132,7 +118,8 @@ with the following path and query parameters:
 
 === Using XSLT endpoints
 
-For example you could use something like
+The following format is an expample of using an XSLT template to formulate a response for a message for InOut
+message exchanges (where there is a `JMSReplyTo` header) 
 
 [source,java]
 ----
@@ -140,8 +127,6 @@ from("activemq:My.Queue").
   to("xslt:com/acme/mytransform.xsl");
 ----
 
-To use an XSLT template to formulate a response for a message for InOut
-message exchanges (where there is a `JMSReplyTo` header).
 
 If you want to use InOnly and consume the message and send it to another
 destination you could use the following route:
@@ -153,12 +138,11 @@ from("activemq:My.Queue").
   to("activemq:Another.Queue");
 ----
 
-=== Getting Parameters into the XSLT to work with
+=== Getting Useable Parameters into the XSLT 
 
-By default, all headers are added as parameters which are available in
+By default, all headers are added as parameters which are then available in
 the XSLT. +
- To do this you will need to declare the parameter so it is then
-_useable_.
+To make the parameters useable, you will need to declare them.
 
 [source,xml]
 ----
@@ -166,7 +150,7 @@ _useable_.
 <to uri="xslt:MyTransform.xsl"/>
 ----
 
-And the XSLT just needs to declare it at the top level for it to be
+The parameter also needs to be declared in the top level of the XSLT for it to be
 available:
 
 [source,xml]
@@ -180,7 +164,7 @@ available:
 
 === Spring XML versions
 
-To use the above examples in Spring XML you would use something like
+To use the above examples in Spring XML you would use something like the following code:
 
 [source,xml]
 ----
@@ -193,110 +177,59 @@ To use the above examples in Spring XML you would use something like
   </camelContext>
 ----
 
-There is a
+To see an example, look at the 
 http://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/java/org/apache/camel/spring/processor/XsltTest.java[test
-case] along with
-http://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/XsltTest-context.xml[its
-Spring XML] if you want a concrete example.
+case] along with its 
+http://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/XsltTest-context.xml[
+Spring XML].
 
 === Using xsl:include
 
 *Camel 2.2 or older* +
- If you use xsl:include in your XSL files then in Camel 2.2 or older it
-uses the default `javax.xml.transform.URIResolver` which means it can
-only lookup files from file system, and its does that relative from the
+If you use `xsl:include` in your XSL files in *Camel 2.2 or older*, the default `javax.xml.transform.URIResolver` is used. Files will be resolved relative to the
 JVM starting folder.
 
-For example this include:
+For example the following include statement will look up the `staff_template.xsl` file starting from the folder where the application was started.
 
 [source,xml]
 ----
 <xsl:include href="staff_template.xsl"/>
 ----
-
-Will lookup the `staff_tempkalte.xsl` file from the starting folder
-where the application was started.
 
 *Camel 2.3 or newer*  +
- Now Camel provides its own implementation of `URIResolver` which allows
-Camel to load included files from the classpath and more intelligent
-than before.
+ For Camel 2.3 or newer, Camel provides its own implementation of `URIResolver`. This allows
+Camel to load included files from the classpath.
 
-For example this include:
+For example the include file in the following code will be located relative to the starting endpoint.
 
 [source,xml]
 ----
 <xsl:include href="staff_template.xsl"/>
 ----
 
-Will now be located relative from the starting endpoint, which for
-example could be:
-
-[source,java]
-----
-.to("xslt:org/apache/camel/component/xslt/staff_include_relative.xsl")
-----
-
-Which means Camel will locate the file in the *classpath* as
-`org/apache/camel/component/xslt/staff_template.xsl`. +
- This allows you to use xsl include and have xsl files located in the
-same folder such as we do in the example
-`org/apache/camel/component/xslt`.
-
-You can use the following two prefixes `classpath:` or `file:` to
-instruct Camel to look either in classpath or file system. If you omit
+This means that Camel will locate the file in the *classpath* as
+*org/apache/camel/component/xslt/staff_template.xsl* +
+ 
+You can use `classpath:` or `file:` to instruct Camel to look either in the classpath or file system. If you omit
 the prefix then Camel uses the prefix from the endpoint configuration.
-If that neither has one, then classpath is assumed.
+If no prefix is specified in the endpoint configuration, the default is `classpath:`.
 
-You can also refer back in the paths such as
+You can also refer backwards in the include paths. In the following example, the xsl file will be resolved  under `org/apache/camel/component`.
 
 [source,java]
 ----
     <xsl:include href="../staff_other_template.xsl"/>
 ----
 
-Which then will resolve the xsl file under `org/apache/camel/component`.
 
 === Using xsl:include and default prefix
 
-When using xsl:include such as:
+In *Camel 2.10.3 and older*, `classpath:` is used as the default prefix. +
+If you configure the starting resource to load using `file:` then all subsequent incudes will have to be prefixed with `file:`.
 
-[source,xml]
-----
-<xsl:include href="staff_template.xsl"/>
-----
+From *Camel 2.10.4*, Camel will use the prefix from the endpoint configuration as the default prefix.
 
-Then in Camel 2.10.3 and older, then Camel will use "classpath:" as the
-default prefix, and load the resource from the classpath. This works for
-most cases, but if you configure the starting resource to load from
-file,
-
-[source,java]
-----
-.to("xslt:file:etc/xslt/staff_include_relative.xsl")
-----
-
-.. then you would have to prefix all your includes with "file:" as well.
-
-[source,xml]
-----
-<xsl:include href="file:staff_template.xsl"/>
-----
-
-From Camel 2.10.4 onwards we have made this easier as Camel will use the
-prefix from the endpoint configuration as the default prefix. So from
-Camel 2.10.4 onwards you can do:
-
-[source,xml]
-----
-<xsl:include href="staff_template.xsl"/>
-----
-
-Which will load the staff_template.xsl resource from the file system, as
-the endpoint was configured with "file:" as prefix. +
- You can still though explicit configure a prefix, and then mix and
-match. And have both file and classpath loading. But that would be
-unusual, as most people either use file or classpath based resources.
+You can explicitly specify `file:` or `classpath:` loading. The two loading types can be mixed in a XSLT script, if necessary.
 
 === Using Saxon extension functions
 
@@ -322,7 +255,7 @@ context.addRoutes(new RouteBuilder() {
 ----
 
 
-And with Spring XML:
+With Spring XML:
 
 [source,xml]
 ----
@@ -346,14 +279,14 @@ to()] for more information.
 
 *Available as of Camel 2.9 (removed in 2.11.4, 2.12.3 and 2.13.0)* +
  Camel provides the `CamelXsltResourceUri` header which you can use to
-define a stylesheet to use instead of what is configured on the endpoint
+define an alternative stylesheet to that configured on the endpoint
 URI. This allows you to provide a dynamic stylesheet at runtime.
 
 === Accessing warnings, errors and fatalErrors from XSLT ErrorListener
 
 *Available as of Camel 2.14*
 
-From Camel 2.14 onwards, any warning/error or fatalError is stored on
+From *Camel 2.14*, any warning/error or fatalError is stored on
 the current Exchange as a property with the
 keys `Exchange.XSLT_ERROR`, `Exchange.XSLT_FATAL_ERROR`,
 or `Exchange.XSLT_WARNING` which allows end users to get hold of any
@@ -380,8 +313,6 @@ xsl:message.
 </xsl:template>
 ----
 
-This information is not available on the Exchange stored as an Exception
-that contains the message in the `getMessage()` method on the exception.
 The exception is stored on the Exchange as a warning with the
 key `Exchange.XSLT_WARNING.`
 


### PR DESCRIPTION
The contents have been given an overhaul. I have corrected grammar and clarified instructions. The original requirements were:


    broken link to Exchange in deleteOutputFile option
    these sentences should probably we reworked a bit:
        "Then in Camel 2.10.3 and older, then Camel will use "classpath:" as the default prefix, and load the resource from the classpath."
        "You can still though explicit configure a prefix, and then mix and match."

I have updated a fair bit more than that, though.
