### PR TITLE
CAMEL-11250: File name pattern and file predicate for poll enrich use.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/Exchange.java
+++ b/camel-core/src/main/java/org/apache/camel/Exchange.java
@@ -141,6 +141,8 @@ public interface Exchange {
     String FILE_LOCK_RANDOM_ACCESS_FILE = "CamelFileLockRandomAccessFile";
     String FILTER_MATCHED       = "CamelFilterMatched";
     String FILTER_NON_XML_CHARS = "CamelFilterNonXmlChars";
+    String FILE_NAME_PATTERN    = "CamelFileNamePattern";
+    String FILE_PREDICATE       = "CamelFilePredicate";
 
     String GROUPED_EXCHANGE = "CamelGroupedExchange";
     

--- a/camel-core/src/main/java/org/apache/camel/processor/PollEnricher.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/PollEnricher.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.processor;
 
+import java.util.function.Predicate;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.AsyncProcessor;
 import org.apache.camel.CamelContext;
@@ -26,6 +27,8 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.PollingConsumer;
+import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.component.file.GenericFileConsumer;
 import org.apache.camel.impl.BridgeExceptionHandlerToErrorHandler;
 import org.apache.camel.impl.ConsumerCache;
 import org.apache.camel.impl.DefaultConsumer;
@@ -217,6 +220,18 @@ public class PollEnricher extends ServiceSupport implements AsyncProcessor, IdAw
         Consumer delegate = consumer;
         if (consumer instanceof EventDrivenPollingConsumer) {
             delegate = ((EventDrivenPollingConsumer) consumer).getDelegateConsumer();
+
+            if (delegate instanceof GenericFileConsumer) {
+                String fileNamePattern = exchange.getIn().getHeader(Exchange.FILE_NAME_PATTERN, String.class);
+                if (fileNamePattern != null) {
+                    ((GenericFileConsumer) delegate).setFileNamePattern(fileNamePattern);
+                }
+
+                Predicate<GenericFile> fileNamePredicate = (Predicate<GenericFile>) exchange.getIn().getHeader(Exchange.FILE_PREDICATE);
+                if (fileNamePredicate != null) {
+                    ((GenericFileConsumer) delegate).setFileNamePredicate(fileNamePredicate);
+                }
+            }
         }
 
         // is the consumer bridging the error handler?

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileNamePatternTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileNamePatternTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+public class FileConsumePollEnrichFileNamePatternTest extends ContextTestSupport {
+
+    @Override
+    protected void setUp() throws Exception {
+        deleteDirectory("target/enrich");
+        deleteDirectory("target/enrichdata");
+        super.setUp();
+    }
+
+    public void testPollEnrichFileNameFilterOut() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.expectedBodiesReceived((Object) null);
+
+        template.sendBody("seda:start", "Start");
+        log.info("Sleeping for 1/4 sec before writing enrichdata file");
+        Thread.sleep(250);
+        template.sendBodyAndHeader("file://target/enrichdata", "Big file", Exchange.FILE_NAME, "BBB.dat");
+        log.info("... write done");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    public void testPollEnrichFileNameFilterIn() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.expectedBodiesReceived("Big file");
+
+        template.sendBody("seda:start", "Start");
+        log.info("Sleeping for 1/4 sec before writing enrichdata file");
+        Thread.sleep(250);
+        template.sendBodyAndHeader("file://target/enrichdata", "Big file", Exchange.FILE_NAME, "AAA.dat");
+        log.info("... write done");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("seda:start")
+                    .setHeader(Exchange.FILE_NAME_PATTERN, () -> "A{3}\\.dat")
+                    .pollEnrich("file://target/enrichdata?initialDelay=0&delay=10&move=.done", 1000)
+                    .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFilePredicateTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFilePredicateTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import java.util.function.Predicate;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+public class FileConsumePollEnrichFilePredicateTest extends ContextTestSupport {
+
+    @Override
+    protected void setUp() throws Exception {
+        deleteDirectory("target/enrich");
+        deleteDirectory("target/enrichdata");
+        super.setUp();
+    }
+
+    public void testPollEnrichFileReject() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.expectedBodiesReceived((Object) null);
+
+        template.sendBody("seda:start", "Start");
+        log.info("Sleeping for 1/4 sec before writing enrichdata file");
+        Thread.sleep(250);
+        template.sendBodyAndHeader("file://target/enrichdata", "O", Exchange.FILE_NAME, "AAA.dat");
+        log.info("... write done");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    public void testPollEnrichFileAccept() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        mock.expectedBodiesReceived("Hi Camel!");
+
+        template.sendBody("seda:start", "Start");
+        log.info("Sleeping for 1/4 sec before writing enrichdata file");
+        Thread.sleep(250);
+        template.sendBodyAndHeader("file://target/enrichdata", "Hi Camel!", Exchange.FILE_NAME, "AAA.dat");
+        log.info("... write done");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("seda:start")
+                    .setHeader(Exchange.FILE_PREDICATE, () -> (Predicate<GenericFile>) genericFile -> genericFile.getFileLength() > 4)
+                    .pollEnrich("file://target/enrichdata?initialDelay=0&delay=10&move=.done", 1000)
+                    .to("mock:result");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
I followed the proposed approach (in Jira) for providing exchange information to poll enrich, while using a static endpoint uri, in order to avoid starting a new thread for each exchange that triggers poll enrich to consume messages.

In addition to having a header with the file name pattern, which is used for querying the file that will be returned, an extra header is provided that is used with a predicate value, giving greater control for file filtering in poll enrich.

I would appreciate your review and feedback!