### PR TITLE
CAMEL-12056 Add NotifyBuilder.destroy() method

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/NotifyBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/NotifyBuilder.java
@@ -43,6 +43,7 @@ import org.apache.camel.support.EventNotifierSupport;
 import org.apache.camel.util.EndpointHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.ServiceHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,13 +67,13 @@ public class NotifyBuilder {
     private final EventNotifierSupport eventNotifier;
 
     // the predicates build with this builder
-    private final List<EventPredicateHolder> predicates = new ArrayList<EventPredicateHolder>();
+    private final List<EventPredicateHolder> predicates = new ArrayList<>();
 
     // latch to be used to signal predicates matches
     private CountDownLatch latch = new CountDownLatch(1);
 
     // the current state while building an event predicate where we use a stack and the operation
-    private final List<EventPredicate> stack = new ArrayList<EventPredicate>();
+    private final List<EventPredicate> stack = new ArrayList<>();
     private EventOperation operation;
     private boolean created;
     // keep state of how many wereSentTo we have added
@@ -251,7 +252,7 @@ public class NotifyBuilder {
      * @return the builder
      */
     public ExpressionClauseSupport<NotifyBuilder> filter() {
-        final ExpressionClauseSupport<NotifyBuilder> clause = new ExpressionClauseSupport<NotifyBuilder>(this);
+        final ExpressionClauseSupport<NotifyBuilder> clause = new ExpressionClauseSupport<>(this);
         stack.add(new EventPredicateSupport() {
 
             @Override
@@ -294,7 +295,7 @@ public class NotifyBuilder {
     public NotifyBuilder wereSentTo(final String endpointUri) {
         // insert in start of stack but after the previous wereSentTo
         stack.add(wereSentToIndex++, new EventPredicateSupport() {
-            private ConcurrentMap<String, String> sentTo = new ConcurrentHashMap<String, String>();
+            private ConcurrentMap<String, String> sentTo = new ConcurrentHashMap<>();
 
             @Override
             public boolean isAbstract() {
@@ -1053,7 +1054,7 @@ public class NotifyBuilder {
      * @see #whenExactBodiesDone(Object...)
      */
     public NotifyBuilder whenExactBodiesDone(Object... bodies) {
-        List<Object> bodyList = new ArrayList<Object>();
+        List<Object> bodyList = new ArrayList<>();
         bodyList.addAll(Arrays.asList(bodies));
         return doWhenBodies(bodyList, false, true);
     }
@@ -1278,7 +1279,7 @@ public class NotifyBuilder {
             sb.append(eventPredicateHolder.toString());
         }
         // a crude way of skipping the first invisible operation
-        return ObjectHelper.after(sb.toString(), "().");
+        return StringHelper.after(sb.toString(), "().");
     }
 
     private void doCreate(EventOperation newOperation) {
@@ -1418,7 +1419,7 @@ public class NotifyBuilder {
     }
 
     private enum EventOperation {
-        and, or, not;
+        and, or, not
     }
 
     private interface EventPredicate {
@@ -1543,7 +1544,7 @@ public class NotifyBuilder {
      */
     private final class CompoundEventPredicate implements EventPredicate {
 
-        private List<EventPredicate> predicates = new ArrayList<EventPredicate>();
+        private List<EventPredicate> predicates = new ArrayList<>();
 
         private CompoundEventPredicate(List<EventPredicate> predicates) {
             this.predicates.addAll(predicates);
@@ -1612,7 +1613,7 @@ public class NotifyBuilder {
         public boolean onExchangeSent(Exchange exchange, Endpoint endpoint, long timeTaken) {
             for (EventPredicate predicate : predicates) {
                 boolean answer = predicate.onExchangeSent(exchange, endpoint, timeTaken);
-                LOG.trace("onExchangeSent() {} {} -> {}", new Object[]{endpoint, predicate, answer});
+                LOG.trace("onExchangeSent() {} {} -> {}", endpoint, predicate, answer);
                 if (!answer) {
                     // break at first false
                     return false;

--- a/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderTest.java
@@ -36,6 +36,45 @@ public class NotifyBuilderTest extends ContextTestSupport {
         }
     }
 
+    public void testDestroyUnregistersBuilder() throws Exception {
+        // Given:
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        // When:
+        int withReg = context.getManagementStrategy().getEventNotifiers().size();
+        notify.destroy();
+        int afterDestroy = context.getManagementStrategy().getEventNotifiers().size();
+        // Then:
+        assertEquals(withReg - afterDestroy, 1);
+    }
+
+    public void testDestroyResetsBuilder() throws Exception {
+        // Given:
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        // When:
+        notify.destroy();
+        // Then:
+        try {
+            notify.matches();
+            fail("Should have thrown an exception");
+        } catch (IllegalStateException e) {
+            assertEquals("NotifyBuilder has not been created. Invoke the create() method before matching.", e.getMessage());
+        }
+    }
+
+    public void testDestroyedBuilderCannotBeRecreated() throws Exception {
+        // Given:
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        // When:
+        notify.destroy();
+        // Then:
+        try {
+            notify.create();
+            fail("Should have thrown an exception");
+        } catch (IllegalStateException e) {
+            assertEquals("A destroyed NotifyBuilder cannot be re-created.", e.getMessage());
+        }
+    }
+
     public void testDirectWhenExchangeDoneSimple() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context)
                 .from("direct:foo").whenDone(1)


### PR DESCRIPTION
+ Java 7 tidy up

Note I used the eventNotifier status in create() to determine "isDestroyed" rather than an explicit field. We could use the same to replace `created` and integrate both concepts together.. (I can amend PR if requested)