### PR TITLE
Cleanup TimeOutChecker threads

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -1448,6 +1448,11 @@ public class AggregateProcessor extends ServiceSupport implements AsyncProcessor
         if (recoverService != null) {
             camelContext.getExecutorServiceManager().shutdown(recoverService);
         }
+        
+        if (timeoutCheckerExecutorService != null) {
+            camelContext.getExecutorServiceManager().shutdownNow(timeoutCheckerExecutorService);
+        }
+        
         ServiceHelper.stopServices(timeoutMap, processor, deadLetterProducerTemplate);
 
         if (closedCorrelationKeys != null) {


### PR DESCRIPTION
When a Aggregator route is stopped, only the AggregateRecoveryChecker threads are stopped and not the AggregateTimeoutChecker threads. They keep lingering around. - CAMEL-12588