### PR TITLE
camel-blueprint-schemagen-fix

### DIFF
--- a/components/camel-blueprint/pom.xml
+++ b/components/camel-blueprint/pom.xml
@@ -316,7 +316,9 @@
     <profile>
       <id>enable-schemagen</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!disable-schemagen</name>
+        </property>
       </activation>
 
       <build>
@@ -326,34 +328,6 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.8</version>
             <inherited>true</inherited>
-            <dependencies>
-              <!-- need JAXB on the classpath to use the xjc SchemaGenTask -->
-              <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>${jaxb-version}</version>
-              </dependency>
-              <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb-version}</version>
-              </dependency>
-              <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-xjc</artifactId>
-                <version>${jaxb-version}</version>
-              </dependency>
-              <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb-version}</version>
-              </dependency>
-              <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
-              </dependency>
-            </dependencies>
             <executions>
               <execution>
                 <id>process-sources</id>
@@ -384,17 +358,6 @@
                         <include name="**/package-info.java"/>
                       </fileset>
                     </copy>
-
-                    <path id="source.files.list">
-                      <fileset dir="${project.build.directory}/schema-src">
-                        <include name="**/*.java"/>
-                      </fileset>
-                    </path>
-                    <property name="source.files.property" refid="source.files.list"/>
-                    <propertyregex property="schema.source.formatted" input="${source.files.property}" regexp=":"
-                                   replace=" " global="true"/>
-                    <property name="schema.source.files" value="${schema.source.formatted}"/>
-                    <echo>Schema files ${schema.source.files}</echo>
                   </target>
                   <exportAntProperties>true</exportAntProperties>
                 </configuration>
@@ -425,9 +388,9 @@
                 <configuration>
                   <target>
                     <echo>Copying XSD schema to be included in JAR</echo>
-                    <move file="${project.basedir}/schema1.xsd"
+                    <move file="${project.build.directory}/schema/schema1.xsd"
                           tofile="${project.build.directory}/schema/camel-blueprint.xsd"/>
-                    <delete file="${project.basedir}/schema2.xsd"/>
+                    <delete file="${project.build.directory}/schema/schema2.xsd"/>
                   </target>
                 </configuration>
                 <goals>
@@ -441,6 +404,9 @@
                 <configuration>
                   <target>
                     <echo>Copying XSD schema to be included in JAR</echo>
+                    <replace file="${project.build.directory}/schema/camel-blueprint.xsd"
+                             token="xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"
+                             value="xmlns=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"/>
                     <replace file="${project.build.directory}/schema/camel-blueprint.xsd"
                              token="http://camel.apache.org/schema/spring"
                              value="http://camel.apache.org/schema/blueprint"/>
@@ -459,21 +425,25 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
+		      <plugin>
             <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
+            <artifactId>jaxb2-maven-plugin</artifactId>
+            <version>2.3.1</version>
             <executions>
               <execution>
-                <id>generate schema</id>
+                <id>generate-schema</id>
                 <phase>generate-test-sources</phase>
                 <goals>
-                  <goal>exec</goal>
+                  <goal>schemagen</goal>
                 </goals>
               </execution>
             </executions>
             <configuration>
-              <executable>schemagen</executable>
-              <commandlineArgs>-cp %classpath ${schema.source.files}</commandlineArgs>
+              <outputDirectory>${project.build.directory}/schema</outputDirectory>
+              <sources>
+                <source>${project.build.directory}/schema-src</source>
+              </sources>
+              <createJavaDocAnnotations>false</createJavaDocAnnotations>
             </configuration>
           </plugin>
         </plugins>
@@ -540,6 +510,27 @@
         </property>
       </activation>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>jaxb2-maven-plugin</artifactId>
+              <version>2.3.1</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.glassfish.jaxb</groupId>
+                  <artifactId>jaxb-jxc-jdk9</artifactId>
+                  <version>2.3.0</version>
+                </dependency>
+                <dependency>
+                  <groupId>javax.activation</groupId>
+                  <artifactId>javax.activation-api</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
@@ -553,51 +544,6 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.8</version>
             <executions>
-              <execution>
-                <id>process-sources</id>
-                <phase>process-classes</phase>
-                <configuration>
-                  <target>
-                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath"/>
-                    <echo>Copying to code together for the XSD generation</echo>
-                    <mkdir dir="${project.build.directory}/schema-src"/>
-                    <mkdir dir="${project.build.directory}/schema"/>
-                    <copy todir="${project.build.directory}/schema-src">
-                      <fileset dir="${basedir}/src/main/java">
-                        <include name="org/apache/camel/blueprint/Camel*.java"/>
-                        <include name="org/apache/camel/blueprint/ErrorHandler*.java"/>
-                        <include name="org/apache/camel/blueprint/package-info.java"/>
-                        <include name="org/apache/camel/util/blueprint/**/*.java"/>
-                      </fileset>
-                      <fileset dir="${basedir}/../camel-core-xml/src/main/java">
-                        <include name="org/apache/camel/core/xml/*.java"/>
-                        <include name="org/apache/camel/core/xml/util/**/*.java"/>
-                      </fileset>
-                      <fileset dir="${basedir}/../../camel-core/src/main/java">
-                        <include name="org/apache/camel/model/**/*.java"/>
-                        <include name="org/apache/camel/ExchangePattern.java"/>
-                        <include name="org/apache/camel/LoggingLevel.java"/>
-                        <include name="org/apache/camel/ManagementStatisticsLevel.java"/>
-                        <include name="**/package-info.java"/>
-                      </fileset>
-                    </copy>
-                    <path id="source.files.list">
-                      <fileset dir="${project.build.directory}/schema-src">
-                        <include name="**/*.java"/>
-                      </fileset>
-                    </path>
-                    <property name="source.files.property" refid="source.files.list"/>
-                    <propertyregex property="schema.source.formatted" input="${source.files.property}" regexp=":"
-                                   replace=" " global="true"/>
-                    <property name="schema.source.files" value="${schema.source.formatted}"/>
-                    <echo>Schema files ${schema.source.files}</echo>
-                  </target>
-                  <exportAntProperties>true</exportAntProperties>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
               <execution>
                 <id>include-sources</id>
                 <phase>package</phase>
@@ -615,62 +561,7 @@
                   <goal>run</goal>
                 </goals>
               </execution>
-              <execution>
-                <id>copy-schema</id>
-                <phase>process-test-sources</phase>
-                <configuration>
-                  <target>
-                    <echo>Copying XSD schema to be included in JAR</echo>
-                    <move file="${project.basedir}/schema1.xsd"
-                          tofile="${project.build.directory}/schema/camel-blueprint.xsd"/>
-                    <delete file="${project.basedir}/schema2.xsd"/>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-              <!-- after the eip-documentation-enricher we need to copy some shchema files -->
-              <execution>
-                <id>include-schemas</id>
-                <phase>prepare-package</phase>
-                <configuration>
-                  <target>
-                    <echo>Copying XSD schema to be included in JAR</echo>
-                    <replace file="${project.build.directory}/schema/camel-blueprint.xsd"
-                             token="http://camel.apache.org/schema/spring"
-                             value="http://camel.apache.org/schema/blueprint"/>
-                    <copy todir="${project.build.directory}/classes">
-                      <fileset dir="${project.build.directory}/schema"/>
-                    </copy>
-                    <!-- copy modified schemas back again in classes so they are included in the JAR -->
-                    <copy todir="${project.build.directory}/classes">
-                      <fileset dir="${project.build.directory}/schema"/>
-                    </copy>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate schema</id>
-                <phase>generate-test-sources</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <executable>schemagen</executable>
-              <commandlineArgs>-cp %classpath ${schema.source.files}</commandlineArgs>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Switched to jaxb2-maven-plugin for camel-spring schemagen (similar to CAMEL-11942)

Also, due to the use of activeByDefault profile for schema generation, the build failed on jdk9 because the schema was never generated. So I applied a common pattern of using a property (named disable-schemagen) instead of activeByDefault, which can be used for disabling schema generation (probably intended for **on-hpjdk** and **on-ibmjdk** profiles). As a result, both jdk9 and jdk < 9 builds succeed. 

However, there is still an issue when disabling schema generation, because the camel-blueprint.xsd is required by **camel-eip-documentation-enricher-maven-plugin**, so in practice schema generation should never be disabled based on the existing build script.