### PR TITLE
CAMEL-12548: NullPointerException in camel-cmis when using wrong cred…

### DIFF
--- a/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
+++ b/components/camel-cmis/src/main/java/org/apache/camel/component/cmis/CMISProducer.java
@@ -195,8 +195,11 @@ public class CMISProducer extends DefaultProducer {
 
     private CMISSessionFacade getSessionFacade() throws Exception {
         if (sessionFacade == null) {
-            sessionFacade = sessionFacadeFactory.create(getEndpoint());
+            CMISSessionFacade sessionFacade = sessionFacadeFactory.create(getEndpoint());
             sessionFacade.initSession();
+            // make sure to set sessionFacade to the field after successful initialisation
+            // so that it has a valid session
+            this.sessionFacade = sessionFacade;
         }
 
         return sessionFacade;


### PR DESCRIPTION
…entials

It makes sure the sessionFacade is assgined to the field only after the session is successfully initialised, so that the sessionFacade never dangles in an incomplete state.