### PR TITLE
CAMEL-12419: camel-elasticsearch-rest should return complete bulk response instead of just ids

### DIFF
--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -18,11 +18,7 @@ package org.apache.camel.component.elasticsearch;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.elasticsearch.converter.ElasticsearchActionRequestConverter;
@@ -35,7 +31,6 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetRequest;
@@ -170,10 +165,7 @@ public class ElasticsearchProducer extends DefaultProducer {
             message.setBody(restHighLevelClient.bulk(bulkRequest).getItems());
         } else if (operation == ElasticsearchOperation.BulkIndex) {
             BulkRequest bulkRequest = ElasticsearchActionRequestConverter.toBulkRequest(message.getBody(), exchange);
-            List<String> indexedIds = Arrays.stream(restHighLevelClient.bulk(bulkRequest).getItems())
-                .map(BulkItemResponse::getId)
-                .collect(Collectors.toList());
-            message.setBody(indexedIds);
+            message.setBody(restHighLevelClient.bulk(bulkRequest).getItems());
         } else if (operation == ElasticsearchOperation.Delete) {
             DeleteRequest deleteRequest = ElasticsearchActionRequestConverter.toDeleteRequest(message.getBody(), exchange);
             message.setBody(restHighLevelClient.delete(deleteRequest).getResult());

--- a/components/camel-elasticsearch-rest/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchBulkTest.java
+++ b/components/camel-elasticsearch-rest/src/test/java/org/apache/camel/component/elasticsearch/ElasticsearchBulkTest.java
@@ -20,22 +20,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.camel.builder.RouteBuilder;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import org.junit.Test;
 
 public class ElasticsearchBulkTest extends ElasticsearchBaseTest {
 
     @Test
     public void testBulkIndex() throws Exception {
-        List<Map<String, String>> documents = new ArrayList<Map<String, String>>();
+        List<Map<String, String>> documents = new ArrayList<>();
         Map<String, String> document1 = createIndexedData("1");
         Map<String, String> document2 = createIndexedData("2");
 
@@ -76,12 +73,13 @@ public class ElasticsearchBulkTest extends ElasticsearchBaseTest {
 
         // when
         @SuppressWarnings("unchecked")
-        List<String> indexedDocumentIds = template.requestBody("direct:bulk_index", request, List.class);
+        BulkItemResponse[] response = template.requestBody("direct:bulk_index", request, BulkItemResponse[].class);
 
         // then
-        assertThat(indexedDocumentIds, notNullValue());
-        assertThat(indexedDocumentIds.size(), equalTo(1));
-        assertThat(indexedDocumentIds, hasItem(prefix + "baz"));
+        assertThat(response, notNullValue());
+        assertThat(response.length, equalTo(1));
+        assertThat(response[0].isFailed(), equalTo(false));
+        assertThat(response[0].getId(), equalTo(prefix + "baz"));
     }
 
     @Test


### PR DESCRIPTION
Currently, when bulk indexing requests are used, only document ids are returned in the exchange body.
That not enough if you really want a good indexing failure management.

Instead, it should return the complete bulk item response.
This way, we could get the exact error messages.