### PR TITLE
CAMEL-12286: Fix camel-milo client component

### DIFF
--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -95,7 +95,7 @@ with the following path and query parameters:
 | *endpointUri* | *Required* The OPC UA server endpoint |  | String
 |===
 
-==== Query Parameters (22 parameters):
+==== Query Parameters (23 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
@@ -108,6 +108,7 @@ with the following path and query parameters:
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
+| *allowedSecurityPolicies* (client) | A set of allowed security policy URIs. Default is to accept all and use the highest. |  | String
 | *applicationName* (client) | The application name | Apache Camel adapter for Eclipse Milo | String
 | *applicationUri* (client) | The application URI | http://camel.apache.org/EclipseMilo/Client | String
 | *channelLifetime* (client) | Channel lifetime in milliseconds |  | Long
@@ -160,6 +161,15 @@ However Camel allows to wrap the actual value inside `RAW(…)`, which makes esc
 ------------------------
 milo-client://user:password@localhost:12345?node=RAW(nsu=http://foo.bar;s=foo/bar)
 ------------------------
+
+==== Security policies
+
+When setting the allowing security policies is it possible to use the well known OPC UA URIs (e.g. `http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15`)
+or to use the Milo enum literals (e.g. `None`). Specifying an unknown security policy URI or enum is an error.
+
+The known security policy URIs and enum literals are can be seen here: https://github.com/eclipse/milo/blob/master/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityPolicy.java[SecurityPolicy.java] 
+
+**Note:** In any case security policies are considered case sensitive.
 
 === See Also
 

--- a/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/client/springboot/MiloClientComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/client/springboot/MiloClientComponentConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.milo.client.springboot;
 
+import java.util.Set;
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -169,6 +170,11 @@ public class MiloClientComponentConfiguration
          * The key password
          */
         private String keyPassword;
+        /**
+         * A set of allowed security policy URIs. Default is to accept all and
+         * use the highest.
+         */
+        private Set allowedSecurityPolicies;
 
         public String getEndpointUri() {
             return endpointUri;
@@ -288,6 +294,14 @@ public class MiloClientComponentConfiguration
 
         public void setKeyPassword(String keyPassword) {
             this.keyPassword = keyPassword;
+        }
+
+        public Set getAllowedSecurityPolicies() {
+            return allowedSecurityPolicies;
+        }
+
+        public void setAllowedSecurityPolicies(Set allowedSecurityPolicies) {
+            this.allowedSecurityPolicies = allowedSecurityPolicies;
         }
     }
 }


### PR DESCRIPTION
This change adapts the client to the changed behavior of
Eclipse Milo 0.2.x. It does an explicit call to connect and also allows
to configure the allowed security policies in order to still support
anonymous access when no keys are used.