### PR TITLE
CAMEL-12016 : ChannelFuture is not clearly erased from the pool on connection error

### DIFF
--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyProducer.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/NettyProducer.java
@@ -642,6 +642,7 @@ public class NettyProducer extends DefaultAsyncProducer {
                 }
                 exchange.setException(cause);
                 callback.done(false);
+                releaseChannel(future);
                 return;
             }
 


### PR DESCRIPTION
* Since 2.17.4, ChannelFuture was never release when a connection error occurs.
https://issues.apache.org/jira/browse/CAMEL-12016