### PR TITLE
CAMEL-12409 Temporary revert CAMEL-12104 Unintuitive default cxf timeout

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfConsumer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfConsumer.java
@@ -52,11 +52,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A Consumer of exchanges for a service in CXF.  CxfConsumer acts a CXF
- * service to receive requests, convert them, and forward them to Camel 
+ * service to receive requests, convert them, and forward them to Camel
  * route for processing. It is also responsible for converting and sending
  * back responses to CXF client.
  *
- * @version 
+ * @version
  */
 public class CxfConsumer extends DefaultConsumer {
     private static final Logger LOG = LoggerFactory.getLogger(CxfConsumer.class);
@@ -150,19 +150,19 @@ public class CxfConsumer extends DefaultConsumer {
     protected boolean isAsyncInvocationSupported(Exchange cxfExchange) {
         Message cxfMessage = cxfExchange.getInMessage();
         Object addressingProperties = cxfMessage.get(CxfConstants.WSA_HEADERS_INBOUND);
-        if (addressingProperties != null 
+        if (addressingProperties != null
                && !ContextUtils.isGenericAddress(getReplyTo(addressingProperties))) {
             //it's decoupled endpoint, so already switch thread and
-            //use executors, which means underlying transport won't 
-            //be block, so we shouldn't rely on continuation in 
-            //this case, as the SuspendedInvocationException can't be 
+            //use executors, which means underlying transport won't
+            //be block, so we shouldn't rely on continuation in
+            //this case, as the SuspendedInvocationException can't be
             //caught by underlying transport. So we should use the SyncInvocation this time
             return false;
         }
         // we assume it should support AsyncInvocation out of box
         return true;
     }
-    
+
     private class CxfConsumerInvoker implements Invoker {
         private final CxfEndpoint endpoint;
 
@@ -197,7 +197,7 @@ public class CxfConsumer extends DefaultConsumer {
 
                     // The continuation could be called before the suspend is called
                     continuation.suspend(cxfEndpoint.getContinuationTimeout());
-                    
+
                     continuation.setObject(camelExchange);
 
                     // use the asynchronous API to process the exchange
@@ -212,7 +212,7 @@ public class CxfConsumer extends DefaultConsumer {
                         }
                     });
 
-                } else if (!continuation.isTimeout() && continuation.isResumed()) {
+                } else if (continuation.isResumed()) {
                     org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange)continuation.getObject();
                     try {
                         setResponseBack(cxfExchange, camelExchange);
@@ -220,8 +220,7 @@ public class CxfConsumer extends DefaultConsumer {
                         CxfConsumer.this.doneUoW(camelExchange);
                         throw ex;
                     }
-
-                } else if (continuation.isTimeout() || (!continuation.isResumed() && !continuation.isPending())) {
+                } else if (!continuation.isResumed() && !continuation.isPending()) {
                     org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange)continuation.getObject();
                     try {
                         if (!continuation.isPending()) {
@@ -234,7 +233,6 @@ public class CxfConsumer extends DefaultConsumer {
                     }
                 }
             }
-            
             return null;
         }
 

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
@@ -104,7 +104,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 });
                 return null;
             }
-            if (!continuation.isTimeout() && continuation.isResumed()) {
+            if (continuation.isResumed()) {
                 cxfExchange.put(SUSPENED, Boolean.FALSE);
                 org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange)continuation.getObject();
                 try {
@@ -114,7 +114,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
                     throw ex;
                 }
             } else {
-                if (continuation.isTimeout() || !continuation.isPending()) {
+                if (!continuation.isPending()) {
                     cxfExchange.put(SUSPENED, Boolean.FALSE);
                     org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange)continuation.getObject();
                     camelExchange.setException(new ExchangeTimedOutException(camelExchange, endpoint.getContinuationTimeout()));

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerContinuationTimeoutTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerContinuationTimeoutTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.camel.util.AsyncProcessorHelper;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class CxfConsumerContinuationTimeoutTest extends CamelTestSupport {
@@ -113,6 +114,7 @@ public class CxfConsumerContinuationTimeoutTest extends CamelTestSupport {
     }
 
     @Test
+    @Ignore("CAMEL-12104")
     public void testTimeout() throws Exception {
         String out = template.requestBodyAndHeader("direct:start", "Bye World", "priority", "slow", String.class);
         assertTrue(out.contains("The OUT message was not received within: 5000 millis."));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12409

This should be un-reverted for Camel 2.22.0
This reverts commit c789e1f6b09b57d1b0882268ebbe8fecfa9c05b2.

@davsclaus could you please review?