### PR TITLE
CAMEL-11162: rest-dsl add client request validation

### DIFF
--- a/camel-core/src/main/docs/rest-dsl.adoc
+++ b/camel-core/src/main/docs/rest-dsl.adoc
@@ -646,6 +646,29 @@ key `verbose` then Camel will now include a header with key `verbose`
 and the value `false` because it was declared as the default value. This
 functionality is only applicable for query parameters.
 
+
+=== Client Request Validation
+
+From *Camel 2.22* onwards its possible to enable validation of the incoming client request.
+The validation checks for the following:
+
+- Content-Type header matches what the Rest DSL consumes.
+- Accept header matches what the Rest DSL produces.
+- Missing required data (query, context-path, body).
+
+If the validation fails then Rest DSL will return back an empty response
+with HTTP error code 415 or 406.
+
+The validation is by default turned off (to be backwards compatible).
+It can be turned on via `clientRequestValidation` as shown below:
+
+[source,java]
+----
+restConfiguration().component("jetty").host("localhost")
+    .clientRequestValidation(true);
+----
+
+
 === Integrating a Camel component with Rest DSL
 
 Any Apache Camel component can integrate with the Rest DSL if they can

--- a/camel-core/src/main/docs/rest-dsl.adoc
+++ b/camel-core/src/main/docs/rest-dsl.adoc
@@ -652,12 +652,12 @@ functionality is only applicable for query parameters.
 From *Camel 2.22* onwards its possible to enable validation of the incoming client request.
 The validation checks for the following:
 
-- Content-Type header matches what the Rest DSL consumes.
-- Accept header matches what the Rest DSL produces.
-- Missing required data (query, context-path, body).
+- Content-Type header matches what the Rest DSL consumes. (Returns HTTP Status 416)
+- Accept header matches what the Rest DSL produces. (Returns HTTP Status 406)
+- Missing required data (query parameters, HTTP headers, body). (Returns HTTP Status 400)
 
 If the validation fails then Rest DSL will return back an empty response
-with HTTP error code 415 or 406.
+with a HTTP error code.
 
 The validation is by default turned off (to be backwards compatible).
 It can be turned on via `clientRequestValidation` as shown below:

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestBindingDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestBindingDefinition.java
@@ -17,7 +17,9 @@
 package org.apache.camel.model.rest;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -46,6 +48,15 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
 
     @XmlTransient
     private Map<String, String> defaultValues;
+
+    @XmlTransient
+    private Boolean requiredBody;
+
+    @XmlTransient
+    private Set<String> requiredHeaders;
+
+    @XmlTransient
+    private Set<String> requiredQueryParameters;
 
     @XmlAttribute
     private String consumes;
@@ -111,7 +122,8 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
 
         if (mode == null || "off".equals(mode)) {
             // binding mode is off, so create a off mode binding processor
-            return new RestBindingAdvice(context, null, null, null, null, consumes, produces, mode, skip, validation, cors, corsHeaders, defaultValues);
+            return new RestBindingAdvice(context, null, null, null, null, consumes, produces, mode, skip, validation,
+                cors, corsHeaders, defaultValues, requiredBody != null ? requiredBody : false, requiredQueryParameters, requiredHeaders);
         }
 
         // setup json data format
@@ -209,7 +221,8 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
             }
         }
 
-        return new RestBindingAdvice(context, json, jaxb, outJson, outJaxb, consumes, produces, mode, skip, validation, cors, corsHeaders, defaultValues);
+        return new RestBindingAdvice(context, json, jaxb, outJson, outJaxb, consumes, produces, mode, skip, validation,
+            cors, corsHeaders, defaultValues, requiredBody != null ? requiredBody : false, requiredQueryParameters, requiredHeaders);
     }
 
     private void setAdditionalConfiguration(RestConfiguration config, CamelContext context,
@@ -262,6 +275,38 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
             defaultValues = new HashMap<>();
         }
         defaultValues.put(paramName, defaultValue);
+    }
+
+    /**
+     * Adds a required query parameter
+     *
+     * @param paramName   query parameter name
+     */
+    public void addRequiredQueryParameter(String paramName) {
+        if (requiredQueryParameters == null) {
+            requiredQueryParameters = new HashSet<>();
+        }
+        requiredQueryParameters.add(paramName);
+    }
+
+    /**
+     * Adds a required HTTP header
+     *
+     * @param headerName   HTTP header name
+     */
+    public void addRequiredHeader(String headerName) {
+        if (requiredHeaders == null) {
+            requiredHeaders = new HashSet<>();
+        }
+        requiredHeaders.add(headerName);
+    }
+
+    public Boolean getRequiredBody() {
+        return requiredBody;
+    }
+
+    public void setRequiredBody(Boolean requiredBody) {
+        this.requiredBody = requiredBody;
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestBindingDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestBindingDefinition.java
@@ -67,6 +67,9 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
     private Boolean skipBindingOnErrorCode;
 
     @XmlAttribute
+    private Boolean clientRequestValidation;
+
+    @XmlAttribute
     private Boolean enableCORS;
 
     @XmlAttribute
@@ -98,13 +101,17 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
         if (skipBindingOnErrorCode != null) {
             skip = skipBindingOnErrorCode;
         }
+        boolean validation = config.isClientRequestValidation();
+        if (clientRequestValidation != null) {
+            validation = clientRequestValidation;
+        }
 
         // cors headers
         Map<String, String> corsHeaders = config.getCorsHeaders();
 
         if (mode == null || "off".equals(mode)) {
             // binding mode is off, so create a off mode binding processor
-            return new RestBindingAdvice(context, null, null, null, null, consumes, produces, mode, skip, cors, corsHeaders, defaultValues);
+            return new RestBindingAdvice(context, null, null, null, null, consumes, produces, mode, skip, validation, cors, corsHeaders, defaultValues);
         }
 
         // setup json data format
@@ -202,7 +209,7 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
             }
         }
 
-        return new RestBindingAdvice(context, json, jaxb, outJson, outJaxb, consumes, produces, mode, skip, cors, corsHeaders, defaultValues);
+        return new RestBindingAdvice(context, json, jaxb, outJson, outJaxb, consumes, produces, mode, skip, validation, cors, corsHeaders, defaultValues);
     }
 
     private void setAdditionalConfiguration(RestConfiguration config, CamelContext context,
@@ -344,6 +351,22 @@ public class RestBindingDefinition extends OptionalIdentifiedDefinition<RestBind
      */
     public void setSkipBindingOnErrorCode(Boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public Boolean getClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     * <p/>
+     * This can be turned on, to enable this check. In case of validation error, then HTTP Status codes 415 or 406 is returned.
+     * <p/>
+     * The default value is false.
+     */
+    public void setClientRequestValidation(Boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     public Boolean getEnableCORS() {

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestConfigurationDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestConfigurationDefinition.java
@@ -90,6 +90,9 @@ public class RestConfigurationDefinition {
     @XmlAttribute
     private Boolean skipBindingOnErrorCode;
 
+    @XmlAttribute
+    private Boolean clientRequestValidation;
+
     @XmlAttribute @Metadata(label = "consumer")
     private Boolean enableCORS;
 
@@ -345,6 +348,22 @@ public class RestConfigurationDefinition {
      */
     public void setSkipBindingOnErrorCode(Boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public Boolean getClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     * <p/>
+     * This can be turned on, to enable this check. In case of validation error, then HTTP Status codes 415 or 406 is returned.
+     * <p/>
+     * The default value is false.
+     */
+    public void setClientRequestValidation(Boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     public Boolean getEnableCORS() {
@@ -631,6 +650,15 @@ public class RestConfigurationDefinition {
     }
 
     /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     */
+    public RestConfigurationDefinition clientRequestValidation(boolean clientRequestValidation) {
+        setClientRequestValidation(clientRequestValidation);
+        return this;
+    }
+
+    /**
      * To specify whether to enable CORS which means Camel will automatic include CORS in the HTTP headers in the response.
      */
     public RestConfigurationDefinition enableCORS(boolean enableCORS) {
@@ -811,6 +839,9 @@ public class RestConfigurationDefinition {
         }
         if (skipBindingOnErrorCode != null) {
             answer.setSkipBindingOnErrorCode(skipBindingOnErrorCode);
+        }
+        if (clientRequestValidation != null) {
+            answer.setClientRequestValidation(clientRequestValidation);
         }
         if (enableCORS != null) {
             answer.setEnableCORS(enableCORS);

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -801,10 +801,20 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
             } else {
                 binding.setEnableCORS(getEnableCORS());
             }
-            // register all the default values for the query parameters
             for (RestOperationParamDefinition param : verb.getParams()) {
+                // register all the default values for the query parameters
                 if (RestParamType.query == param.getType() && ObjectHelper.isNotEmpty(param.getDefaultValue())) {
                     binding.addDefaultValue(param.getName(), param.getDefaultValue());
+                }
+                // register which parameters are required
+                if (param.getRequired()) {
+                    if (RestParamType.query == param.getType()) {
+                        binding.addRequiredQueryParameter(param.getName());
+                    } else if (RestParamType.header == param.getType()) {
+                        binding.addRequiredHeader(param.getName());
+                    } else if (RestParamType.body == param.getType()) {
+                        binding.setRequiredBody(true);
+                    }
                 }
             }
 

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -70,6 +70,9 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
     private Boolean skipBindingOnErrorCode;
 
     @XmlAttribute
+    private Boolean clientRequestValidation;
+
+    @XmlAttribute
     private Boolean enableCORS;
 
     @XmlAttribute
@@ -165,6 +168,22 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
      */
     public void setSkipBindingOnErrorCode(Boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public Boolean getClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     * <p/>
+     * This can be turned on, to enable this check. In case of validation error, then HTTP Status codes 415 or 406 is returned.
+     * <p/>
+     * The default value is false.
+     */
+    public void setClientRequestValidation(Boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     public Boolean getEnableCORS() {
@@ -487,6 +506,18 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return this;
     }
 
+    public RestDefinition clientRequestValidation(boolean clientRequestValidation) {
+        if (getVerbs().isEmpty()) {
+            this.clientRequestValidation = clientRequestValidation;
+        } else {
+            // add on last verb as that is how the Java DSL works
+            VerbDefinition verb = getVerbs().get(getVerbs().size() - 1);
+            verb.setClientRequestValidation(clientRequestValidation);
+        }
+
+        return this;
+    }
+
     public RestDefinition enableCORS(boolean enableCORS) {
         if (getVerbs().isEmpty()) {
             this.enableCORS = enableCORS;
@@ -759,6 +790,11 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                 binding.setSkipBindingOnErrorCode(verb.getSkipBindingOnErrorCode());
             } else {
                 binding.setSkipBindingOnErrorCode(getSkipBindingOnErrorCode());
+            }
+            if (verb.getClientRequestValidation() != null) {
+                binding.setClientRequestValidation(verb.getClientRequestValidation());
+            } else {
+                binding.setClientRequestValidation(getClientRequestValidation());
             }
             if (verb.getEnableCORS() != null) {
                 binding.setEnableCORS(verb.getEnableCORS());

--- a/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -69,6 +69,9 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
     private Boolean skipBindingOnErrorCode;
 
     @XmlAttribute
+    private Boolean clientRequestValidation;
+
+    @XmlAttribute
     private Boolean enableCORS;
 
     @XmlAttribute
@@ -206,6 +209,22 @@ public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition>
      */
     public void setSkipBindingOnErrorCode(Boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public Boolean getClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     * <p/>
+     * This can be turned on, to enable this check. In case of validation error, then HTTP Status codes 415 or 406 is returned.
+     * <p/>
+     * The default value is false.
+     */
+    public void setClientRequestValidation(Boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     public Boolean getEnableCORS() {

--- a/camel-core/src/main/java/org/apache/camel/spi/RestConfiguration.java
+++ b/camel-core/src/main/java/org/apache/camel/spi/RestConfiguration.java
@@ -54,6 +54,7 @@ public class RestConfiguration {
     private RestHostNameResolver hostNameResolver = RestHostNameResolver.allLocalIp;
     private RestBindingMode bindingMode = RestBindingMode.off;
     private boolean skipBindingOnErrorCode = true;
+    private boolean clientRequestValidation;
     private boolean enableCORS;
     private String jsonDataFormat;
     private String xmlDataFormat;
@@ -407,6 +408,22 @@ public class RestConfiguration {
      */
     public void setSkipBindingOnErrorCode(boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public boolean isClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    /**
+     * Whether to enable validation of the client request to check whether the Content-Type and Accept headers from
+     * the client is supported by the Rest-DSL configuration of its consumes/produces settings.
+     * <p/>
+     * This can be turned on, to enable this check. In case of validation error, then HTTP Status codes 415 or 406 is returned.
+     * <p/>
+     * The default value is false.
+     */
+    public void setClientRequestValidation(boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     /**

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty.rest;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.junit.Test;
+
+public class RestJettyAcceptTest extends BaseJettyTest {
+    
+    @Test
+    public void testJettyProducerNoAccept() throws Exception {
+        String out = fluentTemplate
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyProducerAcceptValid() throws Exception {
+        String out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+            .withHeader("Accept", "application/json")
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyProducerAcceptInvalid() throws Exception {
+        try {
+            fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+                .withHeader("Accept", "application/xml")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .withBody("{ \"name\": \"Donald Duck\" }")
+                .to("http://localhost:" + getPort() + "/users/123/update")
+                .request(String.class);
+
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, e.getCause());
+            assertEquals(406, cause.getStatusCode());
+            assertEquals("", cause.getResponseBody());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use jetty on localhost with the given port
+                restConfiguration().component("jetty").host("localhost").port(getPort());
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .post("{id}/update").consumes("application/json").produces("application/json")
+                        .route()
+                        .to("mock:input")
+                        .setBody(constant("{ \"status\": \"ok\" }"));
+            }
+        };
+    }
+
+}

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
@@ -72,7 +72,9 @@ public class RestJettyAcceptTest extends BaseJettyTest {
             @Override
             public void configure() throws Exception {
                 // configure to use jetty on localhost with the given port
-                restConfiguration().component("jetty").host("localhost").port(getPort());
+                restConfiguration().component("jetty").host("localhost").port(getPort())
+                    // turn on client request validation
+                    .clientRequestValidation(true);
 
                 // use the rest DSL to define the rest services
                 rest("/users/")

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty.rest;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.junit.Test;
+
+public class RestJettyContentTypeTest extends BaseJettyTest {
+    
+    @Test
+    public void testJettyProducerNoContentType() throws Exception {
+        String out = fluentTemplate
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyProducerContentTypeValid() throws Exception {
+        String out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyProducerContentTypeInvalid() throws Exception {
+        try {
+            fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/xml")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .withBody("<name>Donald Duck</name>")
+                .to("http://localhost:" + getPort() + "/users/123/update")
+                .request(String.class);
+
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, e.getCause());
+            assertEquals(415, cause.getStatusCode());
+            assertEquals("", cause.getResponseBody());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use jetty on localhost with the given port
+                restConfiguration().component("jetty").host("localhost").port(getPort());
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .post("{id}/update").consumes("application/json").produces("application/json")
+                        .route()
+                        .to("mock:input")
+                        .setBody(constant("{ \"status\": \"ok\" }"));
+            }
+        };
+    }
+
+}

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
@@ -70,7 +70,9 @@ public class RestJettyContentTypeTest extends BaseJettyTest {
             @Override
             public void configure() throws Exception {
                 // configure to use jetty on localhost with the given port
-                restConfiguration().component("jetty").host("localhost").port(getPort());
+                restConfiguration().component("jetty").host("localhost").port(getPort())
+                    // turn on client request validation
+                    .clientRequestValidation(true);
 
                 // use the rest DSL to define the rest services
                 rest("/users/")

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty.rest;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.model.rest.RestParamType;
+import org.junit.Test;
+
+public class RestJettyRequiredBodyTest extends BaseJettyTest {
+    
+    @Test
+    public void testJettyValid() throws Exception {
+        String out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+            .withHeader("Accept", "application/json")
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyInvalid() throws Exception {
+        try {
+            fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+                .withHeader("Accept", "application/json")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .to("http://localhost:" + getPort() + "/users/123/update")
+                .request(String.class);
+
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, e.getCause());
+            assertEquals(400, cause.getStatusCode());
+            assertEquals("", cause.getResponseBody());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use jetty on localhost with the given port
+                restConfiguration().component("jetty").host("localhost").port(getPort())
+                    // turn on client request validation
+                    .clientRequestValidation(true);
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .post("{id}/update").consumes("application/json").produces("application/json")
+                    .param().name("body").required(true).type(RestParamType.body).endParam()
+                        .route()
+                        .to("mock:input")
+                        .setBody(constant("{ \"status\": \"ok\" }"));
+            }
+        };
+    }
+
+}

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredHttpHeaderTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredHttpHeaderTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty.rest;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.model.rest.RestParamType;
+import org.junit.Test;
+
+public class RestJettyRequiredHttpHeaderTest extends BaseJettyTest {
+    
+    @Test
+    public void testJettyValid() throws Exception {
+        String out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+            .withHeader("Accept", "application/json")
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withHeader("country", "uk")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyInvalid() throws Exception {
+        try {
+            fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+                .withHeader("Accept", "application/json")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .withBody("{ \"name\": \"Donald Duck\" }")
+                .to("http://localhost:" + getPort() + "/users/123/update")
+                .request(String.class);
+
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, e.getCause());
+            assertEquals(400, cause.getStatusCode());
+            assertEquals("", cause.getResponseBody());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use jetty on localhost with the given port
+                restConfiguration().component("jetty").host("localhost").port(getPort())
+                    // turn on client request validation
+                    .clientRequestValidation(true);
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .post("{id}/update").consumes("application/json").produces("application/json")
+                    .param().name("country").required(true).type(RestParamType.header).endParam()
+                        .route()
+                        .to("mock:input")
+                        .setBody(constant("{ \"status\": \"ok\" }"));
+            }
+        };
+    }
+
+}

--- a/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredQueryParameterTest.java
+++ b/components/camel-jetty9/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredQueryParameterTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty.rest;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.model.rest.RestParamType;
+import org.junit.Test;
+
+public class RestJettyRequiredQueryParameterTest extends BaseJettyTest {
+    
+    @Test
+    public void testJettyValid() throws Exception {
+        String out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+            .withHeader("Accept", "application/json")
+            .withHeader(Exchange.HTTP_METHOD, "post")
+            .withBody("{ \"name\": \"Donald Duck\" }")
+            .to("http://localhost:" + getPort() + "/users/123/update?country=uk")
+            .request(String.class);
+
+        assertEquals("{ \"status\": \"ok\" }", out);
+    }
+
+    @Test
+    public void testJettyInvalid() throws Exception {
+        try {
+            fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/json")
+                .withHeader("Accept", "application/json")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .withBody("{ \"name\": \"Donald Duck\" }")
+                .to("http://localhost:" + getPort() + "/users/123/update")
+                .request(String.class);
+
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            HttpOperationFailedException cause = assertIsInstanceOf(HttpOperationFailedException.class, e.getCause());
+            assertEquals(400, cause.getStatusCode());
+            assertEquals("", cause.getResponseBody());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // configure to use jetty on localhost with the given port
+                restConfiguration().component("jetty").host("localhost").port(getPort())
+                    // turn on client request validation
+                    .clientRequestValidation(true);
+
+                // use the rest DSL to define the rest services
+                rest("/users/")
+                    .post("{id}/update").consumes("application/json").produces("application/json")
+                    .param().name("country").required(true).type(RestParamType.query).endParam()
+                        .route()
+                        .to("mock:input")
+                        .setBody(constant("{ \"status\": \"ok\" }"));
+            }
+        };
+    }
+
+}

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/model/rest/springboot/RestConfigurationDefinitionProperties.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/model/rest/springboot/RestConfigurationDefinitionProperties.java
@@ -139,6 +139,14 @@ public class RestConfigurationDefinitionProperties {
      */
     private Boolean skipBindingOnErrorCode = false;
     /**
+     * Whether to enable validation of the client request to check whether the
+     * Content-Type and Accept headers from the client is supported by the
+     * Rest-DSL configuration of its consumes/produces settings. This can be
+     * turned on, to enable this check. In case of validation error, then HTTP
+     * Status codes 415 or 406 is returned. The default value is false.
+     */
+    private Boolean clientRequestValidation = false;
+    /**
      * Whether to enable CORS headers in the HTTP response. The default value is
      * false.
      */
@@ -325,6 +333,14 @@ public class RestConfigurationDefinitionProperties {
 
     public void setSkipBindingOnErrorCode(Boolean skipBindingOnErrorCode) {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
+    }
+
+    public Boolean getClientRequestValidation() {
+        return clientRequestValidation;
+    }
+
+    public void setClientRequestValidation(Boolean clientRequestValidation) {
+        this.clientRequestValidation = clientRequestValidation;
     }
 
     public Boolean getEnableCors() {


### PR DESCRIPTION
So we check whether required data is included in the client http request when being processed by rest-dsl consumer. 

We now check for missing
- query parameters
- http headers
- body

The context-path is already handled in the uri path matcher, so it will fail already for invalid context-path.

This can be turned on in the rest configuration. 