### PR TITLE
CAMEL-12448  - camel-consul: filter health checks by service id

### DIFF
--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/cloud/ConsulServiceDiscovery.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/cloud/ConsulServiceDiscovery.java
@@ -62,7 +62,12 @@ public final class ConsulServiceDiscovery extends DefaultServiceDiscovery {
             .getResponse();
 
         return services.stream()
-            .map(service -> newService(name, service, healths))
+            .map(service -> newService(
+                    name,
+                    service,
+                    healths.stream()
+                            .filter(serviceHealth -> serviceHealth.getService().getId().equals(service.getServiceId()))
+                            .collect(Collectors.toList())))
             .collect(Collectors.toList());
     }
 

--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/cloud/ConsulServiceDiscovery.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/cloud/ConsulServiceDiscovery.java
@@ -62,12 +62,7 @@ public final class ConsulServiceDiscovery extends DefaultServiceDiscovery {
             .getResponse();
 
         return services.stream()
-            .map(service -> newService(
-                    name,
-                    service,
-                    healths.stream()
-                            .filter(serviceHealth -> serviceHealth.getService().getId().equals(service.getServiceId()))
-                            .collect(Collectors.toList())))
+            .map(service -> newService(name, service, healths))
             .collect(Collectors.toList());
     }
 
@@ -104,7 +99,11 @@ public final class ConsulServiceDiscovery extends DefaultServiceDiscovery {
             service.getServiceAddress(),
             service.getServicePort(),
             meta,
-            new DefaultServiceHealth(serviceHealthList.stream().allMatch(this::isHealthy))
+            new DefaultServiceHealth(
+                    serviceHealthList.stream()
+                            .filter(h -> ObjectHelper.equal(h.getService().getId(), service.getServiceId()))
+                            .allMatch(this::isHealthy)
+            )
         );
     }
 }


### PR DESCRIPTION
In Consul catalog registered two instances of one service. Health check for first instance have "passed" state, and for second instance - "critical". Camel returns both service instances with healty checks, which method "isHealthy" returns "false".