### PR TITLE
Fix DropboxAPIFacade.java

### DIFF
--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
@@ -111,7 +111,7 @@ public final class DropboxAPIFacade {
         // verify uploading of a single file
         if (fileLocalPath.isFile()) {
             // check if dropbox file exists
-            if (entry != null) {
+            if (entry != null && !DropboxUploadMode.force.equals(mode)) {
                 throw new DropboxException(dropboxPath + " exists on dropbox and is not a file!");
             }
             // in case the entry not exists on dropbox check if the filename
@@ -139,7 +139,7 @@ public final class DropboxAPIFacade {
             // verify uploading of a list of files inside a dir
             LOG.debug("Uploading a dir...");
             // check if dropbox folder exists
-            if (entry != null) {
+            if (entry != null && !DropboxUploadMode.force.equals(mode)) {
                 throw new DropboxException(dropboxPath + " exists on dropbox and is not a folder!");
             }
             if (!dropboxPath.endsWith(DropboxConstants.DROPBOX_FILE_SEPARATOR)) {


### PR DESCRIPTION
Specifically the bug was in class DropboxAPIFacade.java lines 114, 115, 142, 143. The exception thrown is about upload a file into a not file path or a folder into a not folder path, but the new version of dropbox java sdk don't provides the method entry.isFile() or entry.isFolder(), and the code as is now, is throwing erroneous exceptions, if the file exists remotely, a exception will be thrown, and in config, we have the force mode, i think this snipped of code should be erased or the mode=force param needs to be verified.