### PR TITLE
SlackProducer should be able to use a HTTP proxy to reach Slack in a secured environnement

### DIFF
--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
@@ -46,7 +46,7 @@ public class SlackProducer extends DefaultProducer {
     public void process(Exchange exchange) throws Exception {
 
         // Create an HttpClient and Post object
-        HttpClient client = HttpClientBuilder.create().build();
+        HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
         HttpPost httpPost = new HttpPost(slackEndpoint.getWebhookUrl());
 
         // Build Helper object


### PR DESCRIPTION
http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html