### PR TITLE
CAMEL-12445: spring-boot-rest-swagger example does not compile due to

### DIFF
--- a/examples/camel-example-spring-boot-rest-swagger/pom.xml
+++ b/examples/camel-example-spring-boot-rest-swagger/pom.xml
@@ -67,6 +67,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+    </dependency>
 
     <!-- Camel -->
     <dependency>


### PR DESCRIPTION
missing servlet-api dependendency