### PR TITLE
Remove Metric 3.0.1 related classloader leak warning, now that we use…

### DIFF
--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -153,11 +153,6 @@ class MyBean extends RouteBuilder {
 }
 ----
 
-CAUTION: `MetricRegistry` uses internal thread(s) for reporting. There is no
-public API in version DropWizard `3.0.1` for users to clean up on exit. Thus using
-Camel Metrics Component leads to Java classloader leak and my cause
-`OutOfMemoryErrors` in some cases.
-
 ### Usage
 
 Each metric has type and name. Supported types are


### PR DESCRIPTION
… Metrics 3.2.6.

I guess probably referred to https://github.com/dropwizard/metrics/issues/742 which was fixed in 3.1.x