### PR TITLE
CAMEL-12573: Fixing class cast exception

### DIFF
--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/KafkaSpanDecorator.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/decorators/KafkaSpanDecorator.java
@@ -58,7 +58,7 @@ public class KafkaSpanDecorator extends AbstractMessagingSpanDecorator {
     public void pre(Span span, Exchange exchange, Endpoint endpoint) {
         super.pre(span, exchange, endpoint);
 
-        String partition = (String)exchange.getIn().getHeader(PARTITION);
+        String partition = getValue(exchange, PARTITION, Integer.class);
         if (partition != null) {
             span.setTag(KAFKA_PARTITION_TAG, partition);
         }
@@ -73,10 +73,22 @@ public class KafkaSpanDecorator extends AbstractMessagingSpanDecorator {
             span.setTag(KAFKA_KEY_TAG, key);
         }
 
-        String offset = (String)exchange.getIn().getHeader(OFFSET);
+        String offset = getValue(exchange, OFFSET, Long.class);
         if (offset != null) {
             span.setTag(KAFKA_OFFSET_TAG, offset);
         }
+    }
+
+    /**
+     * Extracts header value from the exchange for given header
+     * @param exchange the {@link Exchange}
+     * @param header the header name
+     * @param type the class type of the exchange header
+     * @return
+     */
+    private <T> String getValue(final Exchange exchange, final String header, Class<T> type) {
+         T partition = exchange.getIn().getHeader(header, type);
+         return partition != null ? String.valueOf(partition) : exchange.getIn().getHeader(header, String.class);
     }
 
 }

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/KafkaSpanDecoratorTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/decorators/KafkaSpanDecoratorTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.opentracing.decorators;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 
+import jdk.nashorn.internal.IntDeque;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -59,7 +60,7 @@ public class KafkaSpanDecoratorTest {
     }
 
     @Test
-    public void testPre() {
+    public void testPreOffsetAndPartitionAsStringHeader() {
         String testKey = "TestKey";
         String testOffset = "TestOffset";
         String testPartition = "TestPartition";
@@ -72,8 +73,8 @@ public class KafkaSpanDecoratorTest {
         Mockito.when(endpoint.getEndpointUri()).thenReturn("test");
         Mockito.when(exchange.getIn()).thenReturn(message);
         Mockito.when(message.getHeader(KafkaSpanDecorator.KEY)).thenReturn(testKey);
-        Mockito.when(message.getHeader(KafkaSpanDecorator.OFFSET)).thenReturn(testOffset);
-        Mockito.when(message.getHeader(KafkaSpanDecorator.PARTITION)).thenReturn(testPartition);
+        Mockito.when(message.getHeader(KafkaSpanDecorator.OFFSET, String.class)).thenReturn(testOffset);
+        Mockito.when(message.getHeader(KafkaSpanDecorator.PARTITION, String.class)).thenReturn(testPartition);
         Mockito.when(message.getHeader(KafkaSpanDecorator.PARTITION_KEY)).thenReturn(testPartitionKey);
 
         SpanDecorator decorator = new KafkaSpanDecorator();
@@ -87,6 +88,31 @@ public class KafkaSpanDecoratorTest {
         assertEquals(testOffset, span.tags().get(KafkaSpanDecorator.KAFKA_OFFSET_TAG));
         assertEquals(testPartition, span.tags().get(KafkaSpanDecorator.KAFKA_PARTITION_TAG));
         assertEquals(testPartitionKey, span.tags().get(KafkaSpanDecorator.KAFKA_PARTITION_KEY_TAG));
+    }
+
+    @Test
+    public void testPrePartitionAsIntegerHeaderAndOffsetAsLongHeader() {
+        Long testOffset = 4875454l;
+        Integer testPartition = 0;
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("test");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(KafkaSpanDecorator.OFFSET, Long.class)).thenReturn(testOffset);
+        Mockito.when(message.getHeader(KafkaSpanDecorator.PARTITION, Integer.class)).thenReturn(testPartition);
+
+        SpanDecorator decorator = new KafkaSpanDecorator();
+
+        MockTracer tracer = new MockTracer();
+        MockSpan span = tracer.buildSpan("TestSpan").start();
+
+        decorator.pre(span, exchange, endpoint);
+
+        assertEquals(String.valueOf(testOffset), span.tags().get(KafkaSpanDecorator.KAFKA_OFFSET_TAG));
+        assertEquals(String.valueOf(testPartition), span.tags().get(KafkaSpanDecorator.KAFKA_PARTITION_TAG));
     }
 
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,7 +126,7 @@
     <chronicle-network-version>1.16.0</chronicle-network-version>
     <chronicle-queue-version>4.16.3</chronicle-queue-version>
     <chronicle-threads-version>1.16.0</chronicle-threads-version>
-    <chronicle-wire-version>1.16.1</chronicle-wire-version>
+    <chronicle-wire-version>1.16.2</chronicle-wire-version>
     <chunk-templates-version>3.3.1</chunk-templates-version>
     <chunk-templates-bundle-version>3.3.1_1</chunk-templates-bundle-version>
     <cmis-version>1.1.0</cmis-version>


### PR DESCRIPTION
I have introduced a generic method which extracts the values of the `Partition` and the `Offset` from the Exchange headers according to their corresponding types.

Here is the Jira ticket for it.https://issues.apache.org/jira/browse/CAMEL-12573