### PR TITLE
CAMEL-11893: Restored SolrAddBeanTest in camel-solr

### DIFF
--- a/components/camel-solr/pom.xml
+++ b/components/camel-solr/pom.xml
@@ -36,6 +36,7 @@
     </camel.osgi.export.pkg>
     <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=solr</camel.osgi.export.service>
     <java.awt.headless>true</java.awt.headless>
+    <solr-test-framework-jetty-version>9.3.20.v20170531</solr-test-framework-jetty-version>
   </properties>
 
   <dependencies>
@@ -114,13 +115,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty-version}</version>
+      <version>${solr-test-framework-jetty-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty-version}</version>
+      <version>${solr-test-framework-jetty-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/JettySolrFactory.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/JettySolrFactory.java
@@ -100,6 +100,7 @@ public final class JettySolrFactory {
         System.setProperty("solr.solr.home", solrHome);
         System.setProperty("jetty.testMode", "true");
         System.setProperty("solr.data.dir", "target/test-classes/solr/data" + (dataDirNo++));
+        System.setProperty("solr.log.dir", "target/");
 
         // Instruct Solr to keep the index in memory, for faster testing.
         System.setProperty("solr.directoryFactory", "solr.RAMDirectoryFactory");

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrAddBeanTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrAddBeanTest.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.solr;
 
 import org.apache.solr.client.solrj.beans.Field;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Need refactoring in SolrComponentTestSupport, with new schema and solr-config from solr 5.2.1 and new Cloud Solr cluster instantiation")
 public class SolrAddBeanTest extends SolrComponentTestSupport {
 
     public SolrAddBeanTest(SolrFixtures.TestServerType serverToTest) {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrAddBeansTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrAddBeansTest.java
@@ -23,7 +23,7 @@ import org.apache.solr.client.solrj.beans.Field;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Need refactoring in SolrComponentTestSupport, with new schema and solr-config from solr 5.2.1 and new Cloud Solr cluster instantiation")
+@Ignore("At this stage, a single Test class inheriting from SolrComponentTestSupport is supported per test run")
 public class SolrAddBeansTest extends SolrComponentTestSupport {
 
     public SolrAddBeansTest(SolrFixtures.TestServerType serverToTest) {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrComponentTestSupport.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrComponentTestSupport.java
@@ -74,14 +74,14 @@ public abstract class SolrComponentTestSupport extends SolrTestSupport {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
         SolrClient solrServer = solrFixtures.getServer();
-        return solrServer.query(solrQuery);
+        return solrServer.query("collection1", solrQuery);
     }
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         SolrFixtures.createSolrFixtures();
     }
- 
+
     @AfterClass
     public static void afterClass() throws Exception {
         SolrFixtures.teardownSolrFixtures();
@@ -102,7 +102,7 @@ public abstract class SolrComponentTestSupport extends SolrTestSupport {
             }
         };
     }
-    
+
     @Parameters
     public static Collection<Object[]> serverTypes() {
         Object[][] serverTypes = {{SolrFixtures.TestServerType.USE_CLOUD},

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrDeleteTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrDeleteTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Need refactoring in SolrComponentTestSupport, with new schema and solr-config from solr 5.2.1 and new Cloud Solr cluster instantiation")
+@Ignore("At this stage, a single Test class inheriting from SolrComponentTestSupport is supported per test run")
 public class SolrDeleteTest extends SolrComponentTestSupport {
 
     public SolrDeleteTest(SolrFixtures.TestServerType serverToTest) {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrFixtures.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrFixtures.java
@@ -50,13 +50,13 @@ public class SolrFixtures {
 
     String solrRouteUri() {
         if (serverType == TestServerType.USE_HTTPS) {
-            return "solrs://localhost:" + httpsPort + "/solr";
+            return "solrs://127.0.0.1:" + httpsPort + "/solr/collection1";
         } else if (serverType == TestServerType.USE_CLOUD) {
             String zkAddrStr = cloudFixture.miniCluster.getZkServer().getZkAddress();
             return "solrCloud://localhost:" + httpsPort + "/solr?zkHost=" + zkAddrStr
                    + "&collection=collection1";
         } else {
-            return "solr://localhost:" + port + "/solr";
+            return "solr://localhost:" + port + "/solr/collection1";
         }
     }
         
@@ -64,7 +64,7 @@ public class SolrFixtures {
     SolrClient getServer() {
         if (serverType == TestServerType.USE_HTTPS) {
             return solrHttpsServer;
-        } else if (serverType == TestServerType.USE_CLOUD) {            
+        } else if (serverType == TestServerType.USE_CLOUD) {
             return cloudFixture.solrClient;
         } else {
             return solrServer;
@@ -74,14 +74,14 @@ public class SolrFixtures {
     static void createSolrFixtures() throws Exception {
         solrHttpsRunner = JettySolrFactory.createJettyTestFixture(true);
         httpsPort = solrHttpsRunner.getLocalPort();
-        log.info("Started Https Test Server: " + solrHttpsRunner.getBaseUrl());        
-        solrHttpsServer = new HttpSolrClient.Builder("https://localhost: + httpsPort + /solr").build();
+        log.info("Started Https Test Server: " + solrHttpsRunner.getBaseUrl());
+        solrHttpsServer = new HttpSolrClient.Builder("https://127.0.0.1:" + httpsPort + "/solr").build();
         solrHttpsServer.setConnectionTimeout(60000);
 
         solrRunner = JettySolrFactory.createJettyTestFixture(false);
         port = solrRunner.getLocalPort();
-        
-        solrServer = new HttpSolrClient.Builder("http://localhost: + port + /solr").build();
+
+        solrServer = new HttpSolrClient.Builder("http://localhost:" + port + "/solr").build();
 
         log.info("Started Test Server: " + solrRunner.getBaseUrl());
         cloudFixture = new SolrCloudFixture("src/test/resources/solr");
@@ -102,15 +102,15 @@ public class SolrFixtures {
     public static void clearIndex() throws SolrServerException, IOException {
         if (solrServer != null) {
             // Clear the Solr index.
-            solrServer.deleteByQuery("*:*");
-            solrServer.commit();
+            solrServer.deleteByQuery("collection1", "*:*");
+            solrServer.commit("collection1");
         }
         if (solrHttpsServer != null) {
-            solrHttpsServer.deleteByQuery("*:*");
-            solrHttpsServer.commit();
+            solrHttpsServer.deleteByQuery("collection1", "*:*");
+            solrHttpsServer.commit("collection1");
         }
         if (cloudFixture != null) {
-            cloudFixture.solrClient.deleteByQuery("*:*");            
+            cloudFixture.solrClient.deleteByQuery("*:*");
             cloudFixture.solrClient.commit();
         }
     }

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrTransactionsTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrTransactionsTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.solr;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Need refactoring in SolrComponentTestSupport, with new schema and solr-config from solr 5.2.1 and new Cloud Solr cluster instantiation")
+@Ignore("Rollback is currently not supported in SolrCloud mode. (SOLR-4895)")
 public class SolrTransactionsTest extends SolrComponentTestSupport {
 
     public SolrTransactionsTest(SolrFixtures.TestServerType serverToTest) {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrUpdateTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrUpdateTest.java
@@ -32,7 +32,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Need refactoring in SolrComponentTestSupport, with new schema and solr-config from solr 5.2.1 and new Cloud Solr cluster instantiation")
+@Ignore("Assert.fail:88 expected:<0> but was:<12>")
 public class SolrUpdateTest extends SolrComponentTestSupport {
     private SolrEndpoint solrEndpoint;
 
@@ -51,7 +51,7 @@ public class SolrUpdateTest extends SolrComponentTestSupport {
     public void testInsertSolrInputDocumentAsXMLWithoutAddRoot() throws Exception {
 
         SolrInputDocument doc = new SolrInputDocument();
-        doc.addField("id", "MA147LL/A");        
+        doc.addField("id", "MA147LL/A");
         String docAsXml = ClientUtils.toXML(doc);
         template.sendBodyAndHeader("direct:start", docAsXml, SolrConstants.OPERATION, SolrConstants.OPERATION_INSERT);
         solrCommit();

--- a/components/camel-solr/src/test/resources/solr/collection1/conf/schema.xml
+++ b/components/camel-solr/src/test/resources/solr/collection1/conf/schema.xml
@@ -149,11 +149,11 @@
       value verbatim (and hence don't support range queries, since the
       lexicographic ordering isn't equal to the numeric ordering)
     -->
-    <fieldType name="pint" class="solr.IntField" omitNorms="true"/>
-    <fieldType name="plong" class="solr.LongField" omitNorms="true"/>
-    <fieldType name="pfloat" class="solr.FloatField" omitNorms="true"/>
-    <fieldType name="pdouble" class="solr.DoubleField" omitNorms="true"/>
-    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="pint" class="solr.TrieIntField" omitNorms="true"/>
+    <fieldType name="plong" class="solr.TrieLongField" omitNorms="true"/>
+    <fieldType name="pfloat" class="solr.TrieFloatField" omitNorms="true"/>
+    <fieldType name="pdouble" class="solr.TrieDoubleField" omitNorms="true"/>
+    <fieldType name="pdate" class="solr.TrieDateField" sortMissingLast="true" omitNorms="true"/>
 
 
     <!--
@@ -166,10 +166,10 @@
       but with a lexicographic ordering the same as the numeric ordering,
       so that range queries work correctly.
     -->
-    <fieldType name="sint" class="solr.SortableIntField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="slong" class="solr.SortableLongField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="sfloat" class="solr.SortableFloatField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="sdouble" class="solr.SortableDoubleField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sint" class="solr.TrieIntField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="slong" class="solr.TrieLongField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sfloat" class="solr.TrieFloatField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sdouble" class="solr.TrieDoubleField" sortMissingLast="true" omitNorms="true"/>
 
 
     <!-- The "RandomSortField" is not used to store or search any
@@ -219,7 +219,7 @@
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
@@ -227,7 +227,7 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
@@ -245,13 +245,10 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
         -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -267,7 +264,6 @@
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -298,13 +294,10 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
         -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -317,7 +310,6 @@
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -348,7 +340,7 @@
     <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
            maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
@@ -356,7 +348,7 @@
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -606,12 +598,6 @@
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>
-
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <defaultSearchField>text</defaultSearchField>
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,

--- a/components/camel-solr/src/test/resources/solr/collection1/conf/solrconfig.xml
+++ b/components/camel-solr/src/test/resources/solr/collection1/conf/solrconfig.xml
@@ -260,7 +260,7 @@
          More details on the nuances of each LockFactory...
          http://wiki.apache.org/lucene-java/AvailableLockFactories
     -->
-    <lockType>${solr.lock.type:native}</lockType>
+    <lockType>${solr.lock.type:single}</lockType>
 
     <!-- Unlock On Startup
 
@@ -1138,13 +1138,6 @@
                   class="solr.DocumentAnalysisRequestHandler" 
                   startup="lazy" />
 
-  <!-- Admin Handlers
-
-       Admin Handlers - This will register all the standard admin
-       RequestHandlers.  
-    -->
-  <requestHandler name="/admin/" 
-                  class="solr.admin.AdminHandlers" />
   <!-- This single handler is equivalent to the following... -->
   <!--
      <requestHandler name="/admin/luke"       class="solr.admin.LukeRequestHandler" />

--- a/components/camel-solr/src/test/resources/solr/conf/collection1/schema.xml
+++ b/components/camel-solr/src/test/resources/solr/conf/collection1/schema.xml
@@ -245,13 +245,10 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
         -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -298,13 +295,10 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
         -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
-                enablePositionIncrements="true"
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>

--- a/components/camel-solr/src/test/resources/solr/solr.xml
+++ b/components/camel-solr/src/test/resources/solr/solr.xml
@@ -27,6 +27,8 @@
 
   <solrcloud>
     <str name="host">127.0.0.1</str>
+    <str name="hostContext">${hostContext:solr}</str>
+    <int name="hostPort">${hostPort:8983}</int>
   </solrcloud>
 
   <shardHandlerFactory name="shardHandlerFactory"


### PR DESCRIPTION
Fixed most ERROR level logs in `target/camel-solr-test.log`.
Aligned jetty version with the one used by `solr-test-framework`.

This PR fixes a single test, more to come.

See [CAMEL-11893](https://issues.apache.org/jira/browse/CAMEL-11893) for more.