### PR TITLE
CAMEL-12059: Remove redundant null checks from instanceof checks

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/NotifyBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/NotifyBuilder.java
@@ -192,7 +192,7 @@ public class NotifyBuilder {
                 // and just continue to route that on the consumer side, which causes the EventNotifier not to
                 // emit events when the consumer received the exchange, as its already done. For example by
                 // ProducerTemplate which creates the UoW before producing messages.
-                if (exchange.getFromEndpoint() != null && exchange.getFromEndpoint() instanceof DirectEndpoint) {
+                if (exchange.getFromEndpoint() instanceof DirectEndpoint) {
                     return true;
                 }
                 return EndpointHelper.matchPattern(exchange.getFromRouteId(), "*");

--- a/camel-core/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
@@ -118,7 +118,7 @@ public abstract class AbstractBeanProcessor implements AsyncProcessor {
 
         // is the message proxied using a BeanInvocation?
         BeanInvocation beanInvoke = null;
-        if (in.getBody() != null && in.getBody() instanceof BeanInvocation) {
+        if (in.getBody() instanceof BeanInvocation) {
             // BeanInvocation would be stored directly as the message body
             // do not force any type conversion attempts as it would just be unnecessary and cost a bit performance
             // so a regular instanceof check is sufficient

--- a/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -262,7 +262,7 @@ public class MethodInfo {
 
             public boolean proceed(AsyncCallback callback) {
                 Object body = exchange.getIn().getBody();
-                if (body != null && body instanceof StreamCache) {
+                if (body instanceof StreamCache) {
                     // ensure the stream cache is reset before calling the method
                     ((StreamCache) body).reset();
                 }
@@ -682,7 +682,7 @@ public class MethodInfo {
             Object[] answer = new Object[expressions.length];
             for (int i = 0; i < expressions.length; i++) {
 
-                if (body != null && body instanceof StreamCache) {
+                if (body instanceof StreamCache) {
                     // need to reset stream cache for each expression as you may access the message body in multiple parameters
                     ((StreamCache) body).reset();
                 }

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
@@ -422,7 +422,7 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
                         // throw exception to handle the problem with retrieving the file
                         // then if the method return false or throws an exception is handled the same in here
                         // as in both cases an exception is being thrown
-                        if (cause != null && cause instanceof GenericFileOperationFailedException) {
+                        if (cause instanceof GenericFileOperationFailedException) {
                             throw cause;
                         } else {
                             throw new GenericFileOperationFailedException("Cannot retrieve file: " + file + " from: " + endpoint, cause);

--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -310,7 +310,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
 
         // expression support
         Expression expression = endpoint.getFileName();
-        if (value != null && value instanceof Expression) {
+        if (value instanceof Expression) {
             expression = (Expression) value;
         }
 

--- a/camel-core/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameExclusiveReadLockStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameExclusiveReadLockStrategy.java
@@ -76,7 +76,7 @@ public class GenericFileRenameExclusiveReadLockStrategy<T> implements GenericFil
             try {
                 exclusive = operations.renameFile(file.getAbsoluteFilePath(), newFile.getAbsoluteFilePath());
             } catch (GenericFileOperationFailedException ex) {
-                if (ex.getCause() != null && ex.getCause() instanceof FileNotFoundException) {
+                if (ex.getCause() instanceof FileNotFoundException) {
                     exclusive = false;
                 } else {
                     throw ex;

--- a/camel-core/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
@@ -214,11 +214,11 @@ public class RestApiEndpoint extends DefaultEndpoint {
         // the API then uses the api component (eg usually camel-swagger-java) to build the API
         if (getComponentName() != null) {
             Object comp = getCamelContext().getRegistry().lookupByName(getComponentName());
-            if (comp != null && comp instanceof RestApiConsumerFactory) {
+            if (comp instanceof RestApiConsumerFactory) {
                 factory = (RestApiConsumerFactory) comp;
             } else {
                 comp = getCamelContext().getComponent(getComponentName());
-                if (comp != null && comp instanceof RestApiConsumerFactory) {
+                if (comp instanceof RestApiConsumerFactory) {
                     factory = (RestApiConsumerFactory) comp;
                 }
             }
@@ -237,7 +237,7 @@ public class RestApiEndpoint extends DefaultEndpoint {
         if (factory == null) {
             for (String name : getCamelContext().getComponentNames()) {
                 Component comp = getCamelContext().getComponent(name);
-                if (comp != null && comp instanceof RestApiConsumerFactory) {
+                if (comp instanceof RestApiConsumerFactory) {
                     factory = (RestApiConsumerFactory) comp;
                     cname = name;
                     break;

--- a/camel-core/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
@@ -298,11 +298,11 @@ public class RestEndpoint extends DefaultEndpoint {
         String cname = getComponentName();
         if (cname != null) {
             Object comp = getCamelContext().getRegistry().lookupByName(getComponentName());
-            if (comp != null && comp instanceof RestProducerFactory) {
+            if (comp instanceof RestProducerFactory) {
                 factory = (RestProducerFactory) comp;
             } else {
                 comp = getCamelContext().getComponent(getComponentName());
-                if (comp != null && comp instanceof RestProducerFactory) {
+                if (comp instanceof RestProducerFactory) {
                     factory = (RestProducerFactory) comp;
                 }
             }
@@ -321,7 +321,7 @@ public class RestEndpoint extends DefaultEndpoint {
         if (factory == null) {
             for (String name : getCamelContext().getComponentNames()) {
                 Component comp = getCamelContext().getComponent(name);
-                if (comp != null && comp instanceof RestProducerFactory) {
+                if (comp instanceof RestProducerFactory) {
                     factory = (RestProducerFactory) comp;
                     cname = name;
                     break;
@@ -346,7 +346,7 @@ public class RestEndpoint extends DefaultEndpoint {
             String foundName = null;
             for (String name : DEFAULT_REST_PRODUCER_COMPONENTS) {
                 Object comp = getCamelContext().getComponent(name, true);
-                if (comp != null && comp instanceof RestProducerFactory) {
+                if (comp instanceof RestProducerFactory) {
                     if (found == null) {
                         found = (RestProducerFactory) comp;
                         foundName = name;
@@ -390,11 +390,11 @@ public class RestEndpoint extends DefaultEndpoint {
         String cname = null;
         if (getComponentName() != null) {
             Object comp = getCamelContext().getRegistry().lookupByName(getComponentName());
-            if (comp != null && comp instanceof RestConsumerFactory) {
+            if (comp instanceof RestConsumerFactory) {
                 factory = (RestConsumerFactory) comp;
             } else {
                 comp = getCamelContext().getComponent(getComponentName());
-                if (comp != null && comp instanceof RestConsumerFactory) {
+                if (comp instanceof RestConsumerFactory) {
                     factory = (RestConsumerFactory) comp;
                 }
             }
@@ -413,7 +413,7 @@ public class RestEndpoint extends DefaultEndpoint {
         if (factory == null) {
             for (String name : getCamelContext().getComponentNames()) {
                 Component comp = getCamelContext().getComponent(name);
-                if (comp != null && comp instanceof RestConsumerFactory) {
+                if (comp instanceof RestConsumerFactory) {
                     factory = (RestConsumerFactory) comp;
                     cname = name;
                     break;
@@ -436,7 +436,7 @@ public class RestEndpoint extends DefaultEndpoint {
             String foundName = null;
             for (String name : DEFAULT_REST_CONSUMER_COMPONENTS) {
                 Object comp = getCamelContext().getComponent(name, true);
-                if (comp != null && comp instanceof RestConsumerFactory) {
+                if (comp instanceof RestConsumerFactory) {
                     if (found == null) {
                         found = (RestConsumerFactory) comp;
                         foundName = name;

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -4461,7 +4461,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         DataFormat answer = dataFormatResolver.resolveDataFormat(name, this);
 
         // inject CamelContext if aware
-        if (answer != null && answer instanceof CamelContextAware) {
+        if (answer instanceof CamelContextAware) {
             ((CamelContextAware) answer).setCamelContext(this);
         }
 
@@ -4472,7 +4472,7 @@ public class DefaultCamelContext extends ServiceSupport implements ModelCamelCon
         DataFormat answer = dataFormatResolver.createDataFormat(name, this);
 
         // inject CamelContext if aware
-        if (answer != null && answer instanceof CamelContextAware) {
+        if (answer instanceof CamelContextAware) {
             ((CamelContextAware) answer).setCamelContext(this);
         }
 

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultExchange.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultExchange.java
@@ -317,7 +317,7 @@ public final class DefaultExchange implements Exchange {
     public Message getOut() {
         // lazy create
         if (out == null) {
-            out = (in != null && in instanceof MessageSupport)
+            out = (in instanceof MessageSupport)
                 ? ((MessageSupport)in).newInstance() : new DefaultMessage(getContext());
             configureMessage(out);
         }

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultProcessorFactory.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultProcessorFactory.java
@@ -45,7 +45,7 @@ public class DefaultProcessorFactory implements ProcessorFactory {
         try {
             if (finder != null) {
                 Object object = finder.newInstance(name);
-                if (object != null && object instanceof ProcessorFactory) {
+                if (object instanceof ProcessorFactory) {
                     ProcessorFactory pc = (ProcessorFactory) object;
                     return pc.createChildProcessor(routeContext, definition, mandatory);
                 }
@@ -64,7 +64,7 @@ public class DefaultProcessorFactory implements ProcessorFactory {
         try {
             if (finder != null) {
                 Object object = finder.newInstance(name);
-                if (object != null && object instanceof ProcessorFactory) {
+                if (object instanceof ProcessorFactory) {
                     ProcessorFactory pc = (ProcessorFactory) object;
                     return pc.createProcessor(routeContext, definition);
                 }

--- a/camel-core/src/main/java/org/apache/camel/impl/RouteService.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/RouteService.java
@@ -427,7 +427,7 @@ public class RouteService extends ChildServiceSupport {
             for (Service service : services) {
                 if (service instanceof Channel) {
                     Processor eh = ((Channel) service).getErrorHandler();
-                    if (eh != null && eh instanceof Service) {
+                    if (eh instanceof Service) {
                         extra.add((Service) eh);
                     }
                 }
@@ -447,7 +447,7 @@ public class RouteService extends ChildServiceSupport {
                 OnExceptionDefinition onExceptionDefinition = (OnExceptionDefinition) output;
                 if (onExceptionDefinition.isRouteScoped()) {
                     Processor errorHandler = onExceptionDefinition.getErrorHandler(route.getId());
-                    if (errorHandler != null && errorHandler instanceof Service) {
+                    if (errorHandler instanceof Service) {
                         services.add((Service) errorHandler);
                     }
                 }
@@ -455,7 +455,7 @@ public class RouteService extends ChildServiceSupport {
                 OnCompletionDefinition onCompletionDefinition = (OnCompletionDefinition) output;
                 if (onCompletionDefinition.isRouteScoped()) {
                     Processor onCompletionProcessor = onCompletionDefinition.getOnCompletion(route.getId());
-                    if (onCompletionProcessor != null && onCompletionProcessor instanceof Service) {
+                    if (onCompletionProcessor instanceof Service) {
                         services.add((Service) onCompletionProcessor);
                     }
                 }

--- a/camel-core/src/main/java/org/apache/camel/language/ref/RefLanguage.java
+++ b/camel-core/src/main/java/org/apache/camel/language/ref/RefLanguage.java
@@ -49,9 +49,9 @@ public class RefLanguage implements Language, IsSingleton {
                 Object lookup = exp.evaluate(exchange, Object.class);
 
                 // must favor expression over predicate
-                if (lookup != null && lookup instanceof Expression) {
+                if (lookup instanceof Expression) {
                     target = (Expression) lookup;
-                } else if (lookup != null && lookup instanceof Predicate) {
+                } else if (lookup instanceof Predicate) {
                     target = PredicateToExpressionAdapter.toExpression((Predicate) lookup);
                 }
 

--- a/camel-core/src/main/java/org/apache/camel/management/DefaultManagementLifecycleStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/management/DefaultManagementLifecycleStrategy.java
@@ -554,7 +554,7 @@ public class DefaultManagementLifecycleStrategy extends ServiceSupport implement
             answer = getManagementObjectStrategy().getManagedObjectForService(context, service);
         }
 
-        if (answer != null && answer instanceof ManagedService) {
+        if (answer instanceof ManagedService) {
             ManagedService ms = (ManagedService) answer;
             ms.setRoute(route);
             ms.init(getManagementStrategy());

--- a/camel-core/src/main/java/org/apache/camel/management/ManagedManagementStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/management/ManagedManagementStrategy.java
@@ -189,10 +189,10 @@ public class ManagedManagementStrategy extends DefaultManagementStrategy {
     private ObjectName getObjectName(Object managedObject, Object preferedName) throws Exception {
         ObjectName objectName;
 
-        if (preferedName != null && preferedName instanceof String) {
+        if (preferedName instanceof String) {
             String customName = (String) preferedName;
             objectName = getManagedObjectName(managedObject, customName, ObjectName.class);
-        } else if (preferedName != null && preferedName instanceof ObjectName) {
+        } else if (preferedName instanceof ObjectName) {
             objectName = (ObjectName) preferedName;
         } else {
             objectName = getManagedObjectName(managedObject, null, ObjectName.class);

--- a/camel-core/src/main/java/org/apache/camel/model/AggregateDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/AggregateDefinition.java
@@ -293,7 +293,7 @@ public class AggregateDefinition extends ProcessorDefinition<AggregateDefinition
 
     @Override
     public void configureChild(ProcessorDefinition<?> output) {
-        if (expression != null && expression instanceof ExpressionClause) {
+        if (expression instanceof ExpressionClause) {
             ExpressionClause<?> clause = (ExpressionClause<?>) expression;
             if (clause.getExpressionType() != null) {
                 // if using the Java DSL then the expression may have been set using the

--- a/camel-core/src/main/java/org/apache/camel/model/EnrichDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/EnrichDefinition.java
@@ -114,7 +114,7 @@ public class EnrichDefinition extends NoOutputExpressionNode {
             }
         }
 
-        if (strategy != null && strategy instanceof CamelContextAware) {
+        if (strategy instanceof CamelContextAware) {
             ((CamelContextAware) strategy).setCamelContext(routeContext.getCamelContext());
         }
 

--- a/camel-core/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
@@ -121,7 +121,7 @@ public class PollEnrichDefinition extends NoOutputExpressionNode {
             }
         }
 
-        if (strategy != null && strategy instanceof CamelContextAware) {
+        if (strategy instanceof CamelContextAware) {
             ((CamelContextAware) strategy).setCamelContext(routeContext.getCamelContext());
         }
 

--- a/camel-core/src/main/java/org/apache/camel/model/ProcessorDefinitionHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/model/ProcessorDefinitionHelper.java
@@ -696,7 +696,7 @@ public final class ProcessorDefinitionHelper {
                 if (Constants.PLACEHOLDER_QNAME.equals(key.getNamespaceURI())) {
                     String local = key.getLocalPart();
                     Object value = other.getOtherAttributes().get(key);
-                    if (value != null && value instanceof String) {
+                    if (value instanceof String) {
                         // enforce a properties component to be created if none existed
                         CamelContextHelper.lookupPropertiesComponent(camelContext, true);
 

--- a/camel-core/src/main/java/org/apache/camel/model/RestContextRefDefinitionHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RestContextRefDefinitionHelper.java
@@ -103,7 +103,7 @@ public final class RestContextRefDefinitionHelper {
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         Object clone = unmarshaller.unmarshal(bis);
 
-        if (clone != null && clone instanceof RestDefinition) {
+        if (clone instanceof RestDefinition) {
             RestDefinition def2 = (RestDefinition) clone;
 
             Iterator<VerbDefinition> verbit1 = def.getVerbs().iterator();

--- a/camel-core/src/main/java/org/apache/camel/model/RouteContextRefDefinitionHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RouteContextRefDefinitionHelper.java
@@ -100,7 +100,7 @@ public final class RouteContextRefDefinitionHelper {
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         Object clone = unmarshaller.unmarshal(bis);
 
-        if (clone != null && clone instanceof RouteDefinition) {
+        if (clone instanceof RouteDefinition) {
             RouteDefinition def2 = (RouteDefinition) clone;
 
             // need to clone the namespaces also as they are not JAXB marshalled (as they are transient)

--- a/camel-core/src/main/java/org/apache/camel/model/SplitDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/SplitDefinition.java
@@ -143,7 +143,7 @@ public class SplitDefinition extends ExpressionNode implements ExecutorServiceAw
             }
         }
 
-        if (strategy != null && strategy instanceof CamelContextAware) {
+        if (strategy instanceof CamelContextAware) {
             ((CamelContextAware) strategy).setCamelContext(routeContext.getCamelContext());
         }
 

--- a/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallExpressionConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallExpressionConfiguration.java
@@ -248,7 +248,7 @@ public class ServiceCallExpressionConfiguration extends IdentifiedType implement
 
                     parameters.replaceAll(
                         (k, v) -> {
-                            if (v != null && v instanceof String) {
+                            if (v instanceof String) {
                                 try {
                                     v = camelContext.resolvePropertyPlaceholders((String) v);
                                 } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceChooserConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceChooserConfiguration.java
@@ -164,7 +164,7 @@ public class ServiceCallServiceChooserConfiguration extends IdentifiedType imple
 
                 parameters.replaceAll(
                     (k, v) -> {
-                        if (v != null && v instanceof String) {
+                        if (v instanceof String) {
                             try {
                                 v = camelContext.resolvePropertyPlaceholders((String) v);
                             } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceDiscoveryConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceDiscoveryConfiguration.java
@@ -171,7 +171,7 @@ public class ServiceCallServiceDiscoveryConfiguration extends IdentifiedType imp
 
                 parameters.replaceAll(
                     (k, v) -> {
-                        if (v != null && v instanceof String) {
+                        if (v instanceof String) {
                             try {
                                 v = camelContext.resolvePropertyPlaceholders((String) v);
                             } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceFilterConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceFilterConfiguration.java
@@ -164,7 +164,7 @@ public class ServiceCallServiceFilterConfiguration extends IdentifiedType implem
 
                 parameters.replaceAll(
                     (k, v) -> {
-                        if (v != null && v instanceof String) {
+                        if (v instanceof String) {
                             try {
                                 v = camelContext.resolvePropertyPlaceholders((String) v);
                             } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceLoadBalancerConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/model/cloud/ServiceCallServiceLoadBalancerConfiguration.java
@@ -164,7 +164,7 @@ public class ServiceCallServiceLoadBalancerConfiguration extends IdentifiedType 
 
                 parameters.replaceAll(
                     (k, v) -> {
-                        if (v != null && v instanceof String) {
+                        if (v instanceof String) {
                             try {
                                 v = camelContext.resolvePropertyPlaceholders((String) v);
                             } catch (Exception e) {

--- a/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/CamelInternalProcessor.java
@@ -822,7 +822,7 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor {
             } else {
                 body = exchange.getIn().getBody();
             }
-            if (body != null && body instanceof StreamCache) {
+            if (body instanceof StreamCache) {
                 // reset so the cache is ready to be reused after processing
                 ((StreamCache) body).reset();
             }

--- a/camel-core/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -879,7 +879,7 @@ public class MulticastProcessor extends ServiceSupport implements AsyncProcessor
                           AsyncCallback callback, boolean doneSync, boolean forceExhaust) {
 
         // we are done so close the pairs iterator
-        if (pairs != null && pairs instanceof Closeable) {
+        if (pairs instanceof Closeable) {
             IOHelper.close((Closeable) pairs, "pairs", LOG);
         }
 

--- a/camel-core/src/main/java/org/apache/camel/processor/PollEnricher.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/PollEnricher.java
@@ -223,7 +223,7 @@ public class PollEnricher extends ServiceSupport implements AsyncProcessor, IdAw
         boolean bridgeErrorHandler = false;
         if (delegate instanceof DefaultConsumer) {
             ExceptionHandler handler = ((DefaultConsumer) delegate).getExceptionHandler();
-            if (handler != null && handler instanceof BridgeExceptionHandlerToErrorHandler) {
+            if (handler instanceof BridgeExceptionHandlerToErrorHandler) {
                 bridgeErrorHandler = true;
             }
         }

--- a/camel-core/src/main/java/org/apache/camel/processor/RedeliveryErrorHandler.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/RedeliveryErrorHandler.java
@@ -1460,7 +1460,7 @@ public abstract class RedeliveryErrorHandler extends ErrorHandlerSupport impleme
      */
     public int getPendingRedeliveryCount() {
         int answer = redeliverySleepCounter.get();
-        if (executorService != null && executorService instanceof ThreadPoolExecutor) {
+        if (executorService instanceof ThreadPoolExecutor) {
             answer += ((ThreadPoolExecutor) executorService).getQueue().size();
         }
 

--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyBeanAdapter.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyBeanAdapter.java
@@ -225,7 +225,7 @@ public final class AggregationStrategyBeanAdapter extends ServiceSupport impleme
         mi = bi.createMethodInfo();
 
         // in case the POJO is CamelContextAware
-        if (pojo != null && pojo instanceof CamelContextAware) {
+        if (pojo instanceof CamelContextAware) {
             ((CamelContextAware) pojo).setCamelContext(getCamelContext());
         }
 

--- a/camel-core/src/main/java/org/apache/camel/processor/interceptor/DefaultChannel.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/interceptor/DefaultChannel.java
@@ -218,7 +218,7 @@ public class DefaultChannel extends CamelInternalProcessor implements ModelChann
         // setup instrumentation processor for management (jmx)
         // this is later used in postInitChannel as we need to setup the error handler later as well
         InterceptStrategy managed = routeContext.getManagedInterceptStrategy();
-        if (managed != null && managed instanceof InstrumentationInterceptStrategy) {
+        if (managed instanceof InstrumentationInterceptStrategy) {
             InstrumentationInterceptStrategy iis = (InstrumentationInterceptStrategy) managed;
             instrumentationProcessor = new InstrumentationProcessor(targetOutputDef.getShortName(), target);
             iis.prepareProcessor(targetOutputDef, target, instrumentationProcessor);

--- a/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
@@ -708,7 +708,7 @@ public final class CamelContextHelper {
         if (answer == null) {
             // lookup what is stored under properties, as it may not be the Camel properties component
             Object found = camelContext.getRegistry().lookupByName("properties");
-            if (found != null && found instanceof PropertiesComponent) {
+            if (found instanceof PropertiesComponent) {
                 answer = (PropertiesComponent) found;
                 camelContext.addComponent("properties", answer);
             }

--- a/camel-core/src/main/java/org/apache/camel/util/MessageHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/MessageHelper.java
@@ -125,7 +125,7 @@ public final class MessageHelper {
             return;
         }
         Object body = message.getBody();
-        if (body != null && body instanceof StreamCache) {
+        if (body instanceof StreamCache) {
             ((StreamCache) body).reset();
         }
     }

--- a/camel-core/src/main/java/org/apache/camel/util/ServiceHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ServiceHelper.java
@@ -483,12 +483,12 @@ public final class ServiceHelper {
                         if (includeErrorHandler) {
                             // special for error handler as they are tied to the Channel
                             Processor errorHandler = ((Channel) child).getErrorHandler();
-                            if (errorHandler != null && errorHandler instanceof Service) {
+                            if (errorHandler instanceof Service) {
                                 services.add((Service) errorHandler);
                             }
                         }
                         Processor next = ((Channel) child).getNextProcessor();
-                        if (next != null && next instanceof Service) {
+                        if (next instanceof Service) {
                             services.add((Service) next);
                         }
                     }

--- a/camel-core/src/test/java/org/apache/camel/builder/ExpressionClauseTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/ExpressionClauseTest.java
@@ -83,7 +83,7 @@ public class ExpressionClauseTest extends ContextTestSupport {
     public final class Extractor {
         public String extractName(DataHandler body) {
             DataSource ds = (body != null) ? body.getDataSource() : null;
-            if (ds != null && ds instanceof FileDataSource) {
+            if (ds instanceof FileDataSource) {
                 return ((FileDataSource)ds).getName();
             }
             return null;

--- a/camel-core/src/test/java/org/apache/camel/util/CreateModelFromXmlTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/CreateModelFromXmlTest.java
@@ -107,7 +107,7 @@ public class CreateModelFromXmlTest extends ContextTestSupport {
 
                 NamespaceAware na = null;
                 Expression exp = ed.getExpressionValue();
-                if (exp != null && exp instanceof NamespaceAware) {
+                if (exp instanceof NamespaceAware) {
                     na = (NamespaceAware) exp;
                 } else if (ed instanceof NamespaceAware) {
                     na = (NamespaceAware) ed;

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/handler/CamelNamespaceHandler.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/handler/CamelNamespaceHandler.java
@@ -956,7 +956,7 @@ public class CamelNamespaceHandler implements NamespaceHandler {
         protected boolean isSingleton(Object bean, String beanName) {
             if (beanName != null) {
                 ComponentMetadata meta = blueprintContainer.getComponentMetadata(beanName);
-                if (meta != null && meta instanceof BeanMetadata) {
+                if (meta instanceof BeanMetadata) {
                     String scope = ((BeanMetadata) meta).getScope();
                     if (scope != null) {
                         return BeanMetadata.SCOPE_SINGLETON.equals(scope);

--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/transaction/JtaTransactionErrorHandlerBuilder.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/transaction/JtaTransactionErrorHandlerBuilder.java
@@ -99,14 +99,14 @@ public class JtaTransactionErrorHandlerBuilder extends DefaultErrorHandlerBuilde
             Map<String, TransactedPolicy> mapPolicy = routeContext.lookupByType(TransactedPolicy.class);
             if (mapPolicy != null && mapPolicy.size() == 1) {
                 TransactedPolicy policy = mapPolicy.values().iterator().next();
-                if (policy != null && policy instanceof JtaTransactionPolicy) {
+                if (policy instanceof JtaTransactionPolicy) {
                     transactionPolicy = (JtaTransactionPolicy) policy;
                 }
             }
 
             if (transactionPolicy == null) {
                 TransactedPolicy policy = routeContext.lookup(PROPAGATION_REQUIRED, TransactedPolicy.class);
-                if (policy != null && policy instanceof JtaTransactionPolicy) {
+                if (policy instanceof JtaTransactionPolicy) {
                     transactionPolicy = (JtaTransactionPolicy) policy;
                 }
             }

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/AsyncDockerProducer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/AsyncDockerProducer.java
@@ -243,9 +243,9 @@ public class AsyncDockerProducer extends DefaultAsyncProducer {
 
         BuildImageCmd buildImageCmd;
 
-        if (body != null && body instanceof InputStream) {
+        if (body instanceof InputStream) {
             buildImageCmd = client.buildImageCmd((InputStream)body);
-        } else if (body != null && body instanceof File) {
+        } else if (body instanceof File) {
             buildImageCmd = client.buildImageCmd((File)body);
         } else {
             throw new DockerException("Unable to location source Image");

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/EtcdWatchConsumer.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/EtcdWatchConsumer.java
@@ -65,7 +65,7 @@ public class EtcdWatchConsumer extends AbstractEtcdConsumer implements ResponseP
         Exchange exchange = null;
         Throwable throwable = promise.getException();
 
-        if (throwable != null && throwable instanceof EtcdException) {
+        if (throwable instanceof EtcdException) {
             EtcdException exception = (EtcdException) throwable;
             // Etcd only keeps the responses of the most recent 1000 events
             // across all etcd keys so if we wait for a cleared index, we

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/cloud/EtcdWatchServiceDiscovery.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/cloud/EtcdWatchServiceDiscovery.java
@@ -76,7 +76,7 @@ public class EtcdWatchServiceDiscovery
         }
 
         Throwable throwable = promise.getException();
-        if (throwable != null && throwable instanceof EtcdException) {
+        if (throwable instanceof EtcdException) {
             EtcdException exception = (EtcdException) throwable;
             if (EtcdHelper.isOutdatedIndexException(exception)) {
                 LOGGER.debug("Outdated index, key={}, cause={}", servicePath, exception.etcdCause);

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
@@ -300,7 +300,7 @@ public class EtcdRoutePolicy extends RoutePolicySupport implements ResponsePromi
         }
 
         Throwable throwable = promise.getException();
-        if (throwable != null && throwable instanceof EtcdException) {
+        if (throwable instanceof EtcdException) {
             EtcdException exception = (EtcdException) throwable;
             if (EtcdHelper.isOutdatedIndexException(exception)) {
                 LOGGER.debug("Outdated index, key={}, cause={}", servicePath, exception.etcdCause);

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecResultConverter.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecResultConverter.java
@@ -145,7 +145,7 @@ public final class ExecResultConverter {
      * Resets the stream, only if it's a ByteArrayInputStream.
      */
     private static void resetIfByteArrayInputStream(InputStream stream) {
-        if (stream != null && stream instanceof ByteArrayInputStream) {
+        if (stream instanceof ByteArrayInputStream) {
             try {
                 stream.reset();
             } catch (IOException ioe) {

--- a/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/data/FacebookMethodsTypeHelper.java
+++ b/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/data/FacebookMethodsTypeHelper.java
@@ -352,7 +352,7 @@ public final class FacebookMethodsTypeHelper {
         } catch (Throwable e) {
             // skip wrapper exception to simplify stack
             String msg;
-            if (e.getCause() != null && e.getCause() instanceof FacebookException) {
+            if (e.getCause() instanceof FacebookException) {
                 e = e.getCause();
                 msg = ((FacebookException)e).getErrorMessage();
             } else {

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
@@ -211,7 +211,7 @@ public class FtpConsumer extends RemoteFileConsumer<FTPFile> {
                     return true;
                 }
             }
-            if (cause != null && cause instanceof GenericFileOperationFailedException) {
+            if (cause instanceof GenericFileOperationFailedException) {
                 GenericFileOperationFailedException generic = ObjectHelper.getException(GenericFileOperationFailedException.class, cause);
                 //exchange is null and cause has the reason for failure to read directories
                 if (generic.getCode() == 550) {

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
@@ -209,7 +209,7 @@ public class HttpEndpoint extends HttpCommonEndpoint {
             // need to shutdown the ConnectionManager
             clientConnectionManager.shutdown();
         }
-        if (httpClient != null && httpClient instanceof Closeable) {
+        if (httpClient instanceof Closeable) {
             IOHelper.close((Closeable)httpClient);
         }
     }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
@@ -363,7 +363,7 @@ public class JmsProducer extends DefaultAsyncProducer {
 
                 // the reply to is a String, so we need to look up its Destination instance
                 // and if needed create the destination using the session if needed to
-                if (jmsReplyTo != null && jmsReplyTo instanceof String) {
+                if (jmsReplyTo instanceof String) {
                     String replyTo = (String) jmsReplyTo;
                     // we need to null it as we use the String to resolve it as a Destination instance
                     jmsReplyTo = resolveOrCreateDestination(replyTo, session);

--- a/components/camel-master/src/main/java/org/apache/camel/component/master/MasterConsumer.java
+++ b/components/camel-master/src/main/java/org/apache/camel/component/master/MasterConsumer.java
@@ -90,7 +90,7 @@ public class MasterConsumer extends DefaultConsumer {
 
     @Override
     protected void doResume() throws Exception {
-        if (delegatedConsumer != null && delegatedConsumer instanceof SuspendableService) {
+        if (delegatedConsumer instanceof SuspendableService) {
             ((SuspendableService)delegatedConsumer).resume();
         }
         super.doResume();
@@ -98,7 +98,7 @@ public class MasterConsumer extends DefaultConsumer {
 
     @Override
     protected void doSuspend() throws Exception {
-        if (delegatedConsumer != null && delegatedConsumer instanceof SuspendableService) {
+        if (delegatedConsumer instanceof SuspendableService) {
             ((SuspendableService)delegatedConsumer).suspend();
         }
         super.doSuspend();

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpClientProducer.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpClientProducer.java
@@ -139,7 +139,7 @@ public class MllpTcpClientProducer extends DefaultProducer {
             return;
         } catch (MllpException mllpEx) {
             Throwable mllpExCause = mllpEx.getCause();
-            if (mllpExCause != null && mllpExCause instanceof IOException) {
+            if (mllpExCause instanceof IOException) {
                 MllpSocketUtil.reset(socket, log, mllpEx.getMessage());
             }
             exchange.setException(mllpEx);

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -68,17 +68,17 @@ public class RabbitMQDeclareSupport {
     private void formatSpecialQueueArguments(Map<String, Object> queueArgs) {
         // some arguments must be in numeric values so we need to fix this
         Object queueLengthLimit = queueArgs.get(RabbitMQConstants.RABBITMQ_QUEUE_LENGTH_LIMIT_KEY);
-        if (queueLengthLimit != null && queueLengthLimit instanceof String) {
+        if (queueLengthLimit instanceof String) {
             queueArgs.put(RabbitMQConstants.RABBITMQ_QUEUE_LENGTH_LIMIT_KEY, Long.parseLong((String) queueLengthLimit));
         }
 
         Object queueMessageTtl = queueArgs.get(RabbitMQConstants.RABBITMQ_QUEUE_MESSAGE_TTL_KEY);
-        if (queueMessageTtl != null && queueMessageTtl instanceof String) {
+        if (queueMessageTtl instanceof String) {
             queueArgs.put(RabbitMQConstants.RABBITMQ_QUEUE_MESSAGE_TTL_KEY, Long.parseLong((String) queueMessageTtl));
         }
 
         Object queueExpiration = queueArgs.get(RabbitMQConstants.RABBITMQ_QUEUE_TTL_KEY);
-        if (queueExpiration != null && queueExpiration instanceof String) {
+        if (queueExpiration instanceof String) {
             queueArgs.put(RabbitMQConstants.RABBITMQ_QUEUE_TTL_KEY, Long.parseLong((String) queueExpiration));
         }
     }

--- a/components/camel-rmi/src/main/java/org/apache/camel/component/rmi/RmiConsumer.java
+++ b/components/camel-rmi/src/main/java/org/apache/camel/component/rmi/RmiConsumer.java
@@ -108,7 +108,7 @@ public class RmiConsumer extends DefaultConsumer implements InvocationHandler {
                     break;
                 }
             }
-            if (match != null && match instanceof Throwable) {
+            if (match instanceof Throwable) {
                 // we have a match
                 throw (Throwable) match;
             } else {

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerBuilder.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerBuilder.java
@@ -62,14 +62,14 @@ public class TransactionErrorHandlerBuilder extends DefaultErrorHandlerBuilder {
             Map<String, TransactedPolicy> mapPolicy = routeContext.lookupByType(TransactedPolicy.class);
             if (mapPolicy != null && mapPolicy.size() == 1) {
                 TransactedPolicy policy = mapPolicy.values().iterator().next();
-                if (policy != null && policy instanceof SpringTransactionPolicy) {
+                if (policy instanceof SpringTransactionPolicy) {
                     transactionTemplate = ((SpringTransactionPolicy) policy).getTransactionTemplate();
                 }
             }
 
             if (transactionTemplate == null) {
                 TransactedPolicy policy = routeContext.lookup(PROPAGATION_REQUIRED, TransactedPolicy.class);
-                if (policy != null && policy instanceof SpringTransactionPolicy) {
+                if (policy instanceof SpringTransactionPolicy) {
                     transactionTemplate = ((SpringTransactionPolicy) policy).getTransactionTemplate();
                 }
             }

--- a/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshHelper.java
+++ b/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshHelper.java
@@ -51,7 +51,7 @@ public final class SshHelper {
 
         String userName = configuration.getUsername();
         Object userNameHeaderObj = headers.get(SshConstants.USERNAME_HEADER);
-        if (userNameHeaderObj != null && userNameHeaderObj instanceof String) {
+        if (userNameHeaderObj instanceof String) {
             userName = (String) headers.get(SshConstants.USERNAME_HEADER);
         }
 
@@ -91,7 +91,7 @@ public final class SshHelper {
                 String password = configuration.getPassword();
 
                 Object passwordHeaderObj = headers.get(SshConstants.PASSWORD_HEADER);
-                if (passwordHeaderObj != null && passwordHeaderObj instanceof String) {
+                if (passwordHeaderObj instanceof String) {
                     password = (String) headers.get(SshConstants.PASSWORD_HEADER);
                 }
 

--- a/components/camel-test-blueprint/src/test/java/org/apache/camel/test/blueprint/ContextCreationTimeoutTest.java
+++ b/components/camel-test-blueprint/src/test/java/org/apache/camel/test/blueprint/ContextCreationTimeoutTest.java
@@ -88,8 +88,7 @@ public class ContextCreationTimeoutTest extends Assert {
             ts.getCamelContextCreationTimeout();
             fail();
         } catch (IllegalArgumentException e) {
-            assertTrue(e.getCause() != null
-                    && e.getCause() instanceof NumberFormatException);
+            assertTrue(e.getCause() instanceof NumberFormatException);
         }
     }
     

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
@@ -135,10 +135,10 @@ public class XmppBinding {
         Map<String, Object> answer = new HashMap<String, Object>();
 
         ExtensionElement jpe = stanza.getExtension(JivePropertiesExtension.NAMESPACE);
-        if (jpe != null && jpe instanceof JivePropertiesExtension) {
+        if (jpe instanceof JivePropertiesExtension) {
             extractHeadersFrom((JivePropertiesExtension)jpe, exchange, answer);
         }
-        if (jpe != null && jpe instanceof DefaultExtensionElement) {
+        if (jpe instanceof DefaultExtensionElement) {
             extractHeadersFrom((DefaultExtensionElement)jpe, exchange, answer);
         }
 

--- a/connectors/camel-connector-maven-plugin/src/main/java/org/apache/camel/maven/connector/ConnectorMojo.java
+++ b/connectors/camel-connector-maven-plugin/src/main/java/org/apache/camel/maven/connector/ConnectorMojo.java
@@ -621,9 +621,9 @@ public class ConnectorMojo extends AbstractJarMojo {
         Set<String> enums = null;
         // the enum can either be a List or String
         value = row.get("enum");
-        if (value != null && value instanceof List) {
+        if (value instanceof List) {
             enums = new LinkedHashSet<String>((List)value);
-        } else if (value != null && value instanceof String) {
+        } else if (value instanceof String) {
             String[] array = value.toString().split(",");
             enums = Arrays.stream(array).collect(Collectors.toSet());
         }

--- a/examples/camel-example-kafka/src/main/java/org/apache/camel/example/kafka/StringPartitioner.java
+++ b/examples/camel-example-kafka/src/main/java/org/apache/camel/example/kafka/StringPartitioner.java
@@ -35,7 +35,7 @@ public class StringPartitioner implements Partitioner {
     public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
         int partId = 0;
 
-        if (key != null && key instanceof String) {
+        if (key instanceof String) {
             String sKey = (String) key;
             int len = sKey.length();
 

--- a/tooling/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
+++ b/tooling/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
@@ -142,7 +142,7 @@ public final class CamelJavaParserHelper {
                         }
                     }
                 }
-                if (exp != null && exp instanceof ClassInstanceCreation) {
+                if (exp instanceof ClassInstanceCreation) {
                     ClassInstanceCreation cic = (ClassInstanceCreation) exp;
                     boolean isRouteBuilder = false;
                     if (cic.getType() instanceof SimpleType) {
@@ -477,7 +477,7 @@ public final class CamelJavaParserHelper {
                             }
                         }
                     }
-                    if (parent != null && parent instanceof MethodInvocation) {
+                    if (parent instanceof MethodInvocation) {
                         MethodInvocation emi = (MethodInvocation) parent;
                         String parentName = emi.getName().getIdentifier();
                         predicate = isSimplePredicate(parentName);

--- a/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -153,7 +153,7 @@ public class RouteCoverageMojo extends AbstractExecMojo {
                     String baseDir = ".";
                     JavaType out = Roaster.parse(file);
                     // we should only parse java classes (not interfaces and enums etc)
-                    if (out != null && out instanceof JavaClassSource) {
+                    if (out instanceof JavaClassSource) {
                         JavaClassSource clazz = (JavaClassSource) out;
                         List<CamelNodeDetails> result = RouteBuilderParser.parseRouteBuilderTree(clazz, baseDir, fqn, true);
                         routeTrees.addAll(result);

--- a/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
+++ b/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
@@ -258,7 +258,7 @@ public class ValidateMojo extends AbstractExecMojo {
                     String baseDir = ".";
                     JavaType out = Roaster.parse(file);
                     // we should only parse java classes (not interfaces and enums etc)
-                    if (out != null && out instanceof JavaClassSource) {
+                    if (out instanceof JavaClassSource) {
                         JavaClassSource clazz = (JavaClassSource) out;
                         RouteBuilderParser.parseRouteBuilderEndpoints(clazz, baseDir, fqn, fileEndpoints, unparsable, includeTest);
                         RouteBuilderParser.parseRouteBuilderSimpleExpressions(clazz, baseDir, fqn, fileSimpleExpressions);


### PR DESCRIPTION
If this PR is left open long enough it will get stale but I can easily discard and re-run the IntelliJ replacement that generated it