### PR TITLE
Upgrade Async http client to version 2.4.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,7 +43,7 @@
     <activemq-version>5.15.4</activemq-version>
     <activemq-artemis-version>2.6.0</activemq-artemis-version>
     <aether-version>1.0.2.v20150114</aether-version>
-    <ahc-version>2.4.8</ahc-version>
+    <ahc-version>2.4.9</ahc-version>
     <ant-bundle-version>1.7.0_6</ant-bundle-version>
     <antlr-bundle-version>3.5.2_1</antlr-bundle-version>
     <antlr-runtime-bundle-version>3.5.2_1</antlr-runtime-bundle-version>
@@ -1628,7 +1628,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
         <version>${project.version}</version>
-      </dependency>	  
+      </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milo</artifactId>
@@ -5494,7 +5494,7 @@
         </plugins>
       </build>
     </profile>
-	
+
     <profile>
       <id>revapi</id>
       <build>


### PR DESCRIPTION
In 2.4.8, mockito and hamcrest were in compile scope instead of test
scope