### PR TITLE
CAMEL-12425 SQS Producer support for numeric attributes

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsProducer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsProducer.java
@@ -135,6 +135,11 @@ public class SqsProducer extends DefaultProducer {
                     mav.setDataType("Binary");
                     mav.withBinaryValue((ByteBuffer)value);
                     result.put(entry.getKey(), mav);
+                } else if (value instanceof Number) {
+                    MessageAttributeValue mav = new MessageAttributeValue();
+                    mav.setDataType("Number");
+                    mav.withStringValue(((Number)value).toString());
+                    result.put(entry.getKey(), mav);
                 } else {
                     // cannot translate the message header to message attribute value
                     LOG.warn("Cannot put the message header key={}, value={} into Sqs MessageAttribute", entry.getKey(), entry.getValue());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12425

If a header of type `Number` is provided, map it to an SQS `MessageAttributeValue` of type "Number" with the`MessageAttributeValue`'s StringValue containing a string representation of the number.

See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html