### PR TITLE
CAMEL-12480: HttpOperationFailedException exposes password when using…

### DIFF
--- a/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcOperationFailedException.java
+++ b/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcOperationFailedException.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelException;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.URISupport;
 
 public class AhcOperationFailedException extends CamelException {
     private static final long serialVersionUID = -6731281444593522633L;
@@ -31,8 +32,9 @@ public class AhcOperationFailedException extends CamelException {
     private final String responseBody;
 
     public AhcOperationFailedException(String url, int statusCode, String statusText, String location, Map<String, String> responseHeaders, String responseBody) {
-        super("HTTP operation failed invoking " + url + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
-        this.url = url;
+        // sanitize url so we do not show sensitive information such as passwords
+        super("HTTP operation failed invoking " + URISupport.sanitizeUri(url) + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
+        this.url = URISupport.sanitizeUri(url);
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.redirectLocation = location;

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcOperationFailedExceptionTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcOperationFailedExceptionTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ahc;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+public class AhcOperationFailedExceptionTest {
+
+    @Test
+    public void testUrlIsSanitized() {
+        AhcOperationFailedException ahcOperationFailedException = new AhcOperationFailedException("http://user:password@host", 500, "", "", null, "");
+
+        assertThat(ahcOperationFailedException.getMessage(), not(containsString("password")));
+        assertThat(ahcOperationFailedException.getUrl(), not(containsString("password")));
+    }
+}

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpOperationFailedException.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpOperationFailedException.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelException;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.URISupport;
 
 public class HttpOperationFailedException extends CamelException {
     private static final long serialVersionUID = -8721487434390572634L;
@@ -31,8 +32,9 @@ public class HttpOperationFailedException extends CamelException {
     private final String responseBody;
 
     public HttpOperationFailedException(String uri, int statusCode, String statusText, String location, Map<String, String> responseHeaders, String responseBody) {
-        super("HTTP operation failed invoking " + uri + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
-        this.uri = uri;
+        // sanitize uri so we do not show sensitive information such as passwords
+        super("HTTP operation failed invoking " + URISupport.sanitizeUri(uri) + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
+        this.uri = URISupport.sanitizeUri(uri);
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.redirectLocation = location;

--- a/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpOperationFailedExceptionTest.java
+++ b/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpOperationFailedExceptionTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.http.common;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+public class HttpOperationFailedExceptionTest {
+
+    @Test
+    public void testUriIsSanitized() {
+        HttpOperationFailedException httpOperationFailedException = new HttpOperationFailedException("http://user:password@host", 500, "", "", null, "");
+
+        assertThat(httpOperationFailedException.getMessage(), not(containsString("password")));
+        assertThat(httpOperationFailedException.getUri(), not(containsString("password")));
+    }
+}

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpOperationFailedException.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpOperationFailedException.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.netty.http;
 
 import org.apache.camel.CamelException;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.URISupport;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
 /**
@@ -32,8 +33,9 @@ public class NettyHttpOperationFailedException extends CamelException {
     private final transient HttpResponse response;
 
     public NettyHttpOperationFailedException(String uri, int statusCode, String statusText, String location, HttpResponse response) {
-        super("Netty HTTP operation failed invoking " + uri + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
-        this.uri = uri;
+        // sanitize uri so we do not show sensitive information such as passwords
+        super("Netty HTTP operation failed invoking " + URISupport.sanitizeUri(uri) + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
+        this.uri = URISupport.sanitizeUri(uri);
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.redirectLocation = location;

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpOperationFailedExceptionTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpOperationFailedExceptionTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty.http;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+public class NettyHttpOperationFailedExceptionTest {
+
+    @Test
+    public void testUriIsSanitized() {
+        NettyHttpOperationFailedException nettyHttpOperationFailedException = new NettyHttpOperationFailedException("http://user:password@host", 500, "", "", null);
+
+        assertThat(nettyHttpOperationFailedException.getMessage(), not(containsString("password")));
+        assertThat(nettyHttpOperationFailedException.getUri(), not(containsString("password")));
+    }
+}

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpOperationFailedException.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpOperationFailedException.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpContent;
 import org.apache.camel.CamelException;
 import org.apache.camel.component.netty4.NettyConverter;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.URISupport;
 
 /**
  * Exception when a Netty HTTP operation failed.
@@ -36,8 +37,9 @@ public class NettyHttpOperationFailedException extends CamelException {
     private final String contentAsString;
 
     public NettyHttpOperationFailedException(String uri, int statusCode, String statusText, String location, HttpContent content) {
-        super("Netty HTTP operation failed invoking " + uri + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
-        this.uri = uri;
+        // sanitize uri so we do not show sensitive information such as passwords
+        super("Netty HTTP operation failed invoking " + URISupport.sanitizeUri(uri) + " with statusCode: " + statusCode + (location != null ? ", redirectLocation: " + location : ""));
+        this.uri = URISupport.sanitizeUri(uri);
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.redirectLocation = location;

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpOperationFailedExceptionTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/NettyHttpOperationFailedExceptionTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http;
+
+import org.junit.Test;
+
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+public class NettyHttpOperationFailedExceptionTest {
+
+    @Test
+    public void testUriIsSanitized() {
+        NettyHttpOperationFailedException nettyHttpOperationFailedException = new NettyHttpOperationFailedException("http://user:password@host", 500, "", "", new DefaultLastHttpContent());
+
+        assertThat(nettyHttpOperationFailedException.getMessage(), not(containsString("password")));
+        assertThat(nettyHttpOperationFailedException.getUri(), not(containsString("password")));
+    }
+}


### PR DESCRIPTION
… basic auth with user:password@host notation

Sanitize URI in HttpOperationFailedException constructor.