### PR TITLE
Enable all camel-milo tests by default

### DIFF
--- a/components/camel-milo/pom.xml
+++ b/components/camel-milo/pom.xml
@@ -100,42 +100,12 @@
           <childDelegation>false</childDelegation>
           <useFile>true</useFile>
           <forkCount>1</forkCount>
-          <reuseForks>true</reuseForks>
+          <!-- required due to issue eclipse/milo#23 -->
+          <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
-          <includes>
-            <!-- Here we only run a few tests -->
-            <include>**/ConverterTest.java</include>
-            <include>**/NodeIdTest.java</include>
-            <include>**/ServerSetCertificateManagerTest</include>
-            <include>**/ServerSetSecurityPoliciesTest.java</include>
-          </includes>
         </configuration>
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>milo-test</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <childDelegation>false</childDelegation>
-              <useFile>true</useFile>
-              <forkCount>1</forkCount>
-              <!-- required due to issue eclipse/milo#23 -->
-              <reuseForks>false</reuseForks>
-              <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
-              <includes>
-                <include>**/*Test.java</include>
-              </includes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
As discussed in PR #2262, this PR now enables all camel-milo tests.