### PR TITLE
CAMEL-1067 Fixing broken build

### DIFF
--- a/examples/camel-example-ceylon/pom.xml
+++ b/examples/camel-example-ceylon/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <category>Other Languages</category>
     <ceylon.version>1.3.3</ceylon.version>
+    <skipTests>true</skipTests>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Following up from the discussion here: https://github.com/apache/camel/pull/2303

Project currently succeeds mvn install as well as checkstyle but fails during surfire:test. As there are no tests and [following from this example](https://github.com/apache/camel/blob/3e07a6385b8ba57ba4eb666bd7d2b13ea53306fb/examples/camel-example-spring-boot-geocoder/pom.xml#L37) we can skip that phase all together with this parameter. 