### PR TITLE
Camel-12130: camel-braintree - upgrade Braintree SDK to v2.74.0

### DIFF
--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -198,6 +198,13 @@
                     <substitution>
                       <method>^.+$</method>
                       <argName>^.+$</argName>
+                      <argType>com.braintreegateway.TransactionRefundRequest</argType>
+                      <replacement>refundRequest</replacement>
+                      <replaceWithType>false</replaceWithType>
+                    </substitution>
+                    <substitution>
+                      <method>^.+$</method>
+                      <argName>^.+$</argName>
                       <argType>com.braintreegateway.TransactionCloneRequest</argType>
                       <replacement>cloneRequest</replacement>
                       <replaceWithType>false</replaceWithType>

--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -151,6 +151,22 @@
                   <apiName>merchantAccount</apiName>
                   <proxyClass>com.braintreegateway.MerchantAccountGateway</proxyClass>
                   <fromJavadoc/>
+                  <substitutions>
+                    <substitution>
+                      <method>^.+$</method>
+                      <argName>^.+$</argName>
+                      <argType>com.braintreegateway.MerchantAccountRequest</argType>
+                      <replacement>request</replacement>
+                      <replaceWithType>false</replaceWithType>
+                    </substitution>
+                    <substitution>
+                      <method>^.+$</method>
+                      <argName>^.+$</argName>
+                      <argType>com.braintreegateway.MerchantAccountCreateForCurrencyRequest</argType>
+                      <replacement>currencyRequest</replacement>
+                      <replaceWithType>false</replaceWithType>
+                    </substitution>
+                  </substitutions>
                 </api>
                 <api>
                   <apiName>paymentMethod</apiName>
@@ -158,6 +174,22 @@
                   <fromJavadoc>
                     <excludeMethods>.*parse.*</excludeMethods>
                   </fromJavadoc>
+                  <substitutions>
+                    <substitution>
+                      <method>^.+$</method>
+                      <argName>^.+$</argName>
+                      <argType>com.braintreegateway.PaymentMethodRequest</argType>
+                      <replacement>request</replacement>
+                      <replaceWithType>false</replaceWithType>
+                    </substitution>
+                    <substitution>
+                      <method>^.+$</method>
+                      <argName>^.+$</argName>
+                      <argType>com.braintreegateway.PaymentMethodDeleteRequest</argType>
+                      <replacement>deleteRequest</replacement>
+                      <replaceWithType>false</replaceWithType>
+                    </substitution>
+                  </substitutions>
                 </api>
                 <api>
                   <apiName>paymentMethodNonce</apiName>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,7 +97,7 @@
     <bouncycastle-version>1.57</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
     <box-java-sdk-version>2.8.2</box-java-sdk-version>
-    <braintree-gateway-version>2.64.0</braintree-gateway-version>
+    <braintree-gateway-version>2.74.0</braintree-gateway-version>
     <brave-zipkin-version>4.13.1</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,7 +97,7 @@
     <bouncycastle-version>1.57</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
     <box-java-sdk-version>2.8.2</box-java-sdk-version>
-    <braintree-gateway-version>2.63.0</braintree-gateway-version>
+    <braintree-gateway-version>2.64.0</braintree-gateway-version>
     <brave-zipkin-version>4.13.1</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>


### PR DESCRIPTION
Minimal changes required to be able to upgrade braintree SDK