### PR TITLE
make transport configurable for streaming api

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -150,6 +150,11 @@ public class SalesforceComponent extends DefaultComponent implements VerifiableC
         + " look at properties of SalesforceHttpClient and the Jetty HttpClient for all available options.",
         label = "common,advanced")
     private Map<String, Object> httpClientProperties;
+	
+    @Metadata(description = "Used to set any properties that can be configured on the LongPollingTransport used by the BayeuxClient",
+        label = "common,advanced")
+    private Map<String, Object> longPollingTransportProperties;
+
 
     @Metadata(description = "SSL parameters to use, see SSLContextParameters class for all available options.",
         label = "common,security")
@@ -500,6 +505,14 @@ public class SalesforceComponent extends DefaultComponent implements VerifiableC
 
     public void setHttpClientProperties(Map<String, Object> httpClientProperties) {
         this.httpClientProperties = httpClientProperties;
+    }
+	
+    public Map<String, Object> getLongPollingTransportProperties() {
+        return longPollingTransportProperties;
+    }
+
+    public void setLongPollingTransportProperties(Map<String, Object> longPollingTransportProperties) {
+        this.longPollingTransportProperties = longPollingTransportProperties;
     }
 
     public SSLContextParameters getSslContextParameters() {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -333,8 +333,14 @@ public class SubscriptionHelper extends ServiceSupport {
         // use default Jetty client from SalesforceComponent, its shared by all consumers
         final SalesforceHttpClient httpClient = component.getConfig().getHttpClient();
 
-        Map<String, Object> options = new HashMap<String, Object>();
-        options.put(ClientTransport.MAX_NETWORK_DELAY_OPTION, httpClient.getTimeout());
+        Map<String, Object> options;
+		if(component.getLongPollingTransportProperties() != null){
+		    options = component.getLongPollingTransportProperties();
+		} else {
+		    options = new HashMap<String, Object>();
+		    options.put(ClientTransport.MAX_NETWORK_DELAY_OPTION, httpClient.getTimeout());
+		}
+		
 
         final SalesforceSession session = component.getSession();
         // check login access token


### PR DESCRIPTION
The goal of this PR is to make the LongPollingTransport configurable through the SalesforceComponent.
The need encoutered is :
While using the streaming api (PushTopic), we sometimes receive a message of a size exceeding the BufferingResponseListener maxLength property.
Enabling configurating the LongPollingTransport will give the possibility to control the authorized maxLength.