### PR TITLE
CAMEL-12069: ActiveMQ/JMS component: transferExchange option does not…

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
@@ -518,7 +518,7 @@ public class JmsBinding {
         // special for transferExchange
         if (endpoint != null && endpoint.isTransferExchange()) {
             LOG.trace("Option transferExchange=true so we use JmsMessageType: Object");
-            Serializable holder = DefaultExchangeHolder.marshal(exchange, false, endpoint.isAllowSerializedHeaders());
+            Serializable holder = DefaultExchangeHolder.marshal(exchange, true, endpoint.isAllowSerializedHeaders());
             Message answer = session.createObjectMessage(holder);
             // ensure default delivery mode is used by default
             answer.setJMSDeliveryMode(Message.DEFAULT_DELIVERY_MODE);

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutTransferExchangeTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutTransferExchangeTest.java
@@ -67,6 +67,8 @@ public class JmsInOutTransferExchangeTest extends CamelTestSupport {
                 map.put("double", new Double(1.23));
 
                 exchange.getIn().setHeaders(map);
+
+                exchange.setProperty("PropertyName", "PropertyValue");
             }
         });
 
@@ -88,6 +90,7 @@ public class JmsInOutTransferExchangeTest extends CamelTestSupport {
         assertEquals((Long) 123L, exchange.getIn().getHeader("long", Long.class));
         assertEquals((Double) 1.23, exchange.getIn().getHeader("double", Double.class));
         assertEquals("hello", exchange.getIn().getHeader("string", String.class));
+        assertEquals("PropertyValue", exchange.getProperty("PropertyName"));
         
         Exchange resultExchange = result.getExchanges().get(0);
         assertTrue(resultExchange.getIn() instanceof JmsMessage);
@@ -103,6 +106,7 @@ public class JmsInOutTransferExchangeTest extends CamelTestSupport {
         assertEquals((Long) 123L, exchange.getIn().getHeader("long", Long.class));
         assertEquals((Double) 1.23, exchange.getIn().getHeader("double", Double.class));
         assertEquals("hello", exchange.getIn().getHeader("string", String.class));
+        assertEquals("PropertyValue", exchange.getProperty("PropertyName"));
     }
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTransferExchangeTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTransferExchangeTest.java
@@ -62,6 +62,7 @@ public class JmsTransferExchangeTest extends CamelTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
         mock.expectedHeaderReceived("foo", "cheese");
+        mock.expectedPropertyReceived("bar", 123);
 
         template.send("direct:start", new Processor() {
             public void process(Exchange exchange) throws Exception {


### PR DESCRIPTION
… transfer exchange properties anymore

TransferExchange now includes exchange properties again. This restores the previous behavior accidentally broken by 5dd59162e4ac9335e497934b8d662f598cb779d1.