### PR TITLE
Corrected an error in routing URIs

### DIFF
--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -251,7 +251,7 @@ To send messages to an exchange called C
 
 [source,java]
 -------------------------------
-...to("rabbitmq://localhost/B")
+...to("rabbitmq://localhost/C")
 -------------------------------
 
 Declaring a headers exchange and queue


### PR DESCRIPTION
Corrected an error in routing URIs of Samples Section. 
the URI in Samples should be C instead of B.