### PR TITLE
CAMEL-12057 Fixed missing encoding of query params

### DIFF
--- a/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
+++ b/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
@@ -221,7 +222,7 @@ public final class Olingo2AppImpl implements Olingo2App {
 
         final UriInfoWithType uriInfo = parseUri(edm, resourcePath, queryParams);
 
-        execute(new HttpGet(createUri(resourcePath, queryParams)), getResourceContentType(uriInfo),
+        execute(new HttpGet(createUri(resourcePath, encodeQueryParams(queryParams))), getResourceContentType(uriInfo),
             endpointHttpHeaders, new AbstractFutureCallback<T>(responseHandler) {
 
                 @Override
@@ -242,7 +243,7 @@ public final class Olingo2AppImpl implements Olingo2App {
 
         final UriInfoWithType uriInfo = parseUri(edm, resourcePath, queryParams);
 
-        execute(new HttpGet(createUri(resourcePath, queryParams)), getResourceContentType(uriInfo),
+        execute(new HttpGet(createUri(resourcePath, encodeQueryParams(queryParams))), getResourceContentType(uriInfo),
             endpointHttpHeaders, new AbstractFutureCallback<InputStream>(responseHandler) {
 
                 @Override
@@ -253,6 +254,17 @@ public final class Olingo2AppImpl implements Olingo2App {
                 }
 
             });
+    }
+
+    private Map<String, String> encodeQueryParams(Map<String, String> queryParams) {
+        Map<String, String> encodedQueryParams = queryParams;
+        if (queryParams != null) {
+            encodedQueryParams = new HashMap<String, String>(queryParams.size());
+            for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+                encodedQueryParams.put(entry.getKey(), URLEncoder.encode(entry.getValue()));
+            }
+        }
+        return encodedQueryParams;
     }
 
     private ContentType getResourceContentType(UriInfoWithType uriInfo) {


### PR DESCRIPTION
Fixed problem with missing encoding of query parameters. 
Before it wasnt possible to call Odata endpoint with $filter parameters, f.e. 
```
https://myXXXXXX.crm.ondemand.com/sap/c4c/odata/v1/c4codata/ServiceRequestCollection/?$filter=ReporterEmail eq 'user@company.com'&$select=ID,Name
```