### PR TITLE
CAMEL-12421 - camel-elasticsearch-rest should use Camel converter pattern

### DIFF
--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -21,7 +21,6 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.component.elasticsearch.converter.ElasticsearchActionRequestConverter;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.camel.util.IOHelper;
 import org.apache.http.HttpHost;
@@ -152,25 +151,25 @@ public class ElasticsearchProducer extends DefaultProducer {
         }
 
         if (operation == ElasticsearchOperation.Index) {
-            IndexRequest indexRequest = ElasticsearchActionRequestConverter.toIndexRequest(message.getBody(), exchange);
+            IndexRequest indexRequest = message.getBody(IndexRequest.class);
             message.setBody(restHighLevelClient.index(indexRequest).getId());
         } else if (operation == ElasticsearchOperation.Update) {
-            UpdateRequest updateRequest = ElasticsearchActionRequestConverter.toUpdateRequest(message.getBody(), exchange);
+            UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
             message.setBody(restHighLevelClient.update(updateRequest).getId());
         } else if (operation == ElasticsearchOperation.GetById) {
-            GetRequest getRequest = ElasticsearchActionRequestConverter.toGetRequest(message.getBody(), exchange);
+            GetRequest getRequest = message.getBody(GetRequest.class);
             message.setBody(restHighLevelClient.get(getRequest));
         } else if (operation == ElasticsearchOperation.Bulk) {
             BulkRequest bulkRequest = message.getBody(BulkRequest.class);
             message.setBody(restHighLevelClient.bulk(bulkRequest).getItems());
         } else if (operation == ElasticsearchOperation.BulkIndex) {
-            BulkRequest bulkRequest = ElasticsearchActionRequestConverter.toBulkRequest(message.getBody(), exchange);
+            BulkRequest bulkRequest = message.getBody(BulkRequest.class);
             message.setBody(restHighLevelClient.bulk(bulkRequest).getItems());
         } else if (operation == ElasticsearchOperation.Delete) {
-            DeleteRequest deleteRequest = ElasticsearchActionRequestConverter.toDeleteRequest(message.getBody(), exchange);
+            DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
             message.setBody(restHighLevelClient.delete(deleteRequest).getResult());
         } else if (operation == ElasticsearchOperation.DeleteIndex) {
-            DeleteRequest deleteRequest = ElasticsearchActionRequestConverter.toDeleteRequest(message.getBody(), exchange);
+            DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
             message.setBody(client.performRequest("Delete", deleteRequest.index()).getStatusLine().getStatusCode());
         } else if (operation == ElasticsearchOperation.Exists) {
             // ExistsRequest API is deprecated, using SearchRequest instead with size=0 and terminate_after=1
@@ -191,7 +190,7 @@ public class ElasticsearchProducer extends DefaultProducer {
 
             }
         } else if (operation == ElasticsearchOperation.Search) {
-            SearchRequest searchRequest = ElasticsearchActionRequestConverter.toSearchRequest(message.getBody(), exchange);
+            SearchRequest searchRequest = message.getBody(SearchRequest.class);
             message.setBody(restHighLevelClient.search(searchRequest).getHits());
         } else if (operation == ElasticsearchOperation.Ping) {
             message.setBody(restHighLevelClient.ping());

--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -16,14 +16,11 @@
  */
 package org.apache.camel.component.elasticsearch.converter;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.elasticsearch.ElasticsearchConstants;
@@ -31,7 +28,6 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -42,6 +38,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Converter
 public final class ElasticsearchActionRequestConverter {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchActionRequestConverter.class);
 
@@ -111,16 +108,19 @@ public final class ElasticsearchActionRequestConverter {
                 ElasticsearchConstants.PARAM_INDEX_TYPE, String.class));
     }
 
+    @Converter
     public static IndexRequest toIndexRequest(Object document, Exchange exchange) {
         return createIndexRequest(document, exchange)
             .id(exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_ID, String.class));
     }
 
+    @Converter
     public static UpdateRequest toUpdateRequest(Object document, Exchange exchange) {
         return createUpdateRequest(document, exchange)
             .id(exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_ID, String.class));
     }
 
+    @Converter
     public static GetRequest toGetRequest(Object document, Exchange exchange) {
         if (document instanceof GetRequest) {
             return (GetRequest) document;
@@ -132,6 +132,7 @@ public final class ElasticsearchActionRequestConverter {
                 String.class)).id((String) document);
     }
 
+    @Converter
     public static DeleteRequest toDeleteRequest(Object document, Exchange exchange) {
         if (document instanceof DeleteRequest) {
             return (DeleteRequest) document;
@@ -149,6 +150,7 @@ public final class ElasticsearchActionRequestConverter {
         }
     }
 
+    @Converter
     public static SearchRequest toSearchRequest(Object queryObject, Exchange exchange) throws IOException {
         if (queryObject instanceof SearchRequest) {
             return (SearchRequest) queryObject;
@@ -191,6 +193,7 @@ public final class ElasticsearchActionRequestConverter {
         return searchRequest;
     }
 
+    @Converter
     public static BulkRequest toBulkRequest(Object documents, Exchange exchange) {
         if (documents instanceof BulkRequest) {
             return (BulkRequest) documents;

--- a/components/camel-elasticsearch-rest/src/main/resources/META-INF/services/org/apache/camel/TypeConverter
+++ b/components/camel-elasticsearch-rest/src/main/resources/META-INF/services/org/apache/camel/TypeConverter
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.camel.component.elasticsearch.converter


### PR DESCRIPTION
This new component calls directly the conversion function in order to create Elasticsearch requests.
Instead it should use the converter pattern and let Camel doing the conversion.