### PR TITLE
CAMEL-12460 Fix camel actuator endpoints to get it working with SB2

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/readme.adoc
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/readme.adoc
@@ -26,13 +26,13 @@ You can run this example using
 To show a summary of all the routes
 
 ----
-curl -XGET -s http://localhost:8080/camel/routes
+curl -XGET -s http://localhost:8080/camelroutes
 ----
 
 To show detailed information for a specific route
 
 ----
-curl -XGET -s http://localhost:8080/camel/routes/{id}/info
+curl -XGET -s http://localhost:8080/camelroutes/{id}/detail
 ----
 
 

--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -31,14 +31,17 @@ timer.period = 2000
 # add for example: &repeatCount=5 to the timer endpoint to make Camel idle
 #camel.springboot.duration-max-idle-seconds=15
 
+# expose actuator endpoint via HTTP
+management.endpoints.web.exposure.include=info,health,camelroutes
+
 # all access to actuator endpoints without security
 management.security.enabled = false
 # turn on actuator health check
-endpoints.health.enabled = true
+management.endpoint.health.enabled = true
 
 # allow to obtain basic information about camel routes (read only mode)
-endpoints.camelroutes.enabled = true
-endpoints.camelroutes.read-only = true
+management.endpoint.camelroutes.enabled = true
+management.endpoint.camelroutes.read-only = true
 
 # to configure logging levels
 #logging.level.org.springframework = INFO

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
@@ -39,19 +39,20 @@ import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link Endpoint} to expose {@link org.apache.camel.Route} information.
  */
 @Endpoint(id = "camelroutes", enableByDefault = true)
-@ConfigurationProperties("management.endpoint.camelroutes")
 public class CamelRoutesEndpoint {
 
     private CamelContext camelContext;
-    private boolean readOnly = true;
+    private CamelRoutesEndpointProperties properties;
 
-    public CamelRoutesEndpoint(CamelContext camelContext) {
+    public CamelRoutesEndpoint(CamelContext camelContext, CamelRoutesEndpointProperties properties) {
         this.camelContext = camelContext;
+        this.properties = properties;
     }
 
     @ReadOperation
@@ -72,8 +73,8 @@ public class CamelRoutesEndpoint {
     }
 
     @WriteOperation
-    public void doWriteAction(@Selector String id, @Selector WriteAction action, TimeInfo timeInfo) {
-        if (this.isReadOnly()) {
+    public void doWriteAction(@Selector String id, @Selector WriteAction action, @Nullable TimeInfo timeInfo) {
+        if (this.properties.isReadOnly()) {
             throw new IllegalArgumentException(String.format("Read only: write action %s is not allowed", action));
         }
 
@@ -106,7 +107,7 @@ public class CamelRoutesEndpoint {
 
     @WriteOperation
     public String getRouteDump(@Selector String id) {
-        if (this.isReadOnly()) {
+        if (this.properties.isReadOnly()) {
             throw new IllegalArgumentException("Read only: route dump is not permitted in read-only mode");
         }
 
@@ -119,14 +120,6 @@ public class CamelRoutesEndpoint {
             }
         }
         return null;
-    }
-
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    public void setReadOnly(boolean readOnly) {
-        this.readOnly = readOnly;
     }
 
     private RouteEndpointInfo getRouteInfo(String id) {

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointAutoConfiguration.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointAutoConfiguration.java
@@ -18,11 +18,14 @@ package org.apache.camel.spring.boot.actuate.endpoint;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,17 +33,24 @@ import org.springframework.context.annotation.Configuration;
  * Auto configuration for the {@link CamelRoutesEndpoint}.
  */
 @Configuration
+@EnableConfigurationProperties({ CamelRoutesEndpointProperties.class })
 @ConditionalOnClass({CamelRoutesEndpoint.class})
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelRoutesEndpointAutoConfiguration {
+
+    private CamelRoutesEndpointProperties properties;
+
+    public CamelRoutesEndpointAutoConfiguration(CamelRoutesEndpointProperties properties) {
+        this.properties = properties;
+    }
 
     @Bean
     @ConditionalOnClass(CamelContext.class)
     @ConditionalOnMissingBean
     @ConditionalOnEnabledEndpoint
     public CamelRoutesEndpoint camelEndpoint(CamelContext camelContext) {
-        return new CamelRoutesEndpoint(camelContext);
+        return new CamelRoutesEndpoint(camelContext, properties);
     }
 
 }

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointProperties.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointProperties.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot.actuate.endpoint;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("management.endpoint.camelroutes")
+public class CamelRoutesEndpointProperties {
+
+    private boolean readOnly = true;
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+}

--- a/components/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/components/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,16 +1,10 @@
 {
   "properties": [
     {
-      "name": "management.endpoint.camelroutes.path",
-      "type": "java.lang.String",
-      "description": "The URL path to use for Camel Routes actuator endpoint.",
-      "defaultValue": "/camel/routes"
-    },
-    {
       "name": "management.endpoint.camelroutes.read-only",
       "type": "java.lang.Boolean",
       "description": "Whether Camel Routes actuator is in read-only mode. If not in read-only mode then operations to start/stop routes would be enabled.",
-      "defaultValue": "true"
+      "defaultValue": true
     },
     {
       "name": "management.endpoint.camelroutes.enabled",

--- a/examples/camel-example-spring-boot-supervising-route-controller/pom.xml
+++ b/examples/camel-example-spring-boot-supervising-route-controller/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-actuator</artifactId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/examples/camel-example-spring-boot-supervising-route-controller/readme.adoc
+++ b/examples/camel-example-spring-boot-supervising-route-controller/readme.adoc
@@ -14,35 +14,35 @@ Beside JMX you can use Spring Boot Endpoints to interact with the routes:
 +
 [source]
 ----
-curl -XGET -s http://localhost:8080/camel/routes
+curl -XGET -s http://localhost:8080/actuator/camelroutes
 ----
 +
 +* To get details about a route
 ++
 +[source]
 +----
-+curl -XGET -s http://localhost:8080/camel/routes/{id}/detail
++curl -XGET -s http://localhost:8080/actuator/camelroutes/{id}/detail
 +----
 
 * To get info about a route
 +
 [source]
 ----
-curl -XGET -s http://localhost:8080/camel/routes/{id}/info
+curl -XGET -s http://localhost:8080/actuator/camelroutes/{id}/info
 ----
 
 * To stop a route
 +
 [source]
 ----
-curl -XPOST -s http://localhost:8080/camel/routes/{id}/stop
+curl -XPOST -H "Content-Type: application/json" -s http://localhost:8080/actuator/camelroutes/{id}/stop
 ----
 
 * To start a route
 +
 [source]
 ----
-curl -XPOST -s http://localhost:8080/camel/routes/{id}/stop
+curl -XPOST -H "Content-Type: application/json" -s http://localhost:8080/actuator/camelroutes/{id}/start
 ----
 
 

--- a/examples/camel-example-spring-boot-supervising-route-controller/src/main/resources/application.properties
+++ b/examples/camel-example-spring-boot-supervising-route-controller/src/main/resources/application.properties
@@ -24,13 +24,15 @@ logging.level.org.apache.camel.impl.SupervisingRouteController = DEBUG
 logging.level.org.apache.camel.util.backoff = DEBUG
 logging.level.sample.camel = DEBUG
 
+# expose actuator endpoint via HTTP
+management.endpoints.web.exposure.include=info,health,camelroutes
+
 management.endpoints.enabled-by-default = true
 management.endpoints.jmx.enabled = false
 management.endpoint.health.enabled = true
 
 # camel routes is by default enabled
 # so you do not have to configure below
-# management.endpoint.camelroutes.path = /camel/routes
 # management.endpoint.camelroutes.enabled = true
 
 # turn off read-only so we can stop/start the Camel routes

--- a/examples/camel-example-spring-boot/readme.adoc
+++ b/examples/camel-example-spring-boot/readme.adoc
@@ -34,13 +34,13 @@ curl -XGET -s http://localhost:8080/actuator/health
 To show a summary of all the routes
 
 ----
-curl -XGET -s http://localhost:8080/actuator/camel/routes
+curl -XGET -s http://localhost:8080/actuator/camelroutes
 ----
 
 To show detailed information for a specific route
 
 ----
-curl -XGET -s http://localhost:8080/actuator/camel/routes/{id}/info
+curl -XGET -s http://localhost:8080/actuator/camelroutes/{id}/detail
 ----
 
 

--- a/examples/camel-example-spring-boot/src/main/resources/application.properties
+++ b/examples/camel-example-spring-boot/src/main/resources/application.properties
@@ -31,6 +31,9 @@ timer.period = 2000
 # add for example: &repeatCount=5 to the timer endpoint to make Camel idle
 #camel.springboot.duration-max-idle-seconds=15
 
+# expose actuator endpoint via HTTP
+management.endpoints.web.exposure.include=info,health,camelroutes
+
 # show verbose health details (/actuator/info) so you can see Camel information also
 management.endpoint.health.show-details=always
 
@@ -46,3 +49,4 @@ management.endpoint.camelroutes.read-only = true
 #logging.level.org.apache.camel.spring.boot = INFO
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
+

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5010,6 +5010,7 @@
               <maxmem>512M</maxmem>
               <fork>${compiler.fork}</fork>
               <compilerArgs>
+                <!-- SB2 actuator endpoint requires MethodParameter metadata -->
                 <arg>-parameters</arg>
               </compilerArgs>
           </configuration>
@@ -5690,6 +5691,7 @@
                 <compilerArgs>
                   <arg>-J--add-modules</arg>
                   <arg>-Jjava.xml.bind</arg>
+                  <!-- SB2 actuator endpoint requires MethodParameter metadata -->
                   <arg>-parameters</arg>
                 </compilerArgs>
               </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5009,6 +5009,9 @@
               <target>${jdk.version}</target>
               <maxmem>512M</maxmem>
               <fork>${compiler.fork}</fork>
+              <compilerArgs>
+                <arg>-parameters</arg>
+              </compilerArgs>
           </configuration>
         </plugin>
         <plugin>
@@ -5687,6 +5690,7 @@
                 <compilerArgs>
                   <arg>-J--add-modules</arg>
                   <arg>-Jjava.xml.bind</arg>
+                  <arg>-parameters</arg>
                 </compilerArgs>
               </configuration>
             </plugin>


### PR DESCRIPTION
Also extracted CamelRoutesEndpointProperties as a separated class from CamelRoutesEndpoint

I wanted to make sure if it's OK to add `-parameters` javac option in parent POM.
https://github.com/apache/camel/pull/2307/files#diff-04dc5d029560773ac79faaf3da0fbb22

This option preserves method parameter names in class file, which is required for SB2 actuator endpoint to map path parameters.

https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html
> To allow the input to be mapped to the operation method’s parameters, Java code implementing an endpoint should be compiled with -parameters

Hopefully nothing depends on class file format, so that this option doesn't break anything.