### PR TITLE
CAMEL-12437

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
@@ -228,7 +228,12 @@ public class S3Producer extends DefaultProducer {
             is = new ByteArrayInputStream(baos.toByteArray());
         }
 
-        putObjectRequest = new PutObjectRequest(getConfiguration().getBucketName(), determineKey(exchange), is, objectMetadata);
+        String bucketName = exchange.getIn().getHeader(S3Constants.BUCKET_NAME, String.class);
+        if (bucketName == null){
+            LOG.trace("Bucket name is not in header, using default one  [{}]...", getConfiguration().getBucketName());
+            bucketName = getConfiguration().getBucketName();
+        }
+        putObjectRequest = new PutObjectRequest(bucketName, determineKey(exchange), is, objectMetadata);
 
         String storageClass = determineStorageClass(exchange);
         if (storageClass != null) {


### PR DESCRIPTION
I created a jira ticket for this improvement https://issues.apache.org/jira/browse/CAMEL-12437

Basically with current implementation (as per camel version 2.20.2) there is no way to provide dynamic s3 bucket name when you upload files (it's possible though if copying files from source bucket to destination bucket).
I think we could use S3Constants.BUCKET_NAME provided at exchange header and if it is set use that value as bucket name where file will be uploaded, if S3Constants.BUCKET_NAME is not provided then  use bucket which is preconfigured at configuration.

