### PR TITLE
CAMEL-10905: Make camel-grape work on java 9 by replacing Groovy Ecli…

### DIFF
--- a/components/camel-grape/pom.xml
+++ b/components/camel-grape/pom.xml
@@ -32,9 +32,6 @@
   <description>The grape component allows you to fetch, load and manage additional jars when CamelContext is running</description>
 
   <properties>
-    <groovy-eclipse-batch.version>2.4.3-01</groovy-eclipse-batch.version>
-    <groovy-eclipse-compiler.version>2.9.2-01</groovy-eclipse-compiler.version>
-    <plexus-compiler-api.version>2.8.3</plexus-compiler-api.version>
     <camel.osgi.export.pkg />
   </properties>
 
@@ -90,34 +87,43 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-batch</artifactId>
-            <version>${groovy-eclipse-batch.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>${groovy-eclipse-compiler.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-api</artifactId>
-            <version>${plexus-compiler-api.version}</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <compilerId>groovy-eclipse-compiler</compilerId>
-        </configuration>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>addSources</goal>
+              <goal>addTestSources</goal>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>compileTests</goal>
+              <goal>removeStubs</goal>
+              <goal>removeTestStubs</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-eclipse-compiler</artifactId>
-        <version>${groovy-eclipse-compiler.version}</version>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- if including source jars, use the no-fork goals
+             otherwise both the Groovy sources and Java stub sources
+             will get included in your jar -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
@@ -143,32 +149,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk9-build</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <!--Skip compile on Java 9 https://issues.apache.org/jira/browse/CAMEL-10905 -->
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-compile</id>
-                <phase>none</phase>
-              </execution>
-              <execution>
-                <id>default-testCompile</id>
-                <phase>none</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/components/camel-grape/src/main/groovy/org/apache/camel/component/grape/GrapeProducer.groovy
+++ b/components/camel-grape/src/main/groovy/org/apache/camel/component/grape/GrapeProducer.groovy
@@ -23,7 +23,6 @@ import org.apache.camel.impl.DefaultProducer
 import static GrapeCommand.clearPatches
 import static GrapeCommand.grab
 import static GrapeCommand.listPatches
-import static GrapeConstants.GRAPE_COMMAND
 
 class GrapeProducer extends DefaultProducer {
 
@@ -33,7 +32,7 @@ class GrapeProducer extends DefaultProducer {
 
     @Override
     void process(Exchange exchange) {
-        def command = exchange.in.getHeader(GRAPE_COMMAND, grab, GrapeCommand.class)
+        def command = exchange.in.getHeader(GrapeConstants.GRAPE_COMMAND, grab, GrapeCommand.class)
         switch(command) {
             case grab:
                 def classLoader = exchange.context.applicationContextClassLoader


### PR DESCRIPTION
…pse Compiler with GMavenPlus

Not ready to merge!

The groovy-eclipse-compiler plugin is dead (last release in 2015) and https://github.com/groovy/groovy-eclipse/issues/265 was closed without being resolved.

With GMavenPlus `mvn clean test` works on Java 8 and 9. But when I run `mvn package` I get this error:

```
[INFO] --- camel-package-maven-plugin:2.22.0-SNAPSHOT:validate-components (validate) @ camel-grape ---
[WARNING] The component: grape has validation errors
[WARNING] Missing @UriPath on endpoint
[WARNING] Missing component documentation for the following options:
        metaClass
        patchesRepository
```

Any help with this would be greatly appreciated. 

With GMavenPlus is should also be possible to make `camel-groovy` and `camel-example-groovy` build on Java 9.