### PR TITLE
Adds zipkin http transport and moves off deprecated collector

### DIFF
--- a/components/camel-zipkin/pom.xml
+++ b/components/camel-zipkin/pom.xml
@@ -48,13 +48,23 @@
       <artifactId>camel-core</artifactId>
     </dependency>
 
-    <!-- brave/zkpkin -->
+    <!-- brave/zipkin -->
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-core</artifactId>
       <version>${brave-zipkin-version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>${brave-zipkin-version}</version>
+    </dependency>
     <!-- to send to zipkin server -->
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
+      <version>${zipkin-reporter-version}</version>
+    </dependency>
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-spancollector-scribe</artifactId>

--- a/components/camel-zipkin/src/main/docs/zipkin.adoc
+++ b/components/camel-zipkin/src/main/docs/zipkin.adoc
@@ -29,11 +29,15 @@ endpoint uri's as service names.  +
 However, it's recommended to configure service mappings so you can use
 human-readable names instead of Camel endpoint uris in the names.
 
-Camel will auto-configure a ScribeSpanCollector if no spanCollector has been
-explicitly configured, or if the following SpanCollector hostname and port environment variables
-have been configured:
+Camel will auto-configure a span reporter one hasn't been explicitly configured,
+and if the hostname and port to a zipkin collector has been configured as environment variables
 
-* ZIPKIN_COLLECTOR_THRIFT_SERVICE_HOST - The hostname
+* ZIPKIN_COLLECTOR_HTTP_SERVICE_HOST - The http hostname
+* ZIPKIN_COLLECTOR_HTTP_SERVICE_PORT - The port number
+
+or
+
+* ZIPKIN_COLLECTOR_THRIFT_SERVICE_HOST - The Scribe (Thrift RPC) hostname
 * ZIPKIN_COLLECTOR_THRIFT_SERVICE_PORT - The port number
 
 This makes it easy to use camel-zipkin in container platforms where the
@@ -52,7 +56,7 @@ Options
 zipkin. The rate is expressed as a percentage (1.0f = 100%, 0.5f is 50%, 0.1f is
 10%).
 
-|spanCollector |  |*Mandatory:* The collector to use for sending zipkin span events to the
+|spanReporter |  |*Mandatory:* The reporter to use for sending zipkin span events to the
 zipkin server.
 
 |serviceName |  | To use a global service name that matches all Camel events
@@ -92,8 +96,10 @@ To enable camel-zipkin you need to configure first
 [source,java]
 --------------------------------------------------------------------------------------------------
 ZipkinTracer zipkin = new ZipkinTracer();
-// configure the scribe span collector with the hostname and port for the Zipkin Collector Server
-zipkin.setSpanCollector(new ScribeSpanCollector("192.168.90.100", 9410);
+// Configure a reporter, which controls how often spans are sent
+//   (the dependency is io.zipkin.reporter2:zipkin-sender-okhttp3)
+sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+zipkin.setSpanReporter(AsyncReporter.create(sender));
 // and then add zipkin to the CamelContext
 zipkin.init(camelContext);
 --------------------------------------------------------------------------------------------------
@@ -106,16 +112,22 @@ zipkin tracer beans. Camel will automatically discover and use them.
 
 [source,xml]
 ---------------------------------------------------------------------------------------------------------
-  <!-- configure the scribe span collector with the hostname and port for the Zipkin Collector Server -->
-  <bean id="scribe" class="com.github.kristofa.brave.scribe.ScribeSpanCollector">
-    <constructor-arg index="0" value="192.168.90.100"/>
-    <constructor-arg index="1" value="9410"/>
+  <!-- configure how to reporter spans to a Zipkin collector
+          (the dependency is io.zipkin.reporter2:zipkin-reporter-spring-beans) -->
+  <bean id="http" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
+    <property name="sender">
+      <bean id="sender" class="zipkin2.reporter.beans.OkHttpSenderFactoryBean">
+        <property name="endpoint" value="http://localhost:9411/api/v2/spans"/>
+      </bean>
+    </property>
+    <!-- wait up to half a second for any in-flight spans on close -->
+    <property name="closeTimeout" value="500"/>
   </bean>
 
   <!-- setup zipkin tracer -->
   <bean id="zipkinTracer" class="org.apache.camel.zipkin.ZipkinTracer">
     <property name="serviceName" value="dude"/>
-    <property name="spanCollector" ref="scribe"/>
+    <property name="spanReporter" ref="http"/>
   </bean>
 ---------------------------------------------------------------------------------------------------------
 

--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinLegacyReporterAdapter.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinLegacyReporterAdapter.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.zipkin;
+
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.internal.DefaultSpanCodec;
+import com.twitter.zipkin.gen.Span;
+import zipkin.internal.V2SpanConverter;
+import zipkin2.reporter.Reporter;
+
+final class ZipkinLegacyReporterAdapter implements SpanCollector, Reporter<zipkin2.Span> {
+
+  final SpanCollector delegate;
+
+  ZipkinLegacyReporterAdapter(SpanCollector delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void report(zipkin2.Span span) {
+    collect(DefaultSpanCodec.fromZipkin(V2SpanConverter.toSpan(span)));
+  }
+
+  @Override
+  public void collect(Span span) {
+    delegate.collect(span);
+  }
+
+  @Deprecated
+  @Override
+  public void addDefaultAnnotation(String key, String value) {
+    delegate.addDefaultAnnotation(key, value);
+  }
+}

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinABCRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinABCRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinABCRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -41,7 +46,7 @@ public class ZipkinABCRouteTest extends CamelTestSupport {
         zipkin.addServerServiceMapping("seda:a", "a");
         zipkin.addServerServiceMapping("seda:b", "b");
         zipkin.addServerServiceMapping("seda:c", "c");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinClientRecipientListRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinClientRecipientListRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinClientRecipientListRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -41,7 +46,7 @@ public class ZipkinClientRecipientListRouteTest extends CamelTestSupport {
         zipkin.addServerServiceMapping("seda:a", "a");
         zipkin.addServerServiceMapping("seda:b", "b");
         zipkin.addServerServiceMapping("seda:c", "c");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinMulticastRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinMulticastRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinMulticastRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -41,7 +46,7 @@ public class ZipkinMulticastRouteTest extends CamelTestSupport {
         zipkin.addServerServiceMapping("seda:a", "a");
         zipkin.addServerServiceMapping("seda:b", "b");
         zipkin.addServerServiceMapping("seda:c", "c");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinOneRouteFallbackTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinOneRouteFallbackTest.java
@@ -16,20 +16,14 @@
  */
 package org.apache.camel.zipkin;
 
-import java.util.concurrent.TimeUnit;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 import zipkin2.reporter.Reporter;
 
-public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
+public class ZipkinOneRouteFallbackTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
 
@@ -38,20 +32,14 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
     }
 
     @Override
-    protected boolean useJmx() {
-        return true;
-    }
-
-    protected MBeanServer getMBeanServer() {
-        return context.getManagementStrategy().getManagementAgent().getMBeanServer();
-    }
-
-    @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
 
         zipkin = new ZipkinTracer();
-        zipkin.setServiceName("dude");
+        // no service so should use fallback naming style
+        // we do not want to trace any direct endpoints
+        zipkin.addExcludePattern("direct:*");
+        zipkin.setIncludeMessageBody(true);
         setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
@@ -62,26 +50,8 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
 
     @Test
     public void testZipkinRoute() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        if (isPlatform("aix")) {
-            return;
-        }
-
-        MBeanServer mbeanServer = getMBeanServer();
-        ObjectName on = new ObjectName("org.apache.camel:context=camel-1,type=services,name=ZipkinTracer");
-        assertNotNull(on);
-        assertTrue(mbeanServer.isRegistered(on));
-
-        Float rate = (Float) mbeanServer.getAttribute(on, "Rate");
-        assertEquals("Should be 1.0f", 1.0f, rate.floatValue(), 0.1f);
-
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(5).create();
-
-        for (int i = 0; i < 5; i++) {
-            template.sendBody("seda:dude", "Hello World");
-        }
-
-        assertTrue(notify.matches(30, TimeUnit.SECONDS));
+        template.requestBody("direct:start", "Hello Goofy");
+        template.requestBody("direct:start", "Hello again Goofy");
     }
 
     @Override
@@ -89,9 +59,11 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("seda:dude").routeId("dude")
+                from("direct:start").to("seda:goofy");
+
+                from("seda:goofy").routeId("goofy")
                         .log("routing at ${routeId}")
-                        .delay(simple("${random(10,20)}"));
+                        .delay(simple("${random(1000,2000)}"));
             }
         };
     }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinRecipientListRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinRecipientListRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinRecipientListRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -41,7 +46,7 @@ public class ZipkinRecipientListRouteTest extends CamelTestSupport {
         zipkin.addServerServiceMapping("seda:a", "a");
         zipkin.addServerServiceMapping("seda:b", "b");
         zipkin.addServerServiceMapping("seda:c", "c");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinRouteConcurrentTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinRouteConcurrentTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinRouteConcurrentTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -36,7 +41,7 @@ public class ZipkinRouteConcurrentTest extends CamelTestSupport {
         zipkin = new ZipkinTracer();
         zipkin.addClientServiceMapping("seda:foo", "foo");
         zipkin.addServerServiceMapping("seda:bar", "bar");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinSimpleLogStreamsRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinSimpleLogStreamsRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinSimpleLogStreamsRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -36,7 +41,7 @@ public class ZipkinSimpleLogStreamsRouteTest extends CamelTestSupport {
         zipkin = new ZipkinTracer();
         zipkin.setServiceName("dude");
         zipkin.setIncludeMessageBodyStreams(true);
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinSimpleRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinSimpleRouteTest.java
@@ -24,10 +24,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinSimpleRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -35,7 +40,7 @@ public class ZipkinSimpleRouteTest extends CamelTestSupport {
 
         zipkin = new ZipkinTracer();
         zipkin.setServiceName("dude");
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinTwoRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinTwoRouteTest.java
@@ -21,10 +21,15 @@ import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 public class ZipkinTwoRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -38,7 +43,7 @@ public class ZipkinTwoRouteTest extends CamelTestSupport {
         zipkin.addServerServiceMapping("seda:dog", "dog");
         // capture message body as well
         zipkin.setIncludeMessageBody(true);
-        zipkin.setSpanCollector(new ZipkinLoggingSpanCollector());
+        setSpanReporter(zipkin);
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinABCRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinABCRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
+import org.apache.camel.zipkin.ZipkinABCRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinABCRouteHttp extends ZipkinABCRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinAutoConfigureHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinAutoConfigureHttp.java
@@ -14,45 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin;
-
-import java.util.concurrent.TimeUnit;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
+package org.apache.camel.zipkin.http;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinTracer;
 import org.junit.Test;
-import zipkin2.reporter.Reporter;
 
-public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
+/**
+ * Integration test requires running Zipkin running
+ *
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * java -jar zipkin.jar
+ * }</pre>
+ *
+ * <p>This test has to be run with environment variables set. For example:
+ * <pre>{@code
+ * ZIPKIN_COLLECTOR_HTTP_SERVICE_HOST=localhost
+ * ZIPKIN_COLLECTOR_HTTP_SERVICE_PORT=9411
+ * }</pre>
+ */
+public class ZipkinAutoConfigureHttp extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
-
-    protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanReporter(Reporter.NOOP);
-    }
-
-    @Override
-    protected boolean useJmx() {
-        return true;
-    }
-
-    protected MBeanServer getMBeanServer() {
-        return context.getManagementStrategy().getManagementAgent().getMBeanServer();
-    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
 
         zipkin = new ZipkinTracer();
-        zipkin.setServiceName("dude");
-        setSpanReporter(zipkin);
+        // we have one route as service
+        zipkin.addClientServiceMapping("seda:cat", "cat");
+        zipkin.addServerServiceMapping("seda:cat", "cat");
+        // should auto configure as we have not setup a span reporter
+        // NOTE: this won't work unless you have an auto-configuration file in src/test/resources
 
         // attaching ourself to CamelContext
         zipkin.init(context);
@@ -62,26 +61,7 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
 
     @Test
     public void testZipkinRoute() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        if (isPlatform("aix")) {
-            return;
-        }
-
-        MBeanServer mbeanServer = getMBeanServer();
-        ObjectName on = new ObjectName("org.apache.camel:context=camel-1,type=services,name=ZipkinTracer");
-        assertNotNull(on);
-        assertTrue(mbeanServer.isRegistered(on));
-
-        Float rate = (Float) mbeanServer.getAttribute(on, "Rate");
-        assertEquals("Should be 1.0f", 1.0f, rate.floatValue(), 0.1f);
-
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(5).create();
-
-        for (int i = 0; i < 5; i++) {
-            template.sendBody("seda:dude", "Hello World");
-        }
-
-        assertTrue(notify.matches(30, TimeUnit.SECONDS));
+        template.requestBody("direct:start", "Hello Cat");
     }
 
     @Override
@@ -89,9 +69,11 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("seda:dude").routeId("dude")
+                from("direct:start").to("seda:cat");
+
+                from("seda:cat").routeId("cat")
                         .log("routing at ${routeId}")
-                        .delay(simple("${random(10,20)}"));
+                        .delay(simple("${random(1000,2000)}"));
             }
         };
     }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinMulticastRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinMulticastRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
 import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinMulticastRouteHttp extends ZipkinMulticastRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinOneRouteFallbackHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinOneRouteFallbackHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
+import org.apache.camel.zipkin.ZipkinOneRouteFallbackTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinOneRouteFallbackHttp extends ZipkinOneRouteFallbackTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinOneRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinOneRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
+import org.apache.camel.zipkin.ZipkinOneRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinOneRouteHttp extends ZipkinOneRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinSimpleRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinSimpleRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
+import org.apache.camel.zipkin.ZipkinSimpleRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinSimpleRouteHttp extends ZipkinSimpleRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinTimerRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinTimerRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
+import org.apache.camel.zipkin.ZipkinTimerRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinTimerRouteHttp extends ZipkinTimerRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinTwoRouteHttp.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/http/ZipkinTwoRouteHttp.java
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.zipkin.scribe;
+package org.apache.camel.zipkin.http;
 
-import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.zipkin.ZipkinMulticastRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
+import org.apache.camel.zipkin.ZipkinTwoRouteTest;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /**
- * Integration test requires running Zipkin/Scribe running
+ * Integration test requires running Zipkin running
  *
  * <p>The easiest way to run is locally:
  * <pre>{@code
  * curl -sSL https://zipkin.io/quickstart.sh | bash -s
- * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * java -jar zipkin.jar
  * }</pre>
  */
-public class ZipkinMulticastRouteScribe extends ZipkinMulticastRouteTest {
+public class ZipkinTwoRouteHttp extends ZipkinTwoRouteTest {
     @Override protected void setSpanReporter(ZipkinTracer zipkin) {
-        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
+        zipkin.setSpanReporter(
+            AsyncReporter.create(URLConnectionSender.create("http://locahost:9411/api/v2/spans"))
+        );
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinABCRouteScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinABCRouteScribe.java
@@ -16,81 +16,21 @@
  */
 package org.apache.camel.zipkin.scribe;
 
-import java.util.concurrent.TimeUnit;
-
 import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinABCRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
-import org.junit.Test;
 
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
- *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  */
-public class ZipkinABCRouteScribe extends CamelTestSupport {
-
-    private String ip = "192.168.99.100";
-    private ZipkinTracer zipkin;
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-
-        zipkin = new ZipkinTracer();
-
-        zipkin.addClientServiceMapping("seda:a", "a");
-        zipkin.addClientServiceMapping("seda:b", "b");
-        zipkin.addClientServiceMapping("seda:c", "c");
-        zipkin.addServerServiceMapping("seda:a", "a");
-        zipkin.addServerServiceMapping("seda:b", "b");
-        zipkin.addServerServiceMapping("seda:c", "c");
-        zipkin.setSpanCollector(new ScribeSpanCollector(ip, 9410));
-
-        // attaching ourself to CamelContext
-        zipkin.init(context);
-
-        return context;
-    }
-
-    @Test
-    public void testZipkinRoute() throws Exception {
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
-
-        template.requestBody("direct:start", "Hello World");
-
-        assertTrue(notify.matches(30, TimeUnit.SECONDS));
-    }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                from("direct:start").to("seda:a").routeId("start");
-
-                from("seda:a").routeId("a")
-                    .log("routing at ${routeId}")
-                    .to("seda:b")
-                    .delay(2000)
-                    .to("seda:c")
-                    .log("End of routing");
-
-                from("seda:b").routeId("b")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(1000,2000)}"));
-
-                from("seda:c").routeId("c")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(0,100)}"));
-            }
-        };
+public class ZipkinABCRouteScribe extends ZipkinABCRouteTest {
+    @Override protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinAutoConfigureScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinAutoConfigureScribe.java
@@ -26,10 +26,17 @@ import org.junit.Test;
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>This test has to be run with environment variables set. For example:
+ * <pre>{@code
+ * ZIPKIN_COLLECTOR_THRIFT_SERVICE_HOST=localhost
+ * ZIPKIN_COLLECTOR_THRIFT_SERVICE_PORT=9410
+ * }</pre>
  */
 public class ZipkinAutoConfigureScribe extends CamelTestSupport {
 
@@ -43,7 +50,7 @@ public class ZipkinAutoConfigureScribe extends CamelTestSupport {
         // we have one route as service
         zipkin.addClientServiceMapping("seda:cat", "cat");
         zipkin.addServerServiceMapping("seda:cat", "cat");
-        // should auto configure as we have not setup a spanCollector
+        // should auto configure as we have not setup a span reporter
 
         // attaching ourself to CamelContext
         zipkin.init(context);

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinOneRouteScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinOneRouteScribe.java
@@ -17,58 +17,20 @@
 package org.apache.camel.zipkin.scribe;
 
 import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinOneRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
-import org.junit.Test;
 
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
- *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  */
-public class ZipkinOneRouteScribe extends CamelTestSupport {
-
-    private String ip = "192.168.99.100";
-    private ZipkinTracer zipkin;
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-
-        zipkin = new ZipkinTracer();
-        // we have one route as service
-        zipkin.addClientServiceMapping("seda:cat", "cat");
-        zipkin.addServerServiceMapping("seda:cat", "cat");
-        zipkin.setSpanCollector(new ScribeSpanCollector(ip, 9410));
-
-        // attaching ourself to CamelContext
-        zipkin.init(context);
-
-        return context;
-    }
-
-    @Test
-    public void testZipkinRoute() throws Exception {
-        template.requestBody("direct:start", "Hello Cat");
-    }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                from("direct:start").to("seda:cat");
-
-                from("seda:cat").routeId("cat")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(1000,2000)}"));
-            }
-        };
+public class ZipkinOneRouteScribe extends ZipkinOneRouteTest {
+    @Override protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinSimpleRouteScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinSimpleRouteScribe.java
@@ -17,60 +17,20 @@
 package org.apache.camel.zipkin.scribe;
 
 import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinSimpleRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
-import org.junit.Test;
 
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
- *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  */
-public class ZipkinSimpleRouteScribe extends CamelTestSupport {
-
-    private String ip = "192.168.99.100";
-    private ZipkinTracer zipkin;
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-
-        zipkin = new ZipkinTracer();
-        // we have one route as service
-        zipkin.addClientServiceMapping("seda:dude", "dude");
-        zipkin.addServerServiceMapping("seda:dude", "dude");
-        zipkin.setSpanCollector(new ScribeSpanCollector(ip, 9410));
-
-        // attaching ourself to CamelContext
-        zipkin.init(context);
-
-        return context;
-    }
-
-    @Test
-    public void testZipkinRoute() throws Exception {
-        for (int i = 0; i < 5; i++) {
-            template.requestBody("direct:start", "Hello World");
-        }
-    }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                from("direct:start").to("seda:dude");
-
-                from("seda:dude").routeId("dude")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(1000,2000)}"));
-            }
-        };
+public class ZipkinSimpleRouteScribe extends ZipkinSimpleRouteTest {
+    @Override protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinTimerRouteScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinTimerRouteScribe.java
@@ -16,67 +16,21 @@
  */
 package org.apache.camel.zipkin.scribe;
 
-import java.util.concurrent.TimeUnit;
-
 import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.CamelContext;
-import org.apache.camel.ExchangePattern;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinTimerRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
-import org.junit.Test;
 
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
- *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  */
-public class ZipkinTimerRouteScribe extends CamelTestSupport {
-
-    private String ip = "192.168.99.100";
-    private ZipkinTracer zipkin;
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-
-        zipkin = new ZipkinTracer();
-        // we have one route as service
-        zipkin.addClientServiceMapping("seda:timer", "timer");
-        zipkin.addServerServiceMapping("seda:timer", "timer");
-        zipkin.setSpanCollector(new ScribeSpanCollector(ip, 9410));
-
-        // attaching ourself to CamelContext
-        zipkin.init(context);
-
-        return context;
-    }
-
-    @Test
-    public void testZipkinRoute() throws Exception {
-        NotifyBuilder notify = new NotifyBuilder(context).from("seda:timer").whenDone(1).create();
-
-        template.sendBody("direct:start", "Hello Timer");
-
-        assertTrue(notify.matches(30, TimeUnit.SECONDS));
-    }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                from("direct:start").to(ExchangePattern.InOut, "seda:timer");
-
-                from("seda:timer").routeId("timer")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(1000,2000)}"));
-            }
-        };
+public class ZipkinTimerRouteScribe extends ZipkinTimerRouteTest {
+    @Override protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
     }
 }

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinTwoRouteScribe.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/scribe/ZipkinTwoRouteScribe.java
@@ -17,69 +17,20 @@
 package org.apache.camel.zipkin.scribe;
 
 import com.github.kristofa.brave.scribe.ScribeSpanCollector;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.zipkin.ZipkinTwoRouteTest;
 import org.apache.camel.zipkin.ZipkinTracer;
-import org.junit.Test;
 
 /**
  * Integration test requires running Zipkin/Scribe running
  *
- * The easiest way is to run using zipkin-docker: https://github.com/openzipkin/docker-zipkin
- *
- * Adjust the IP address to what IP docker-machines have assigned, you can use
- * <tt>docker-machines ls</tt>
+ * <p>The easiest way to run is locally:
+ * <pre>{@code
+ * curl -sSL https://zipkin.io/quickstart.sh | bash -s
+ * SCRIBE_ENABLED=true java -jar zipkin.jar
+ * }</pre>
  */
-public class ZipkinTwoRouteScribe extends CamelTestSupport {
-
-    private String ip = "192.168.99.100";
-    private ZipkinTracer zipkin;
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-
-        zipkin = new ZipkinTracer();
-        // we have 2 routes as services
-        zipkin.addClientServiceMapping("seda:cat", "cat");
-        zipkin.addServerServiceMapping("seda:cat", "cat");
-        zipkin.addClientServiceMapping("seda:dog", "dog");
-        zipkin.addServerServiceMapping("seda:dog", "dog");
-        // capture message body as well
-        zipkin.setIncludeMessageBody(true);
-        zipkin.setSpanCollector(new ScribeSpanCollector(ip, 9410));
-
-        // attaching ourself to CamelContext
-        zipkin.init(context);
-
-        return context;
-    }
-
-    @Test
-    public void testZipkinRoute() throws Exception {
-        template.requestBody("direct:start", "Camel say hello Cat");
-    }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                from("direct:start").to("seda:cat");
-
-                from("seda:cat").routeId("cat")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(1000,2000)}"))
-                        .setBody().constant("Cat says hello Dog")
-                        .to("seda:dog");
-
-                from("seda:dog").routeId("dog")
-                        .log("routing at ${routeId}")
-                        .delay(simple("${random(0,500)}"))
-                        .setBody().constant("Dog say hello Cat and Camel");
-            }
-        };
+public class ZipkinTwoRouteScribe extends ZipkinTwoRouteTest {
+    @Override protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanCollector(new ScribeSpanCollector("127.0.0.1", 9410));
     }
 }

--- a/examples/camel-example-zipkin/README.md
+++ b/examples/camel-example-zipkin/README.md
@@ -24,7 +24,7 @@ Client is configured in the `src/main/java/sample/camel/ClientApplication.java` 
 
 ### Build
 
-First, start Zipkin as described below in the [Zipkin web console]("Zipkin web console") section
+First, start Zipkin as described below in the [Installing Zipkin Server]("Installing Zipkin Server") section
 
 Then compile this example:
 
@@ -55,18 +55,18 @@ $ cd client
 $ mvn compile camel:run
 ```
 
-### Zipkin web console
+### Zipkin UI
 
-You should be able to visualize the traces and timings from this example using the Zipkin Web Console.
+You should be able to visualize the traces and timings from this example using the Zipkin UI.
 The services are named `service1` and `service2`.
 
 In the screen shot below we are showing a trace of a client calling service1 and service2.
 
-![Zipkin Web Console Trace Details](images/zipkin-web-console-1.png "Detail of a trace")
+![Zipkin UI Trace Details](images/zipkin-web-console-1.png "Detail of a trace")
 
 You can then click on each span and get annotated data from the Camel exchange and about the requests as shown:
 
-![Zipkin Web Console Span Details](images/zipkin-web-console-2.png "Detail of the span")
+![Zipkin UI Span Details](images/zipkin-web-console-2.png "Detail of the span")
 
 
 ### Installing Zipkin Server 
@@ -74,13 +74,13 @@ You can then click on each span and get annotated data from the Camel exchange a
 The quickest way to get Zipkin started is to fetch the [latest released server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar.
 
 ```bash
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 ```
 
 .. and then run it
 
 ```bash
-java -DSCRIBE_ENABLED=true -jar zipkin.jar
+java -jar zipkin.jar
 ```
 
 Finally, browse to http://localhost:9411 to find traces!

--- a/examples/camel-example-zipkin/client/src/main/java/sample/camel/ClientApplication.java
+++ b/examples/camel-example-zipkin/client/src/main/java/sample/camel/ClientApplication.java
@@ -28,8 +28,7 @@ public class ClientApplication {
     public void setupCamel(@Observes CamelContextStartingEvent event) {
         // create zipkin
         ZipkinTracer zipkin = new ZipkinTracer();
-        zipkin.setHostName("localhost");
-        zipkin.setPort(9410);
+        zipkin.setEndpoint("http://localhost:9411/api/v2/spans");
         zipkin.addClientServiceMapping("http://localhost:9090/service1", "service1");
         // capture 100% of all the events
         zipkin.setRate(1.0f);

--- a/examples/camel-example-zipkin/service1/src/main/resources/application.properties
+++ b/examples/camel-example-zipkin/service1/src/main/resources/application.properties
@@ -20,8 +20,7 @@ camel.springboot.name=Service1
 camel.springboot.main-run-controller=true
 
 # configure zipkin
-camel.zipkin.host-name=localhost
-camel.zipkin.port=9410
+camel.zipkin.endpoint=http://localhost:9411/api/v2/spans
 
 # the zipkin service name
 camel.zipkin.server-service-mappings.*=service1

--- a/examples/camel-example-zipkin/service2/src/main/java/sample/camel/Service2Route.java
+++ b/examples/camel-example-zipkin/service2/src/main/java/sample/camel/Service2Route.java
@@ -25,8 +25,7 @@ public class Service2Route extends RouteBuilder {
     public void configure() throws Exception {
         // create zipkin
         ZipkinTracer zipkin = new ZipkinTracer();
-        zipkin.setHostName("localhost");
-        zipkin.setPort(9410);
+        zipkin.setEndpoint("http://localhost:9411/api/v2/spans");
         // set the service name
         zipkin.setServiceName("service2");
         // capture 100% of all the events

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,7 +98,7 @@
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
     <box-java-sdk-version>2.8.2</box-java-sdk-version>
     <braintree-gateway-version>2.63.0</braintree-gateway-version>
-    <brave-zipkin-version>4.5.2</brave-zipkin-version>
+    <brave-zipkin-version>4.12.0</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>
     <c3p0-bundle-version>0.9.5.2_1</c3p0-bundle-version>
@@ -743,8 +743,8 @@
     <yammer-metrics-version>2.2.0</yammer-metrics-version>
     <zendesk-client-version>0.5.4</zendesk-client-version>
     <zipkin-libthrift-version>0.9.3</zipkin-libthrift-version>
-    <zipkin-reporter-version>1.0.1</zipkin-reporter-version>
-    <zipkin-version>1.29.1</zipkin-version>
+    <zipkin-reporter-version>2.2.1</zipkin-reporter-version>
+    <zipkin-version>2.4.1</zipkin-version>
     <zjsonpatch-version>0.3.0</zjsonpatch-version>
     <zookeeper-version>3.4.10</zookeeper-version>
     <zookeeper-guava-version>16.0</zookeeper-guava-version>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -2416,10 +2416,12 @@
   </feature>
   <feature name='camel-zipkin' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
+    <bundle dependency='true'>mvn:io.zipkin.brave/brave/${brave-zipkin-version}</bundle>
     <bundle dependency='true'>mvn:io.zipkin.brave/brave-core/${brave-zipkin-version}</bundle>
     <bundle dependency='true'>mvn:io.zipkin.brave/brave-spancollector-scribe/${brave-zipkin-version}</bundle>
     <bundle dependency='true'>mvn:io.zipkin.java/zipkin/${zipkin-version}</bundle>
-    <bundle dependency='true'>mvn:io.zipkin.reporter/zipkin-reporter/${zipkin-reporter-version}</bundle>
+    <bundle dependency='true'>mvn:io.zipkin.reporter2/zipkin-reporter/${zipkin-reporter-version}</bundle>
+    <bundle dependency='true'>mvn:io.zipkin.reporter2/zipkin-sender-urlconnection/${zipkin-reporter-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.thrift/libthrift/${zipkin-libthrift-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-zipkin/${project.version}</bundle>
   </feature>

--- a/platforms/spring-boot/components-starter/camel-zipkin-starter/src/main/java/org/apache/camel/zipkin/starter/ZipkinAutoConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-zipkin-starter/src/main/java/org/apache/camel/zipkin/starter/ZipkinAutoConfiguration.java
@@ -37,6 +37,7 @@ public class ZipkinAutoConfiguration {
                                      ZipkinConfigurationProperties config) {
 
         ZipkinTracer zipkin = new ZipkinTracer();
+        zipkin.setEndpoint(config.getEndpoint());
         zipkin.setHostName(config.getHostName());
         zipkin.setPort(config.getPort());
         zipkin.setRate(config.getRate());

--- a/platforms/spring-boot/components-starter/camel-zipkin-starter/src/main/java/org/apache/camel/zipkin/starter/ZipkinConfigurationProperties.java
+++ b/platforms/spring-boot/components-starter/camel-zipkin-starter/src/main/java/org/apache/camel/zipkin/starter/ZipkinConfigurationProperties.java
@@ -23,14 +23,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.zipkin")
 public class ZipkinConfigurationProperties {
+    /**
+     * Sets the POST URL for zipkin's <a href="http://zipkin.io/zipkin-api/#/">v2 api</a>, usually
+     * "http://zipkinhost:9411/api/v2/spans"
+     */
+    private String endpoint;
 
     /**
-     * Sets a hostname for the remote zipkin server to use.
+     * Sets the hostname if sending spans to a remote zipkin scribe (thrift RPC) collector.
      */
     private String hostName;
 
     /**
-     * Sets the port number for the remote zipkin server to use.
+     * Sets the port if sending spans to a remote zipkin scribe (thrift RPC) collector.
      */
     private int port;
 
@@ -79,6 +84,14 @@ public class ZipkinConfigurationProperties {
     private Map<String, String> serverServiceMappings;
 
     // Getters & setters
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
 
     public String getHostName() {
         return hostName;


### PR DESCRIPTION
This allows you to use zipkin's http endpoint, and any modern transport.
This is important as scribe is deprecated. Notably, this doesn't change
internal plumbing to use new Brave Tracer api, though that can be done
in a later change.