### PR TITLE
[azure-starter] Fix of a typo in springg.factories for azure-starter

### DIFF
--- a/platforms/spring-boot/components-starter/camel-azure-starter/src/main/resources/META-INF/spring.factories
+++ b/platforms/spring-boot/components-starter/camel-azure-starter/src/main/resources/META-INF/spring.factories
@@ -16,5 +16,5 @@
 ## ---------------------------------------------------------------------------
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.apache.camel.component.azure.blob.springboot.BlobServiceComponentAutoConfiguration,\
-org.apache.camel.component.azure.blob.springboot.QueueServiceComponentAutoConfiguration
+org.apache.camel.component.azure.queue.springboot.QueueServiceComponentAutoConfiguration
 


### PR DESCRIPTION
There was a typo which caused camel-azure-starter to fail