### PR TITLE
CAMEL-12111: Fix reconnect if broker is down on startup.  Also fix so…

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -295,16 +295,21 @@ class RabbitConsumer implements com.rabbitmq.client.Consumer {
         if (isChannelOpen()) {
             // The connection is good, so nothing to do
             return;
-        } else if (!isChannelOpen() && this.consumer.getEndpoint().getAutomaticRecoveryEnabled()) {
+        } else if (channel != null && !channel.isOpen() && isAutomaticRecoveryEnabled()) {
             // Still need to wait for channel to re-open
             throw new IOException("Waiting for channel to re-open.");
-        } else if (!this.consumer.getEndpoint().getAutomaticRecoveryEnabled()) {
+        } else if (channel == null || !isAutomaticRecoveryEnabled()) {
             log.info("Attempting to open a new rabbitMQ channel");
             Connection conn = consumer.getConnection();
             channel = openChannel(conn);
             // Register the channel to the tag
             start();
         }
+    }
+
+    private boolean isAutomaticRecoveryEnabled() {
+        return this.consumer.getEndpoint().getAutomaticRecoveryEnabled() != null
+            && this.consumer.getEndpoint().getAutomaticRecoveryEnabled();
     }
 
     private boolean isChannelOpen() {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -74,7 +74,7 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
         if (this.conn == null) {
             openConnection();
             return this.conn;
-        } else if (!this.conn.isOpen() && this.endpoint.getAutomaticRecoveryEnabled()) {
+        } else if (this.conn.isOpen() || (!this.conn.isOpen() && isAutomaticRecoveryEnabled())) {
             return this.conn;
         } else {
             log.debug("The existing connection is closed");
@@ -83,16 +83,24 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
         }
     }
 
-
+    private boolean isAutomaticRecoveryEnabled() {
+        return this.endpoint.getAutomaticRecoveryEnabled() != null
+            && this.endpoint.getAutomaticRecoveryEnabled();
+    }
     /**
-     * Add a consumer thread for given channel
+     * Create the consumers but don't start yet
      */
-    private void startConsumers() throws IOException {
-
+    private void createConsumers() throws IOException {
         // Create consumers but don't start yet
         for (int i = 0; i < endpoint.getConcurrentConsumers(); i++) {
             createConsumer();
         }
+    }
+
+    /**
+     * Start the consumers (already created)
+     */
+    private void startConsumers() {
 
         // Try starting consumers (which will fail if RabbitMQ can't connect)
         try {
@@ -160,6 +168,7 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
     protected void doStart() throws Exception {
         executor = endpoint.createExecutor();
         log.debug("Using executor {}", executor);
+        createConsumers();
         startConsumers();
     }
 
@@ -210,9 +219,6 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
                     log.info("Connection failed, will retry in " + connectionRetryInterval + "ms", e);
                     Thread.sleep(connectionRetryInterval);
                 }
-            }
-            if (!connectionFailed) {
-                startConsumers();
             }
             stop();
             return null;


### PR DESCRIPTION
… channels share connections again.  Also fix consumers getting started twice on reconnect at startup.  Also fix null pointers if automaticRecoveryEnabled is not set on the endpoint.