### PR TITLE
CAMEL-12081: Cherry-pick commits which are updating saxon from 9.7 to 9.8

### DIFF
--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/terminate.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/terminate.xsl
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:template match="/">
     <html>

--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform.xsl
@@ -17,7 +17,7 @@
 -->
 <xsl:stylesheet
   xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
-  version='1.0'>
+  version='2.0'>
 
   <xsl:output method="xml" indent="yes" encoding="ISO-8859-1"/>
 

--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_dtd.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_dtd.xsl
@@ -17,7 +17,7 @@
 -->
 <xsl:stylesheet
   xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
-  version='1.0'>
+  version='2.0'>
 
   <xsl:output method="xml" indent="yes" encoding="ISO-8859-1"/>
 

--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_includes_data.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_includes_data.xsl
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<xsl:stylesheet xmlns:date="http://exslt.org/dates-and-times" version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet xmlns:date="http://exslt.org/dates-and-times" version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <date:months>
         <date:month length="31" abbr="Jan">January</date:month>
         <date:month length="28" abbr="Feb">February</date:month>

--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_text.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_text.xsl
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="1.1"
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"           
  xmlns:date="http://xml.apache.org/xalan/java/java.util.Date"
  xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime"

--- a/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_text_imported.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/component/xslt/transform_text_imported.xsl
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
  
  <xsl:import href="transform_text.xsl"/>

--- a/components/camel-saxon/src/test/resources/org/apache/camel/util/toolbox/aggregate-user-property.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/util/toolbox/aggregate-user-property.xsl
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <xsl:output method="xml" indent="no"/>
     <xsl:strip-space elements="*"/>

--- a/components/camel-saxon/src/test/resources/org/apache/camel/util/toolbox/aggregate.xsl
+++ b/components/camel-saxon/src/test/resources/org/apache/camel/util/toolbox/aggregate.xsl
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <xsl:output method="xml" indent="no"/>
     <xsl:strip-space elements="*"/>

--- a/components/camel-schematron/src/main/resources/iso-schematron-xslt2/ExtractSchFromXSD-2.xsl
+++ b/components/camel-schematron/src/main/resources/iso-schematron-xslt2/ExtractSchFromXSD-2.xsl
@@ -54,7 +54,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-<xsl:transform version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:transform version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
 xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xs="http://www.w3.org/2001/XMLSchema">
         <!-- Set the output to be XML with an XML declaration and use indentation -->
         <xsl:output method="xml" omit-xml-declaration="no" indent="yes" standalone="yes"/>

--- a/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_abstract_expand.xsl
+++ b/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_abstract_expand.xsl
@@ -93,7 +93,7 @@ VERSION INFORMATION
      * Original written for old namespace
      * http://www.topologi.com/resources/iso-pre-pro.xsl
 -->	
-<xslt:stylesheet version="1.0" xmlns:xslt="http://www.w3.org/1999/XSL/Transform" 
+<xslt:stylesheet version="2.0" xmlns:xslt="http://www.w3.org/1999/XSL/Transform" 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:iso="http://purl.oclc.org/dsdl/schematron"  
     xmlns:nvdl="http://purl.oclc.org/dsdl/nvdl"  

--- a/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_dsdl_include.xsl
+++ b/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_dsdl_include.xsl
@@ -126,7 +126,7 @@ THE SOFTWARE.
 	* RJ New
 -->
 
-<xslt:stylesheet version="1.0"
+<xslt:stylesheet version="2.0"
 	xmlns:xslt="http://www.w3.org/1999/XSL/Transform"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:iso="http://purl.oclc.org/dsdl/schematron"

--- a/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_svrl_for_xslt2.xsl
+++ b/components/camel-schematron/src/main/resources/iso-schematron-xslt2/iso_svrl_for_xslt2.xsl
@@ -163,7 +163,7 @@ THE SOFTWARE.
 -->
 
 <xsl:stylesheet
-   version="1.0"
+   version="2.0"
    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
    xmlns:axsl="http://www.w3.org/1999/XSL/TransformAlias"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -593,8 +593,8 @@
     <rxjava-version>1.3.4</rxjava-version>
     <rxjava2-version>2.1.7</rxjava2-version>
     <saaj-impl-version>1.3.2_2</saaj-impl-version>
-    <saxon-bundle-version>9.7.0-18_1</saxon-bundle-version>
-    <saxon-version>9.7.0-18</saxon-version>
+    <saxon-bundle-version>9.8.0-5_1</saxon-bundle-version>
+    <saxon-version>9.8.0-5</saxon-version>
     <scala-version>2.11.7</scala-version>
     <scala-maven-plugin-version>3.2.2</scala-maven-plugin-version>
     <scalatest-version>2.2.5</scalatest-version>
@@ -774,7 +774,7 @@
       org.mortbay.cometd.*;version="[6.1,7)",
       org.slf4j.*;version="[1.7,2)",
       net.sf.flatpack.*;version="[3.1.1,4)",
-      net.sf.saxon.*;version="[9.7.0,9.8)",
+      net.sf.saxon.*;version="[9.8.0,9.9)",
       freemarker.*;version="[2.3.15,3)",
       javax.persistence.*;version="[1.1,3)",
       org.apache.lucene.*;version="${lucene-version-range}",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -593,8 +593,8 @@
     <rxjava-version>1.3.4</rxjava-version>
     <rxjava2-version>2.1.7</rxjava2-version>
     <saaj-impl-version>1.3.2_2</saaj-impl-version>
-    <saxon-bundle-version>9.8.0-5_1</saxon-bundle-version>
-    <saxon-version>9.8.0-5</saxon-version>
+    <saxon-bundle-version>9.8.0-6_1</saxon-bundle-version>
+    <saxon-version>9.8.0-6</saxon-version>
     <scala-version>2.11.7</scala-version>
     <scala-maven-plugin-version>3.2.2</scala-maven-plugin-version>
     <scalatest-version>2.2.5</scalatest-version>

--- a/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
+++ b/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
@@ -179,7 +179,7 @@
       <dependency>
         <groupId>net.sf.saxon</groupId>
         <artifactId>Saxon-HE</artifactId>
-        <version>9.7.0-18</version>
+        <version>9.8.0-5</version>
       </dependency>
       <dependency>
         <groupId>ognl</groupId>


### PR DESCRIPTION
This issue is related to saxon and not related to camel-saxon component implementation.
I've checked provided test on top of the Camel 2.21.0-SNAPSHOT version and it's working correctly.
This PR is created to update saxon to the version 9.8.0-6 on top of the Camel 2.20.2.