### PR TITLE
Added BatchAggregationStrategy

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/BatchAggregationStrategy.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/BatchAggregationStrategy.java
@@ -1,0 +1,16 @@
+import org.apache.camel.Exchange;
+import org.apache.camel.processor.aggregate.AbstractListAggregationStrategy;
+
+/**
+ * Aggregate body of input {@link Message} into a single combined Exchange holding all the
+ * aggregated bodies in a {@link List} of type {@link Object} as the message body.
+ *
+ * This aggregation strategy can used in combination with {@link org.apache.camel.processor.Splitter} to batch messages
+ *
+ * @version
+ */
+public class BatchAggregationStrategy extends AbstractListAggregationStrategy<Object> {
+    public Object getValue(Exchange exchange) {
+        return exchange.getIn().getBody();
+    }
+}

--- a/camel-core/src/main/java/org/apache/camel/util/toolbox/AggregationStrategies.java
+++ b/camel-core/src/main/java/org/apache/camel/util/toolbox/AggregationStrategies.java
@@ -76,6 +76,13 @@ public final class AggregationStrategies {
     }
 
     /**
+     * Creates a {@link BatchAggregationStrategy} aggregation strategy.
+     */
+    public static AggregationStrategy batch() {
+        return new BatchAggregationStrategy();
+    }
+
+    /**
      * Creates a {@link AggregationStrategyBeanAdapter} for using a POJO as the aggregation strategy.
      */
     public static AggregationStrategy bean(Object bean) {


### PR DESCRIPTION
I mostly found myself having the need to group the bodies (only) in a List (not Exchange or Message), so I think it will be useful to have this generic "batch" aggregation strategy in the Camel core.

Maybe the more proper naming could be GroupedBodyAggregationStrategy or GroupedInputBodyAggregationStrategy, but they're quite long :-). So I leave the naming change consideration up to you.