### PR TITLE
CAMEL-12185 - Camel-MongoDB : add option outputType for aggregate operation

### DIFF
--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -86,7 +86,7 @@ with the following path and query parameters:
 | *createCollection* (common) | Create collection during initialisation if it doesn't exist. Default is true. | true | boolean
 | *database* (common) | Sets the name of the MongoDB database to target |  | String
 | *operation* (common) | Sets the operation this endpoint will execute against MongoDB. For possible values see MongoDbOperation. |  | MongoDbOperation
-| *outputType* (common) | Convert the output of the producer to the selected type : DBObjectList DBObject or DBCursor. DBObjectList or DBObject applies to findAll. DBCursor applies to all other operations. |  | MongoDbOutputType
+| *outputType* (common) | Convert the output of the producer to the selected type : DBObjectList DBObject or DBCursor. DBObjectList or DBCursor applies to findAll and aggregate. DBObject applies to all other operations. |  | MongoDbOutputType
 | *writeConcern* (common) | Set the WriteConcern for write operations on MongoDB using the standard ones. Resolved from the fields of the WriteConcern class by calling the link WriteConcernvalueOf(String) method. | ACKNOWLEDGED | WriteConcern
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
@@ -253,6 +253,23 @@ send a request to close the cursor server-side. The batch size can be
 changed even after a cursor is iterated, in which case the setting will
 apply on the next batch retrieval. |int/Integer
 |=======================================================================
+
+You can also "stream" the documents returned from the server into your route by including outputType=DBCursor (Camel 2.16+) as an endpoint option
+which may prove simpler than setting the above headers. This hands your Exchange the DBCursor from the Mongo driver, just as if you were executing
+the findAll() within the Mongo shell, allowing your route to iterate over the results. By default and without this option, this component will load
+the documents from the driver's cursor into a List and return this to your route - which may result in a large number of in-memory objects. Remember,
+with a DBCursor do not ask for the number of documents matched - see the MongoDB documentation site for details.
+
+Example with option outputType=DBCursor and batch size :
+
+[source,java]
+-----------------------------------------------------------------------------
+from("direct:findAll")
+    .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
+    .setBody().constant("{ \"name\": \"Raul Kripalani\" }")
+    .to("mongodb:myDb?database=flights&collection=tickets&operation=findAll&outputType=DBCursor")
+    .to("mock:resultFindAll");
+-----------------------------------------------------------------------------
 
 The `findAll` operation will also return the following OUT headers to
 enable you to iterate through result pages if you are using paging:
@@ -519,6 +536,34 @@ from("direct:aggregate")
     .to("mongodb:myDb?database=science&collection=notableScientists&operation=aggregate")
     .to("mock:resultAggregate");
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Efficient retrieval is supported via outputType=DBCursor and the following header :
+
+[width="100%",cols="10%,10%,10%,70%",options="header",]
+|=======================================================================
+|Header key |Quick constant |Description (extracted from MongoDB API doc) |Expected type
+
+|`CamelMongoDbBatchSize` |`MongoDbConstants.BATCH_SIZE` | Sets the number of documents to return per batch. |int/Integer
+|=======================================================================
+
+You can also "stream" the documents returned from the server into your route by including outputType=DBCursor (Camel 2.21+) as an endpoint option
+which may prove simpler than setting the above headers. This hands your Exchange the DBCursor from the Mongo driver, just as if you were executing
+the aggregate() within the Mongo shell, allowing your route to iterate over the results. By default and without this option, this component will load
+the documents from the driver's cursor into a List and return this to your route - which may result in a large number of in-memory objects. Remember,
+with a DBCursor do not ask for the number of documents matched - see the MongoDB documentation site for details.
+
+Example with option outputType=DBCursor and batch size:
+
+[source,java]
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// route: from("direct:aggregate").to("mongodb:myDb?database=science&collection=notableScientists&operation=aggregate");
+from("direct:aggregate")
+    .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
+    .setBody().constant("[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}},{ $group: { _id: \"$scientist\", count: { $sum: 1 }} } ]")
+    .to("mongodb:myDb?database=science&collection=notableScientists&operation=aggregate&outputType=DBCursor")
+    .to("mock:resultAggregate");
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 
 #### getDbStats
 

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbAggregateOperationTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbAggregateOperationTest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mongodb;
+
+import java.util.List;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.client.MongoIterable;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+
+public class MongoDbAggregateOperationTest extends AbstractMongoDbTest {
+
+   
+    @Test
+    public void testAggregate() throws Exception {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        // result sorted by _id
+        Object result = template
+            .requestBody("direct:aggregate",
+                         "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}},"
+                         + "{ $group: { _id: \"$scientist\", count: { $sum: 1 }} },{ $sort : { _id : 1}} ]");
+        
+        assertTrue("Result is not of type List", result instanceof List);
+
+        @SuppressWarnings("unchecked")
+        List<BasicDBObject> resultList = (List<BasicDBObject>) result;
+        assertListSize("Result does not contain 2 elements", resultList, 2);
+
+        assertEquals("First result DBOject._id should be Darwin", "Darwin", resultList.get(0).get("_id"));
+        assertEquals("First result DBOject.count should be 100", 100, resultList.get(0).get("count"));
+        assertEquals("Second result DBOject._id should be Einstein", "Einstein", resultList.get(1).get("_id"));
+        assertEquals("Second result DBOject.count should be 100", 100, resultList.get(1).get("count"));
+    }
+    
+    @Test
+    public void testAggregateDBCursor() {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        Object result = template
+                .requestBody("direct:aggregateDBCursor",
+                        "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}}]");
+        
+        assertTrue("Result is not of type DBCursor", result instanceof MongoIterable);
+
+        MongoIterable<BasicDBObject> resultCursor = (MongoIterable<BasicDBObject>) result;
+        // Ensure that all returned documents contain all fields
+        int count = 0;
+        for (DBObject dbObject : resultCursor) {
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("_id"));
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("scientist"));
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("fixedField"));
+            count++;
+        }
+        assertEquals("Result does not contain 200 elements", 200, count);
+    }
+
+    @Test
+    public void testAggregateDBCursorBatchSize() {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        Object result = template
+                .requestBodyAndHeader("direct:aggregateDBCursor",
+                        "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}}]", MongoDbConstants.BATCH_SIZE, 10);
+        
+        assertTrue("Result is not of type DBCursor", result instanceof MongoIterable);
+
+        MongoIterable<BasicDBObject> resultCursor = (MongoIterable<BasicDBObject>) result;
+
+        // Ensure that all returned documents contain all fields
+        int count = 0;
+        for (DBObject dbObject : resultCursor) {
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("_id"));
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("scientist"));
+            assertNotNull("DBObject in returned list should contain all fields", dbObject.get("fixedField"));
+            count++;
+        }
+        assertEquals("Result does not contain 200 elements", 200, count);
+    }
+
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:aggregate")
+                    .to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregate");
+                from("direct:aggregateDBCursor")
+                    .to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregate&dynamicity=true&outputType=DBCursor")
+                      .to("mock:resultAggregateDBCursor");
+                }
+            };
+    }
+}
+

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbOperationsTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbOperationsTest.java
@@ -243,24 +243,6 @@ public class MongoDbOperationsTest extends AbstractMongoDbTest {
     }
     
     @Test
-    public void testAggregate() throws Exception {
-        // Test that the collection has 0 documents in it
-        assertEquals(0, testCollection.count());
-        pumpDataIntoTestCollection();
-
-        // Repeat ten times, obtain 10 batches of 100 results each time
-        Object result = template
-            .requestBody("direct:aggregate",
-                         "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}},{ $group: { _id: \"$scientist\", count: { $sum: 1 }} } ]");
-        assertTrue("Result is not of type List", result instanceof List);
-
-        @SuppressWarnings("unchecked")
-        List<BasicDBObject> resultList = (List<BasicDBObject>)result;
-        assertListSize("Result does not contain 2 elements", resultList, 2);
-        // TODO Add more asserts
-    }
-    
-    @Test
     public void testDbStats() throws Exception {
         assertEquals(0, testCollection.count());
         Object result = template.requestBody("direct:getDbStats", "irrelevantBody");
@@ -330,7 +312,6 @@ public class MongoDbOperationsTest extends AbstractMongoDbTest {
                     setBody().header(MongoDbConstants.OID);
                 from("direct:update").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=update&writeConcern=SAFE");
                 from("direct:remove").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=remove&writeConcern=SAFE");
-                from("direct:aggregate").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregate&writeConcern=SAFE");
                 from("direct:getDbStats").to("mongodb:myDb?database={{mongodb.testDb}}&operation=getDbStats");
                 from("direct:getColStats").to("mongodb:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=getColStats");
                 from("direct:command").to("mongodb:myDb?database={{mongodb.testDb}}&operation=command");

--- a/components/camel-mongodb3/src/main/docs/mongodb3-component.adoc
+++ b/components/camel-mongodb3/src/main/docs/mongodb3-component.adoc
@@ -88,7 +88,7 @@ with the following path and query parameters:
 | *createCollection* (common) | Create collection during initialisation if it doesn't exist. Default is true. | true | boolean
 | *database* (common) | Sets the name of the MongoDB database to target |  | String
 | *operation* (common) | Sets the operation this endpoint will execute against MongoDB. For possible values see MongoDbOperation. |  | MongoDbOperation
-| *outputType* (common) | Convert the output of the producer to the selected type : DocumentList Document or MongoIterable. DocumentList or Document applies to findAll. MongoIterable applies to all other operations. |  | MongoDbOutputType
+| *outputType* (common) | Convert the output of the producer to the selected type : DocumentList Document or MongoIterable. DocumentList or MongoIterable applies to findAll and aggregate. Document applies to all other operations. |  | MongoDbOutputType
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler which mean any exceptions occurred while the consumer is trying to pickup incoming messages or the likes will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
@@ -267,6 +267,17 @@ send a request to close the cursor server-side. The batch size can be
 changed even after a cursor is iterated, in which case the setting will
 apply on the next batch retrieval. |int/Integer
 |=======================================================================
+
+Example with option outputType=MongoIterable and batch size :
+
+[source,java]
+-----------------------------------------------------------------------------
+from("direct:findAll")
+    .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
+    .setHeader(MongoDbConstants.CRITERIA, Filters.eq("name", "Raul Kripalani"))
+    .to("mongodb3:myDb?database=flights&collection=tickets&operation=findAll&outputType=MongoIterable")
+    .to("mock:resultFindAll");
+-----------------------------------------------------------------------------
 
 The `findAll` operation will also return the following OUT headers to
 enable you to iterate through result pages if you are using paging:
@@ -573,6 +584,37 @@ from("direct:aggregate")
     .to("mongodb3:myDb?database=science&collection=notableScientists&operation=aggregate")
     .to("mock:resultAggregate");
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+Efficient retrieval is supported via outputType=MongoIterable and the following header :
+
+[width="100%",cols="10%,10%,10%,70%",options="header",]
+|=======================================================================
+|Header key |Quick constant |Description (extracted from MongoDB API doc) |Expected type
+
+|`CamelMongoDbBatchSize` |`MongoDbConstants.BATCH_SIZE` | Sets the number of documents to return per batch. |int/Integer
+|=======================================================================
+
+You can also "stream" the documents returned from the server into your route by including outputType=DBCursor (Camel 2.21+) as an endpoint option
+which may prove simpler than setting the above headers. This hands your Exchange the DBCursor from the Mongo driver, just as if you were executing
+the aggregate() within the Mongo shell, allowing your route to iterate over the results. By default and without this option, this component will load
+the documents from the driver's cursor into a List and return this to your route - which may result in a large number of in-memory objects. Remember,
+with a DBCursor do not ask for the number of documents matched - see the MongoDB documentation site for details.
+
+Example with option outputType=MongoIterable and batch size:
+
+[source,java]
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// route: from("direct:aggregate").to("mongodb3:myDb?database=science&collection=notableScientists&operation=aggregate&outputType=MongoIterable");
+List<Bson> aggregate = Arrays.asList(match(or(eq("scientist", "Darwin"), eq("scientist", 
+        group("$scientist", sum("count", 1)));
+from("direct:aggregate")
+    .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
+    .setBody().constant(aggregate)
+    .to("mongodb3:myDb?database=science&collection=notableScientists&operation=aggregate&outputType=MongoIterable")
+    .to("mock:resultAggregate");
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 
 #### getDbStats
 

--- a/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbAggregateOperationTest.java
+++ b/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbAggregateOperationTest.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mongodb3;
+
+import java.util.List;
+
+import com.mongodb.client.MongoIterable;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.bson.Document;
+import org.junit.Test;
+
+public class MongoDbAggregateOperationTest extends AbstractMongoDbTest {
+
+   
+    @Test
+    public void testAggregate() throws Exception {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        // result sorted by _id
+        Object result = template
+            .requestBody("direct:aggregate",
+                         "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}},"
+                         + "{ $group: { _id: \"$scientist\", count: { $sum: 1 }} },{ $sort : { _id : 1}} ]");
+        
+        assertTrue("Result is not of type List", result instanceof List);
+
+        @SuppressWarnings("unchecked")
+        List<Document> resultList = (List<Document>) result;
+        assertListSize("Result does not contain 2 elements", resultList, 2);
+
+        assertEquals("First result Document._id should be Darwin", "Darwin", resultList.get(0).get("_id"));
+        assertEquals("First result Document.count should be 100", 100, resultList.get(0).get("count"));
+        assertEquals("Second result Document._id should be Einstein", "Einstein", resultList.get(1).get("_id"));
+        assertEquals("Second result Document.count should be 100", 100, resultList.get(1).get("count"));
+    }
+    
+    @Test
+    public void testAggregateDBCursor() {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        Object result = template
+                .requestBody("direct:aggregateDBCursor",
+                        "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}}]");
+        
+        assertTrue("Result is not of type DBCursor", result instanceof MongoIterable);
+
+        MongoIterable<Document> resultCursor = (MongoIterable<Document>) result;
+        // Ensure that all returned documents contain all fields
+        int count = 0;
+        for (Document document : resultCursor) {
+            assertNotNull("Document in returned list should contain all fields", document.get("_id"));
+            assertNotNull("Document in returned list should contain all fields", document.get("scientist"));
+            assertNotNull("Document in returned list should contain all fields", document.get("fixedField"));
+            count++;
+        }
+        assertEquals("Result does not contain 200 elements", 200, count);
+    }
+
+    @Test
+    public void testAggregateDBCursorBatchSize() {
+        // Test that the collection has 0 documents in it
+        assertEquals(0, testCollection.count());
+        pumpDataIntoTestCollection();
+
+        Object result = template
+                .requestBodyAndHeader("direct:aggregateDBCursor",
+                        "[{ $match : {$or : [{\"scientist\" : \"Darwin\"},{\"scientist\" : \"Einstein\"}]}}]", MongoDbConstants.BATCH_SIZE, 10);
+
+        assertTrue("Result is not of type DBCursor", result instanceof MongoIterable);
+
+        MongoIterable<Document> resultCursor = (MongoIterable<Document>) result;
+
+        // Ensure that all returned documents contain all fields
+        int count = 0;
+        for (Document document : resultCursor) {
+            assertNotNull("Document in returned list should contain all fields", document.get("_id"));
+            assertNotNull("Document in returned list should contain all fields", document.get("scientist"));
+            assertNotNull("Document in returned list should contain all fields", document.get("fixedField"));
+            count++;
+        }
+        assertEquals("Result does not contain 200 elements", 200, count);
+    }
+
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:aggregate")
+                    .to("mongodb3:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregate");
+                from("direct:aggregateDBCursor")
+                    .to("mongodb3:myDb?database={{mongodb.testDb}}&collection={{mongodb.testCollection}}&operation=aggregate&dynamicity=true&outputType=MongoIterable")
+                      .to("mock:resultAggregateDBCursor");
+            }
+        };
+    }
+}


### PR DESCRIPTION
New option for aggregate operation :

- camel-mongodb : `outputType=DBCursor`
- camel-mongodb3 : `outputType=MongoIterable`

Please review documentation...

cc @csarrazi