### PR TITLE
CAMEL-12260: Default value for String field results is null for CSV/Bindy

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyAbstractFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyAbstractFactory.java
@@ -79,6 +79,7 @@ public abstract class BindyAbstractFactory implements BindyFactory {
      *  
      * @param root
      */
+    @SuppressWarnings("rawtypes")
     private void loadModels(Class<?> root) {
         models.add(root);
         modelClassNames.add(root.getName());
@@ -231,6 +232,8 @@ public abstract class BindyAbstractFactory implements BindyFactory {
             return Character.MIN_VALUE;
         } else if (clazz == boolean.class) {
             return false;
+        } else if (clazz == String.class) {
+            return ""; 
         } else {
             return null;
         }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
@@ -313,6 +313,7 @@ public class BindyFixedLengthDataFormat extends BindyAbstractDataFormat {
         return factory.isIgnoreTrailingChars() && myLine.length() > factory.recordLength();
     }
 
+    @SuppressWarnings("unused")
     private String rightPad(String myLine, int length) {
         return String.format("%1$-" + length + "s", myLine);
     }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyRecordFieldStartingWithSeperatorCharTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyRecordFieldStartingWithSeperatorCharTest.java
@@ -61,7 +61,7 @@ public class BindyRecordFieldStartingWithSeperatorCharTest extends CamelTestSupp
         assertEquals(BigDecimal.valueOf(3), row.getNumber());
 
         row = mockEndPoint.getExchanges().get(3).getIn().getBody(BindyCsvRowFormat.class);
-        assertEquals(null, row.getFirstField());
+        assertEquals("", row.getFirstField());
         assertEquals(",val2,", row.getSecondField());
         assertEquals(BigDecimal.valueOf(4), row.getNumber());
     }
@@ -79,6 +79,7 @@ public class BindyRecordFieldStartingWithSeperatorCharTest extends CamelTestSupp
     }
 
     //from https://issues.apache.org/jira/browse/CAMEL-11065
+    @SuppressWarnings("serial")
     @CsvRecord(separator = ",", quote = "'")
     public static class BindyCsvRowFormat implements Serializable {
 

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvUnmarshallTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.annotation.DataField;
 import org.apache.camel.dataformat.bindy.format.FormatException;
 import org.apache.camel.dataformat.bindy.model.simple.oneclass.Order;
 import org.apache.camel.processor.interceptor.Tracer;
@@ -127,8 +128,13 @@ public class BindySimpleCsvUnmarshallTest extends AbstractJUnit4SpringContextTes
 
         assertNotNull(orders);
         // As the @DataField defines a default value for the firstName, the
-        // value might not be empty
+        // value might not be empty and equal to defaultValue property 
+        // inside @DataField annotation
         assertFalse(orders.get(0).getFirstName().isEmpty());
+        assertEquals("Joe", orders.get(0).getFirstName());
+        
+        // Check default String value set to empty ("") for the skipped clientNr field
+        assertEquals("", orders.get(0).getClientNr());
     }
     
     public static class ContextConfig extends RouteBuilder {

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/fixed/BindyPaddingAndTrimmingTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/fixed/BindyPaddingAndTrimmingTest.java
@@ -26,8 +26,6 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
-import static org.hamcrest.core.IsNull.nullValue;
-
 public class BindyPaddingAndTrimmingTest extends CamelTestSupport {
 
     private static final String URI_DIRECT_UNMARSHAL = "direct:unmarshall";
@@ -56,7 +54,7 @@ public class BindyPaddingAndTrimmingTest extends CamelTestSupport {
         unmarhsalResult.assertIsSatisfied();
         MyBindyModel myBindyModel = unmarhsalResult.getReceivedExchanges().get(0).getIn().getBody(MyBindyModel.class);
         assertEquals("foo  ", myBindyModel.foo);
-        assertThat(myBindyModel.bar, Is.is(nullValue()));
+        assertThat(myBindyModel.bar, Is.is(""));
     }
 
     @Test


### PR DESCRIPTION
The DataField.defaultValue always "" for String by default.