### PR TITLE
 CAMEL-12192 support csv bindy skip fields

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
@@ -37,8 +37,6 @@ import org.apache.camel.dataformat.bindy.annotation.OneToMany;
 import org.apache.camel.dataformat.bindy.annotation.Section;
 import org.apache.camel.dataformat.bindy.format.FormatException;
 import org.apache.camel.dataformat.bindy.util.ConverterUtils;
-import org.apache.camel.impl.DefaultClassResolver;
-import org.apache.camel.spi.ClassResolver;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.ReflectionHelper;
 import org.slf4j.Logger;
@@ -67,6 +65,7 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
 
     private String separator;
     private boolean skipFirstLine;
+    private boolean skipField;
     private boolean generateHeaderColumnNames;
     private boolean messageOrdered;
     private String quote;
@@ -75,20 +74,12 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
     private boolean allowEmptyStream;
     private boolean quotingEscaped;
     private boolean endWithLineBreak;
-    
-    private boolean isSkipField;
 
     public BindyCsvFactory(Class<?> type) throws Exception {
-        this(type, false);
-    }
-
-    public BindyCsvFactory(Class<?> type, boolean isSkipField) throws Exception {
         super(type);
 
         // initialize specific parameters of the csv model
         initCsvModel();
-        
-        this.isSkipField = isSkipField;
     }
 
     /**
@@ -611,6 +602,10 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
                     skipFirstLine = record.skipFirstLine();
                     LOG.debug("Skip First Line parameter of the CSV: {}" + skipFirstLine);
 
+                    // Get skipFirstLine parameter
+                    skipField = record.skipField();
+                    LOG.debug("Skip Field parameter of the CSV: {}" + skipField);
+
                     // Get generateHeaderColumnNames parameter
                     generateHeaderColumnNames = record.generateHeaderColumns();
                     LOG.debug("Generate header column names parameter of the CSV: {}", generateHeaderColumnNames);
@@ -710,6 +705,15 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
     }
 
     /**
+     *  Indicate if can skip fields
+     * 
+     * @return boolean
+     */
+    public boolean isSkipField() {
+        return this.skipField;
+    }
+
+    /**
      * If last record is to span the rest of the line
      */
     public boolean getAutospanLine() {
@@ -740,13 +744,5 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
     public boolean isEndWithLineBreak() {
         return endWithLineBreak;
     }
-
-    /**
-     * Indicate if DataField can be ignored
-     * 
-     * @return boolean
-     */
-    public boolean isSkipField() {
-        return this.isSkipField;
-    }
+    
 }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
@@ -54,6 +54,12 @@ public @interface CsvRecord {
     boolean skipFirstLine() default false;
 
     /**
+     * The skipField parameter will allow to skip fields of a CSV file. 
+     * If some fields are not necessary, they can be skipped.
+     */
+    boolean skipField() default false;
+
+    /**
      * Character to be used to add a carriage return after each record
      * (optional) Three values can be used : WINDOWS, UNIX or MAC.
      */

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -47,21 +47,11 @@ import org.slf4j.LoggerFactory;
 public class BindyCsvDataFormat extends BindyAbstractDataFormat {
     private static final Logger LOG = LoggerFactory.getLogger(BindyCsvDataFormat.class);
 
-    /**
-     * If isSkipField = true, a CSV file doesn't need to declare all the fields, otherwise, all the fields are mandatory.
-     */
-    private boolean isSkipField;
-
     public BindyCsvDataFormat() {
     }
 
     public BindyCsvDataFormat(Class<?> type) {
-       this(type, false);
-    }
-    
-    public BindyCsvDataFormat(Class<?> type, boolean isSkipField) {
         super(type);
-        this.isSkipField = isSkipField;
     }
 
     @Override
@@ -320,12 +310,8 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
 
     @Override
     protected BindyAbstractFactory createModelFactory(FormatFactory formatFactory) throws Exception {
-        BindyCsvFactory bindyCsvFactory = new BindyCsvFactory(getClassType(), isSkipField());
+        BindyCsvFactory bindyCsvFactory = new BindyCsvFactory(getClassType());
         bindyCsvFactory.setFormatFactory(formatFactory);
         return bindyCsvFactory;
-    }
-
-    private boolean isSkipField() {
-        return this.isSkipField;
     }
 }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -47,11 +47,21 @@ import org.slf4j.LoggerFactory;
 public class BindyCsvDataFormat extends BindyAbstractDataFormat {
     private static final Logger LOG = LoggerFactory.getLogger(BindyCsvDataFormat.class);
 
+    /**
+     * If isSkipField = true, a CSV file doesn't need to declare all the fields, otherwise, all the fields are mandatory.
+     */
+    private boolean isSkipField;
+
     public BindyCsvDataFormat() {
     }
 
     public BindyCsvDataFormat(Class<?> type) {
+       this(type, false);
+    }
+    
+    public BindyCsvDataFormat(Class<?> type, boolean isSkipField) {
         super(type);
+        this.isSkipField = isSkipField;
     }
 
     @Override
@@ -310,8 +320,12 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
 
     @Override
     protected BindyAbstractFactory createModelFactory(FormatFactory formatFactory) throws Exception {
-        BindyCsvFactory bindyCsvFactory = new BindyCsvFactory(getClassType());
+        BindyCsvFactory bindyCsvFactory = new BindyCsvFactory(getClassType(), isSkipField());
         bindyCsvFactory.setFormatFactory(formatFactory);
         return bindyCsvFactory;
+    }
+
+    private boolean isSkipField() {
+        return this.isSkipField;
     }
 }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest.java
@@ -57,7 +57,7 @@ public class BindyCsvSkipFieldTest  extends AbstractJUnit4SpringContextTests {
     }
 
     public static class ContextConfig extends RouteBuilder {
-        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(CsvSkipField.class, true);
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(CsvSkipField.class);
 
         public void configure() {
             from(URI_DIRECT_START).unmarshal(camelDataFormat)
@@ -82,7 +82,7 @@ public class BindyCsvSkipFieldTest  extends AbstractJUnit4SpringContextTests {
 
     }
     
-    @CsvRecord(separator = ",")
+    @CsvRecord(separator = ",", skipField = true)
     public static class CsvSkipField {
         @DataField(pos = 1)
         private String attention;

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.csv;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.annotation.CsvRecord;
+import org.apache.camel.dataformat.bindy.annotation.DataField;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+
+@ContextConfiguration
+public class BindyCsvSkipFieldTest  extends AbstractJUnit4SpringContextTests {
+
+    private static final String URI_MOCK_RESULT = "mock:result";
+    private static final String URI_DIRECT_START = "direct:start";
+    
+    private static String input = "VOA,12 abc street,Skip Street,Melbourne,VIC,3000,Australia,Skip dummy1,end of record";
+
+    @Produce(uri = URI_DIRECT_START)
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = URI_MOCK_RESULT)
+    private MockEndpoint result;
+
+    private String expected;
+    
+    @Test
+    @DirtiesContext
+    public void testUnMarshalAndMarshal() throws Exception {
+        
+        template.sendBody(input);
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+    }
+
+    public static class ContextConfig extends RouteBuilder {
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(CsvSkipField.class, true);
+
+        public void configure() {
+            from(URI_DIRECT_START).unmarshal(camelDataFormat)
+                    .process(new Processor() {
+                        @Override
+                        public void process(Exchange exchange) throws Exception {
+                            CsvSkipField csvSkipField = (CsvSkipField) exchange.getIn().getBody();
+                            assert  csvSkipField.getAttention().equals("VOA");
+                            assert  csvSkipField.getAddressLine1().equals("12 abc street");
+                            assert  csvSkipField.getCity().equals("Melbourne");
+                            assert  csvSkipField.getState().equals("VIC");
+                            assert  csvSkipField.getZip().equals("3000");
+                            assert  csvSkipField.getCountry() .equals("Australia");
+                            assert  csvSkipField.getDummy2().equals("end of record");
+                        }
+                    })
+                    
+                    .marshal(camelDataFormat)
+                    .convertBodyTo(String.class)
+                    .to(URI_MOCK_RESULT);
+        }
+
+    }
+    
+    @CsvRecord(separator = ",")
+    public static class CsvSkipField {
+        @DataField(pos = 1)
+        private String attention;
+        
+        @DataField(pos = 2)
+        private String addressLine1;
+        
+        @DataField(pos = 4)
+        private String city;
+        
+        @DataField(pos = 5)
+        private String state;
+        
+        @DataField(pos = 6)
+        private String zip;
+        
+        @DataField(pos = 7)
+        private String country;
+        
+        @DataField(pos = 9)
+        private String dummy2;
+
+        public String getAttention() {
+            return attention;
+        }
+
+        public void setAttention(String attention) {
+            this.attention = attention;
+        }
+
+        public String getAddressLine1() {
+            return addressLine1;
+        }
+
+        public void setAddressLine1(String addressLine1) {
+            this.addressLine1 = addressLine1;
+        }
+
+        public String getCity() {
+            return city;
+        }
+
+        public void setCity(String city) {
+            this.city = city;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public void setState(String state) {
+            this.state = state;
+        }
+
+        public String getZip() {
+            return zip;
+        }
+
+        public void setZip(String zip) {
+            this.zip = zip;
+        }
+
+        public String getCountry() {
+            return country;
+        }
+
+        public void setCountry(String country) {
+            this.country = country;
+        }
+
+        public String getDummy2() {
+            return dummy2;
+        }
+
+        public void setDummy2(String dummy2) {
+            this.dummy2 = dummy2;
+        }
+
+        @Override
+        public String toString() {
+            return "Record [attention=" + getAttention() + ", addressLine1=" + getAddressLine1() + ", " + "city=" + getCity() + ", state=" + getState() + ", zip=" + getZip() + ", country="
+                    + getCountry() + ", dummy2=" + getDummy2() + "]";
+        }
+    }
+}

--- a/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest-context.xml
+++ b/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyCsvSkipFieldTest-context.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+     http://www.springframework.org/schema/beans
+     http://www.springframework.org/schema/beans/spring-beans.xsd
+     http://camel.apache.org/schema/spring
+     http://camel.apache.org/schema/spring/camel-spring.xsd">
+     
+	<camelContext xmlns="http://camel.apache.org/schema/spring">
+		<routeBuilder ref="myBuilder" /> 
+	</camelContext>
+	
+	<bean id="myBuilder" class="org.apache.camel.dataformat.bindy.csv.BindyCsvSkipFieldTest$ContextConfig"/>
+	
+</beans>


### PR DESCRIPTION
added skipField to CsvRecord annotation, keeping the same implementation as skipFirstLine
 