### PR TITLE
Use secure repository URL

### DIFF
--- a/components/camel-restlet/pom.xml
+++ b/components/camel-restlet/pom.xml
@@ -43,7 +43,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.com</url>
     </repository>
   </repositories>
 

--- a/components/camel-restlet/src/main/docs/restlet-component.adoc
+++ b/components/camel-restlet/src/main/docs/restlet-component.adoc
@@ -383,7 +383,7 @@ well:
 <repository>  
    <id>maven-restlet</id>  
    <name>Public online Restlet repository</name>  
-   <url>http://maven.restlet.org</url>  
+   <url>https://maven.restlet.com</url>
 </repository>
 ----
 

--- a/examples/camel-example-restlet-jdbc/pom.xml
+++ b/examples/camel-example-restlet-jdbc/pom.xml
@@ -42,7 +42,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.com</url>
     </repository>
   </repositories>
 

--- a/platforms/karaf/features/pom.xml
+++ b/platforms/karaf/features/pom.xml
@@ -212,16 +212,4 @@
 
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>com.springsource.repository.bundles.release</id>
-      <name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
-    </repository>
-    <repository>
-      <id>com.springsource.repository.bundles.external</id>
-      <name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-      <url>http://repository.springsource.com/maven/bundles/external</url>
-    </repository>
-  </repositories>
 </project>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1824,8 +1824,8 @@
     <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
-    <bundle dependency='true'>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet/${restlet-version}</bundle>
-    <bundle dependency='true'>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.httpclient/${restlet-version}</bundle>
+    <bundle dependency='true'>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet/${restlet-version}</bundle>
+    <bundle dependency='true'>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.httpclient/${restlet-version}</bundle>
     <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/${javax.servlet-api-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-http-common/${project.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-restlet/${project.version}</bundle>
@@ -1844,13 +1844,13 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${jackson2-version}</bundle>
-    <bundle>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.jackson/${restlet-version}</bundle>
+    <bundle>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.jackson/${restlet-version}</bundle>
   </feature>
   <feature name='camel-restlet-gson' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-restlet</feature>
     <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime2-bundle-version}</bundle>
     <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
-    <bundle>mvn:http://maven.restlet.org@id=restlet!org.restlet.osgi/org.restlet.ext.gson/${restlet-version}</bundle>
+    <bundle>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.gson/${restlet-version}</bundle>
   </feature>
   <feature name='camel-rmi' version='${project.version}' resolver='(obr)' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>

--- a/platforms/karaf/pom.xml
+++ b/platforms/karaf/pom.xml
@@ -46,7 +46,7 @@
         </releases>
         <id>apache.snapshots</id>
         <name>Apache Snapshot Repository</name>
-        <url>http://repository.apache.org/snapshots</url>
+        <url>https://repository.apache.org/snapshots</url>
       </pluginRepository>
     </pluginRepositories>
 -->

--- a/platforms/spring-boot/components-starter/camel-restlet-starter/pom.xml
+++ b/platforms/spring-boot/components-starter/camel-restlet-starter/pom.xml
@@ -63,7 +63,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.com</url>
     </repository>
   </repositories>
   <!--END OF GENERATED CODE-->

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
   <repositories>
     <repository>
       <id>apache.snapshots</id>
-      <url>http://repository.apache.org/snapshots/</url>
+      <url>https://repository.apache.org/snapshots/</url>
       <name>Apache Snapshot Repo</name>
       <snapshots>
         <enabled>true</enabled>
@@ -127,7 +127,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>apache.snapshots</id>
-      <url>http://repository.apache.org/snapshots/</url>
+      <url>https://repository.apache.org/snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
   maven.restlet.org : Valid TLS certificate only for maven.restlet.com
   springsource.com : Repository unnecessary
   apache snapshots: Use TLS.

