### PR TITLE
CAMEL-12407: camel-olingo4-api should explicitly depend on commons-io

### DIFF
--- a/components/camel-olingo4/camel-olingo4-api/pom.xml
+++ b/components/camel-olingo4/camel-olingo4-api/pom.xml
@@ -58,15 +58,20 @@
       <artifactId>odata-server-core</artifactId>
       <version>${olingo4-version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <!-- logging -->


### PR DESCRIPTION
This should please be ported to `camel-2.21.x` too