### PR TITLE
CAMEL-12343 : refer to new constructor with defaultCamelContext for deprecated constructor

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/GenericFileMessage.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/GenericFileMessage.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultMessage;
 
 /**
@@ -31,6 +32,7 @@ public class GenericFileMessage<T> extends DefaultMessage {
      */
     @Deprecated
     public GenericFileMessage() {
+        this(new DefaultCamelContext());
     }
 
     public GenericFileMessage(CamelContext camelContext) {
@@ -42,7 +44,7 @@ public class GenericFileMessage<T> extends DefaultMessage {
      */
     @Deprecated
     public GenericFileMessage(GenericFile<T> file) {
-        this.file = file;
+        this(new DefaultCamelContext(), file);
     }
 
     public GenericFileMessage(CamelContext camelContext, GenericFile<T> file) {

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultMessage.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultMessage.java
@@ -54,6 +54,7 @@ public class DefaultMessage extends MessageSupport {
      */
     @Deprecated
     public DefaultMessage() {
+        this(new DefaultCamelContext());
     }
 
     public DefaultMessage(CamelContext camelContext) {


### PR DESCRIPTION
Migrate from 2.19.2 to 2.20.2 failed.

```
java.lang.IllegalArgumentException: CamelContext must be specified on: Message[]
	at org.apache.camel.util.ObjectHelper.notNull(ObjectHelper.java:342)
```

 