### PR TITLE
CAMEL-12037 Idempotent repository cache initialization fix.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/idempotent/FileIdempotentRepository.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/idempotent/FileIdempotentRepository.java
@@ -334,8 +334,11 @@ public class FileIdempotentRepository extends ServiceSupport implements Idempote
     protected void doStart() throws Exception {
         ObjectHelper.notNull(fileStore, "fileStore", this);
 
-        // default use a 1st level cache
-        this.cache = LRUCacheFactory.newLRUCache(1000);
+        //CAMEL-12037
+        if (this.cache == null) {
+        	// default use a 1st level cache
+        	this.cache = LRUCacheFactory.newLRUCache(1000);
+        }
 
         // init store if not loaded before
         if (init.compareAndSet(false, true)) {


### PR DESCRIPTION
Also consider moving this initalization block to a default constructor.