### PR TITLE
CAMEL-10671: Adding Camel example project for the Ceylon JVM language

### DIFF
--- a/examples/camel-example-ceylon/.gitignore
+++ b/examples/camel-example-ceylon/.gitignore
@@ -1,0 +1,1 @@
+module.ceylon

--- a/examples/camel-example-ceylon/ReadMe.md
+++ b/examples/camel-example-ceylon/ReadMe.md
@@ -1,0 +1,29 @@
+# Camel Router with Ceylon Project
+
+A simple example that uses Ceylon programming language to define a little Camel route.
+
+The Camel route listen on HTTP port 8080 and return back a constant response.
+
+### How to run
+
+To build this project use
+
+    mvn clean install
+
+To run this project
+
+    mvn resources:resources ceylon:run
+    
+You can then open the following url from a web browser: <http://localhost:8080>
+
+
+### Forum, Help, etc
+
+If you hit an problems please let us know on the Camel Forums
+	<http://camel.apache.org/discussion-forums.html>
+
+Please help us make Apache Camel better - we appreciate any feedback you may
+have.  Enjoy!
+
+
+The Camel riders!

--- a/examples/camel-example-ceylon/pom.xml
+++ b/examples/camel-example-ceylon/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel.example</groupId>
+    <artifactId>examples</artifactId>
+    <version>2.22.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-example-ceylon</artifactId>
+  <packaging>jar</packaging>
+  <name>Camel :: Example :: Ceylon</name>
+  <description>A Camel route using Ceylon</description>
+
+  <properties>
+    <category>Other Languages</category>
+    <ceylon.version>1.3.3</ceylon.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+
+    <!-- used for jetty -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jetty</artifactId>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources/module</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/module.ceylon</include>
+        </includes>
+      </resource>
+    </resources>
+
+    <sourceDirectory>${project.basedir}/src/main/ceylon</sourceDirectory>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <configuration>
+              <tasks>
+                <copy file="${project.build.outputDirectory}/module.ceylon"
+                      toFile="${project.basedir}/src/main/ceylon/org/apache/camel/example/module.ceylon" overwrite="true" />
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.ceylon-lang</groupId>
+        <artifactId>ceylon-maven-plugin</artifactId>
+        <version>${ceylon.version}</version>
+        <configuration>
+          <disablePomChecks>true</disablePomChecks>
+          <module>org.apache.camel.example/${project.version}</module>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/MyRouteBuilder.ceylon
+++ b/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/MyRouteBuilder.ceylon
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder { RouteBuilder }
+
+class MyRouteBuilder() extends RouteBuilder() {
+
+    shared actual void configure() {
+        from("jetty:http://0.0.0.0:8080")
+                .transform(constant("Hello from Ceylon"));
+    }
+}

--- a/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/package.ceylon
+++ b/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/package.ceylon
@@ -1,0 +1,17 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+shared package org.apache.camel.example;

--- a/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/run.ceylon
+++ b/examples/camel-example-ceylon/src/main/ceylon/org/apache/camel/example/run.ceylon
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.main { CamelMain = Main }
+import org.apache.camel.example { MyRouteBuilder }
+import ceylon.interop.java { createJavaStringArray }
+import java.lang { System }
+
+shared void run() {
+    print("\n\n\n\n");
+    print("===============================================");
+    print("Open your web browser on http://localhost:8080");
+    print("Press ctrl+c to stop this example");
+    print("===============================================");
+    print("\n\n\n\n");
+
+    CamelMain main = CamelMain();
+    main.addRouteBuilder(MyRouteBuilder());
+    main.run(createJavaStringArray(process.arguments));
+    System.exit(main.exitCode);
+
+}

--- a/examples/camel-example-ceylon/src/main/resources/log4j2.properties
+++ b/examples/camel-example-ceylon/src/main/resources/log4j2.properties
@@ -1,0 +1,23 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+appender.out.type = Console
+appender.out.name = out
+appender.out.layout.type = PatternLayout
+appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+rootLogger.level = INFO
+rootLogger.appenderRef.out.ref = out

--- a/examples/camel-example-ceylon/src/main/resources/module/module.ceylon
+++ b/examples/camel-example-ceylon/src/main/resources/module/module.ceylon
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+native("jvm")
+module org.apache.camel.example "${project.version}" {
+
+    shared import "ceylon.interop.java" "${ceylon.version}";
+    shared import maven:"org.apache.camel:camel-core" "${project.version}";
+    shared import maven:"org.apache.camel:camel-jetty" "${project.version}";
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -52,6 +52,7 @@
     <module>camel-example-cdi-rest-servlet</module>
     <module>camel-example-cdi-test</module>
     <module>camel-example-cdi-xml</module>
+    <module>camel-example-ceylon</module>
     <module>camel-example-cxf</module>
     <module>camel-example-cxf-blueprint</module>
     <module>camel-example-cxf-proxy</module>


### PR DESCRIPTION
Adding Camel example for Ceylon 1.3.3. 

Followed the path of the Kotlin example as instructed on the ticket. 

Compile/Runs without errors and I'm able to access Jetty's localhost:8080 for the welcome message.

Things I couldn't get around: 

1.  The module.ceylon file cannot refer to Maven POM versions/properties unfortunately needing a hardcoded version of the used libs ([double-checked on the Ceylon Gitter channel too](https://gitter.im/ceylon/user?at=5adda26e62316e0505eceb43))
2. I had to hardcode the version of camel-http-common since the 2.22.0-SNAPSHOT does not exist