### PR TITLE
CAMEL-12487 S3Producer must close the streams it opens 

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/s3/S3Producer.java
@@ -242,10 +242,11 @@ public class S3Producer extends DefaultProducer {
             message.setHeader(S3Constants.VERSION_ID, putObjectResult.getVersionId());
         }
 
+        // close streams
+        IOHelper.close(putObjectRequest.getInputStream());
+        IOHelper.close(is);
+
         if (getConfiguration().isDeleteAfterWrite() && filePayload != null) {
-            // close streams
-            IOHelper.close(putObjectRequest.getInputStream());
-            IOHelper.close(is);
             FileUtil.deleteFile(filePayload);
         }
     }


### PR DESCRIPTION
If S3Producer is not configured to delete file after upload, it leaves dangling streams.