### PR TITLE
add missing attributes in RedeliveryPolicyFactoryBean

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/RedeliveryPolicy.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/RedeliveryPolicy.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
  *   <li>logHandled = false</li>
  *   <li>logExhausted = true</li>
  *   <li>logExhaustedMessageHistory = true</li>
+ *   <li>logExhaustedMessageBody = false</li>
  *   <li>logNewException = true</li>
  *   <li>allowRedeliveryWhileStopping = true</li>
  * </ul>

--- a/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelRedeliveryPolicyFactoryBean.java
+++ b/components/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelRedeliveryPolicyFactoryBean.java
@@ -79,6 +79,9 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
     @Metadata(defaultValue = "false", description = "Sets whether errors should be logged even if its handled")
     private String logHandled;
     @XmlAttribute
+    @Metadata(defaultValue = "true", description = "Sets whether errors should be logged when a new exception occurred during handling a previous exception")
+    private String logNewException;
+    @XmlAttribute
     @Metadata(defaultValue = "false", description = "Sets whether errors should be logged even if its continued")
     private String logContinued;
     @XmlAttribute
@@ -87,6 +90,9 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
     @XmlAttribute
     @Metadata(defaultValue = "false", description = "Sets whether to log exhausted errors including message history")
     private String logExhaustedMessageHistory;
+    @XmlAttribute
+    @Metadata(defaultValue = "false", description = "Sets whether exhausted message body/headers should be logged with message history included")
+    private String logExhaustedMessageBody;
     @XmlAttribute
     @Metadata(defaultValue = "false", description = "Disables redelivery by setting maximum redeliveries to 0.")
     private String disableRedelivery;
@@ -146,6 +152,9 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
         if (logHandled != null) {
             answer.setLogHandled(CamelContextHelper.parseBoolean(context, logHandled));
         }
+        if (logNewException != null) {
+            answer.setLogNewException(CamelContextHelper.parseBoolean(context, logNewException));
+        }
         if (logContinued != null) {
             answer.setLogContinued(CamelContextHelper.parseBoolean(context, logContinued));
         }
@@ -157,6 +166,9 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
         }
         if (logExhaustedMessageHistory != null) {
             answer.setLogExhaustedMessageHistory(CamelContextHelper.parseBoolean(context, logExhaustedMessageHistory));
+        }
+        if (logExhaustedMessageBody != null) {
+            answer.setLogExhaustedMessageBody(CamelContextHelper.parseBoolean(context, logExhaustedMessageBody));
         }
         if (disableRedelivery != null) {
             if (CamelContextHelper.parseBoolean(context, disableRedelivery)) {
@@ -292,6 +304,14 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
         this.logHandled = logHandled;
     }
 
+    public String getLogNewException() {
+        return logNewException;
+    }
+
+    public void setLogNewException(String logNewException) {
+        this.logNewException = logNewException;
+    }
+
     public String getLogContinued() {
         return logContinued;
     }
@@ -316,10 +336,21 @@ public abstract class AbstractCamelRedeliveryPolicyFactoryBean extends AbstractC
         this.logExhaustedMessageHistory = logExhaustedMessageHistory;
     }
 
+    public String getLogExhaustedMessageBody() {
+        return logExhaustedMessageBody;
+    }
+
+    public void setLogExhaustedMessageBody(String logExhaustedMessageBody) {
+        this.logExhaustedMessageBody = logExhaustedMessageBody;
+    }
+
     public String getDisableRedelivery() {
         return disableRedelivery;
     }
 
+    /**
+     * Disables redelivery (same as setting maximum redeliveries to 0)
+     */
     public void setDisableRedelivery(String disableRedelivery) {
         this.disableRedelivery = disableRedelivery;
     }


### PR DESCRIPTION
this synchronizes the attributes present in two similar classes:
- RedeliveryPolicyDefinition
- RedeliveryPolicyFactoryBean

the latter was missing: `logNewException` and `logExhaustedMessageBody`, making it impossible to use it in xml routes definitions.