### PR TITLE
FUSEDOC-2094 - update snippets links and grammar

### DIFF
--- a/components/camel-rss/src/main/docs/rss-component.adoc
+++ b/components/camel-rss/src/main/docs/rss-component.adoc
@@ -1,4 +1,4 @@
-== RSS Component
+ls== RSS Component
 
 *Available as of Camel version 2.0*
 
@@ -132,28 +132,39 @@ convert between String (as XML) and ROME RSS model objects.
 * marshal = from ROME `SyndFeed` to XML `String`
 * unmarshal = from XML `String` to ROME `SyndFeed`
 
-A route using this would look something like this:
+A route using the RSS dataformat will look like this:
+`from("rss:file:src/test/data/rss20.xml?splitEntries=false&consumer.delay=1000").marshal().rss().to("mock:marshal");`
 
-The purpose of this feature is to make it possible to use Camel's lovely
-built-in expressions for manipulating RSS messages. As shown below, an
-XPath expression can be used to filter the RSS message:
+The purpose of this feature is to make it possible to use Camel's built-in expressions for manipulating RSS messages. As shown below, an
+XPath expression can be used to filter the RSS message. In the following example, on ly entries with Camel in the title will get through the filter.
+
+  `from("rss:file:src/test/data/rss20.xml?splitEntries=true&consumer.delay=100").marshal().rss().filter().xpath("//item/title[contains(.,'Camel')]").to("mock:result");`
 
 
 TIP: *Query parameters*
 If the URL for the RSS feed uses query parameters, this component will
-understand them as well, for example if the feed uses `alt=rss`, then
-you can for example do 
+resolve them. For example if the feed uses `alt=rss`, then the following example will be resolved: 
 `from("rss:http://someserver.com/feeds/posts/default?alt=rss&splitEntries=false&consumer.delay=1000").to("bean:rss");`
 
 ### Filtering entries
 
-You can filter out entries quite easily using XPath, as shown in the
+You can filter out entries using XPath, as shown in the
 data format section above. You can also exploit Camel's
 link:bean-integration.html[Bean Integration] to implement your own
 conditions. For instance, a filter equivalent to the XPath example above
 would be:
 
+`from("rss:file:src/test/data/rss20.xml?splitEntries=true&consumer.delay=100").
+filter().method("myFilterBean", "titleContainsCamel").to("mock:result");`
+
 The custom bean for this would be:
+[source,java]
+----
+public static class FilterBean {
+       public boolean titleContainsCamel(@Body SyndFeed feed) {
+           SyndEntry firstEntry = (SyndEntry) feed.getEntries().get(0);
+return firstEntry.getTitle().contains("Camel");
+----
 
 ### See Also
 


### PR DESCRIPTION
I've updated some of the grammar here and there. 

The section called 'Using the JPA based idempotent repository' particularly needs to be looked at because:
- The instructions were not clear. The language was very strange and sometimes incomprehensible. I've rewritten it as best as I can but it needs a review.
- It seemed that assumptions were made about the level of prior knowledge as far as this subject goes. A straw poll of developers here shows that they know the concept, but not necessarily that terminology. 
- The examples were missing. Asciidoc doesn't seem to handle snippets at all.