### PR TITLE
CAMEL-12180 - upgrade Braintree Java SDK to version 2.75.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,8 +97,7 @@
     <bouncycastle-version>1.57</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
     <box-java-sdk-version>2.10.0</box-java-sdk-version>
-    <!-- cannot upgrade, see https://issues.apache.org/jira/browse/CAMEL-12180 -->
-    <braintree-gateway-version>2.72.1</braintree-gateway-version>
+    <braintree-gateway-version>2.75.0</braintree-gateway-version>
     <brave-zipkin-version>4.13.4</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>


### PR DESCRIPTION
Upgrade Braintree Java SDK to version 2.75.0. Previous versions used the org.json library, whose license has been deemed x-category by the ASF, and cannot be used at all.