### PR TITLE
CAMEL-12245 Bridged http servlet endpoints should not populate reques…

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
@@ -171,7 +171,15 @@ public class DefaultHttpBinding implements HttpBinding {
         }
 
         try {
-            populateRequestParameters(request, message);
+            // only populate request parameters if we are not bridged
+            boolean bridged = false;
+            Endpoint endpoint = message.getExchange().getFromEndpoint();
+            if (endpoint instanceof HttpCommonEndpoint && ((HttpCommonEndpoint)endpoint).isBridgeEndpoint()) {
+                bridged = true;
+            } 
+            if (!bridged) {
+                populateRequestParameters(request, message);
+            }
         } catch (Exception e) {
             throw new RuntimeCamelException("Cannot read request parameters due " + e.getMessage(), e);
         }


### PR DESCRIPTION
When you create a servlet endpoint and use the bridgeEndpoint option, the queryParameters should NOT be put into the exchange headers, because when you pass this on to the next  (http4) endpoint you have the query parameters and an the same parameters as http headers.  So now you are sending additional headers instead of bridging.

`from("servlet:?matchOnUriPrefix=true&bridgeEndpoint=true")
  .to("http4://localhost:8080/testService);`
                   

You can work around this by creating a custom httpBinding, but you should not have to do this when the connection is bridged.