### PR TITLE
Update xquery-component.adoc

### DIFF
--- a/components/camel-saxon/src/main/docs/xquery-component.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-component.adoc
@@ -218,6 +218,8 @@ The following example shows how to take a message of an ActiveMQ queue
   </camelContext>
 -------------------------------------------------------------------------
 
+Currently custom functions in XQuery might result in a NullPointerException (Camel 2.18, 2.19 and 2.20). This is expected to be fixed in Camel 2.21
+
 ### Examples
 
 Here is a simple


### PR DESCRIPTION
It took me quite a while to figure out that custom functions in Camel 2.18, 2.19 and 2.20 could result in a NullPointerException, so I think it could save others some time and frustration if there is a note like the one i propose in the documentation. I can not for sure promise that this will work in 2.21, but based on the discussions in PR CAMEL-12081, it looks like it will be fixed there.