### PR TITLE
[CAMEL-11856] Use wrap protocol for odata-server-core until OLINGO-12…

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1607,14 +1607,14 @@
     <bundle dependency='true'>mvn:org.apache.camel/camel-olingo2-api/${project.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-olingo2/${project.version}</bundle>
   </feature>
-  <!-- TODO: https://issues.apache.org/jira/browse/CAMEL-11856
   <feature name='camel-olingo4' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature>http</feature>
     <bundle dependency='true'>mvn:org.apache.olingo/odata-commons-api/${olingo4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.olingo/odata-commons-core/${olingo4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.olingo/odata-server-api/${olingo4-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.olingo/odata-server-core/${olingo4-version}</bundle>
+    // TODO remove wrap protocol when https://issues.apache.org/jira/browse/OLINGO-1206 is resolved
+    <bundle dependency='true'>wrap:mvn:org.apache.olingo/odata-server-core/${olingo4-version}$overwrite=merge&amp;Export-Package=org.apache.olingo.server.core;version=${olingo4-version},org.apache.olingo.server.core.uri.parser;version=${olingo4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.olingo/odata-client-api/${olingo4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.olingo/odata-client-core/${olingo4-version}</bundle>
     <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
@@ -1635,7 +1635,7 @@
     <bundle dependency='true'>mvn:com.fasterxml/aalto-xml/0.9.10</bundle>
     <bundle dependency='true'>mvn:org.apache.camel/camel-olingo4-api/${project.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-olingo4/${project.version}</bundle>
-  </feature> -->
+  </feature>
   <feature name='camel-openshift' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>wrap:mvn:com.openshift/openshift-java-client/${openshift-java-client-version}</bundle>

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo4Test.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/CamelOlingo4Test.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 
-@Ignore("https://issues.apache.org/jira/browse/CAMEL-11856")
 @RunWith(PaxExam.class)
 public class CamelOlingo4Test extends BaseKarafTest {
 


### PR DESCRIPTION
…06 is resolved
https://issues.apache.org/jira/browse/CAMEL-11856

I've tested with karaf 4.1.3. I'll be pushing a camel-example soon. Thanks!
