### PR TITLE
Added snippet of code to showing how to download from SNAPSHOTS

### DIFF
--- a/components/camel-elasticsearch5-rest/src/main/docs/elasticsearch5-rest-component.adoc
+++ b/components/camel-elasticsearch5-rest/src/main/docs/elasticsearch5-rest-component.adoc
@@ -11,6 +11,13 @@ for this component:
 
 [source,xml]
 ----
+<!-- will be available as of 2.21 --> 
+<repository>
+    <id>camel-snapshots</id>
+    <name>Apache Snapshot Repository</name>
+    <url>https://repository.apache.org/content/repositories/snapshots/</url>
+</repository>
+
 <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-elasticsearch5-rest</artifactId>


### PR DESCRIPTION
As the component is still not available in non SNAPSHOT maven repositories, added `will be available as of 2.21.` with sample on how to get it from snapshot repository.