### PR TITLE
CAMEL-12500: Add missing . between region and host in SqsEndpoint

### DIFF
--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
@@ -129,7 +129,7 @@ public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterSt
             if (configuration.getRegion() != null && configuration.getQueueOwnerAWSAccountId() != null) {
                 String host = configuration.getAmazonAWSHost();
                 host = FileUtil.stripTrailingSeparator(host);
-                queueUrl = "https://sqs." + configuration.getRegion() + host + "/"
+                queueUrl = "https://sqs." + configuration.getRegion() + "." + host + "/"
                         + configuration.getQueueOwnerAWSAccountId() + "/" + configuration.getQueueName();
             } else if (configuration.getQueueOwnerAWSAccountId() != null) {
                 GetQueueUrlRequest getQueueUrlRequest = new GetQueueUrlRequest();


### PR DESCRIPTION
There should be a . between the region and the host. Without this change, the queueUrl is, for example, `https://sqs.sqs.us-gov-west-1amazonaws.com` - it should be `https://sqs.sqs.us-gov-west-1.amazonaws.com`.

https://issues.apache.org/jira/browse/CAMEL-12500