### PR TITLE
Add url parameter to configure the queueUrl of an SqsEndpoint

### DIFF
--- a/components/camel-aws/src/main/docs/aws-sqs-component.adoc
+++ b/components/camel-aws/src/main/docs/aws-sqs-component.adoc
@@ -68,7 +68,7 @@ with the following path and query parameters:
 |===
 
 
-==== Query Parameters (46 parameters):
+==== Query Parameters (47 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -78,6 +78,7 @@ with the following path and query parameters:
 | *amazonSQSClient* (common) | To use the AmazonSQS as client |  | AmazonSQS
 | *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to map headers to/from Camel. |  | HeaderFilterStrategy
 | *queueOwnerAWSAccountId* (common) | Specify the queue owner aws account id when you need to connect the queue with different account owner. |  | String
+| *queueUrl* (common) | To define the queueUrl explicitly. All other parameters which would influence the queueUrl are ignored. |  | String
 | *region* (common) | Specify the queue region which could be used with queueOwnerAWSAccountId to build the service URL. |  | String
 | *attributeNames* (consumer) | A list of attribute names to receive when consuming. Multiple names can be separated by comma. |  | String
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean

--- a/components/camel-aws/src/main/docs/aws-sqs-component.adoc
+++ b/components/camel-aws/src/main/docs/aws-sqs-component.adoc
@@ -78,7 +78,6 @@ with the following path and query parameters:
 | *amazonSQSClient* (common) | To use the AmazonSQS as client |  | AmazonSQS
 | *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to map headers to/from Camel. |  | HeaderFilterStrategy
 | *queueOwnerAWSAccountId* (common) | Specify the queue owner aws account id when you need to connect the queue with different account owner. |  | String
-| *queueUrl* (common) | To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored. |  | String
 | *region* (common) | Specify the queue region which could be used with queueOwnerAWSAccountId to build the service URL. |  | String
 | *attributeNames* (consumer) | A list of attribute names to receive when consuming. Multiple names can be separated by comma. |  | String
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
@@ -98,6 +97,7 @@ with the following path and query parameters:
 | *delaySeconds* (producer) | Delay sending messages for a number of seconds. |  | Integer
 | *messageDeduplicationId Strategy* (producer) | Only for FIFO queues. Strategy for setting the messageDeduplicationId on the message. Can be one of the following options: useExchangeId, useContentBasedDeduplication. For the useContentBasedDeduplication option, no messageDeduplicationId will be set on the message. | useExchangeId | MessageDeduplicationId Strategy
 | *messageGroupIdStrategy* (producer) | Only for FIFO queues. Strategy for setting the messageGroupId on the message. Can be one of the following options: useConstant, useExchangeId, usePropertyValue. For the usePropertyValue option, the value of property CamelAwsMessageGroupId will be used. |  | MessageGroupIdStrategy
+| *queueUrl* (advanced) | To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored. This parameter is intended to be used, to connect to a mock implementation of SQS, for testing purposes. |  | String
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 | *backoffErrorThreshold* (scheduler) | The number of subsequent error polls (failed due some error) that should happen before the backoffMultipler should kick-in. |  | int
 | *backoffIdleThreshold* (scheduler) | The number of subsequent idle polls that should happen before the backoffMultipler should kick-in. |  | int

--- a/components/camel-aws/src/main/docs/aws-sqs-component.adoc
+++ b/components/camel-aws/src/main/docs/aws-sqs-component.adoc
@@ -78,7 +78,7 @@ with the following path and query parameters:
 | *amazonSQSClient* (common) | To use the AmazonSQS as client |  | AmazonSQS
 | *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to map headers to/from Camel. |  | HeaderFilterStrategy
 | *queueOwnerAWSAccountId* (common) | Specify the queue owner aws account id when you need to connect the queue with different account owner. |  | String
-| *queueUrl* (common) | To define the queueUrl explicitly. All other parameters which would influence the queueUrl are ignored. |  | String
+| *queueUrl* (common) | To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored. |  | String
 | *region* (common) | Specify the queue region which could be used with queueOwnerAWSAccountId to build the service URL. |  | String
 | *attributeNames* (consumer) | A list of attribute names to receive when consuming. Multiple names can be separated by comma. |  | String
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
@@ -63,7 +63,7 @@ public class SqsConfiguration implements Cloneable {
     private boolean extendMessageVisibility;
     @UriParam(label = "consumer", defaultValue = "1")
     private int concurrentConsumers = 1;
-    @UriParam
+    @UriParam(label = "advanced")
     private String queueUrl;
 
     // producer properties
@@ -350,6 +350,7 @@ public class SqsConfiguration implements Cloneable {
 	
     /**
      *  To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored.
+     *  This parameter is intended to be used, to connect to a mock implementation of SQS, for testing purposes.
      */
     public String getQueueUrl() {
         return queueUrl;

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
@@ -63,6 +63,8 @@ public class SqsConfiguration implements Cloneable {
     private boolean extendMessageVisibility;
     @UriParam(label = "consumer", defaultValue = "1")
     private int concurrentConsumers = 1;
+	@UriParam
+    private String queueUrl;
 
     // producer properties
     @UriParam(label = "producer")
@@ -344,6 +346,17 @@ public class SqsConfiguration implements Cloneable {
 
     public void setConcurrentConsumers(int concurrentConsumers) {
         this.concurrentConsumers = concurrentConsumers;
+    }
+	
+	/**
+     *  To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored.
+     */
+    public String getQueueUrl() {
+        return queueUrl;
+    }
+
+    public void setQueueUrl(String queueUrl) {
+        this.queueUrl = queueUrl;
     }
 
     /**

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsConfiguration.java
@@ -63,7 +63,7 @@ public class SqsConfiguration implements Cloneable {
     private boolean extendMessageVisibility;
     @UriParam(label = "consumer", defaultValue = "1")
     private int concurrentConsumers = 1;
-	@UriParam
+    @UriParam
     private String queueUrl;
 
     // producer properties
@@ -348,7 +348,7 @@ public class SqsConfiguration implements Cloneable {
         this.concurrentConsumers = concurrentConsumers;
     }
 	
-	/**
+    /**
      *  To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored.
      */
     public String getQueueUrl() {

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
@@ -127,7 +127,9 @@ public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterSt
             // If both region and Account ID is provided the queue URL can be built manually.
             // This allows accessing queues where you don't have permission to list queues or query queues
             if (configuration.getRegion() != null && configuration.getQueueOwnerAWSAccountId() != null) {
-                queueUrl = "https://sqs." + configuration.getRegion() + ".amazonaws.com/"
+                String host = configuration.getAmazonAWSHost();
+                host = FileUtil.stripTrailingSeparator(host);
+                queueUrl = "https://sqs." + configuration.getRegion() + host + "/"
                         + configuration.getQueueOwnerAWSAccountId() + "/" + configuration.getQueueName();
             } else if (configuration.getQueueOwnerAWSAccountId() != null) {
                 GetQueueUrlRequest getQueueUrlRequest = new GetQueueUrlRequest();
@@ -144,7 +146,7 @@ public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterSt
                         LOG.trace("Queue available at '{}'.", queueUrl);
                         break;
                     }
-				}
+                }
             }
         }
 

--- a/components/camel-aws/src/test/java/org/apache/camel/component/aws/sqs/SqsEndpointExplicitQueueUrlTest.java
+++ b/components/camel-aws/src/test/java/org/apache/camel/component/aws/sqs/SqsEndpointExplicitQueueUrlTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.sqs;
+
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.mockito.Mockito;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class SqsEndpointExplicitQueueUrlTest extends Assert {
+
+    private static final String QUEUE_URL = "http://localhost:9324/queue/default";
+    private SqsEndpoint endpoint;
+    private AmazonSQSClient amazonSQSClient;
+
+    @Before
+    public void setUp() {
+        amazonSQSClient = Mockito.mock(AmazonSQSClient.class);
+        
+        SqsConfiguration config = new SqsConfiguration();
+        config.setQueueUrl(QUEUE_URL);
+        config.setAmazonSQSClient(amazonSQSClient);
+        
+        endpoint = new SqsEndpoint("aws-sqs://test-queue", new SqsComponent(new DefaultCamelContext()), config);
+    }
+
+    @Test
+    public void doStartWithExplicitQueueUrlInConfigShouldNotCallSqsClientListQueues() throws Exception {
+        endpoint.doStart();
+
+        assertEquals(endpoint.getQueueUrl(), QUEUE_URL);
+    }
+}


### PR DESCRIPTION
I think it would be preferable to configure the queueUrl of an SqsEndpoint, to allow for integration testing against a mock implementation of AWS SQS, such as ElasticMQ.

To do so the most important things to be able to change are the protocol (http/https) and the host (localhost/sqs.{region}.amazonaws.com). In my opinion being able to control the complete queueUrl via urlParam is preferable over just controlling protocol and host, because it is easier to understand and it provides additional flexibility.