### PR TITLE
CAMEL-12129: fix broken integration test from CAMEL-12111

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -161,7 +161,8 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
 
     @Override
     protected void doResume() throws Exception {
-        reconnect();
+        createConsumers();
+        startConsumers();
     }
 
     @Override


### PR DESCRIPTION
Suspend calls closeConnectionAndChannel() which calls this.consumers.clear(); thus leaving no consumers to reconnect on resume.  This used to work because the reconnect was creating consumers a second time with the startConsumers() call in StartConsumerCallable.call() but that was creating twice the required number of consumers in other normal use cases.  In this case because clear is called we need to create those consumers again on resume hence the code changes here.  All integration tests passing now.