### PR TITLE
CAMEL-12014: Added support for redelivered tag for RabbitMQ

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConstants.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConstants.java
@@ -23,6 +23,7 @@ public final class RabbitMQConstants {
     public static final String CONTENT_TYPE = "rabbitmq.CONTENT_TYPE";
     public static final String PRIORITY = "rabbitmq.PRIORITY";
     public static final String DELIVERY_TAG = "rabbitmq.DELIVERY_TAG";
+    public static final String REDELIVERY_TAG = "rabbitmq.REDELIVERY_TAG";
     public static final String CORRELATIONID = "rabbitmq.CORRELATIONID";
     public static final String MESSAGE_ID = "rabbitmq.MESSAGE_ID";
     public static final String DELIVERY_MODE = "rabbitmq.DELIVERY_MODE";

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQMessageConverter.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQMessageConverter.java
@@ -247,6 +247,7 @@ public class RabbitMQMessageConverter {
             message.setHeader(RabbitMQConstants.ROUTING_KEY, envelope.getRoutingKey());
             message.setHeader(RabbitMQConstants.EXCHANGE_NAME, envelope.getExchange());
             message.setHeader(RabbitMQConstants.DELIVERY_TAG, envelope.getDeliveryTag());
+            message.setHeader(RabbitMQConstants.REDELIVERY_TAG, envelope.isRedelivery());
         }
     }
 

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQEndpointTest.java
@@ -19,10 +19,7 @@ package org.apache.camel.component.rabbitmq;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeoutException;
@@ -76,10 +73,12 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         String routingKey = UUID.randomUUID().toString();
         String exchangeName = UUID.randomUUID().toString();
         long tag = UUID.randomUUID().toString().hashCode();
+        Boolean redelivery = new Random().nextBoolean();
 
         Mockito.when(envelope.getRoutingKey()).thenReturn(routingKey);
         Mockito.when(envelope.getExchange()).thenReturn(exchangeName);
         Mockito.when(envelope.getDeliveryTag()).thenReturn(tag);
+        Mockito.when(envelope.isRedelivery()).thenReturn(redelivery);
         Mockito.when(properties.getHeaders()).thenReturn(null);
 
         byte[] body = new byte[20];
@@ -87,6 +86,7 @@ public class RabbitMQEndpointTest extends CamelTestSupport {
         assertEquals(exchangeName, exchange.getIn().getHeader(RabbitMQConstants.EXCHANGE_NAME));
         assertEquals(routingKey, exchange.getIn().getHeader(RabbitMQConstants.ROUTING_KEY));
         assertEquals(tag, exchange.getIn().getHeader(RabbitMQConstants.DELIVERY_TAG));
+        assertEquals(redelivery, exchange.getIn().getHeader(RabbitMQConstants.REDELIVERY_TAG));
         assertEquals(body, exchange.getIn().getBody());
     }
 


### PR DESCRIPTION
This fix sets REDELIVERY_TAG header on exchanges that were already delivered once by rabbitmq. https://www.rabbitmq.com/reliability.html