### PR TITLE
CAMEL-12287: Allow overriding the endpoint host

### DIFF
--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -95,7 +95,7 @@ with the following path and query parameters:
 | *endpointUri* | *Required* The OPC UA server endpoint |  | String
 |===
 
-==== Query Parameters (23 parameters):
+==== Query Parameters (24 parameters):
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
@@ -119,6 +119,7 @@ with the following path and query parameters:
 | *keyStoreUrl* (client) | The URL where the key should be loaded from |  | URL
 | *maxPendingPublishRequests* (client) | The maximum number of pending publish requests |  | Long
 | *maxResponseMessageSize* (client) | The maximum number of bytes a response message may have |  | Long
+| *overrideHost* (client) | Override the server reported endpoint host with the host from the endpoint URI. | false | boolean
 | *productUri* (client) | The product URI | http://camel.apache.org/EclipseMilo | String
 | *requestTimeout* (client) | Request timeout in milliseconds |  | Long
 | *sessionName* (client) | Session name |  | String

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -85,6 +85,9 @@ public class MiloClientConfiguration implements Cloneable {
     @UriParam(label = "client", javaType = "java.lang.String")
     private Set<String> allowedSecurityPolicies = new HashSet<>();
 
+    @UriParam(label = "client")
+    private boolean overrideHost;
+
     public MiloClientConfiguration() {
     }
 
@@ -95,6 +98,7 @@ public class MiloClientConfiguration implements Cloneable {
         this.productUri = other.productUri;
         this.requestTimeout = other.requestTimeout;
         this.allowedSecurityPolicies = allowedSecurityPolicies != null ? new HashSet<>(other.allowedSecurityPolicies) : null;
+        this.overrideHost = other.overrideHost;
     }
 
     public void setEndpointUri(final String endpointUri) {
@@ -316,7 +320,19 @@ public class MiloClientConfiguration implements Cloneable {
     }
 
     public Set<String> getAllowedSecurityPolicies() {
-        return allowedSecurityPolicies;
+        return this.allowedSecurityPolicies;
+    }
+
+    /**
+     * Override the server reported endpoint host with the host from the
+     * endpoint URI.
+     */
+    public void setOverrideHost(boolean overrideHost) {
+        this.overrideHost = overrideHost;
+    }
+
+    public boolean isOverrideHost() {
+        return overrideHost;
     }
 
     @Override

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.milo.client.internal;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -416,7 +417,11 @@ public class SubscriptionManager {
                 }
             }
 
-            return findEndpoint(endpoints);
+            try {
+                return findEndpoint(endpoints);
+            } catch (final URISyntaxException e) {
+                throw new RuntimeException("Failed to find endpoints", e);
+            }
         }).get();
 
         LOG.debug("Selected endpoint: {}", endpoint);
@@ -495,7 +500,7 @@ public class SubscriptionManager {
         }
     }
 
-    private EndpointDescription findEndpoint(final EndpointDescription[] endpoints) {
+    private EndpointDescription findEndpoint(final EndpointDescription[] endpoints) throws URISyntaxException {
 
         final Predicate<String> allowed;
         final Set<String> uris = this.configuration.getAllowedSecurityPolicies();
@@ -517,7 +522,55 @@ public class SubscriptionManager {
                 best = ep;
             }
         }
-        return best;
+
+        // return result, might override the host part
+
+        return overrideHost(best);
+    }
+
+    /**
+     * Optionally override the host of the endpoint URL with the configured one.
+     * <br>
+     * The method will call {@link #overrideHost(String)} if the endpoint is not
+     * {@code null} and {@link MiloClientConfiguration#isOverrideHost()} returns
+     * {@code true}.
+     * 
+     * @param desc The endpoint descriptor to work on
+     * @return Either the provided or updated endpoint descriptor. Only returns
+     *         {@code null} when the input was {@code null}.
+     * @throws URISyntaxException on case the URI is malformed
+     */
+    private EndpointDescription overrideHost(final EndpointDescription desc) throws URISyntaxException {
+        if (desc == null) {
+            return null;
+        }
+
+        if (!this.configuration.isOverrideHost()) {
+            return desc;
+        }
+
+        return new EndpointDescription(overrideHost(desc.getEndpointUrl()), desc.getServer(), desc.getServerCertificate(), desc.getSecurityMode(), desc.getSecurityPolicyUri(),
+                                       desc.getUserIdentityTokens(), desc.getTransportProfileUri(), desc.getSecurityLevel());
+    }
+
+    /**
+     * Override host part of the endpoint URL with the configured one.
+     * 
+     * @param endpointUrl the server provided endpoint URL
+     * @return A new endpoint URL with the host part exchanged by the configured
+     *         host. Will be {@code null} when the input is {@code null}.
+     * @throws URISyntaxException on case the URI is malformed
+     */
+    private String overrideHost(final String endpointUrl) throws URISyntaxException {
+
+        if (endpointUrl == null) {
+            return null;
+        }
+
+        final URI uri = URI.create(endpointUrl);
+        final URI originalUri = URI.create(configuration.getEndpointUri());
+
+        return new URI(uri.getScheme(), uri.getUserInfo(), originalUri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
     }
 
     protected synchronized void whenConnected(final Worker<Connected> worker) {

--- a/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/client/springboot/MiloClientComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/client/springboot/MiloClientComponentConfiguration.java
@@ -175,6 +175,11 @@ public class MiloClientComponentConfiguration
          * use the highest.
          */
         private Set allowedSecurityPolicies;
+        /**
+         * Override the server reported endpoint host with the host from the
+         * endpoint URI.
+         */
+        private Boolean overrideHost = false;
 
         public String getEndpointUri() {
             return endpointUri;
@@ -302,6 +307,14 @@ public class MiloClientComponentConfiguration
 
         public void setAllowedSecurityPolicies(Set allowedSecurityPolicies) {
             this.allowedSecurityPolicies = allowedSecurityPolicies;
+        }
+
+        public Boolean getOverrideHost() {
+            return overrideHost;
+        }
+
+        public void setOverrideHost(Boolean overrideHost) {
+            this.overrideHost = overrideHost;
         }
     }
 }


### PR DESCRIPTION
This change adds the ability to override the server reported
hostname/IP with the originally provided host/IP when connecting
to the server.