### PR TITLE
 Enable http2 for undertow component

### DIFF
--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -76,12 +76,13 @@ with the following path and query parameters:
 | *httpURI* | *Required* The url of the HTTP endpoint to use. |  | URI
 |===
 
-==== Query Parameters (17 parameters):
+==== Query Parameters (18 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored. | false | boolean
+| *http2Enabled* (consumer) | Specifies whether to enable HTTP2 for embedded undertow. By default http2Enabled is turned off. | false | boolean
 | *httpMethodRestrict* (consumer) | Used to only allow consuming if the HttpMethod matches such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
 | *matchOnUriPrefix* (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | Boolean
 | *optionsEnabled* (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
@@ -98,6 +99,7 @@ with the following path and query parameters:
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | *undertowHttpBinding* (advanced) | To use a custom UndertowHttpBinding to control the mapping between Camel message and undertow. |  | UndertowHttpBinding
 | *sslContextParameters* (security) | To configure security using SSLContextParameters |  | SSLContextParameters
+| *http2Enabled* (consumer) | Specifies whether to enable HTTP2 for embedded undertow. By default http2Enabled is turned off. | false | boolean 
 |===
 // endpoint options: END
 

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -99,7 +99,6 @@ with the following path and query parameters:
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | *undertowHttpBinding* (advanced) | To use a custom UndertowHttpBinding to control the mapping between Camel message and undertow. |  | UndertowHttpBinding
 | *sslContextParameters* (security) | To configure security using SSLContextParameters |  | SSLContextParameters
-| *http2Enabled* (consumer) | Specifies whether to enable HTTP2 for embedded undertow. By default http2Enabled is turned off. | false | boolean 
 |===
 // endpoint options: END
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHost.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHost.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.undertow;
 import java.net.URI;
 
 import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
 import io.undertow.server.HttpHandler;
 
 import org.apache.camel.component.undertow.handlers.CamelRootHandler;
@@ -37,6 +38,7 @@ public class DefaultUndertowHost implements UndertowHost {
     private CamelRootHandler rootHandler;
     private Undertow undertow;
     private String hostString;
+    private boolean http2Enabled;
 
     public DefaultUndertowHost(UndertowHostKey key) {
         this(key, null);
@@ -46,6 +48,13 @@ public class DefaultUndertowHost implements UndertowHost {
         this.key = key;
         this.options = options;
         rootHandler = new CamelRootHandler(new NotFoundHandler());
+    }
+    
+    public DefaultUndertowHost(UndertowHostKey key, UndertowHostOptions options, boolean http2Enabled) {
+        this.key = key;
+        this.options = options;
+        rootHandler = new CamelRootHandler(new NotFoundHandler());
+        this.http2Enabled = http2Enabled;
     }
 
     @Override
@@ -78,7 +87,8 @@ public class DefaultUndertowHost implements UndertowHost {
                 }
             }
 
-            undertow = builder.setHandler(rootHandler).build();
+            
+            undertow = builder.setServerOption(UndertowOptions.ENABLE_HTTP2, http2Enabled).setHandler(rootHandler).build();
             LOG.info("Starting Undertow server on {}://{}:{}", key.getSslContext() != null ? "https" : "http", key.getHost(), key.getPort());
 
             try {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
@@ -304,7 +304,7 @@ public class UndertowComponent extends DefaultComponent implements RestConsumerF
         UndertowHostKey key = new UndertowHostKey(uri.getHost(), uri.getPort(), consumer.getEndpoint().getSslContext());
         UndertowHost host = undertowRegistry.get(key);
         if (host == null) {
-            host = createUndertowHost(key);
+            host = createUndertowHost(key, consumer.getEndpoint().isHttp2Enabled());
             undertowRegistry.put(key, host);
         }
         host.validateEndpointURI(uri);
@@ -318,8 +318,8 @@ public class UndertowComponent extends DefaultComponent implements RestConsumerF
         host.unregisterHandler(consumer.getHttpHandlerRegistrationInfo());
     }
 
-    protected UndertowHost createUndertowHost(UndertowHostKey key) {
-        return new DefaultUndertowHost(key, hostOptions);
+    protected UndertowHost createUndertowHost(UndertowHostKey key, boolean http2Enabled) {
+        return new DefaultUndertowHost(key, hostOptions, http2Enabled);
     }
 
     public UndertowHttpBinding getUndertowHttpBinding() {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -87,6 +87,8 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private boolean optionsEnabled;
     @UriParam(label = "producer")
     private CookieHandler cookieHandler;
+    @UriParam(label = "consumer", defaultValue = "false", description = "Specifies whether to enable HTTP2 for embedded undertow. By default http2Enabled is turned off.")
+    private boolean http2Enabled;
 
     public UndertowEndpoint(String uri, UndertowComponent component) throws URISyntaxException {
         super(uri, component);
@@ -306,6 +308,14 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
      */
     public void setCookieHandler(CookieHandler cookieHandler) {
         this.cookieHandler = cookieHandler;
+    }
+    
+    public boolean isHttp2Enabled() {
+        return http2Enabled;
+    }
+
+    public void setHttp2Enabled(boolean http2Enabled) {
+        this.http2Enabled = http2Enabled;
     }
 
     @Override


### PR DESCRIPTION

Enable http2 protocol for undertow component. Added an option 'http2Enabled' for consumer, once true than should support http2. By default set to false.