### PR TITLE
CAMEL-12235 - Added timestamp to message header

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConstants.java
@@ -25,6 +25,7 @@ public final class KafkaConstants {
     public static final String OFFSET = "kafka.OFFSET";
     public static final String HEADERS = "kafka.HEADERS";
     public static final String LAST_RECORD_BEFORE_COMMIT = "kafka.LAST_RECORD_BEFORE_COMMIT";
+    public static final String TIMESTAMP = "kafka.TIMESTAMP";
 
     @Deprecated
     public static final String KAFKA_DEFAULT_ENCODER = "kafka.serializer.DefaultEncoder";

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
@@ -173,6 +173,7 @@ public class KafkaEndpoint extends DefaultEndpoint implements MultipleConsumersS
         message.setHeader(KafkaConstants.TOPIC, record.topic());
         message.setHeader(KafkaConstants.OFFSET, record.offset());
         message.setHeader(KafkaConstants.HEADERS, record.headers());
+        message.setHeader(KafkaConstants.TIMESTAMP, record.timestamp());
         if (record.key() != null) {
             message.setHeader(KafkaConstants.KEY, record.key());
         }


### PR DESCRIPTION
Currently, the timestamp of the message produced by the publisher cannot be accessed by the Message API in the custom processor where the message is being consumed. This improvement adds the timestamp to the Message Header.