### PR TITLE
CAMEL-12274: Bindy - Unescape double quotes inside CSV field

### DIFF
--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyDoubleQuotesInFieldCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyDoubleQuotesInFieldCsvUnmarshallTest.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.csv;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.annotation.CsvRecord;
+import org.apache.camel.dataformat.bindy.annotation.DataField;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration
+public class BindyDoubleQuotesInFieldCsvUnmarshallTest extends AbstractJUnit4SpringContextTests {
+
+    private static final String URI_MOCK_RESULT = "mock:result";
+    private static final String URI_DIRECT_START = "direct:start";
+
+    @Produce(uri = URI_DIRECT_START)
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = URI_MOCK_RESULT)
+    private MockEndpoint result;
+
+    private String expected;
+
+    @Test
+    @DirtiesContext
+    public void testUnMarshallMessage() throws Exception {
+
+        expected = "\"10\",\"A9\",\"Pauline de \"\"Quotes\"\"\",\"M\",\"ISIN\",\"XD12345678\",\"BUY\",\"Share\",\"2500.45\",\"USD\",\"08-01-2009\"";
+
+        template.sendBody(expected);
+
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+        
+        Order order = result.getReceivedExchanges().get(0).getIn().getBody(Order.class);
+        Assert.assertEquals("Pauline de \"Quotes\"", order.getFirstName());
+    }
+
+    public static class ContextConfig extends RouteBuilder {
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(Order.class);
+
+        public void configure() {
+            from(URI_DIRECT_START).unmarshal(camelDataFormat).to(URI_MOCK_RESULT);
+        }
+
+    }
+    
+    @CsvRecord(separator = ",")
+    public static class Order {
+
+        @DataField(pos = 1)
+        private int orderNr;
+
+        @DataField(pos = 2)
+        private String clientNr;
+
+        @DataField(pos = 3)
+        private String firstName;
+
+        @DataField(pos = 4)
+        private String lastName;
+
+        @DataField(pos = 5)
+        private String instrumentCode;
+
+        @DataField(pos = 6)
+        private String instrumentNumber;
+
+        @DataField(pos = 7)
+        private String orderType;
+
+        @DataField(name = "Name", pos = 8)
+        private String instrumentType;
+
+        @DataField(pos = 9, precision = 2)
+        private BigDecimal amount;
+
+        @DataField(pos = 10)
+        private String currency;
+
+        @DataField(pos = 11, pattern = "dd-MM-yyyy")
+        private Date orderDate;
+
+        public int getOrderNr() {
+            return orderNr;
+        }
+
+        public void setOrderNr(int orderNr) {
+            this.orderNr = orderNr;
+        }
+
+        public String getClientNr() {
+            return clientNr;
+        }
+
+        public void setClientNr(String clientNr) {
+            this.clientNr = clientNr;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getInstrumentCode() {
+            return instrumentCode;
+        }
+
+        public void setInstrumentCode(String instrumentCode) {
+            this.instrumentCode = instrumentCode;
+        }
+
+        public String getInstrumentNumber() {
+            return instrumentNumber;
+        }
+
+        public void setInstrumentNumber(String instrumentNumber) {
+            this.instrumentNumber = instrumentNumber;
+        }
+
+        public String getOrderType() {
+            return orderType;
+        }
+
+        public void setOrderType(String orderType) {
+            this.orderType = orderType;
+        }
+
+        public String getInstrumentType() {
+            return instrumentType;
+        }
+
+        public void setInstrumentType(String instrumentType) {
+            this.instrumentType = instrumentType;
+        }
+
+        public BigDecimal getAmount() {
+            return amount;
+        }
+
+        public void setAmount(BigDecimal amount) {
+            this.amount = amount;
+        }
+
+        public String getCurrency() {
+            return currency;
+        }
+
+        public void setCurrency(String currency) {
+            this.currency = currency;
+        }
+
+        public Date getOrderDate() {
+            return orderDate;
+        }
+
+        public void setOrderDate(Date orderDate) {
+            this.orderDate = orderDate;
+        }
+
+        @Override
+        public String toString() {
+            return "Model : " + Order.class.getName() + " : " + this.orderNr + ", " + this.orderType + ", " + String.valueOf(this.amount) + ", " + this.instrumentCode + ", "
+                   + this.instrumentNumber + ", " + this.instrumentType + ", " + this.currency + ", " + this.clientNr + ", " + this.firstName + ", " + this.lastName + ", "
+                   + String.valueOf(this.orderDate);
+        }
+    }
+
+}

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest.java
@@ -51,7 +51,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest extends Camel
 
         BindyCsvRowFormat75191 body = new BindyCsvRowFormat75191();
         body.setFirstField("123");
-        body.setSecondField("\"\"foo\"\"");
+        body.setSecondField("\"foo\"");
         body.setNumber(new BigDecimal(10));
         template.sendBody("direct:startMarshal1", body);
         
@@ -60,7 +60,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest extends Camel
         BindyCsvRowFormat75191 model = mockEndPointUnMarshal1.getReceivedExchanges().get(0).getIn().getBody(BindyCsvRowFormat75191.class);
         
         assertEquals("123", model.getFirstField());
-        assertEquals("\"\"foo\"\"", model.getSecondField());
+        assertEquals("\"foo\"", model.getSecondField());
         assertEquals(new BigDecimal(10), model.getNumber());
     }
     
@@ -120,6 +120,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest extends Camel
     //from https://issues.apache.org/jira/browse/CAMEL-7519
     @CsvRecord(separator = ",", quote = "\"", quoting = true, quotingEscaped = false)
     public static class BindyCsvRowFormat75191 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;
@@ -157,6 +158,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest extends Camel
     
     @CsvRecord(separator = ",", quote = "'", quoting = true, quotingEscaped = false)
     public static class BindyCsvRowFormat75192 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;
@@ -191,6 +193,4 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeFalseTest extends Camel
             this.number = number;
         }
     }
-
-
 }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvContainingMultiQuoteCharEscapeTrueTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvContainingMultiQuoteCharEscapeTrueTest.java
@@ -120,6 +120,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeTrueTest extends CamelT
     //from https://issues.apache.org/jira/browse/CAMEL-7519
     @CsvRecord(separator = ",", quote = "\"", quoting = true, quotingEscaped = true)
     public static class BindyCsvRowFormat75191 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;
@@ -157,6 +158,7 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeTrueTest extends CamelT
     
     @CsvRecord(separator = ",", quote = "'", quoting = true, quotingEscaped = true)
     public static class BindyCsvRowFormat75192 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;
@@ -191,6 +193,4 @@ public class BindySimpleCsvContainingMultiQuoteCharEscapeTrueTest extends CamelT
             this.number = number;
         }
     }
-
-
 }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvFunctionWithClassMethodTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvFunctionWithClassMethodTest.java
@@ -51,7 +51,7 @@ public class BindySimpleCsvFunctionWithClassMethodTest extends CamelTestSupport 
 
         BindyCsvRowFormat7621 body = new BindyCsvRowFormat7621();
         body.setFirstField("123");
-        body.setSecondField("\"\"foo\"\"");
+        body.setSecondField("\"foo\"");
         body.setNumber(new BigDecimal(10));
         template.sendBody("direct:startMarshal1", body);
         
@@ -60,7 +60,7 @@ public class BindySimpleCsvFunctionWithClassMethodTest extends CamelTestSupport 
         BindyCsvRowFormat7621 model = mockEndPointUnMarshal1.getReceivedExchanges().get(0).getIn().getBody(BindyCsvRowFormat7621.class);
         
         assertEquals("123", model.getFirstField());
-        assertEquals("\"\"FOO\"\"", model.getSecondField());
+        assertEquals("\"FOO\"", model.getSecondField());
         assertEquals(new BigDecimal(10), model.getNumber());
     }
 
@@ -86,6 +86,7 @@ public class BindySimpleCsvFunctionWithClassMethodTest extends CamelTestSupport 
 
     @CsvRecord(separator = ",", quote = "\"", quoting = true, quotingEscaped = false)
     public static class BindyCsvRowFormat7621 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvFunctionWithExternalMethodTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySimpleCsvFunctionWithExternalMethodTest.java
@@ -55,7 +55,7 @@ public class BindySimpleCsvFunctionWithExternalMethodTest extends CamelTestSuppo
 
         BindyCsvRowFormat7621 body = new BindyCsvRowFormat7621();
         body.setFirstField("123");
-        body.setSecondField("\"\"foo\"\"");
+        body.setSecondField("\"foo\"");
         body.setNumber(new BigDecimal(10));
         template.sendBody("direct:startMarshal1", body);
         
@@ -64,7 +64,7 @@ public class BindySimpleCsvFunctionWithExternalMethodTest extends CamelTestSuppo
         BindyCsvRowFormat7621 model = mockEndPointUnMarshal1.getReceivedExchanges().get(0).getIn().getBody(BindyCsvRowFormat7621.class);
         
         assertEquals("123", model.getFirstField());
-        assertEquals("\"\"bar\"\"", model.getSecondField());
+        assertEquals("\"bar\"", model.getSecondField());
         assertEquals(new BigDecimal(10), model.getNumber());
     }
 
@@ -90,6 +90,7 @@ public class BindySimpleCsvFunctionWithExternalMethodTest extends CamelTestSuppo
 
     @CsvRecord(separator = ",", quote = "\"", quoting = true, quotingEscaped = false)
     public static class BindyCsvRowFormat7621 implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         @DataField(pos = 1)
         private String firstField;

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.csv;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.model.simple.oneclasssinglequote.Order;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration
+public class BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest extends AbstractJUnit4SpringContextTests {
+    
+    private static final String URI_MOCK_RESULT = "mock:result";
+    private static final String URI_DIRECT_START = "direct:start";
+
+    @Produce(uri = URI_DIRECT_START)
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = URI_MOCK_RESULT)
+    private MockEndpoint result;
+
+    private String expected;
+
+    @Test
+    @DirtiesContext
+    public void testUnMarshallMessage() throws Exception {
+
+        expected = "10,A9,'Pauline de \"\"Quotes\"\"','O'Donald',ISIN,XD12345678,BUY,Share,2500.45,USD,08-01-2009";
+
+        template.sendBody(expected);
+
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+
+        Order order = result.getReceivedExchanges().get(0).getIn().getBody(Order.class);
+        Assert.assertEquals(10, order.getOrderNr());
+        Assert.assertEquals("Pauline de \"\"Quotes\"\"", order.getFirstName());
+        Assert.assertEquals("O'Donald", order.getLastName());
+    }
+
+    public static class ContextConfig extends RouteBuilder {
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(org.apache.camel.dataformat.bindy.model.simple.oneclasssinglequote.Order.class);
+
+        public void configure() {
+            from(URI_DIRECT_START).unmarshal(camelDataFormat).to(URI_MOCK_RESULT);
+        }
+    }
+}

--- a/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyDoubleQuotesInFieldCsvUnmarshallTest-context.xml
+++ b/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyDoubleQuotesInFieldCsvUnmarshallTest-context.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="      http://www.springframework.org/schema/beans      http://www.springframework.org/schema/beans/spring-beans.xsd      http://camel.apache.org/schema/spring      http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <camelContext id="camelContext-c82c721b-cdcb-4454-9994-26a6cded0e15" xmlns="http://camel.apache.org/schema/spring">
+    <routeBuilder ref="myBuilder"/>
+  </camelContext>
+  <bean
+    class="org.apache.camel.dataformat.bindy.csv.BindyDoubleQuotesInFieldCsvUnmarshallTest$ContextConfig" id="myBuilder"/>
+</beans>

--- a/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest-context.xml
+++ b/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest-context.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="      http://www.springframework.org/schema/beans      http://www.springframework.org/schema/beans/spring-beans.xsd      http://camel.apache.org/schema/spring      http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <camelContext id="camelContext-8b6febc1-7092-4b97-8847-38f4482d2ca2" xmlns="http://camel.apache.org/schema/spring">
+    <routeBuilder ref="myBuilder"/>
+  </camelContext>
+  <bean
+    class="org.apache.camel.dataformat.bindy.csv.BindySingleQuotesWithDoubleQuotesInFieldCsvUnmarshallTest$ContextConfig" id="myBuilder"/>
+</beans>


### PR DESCRIPTION
This fix is related to RFC 4180 section 2.7 https://tools.ietf.org/html/rfc4180#section-2 