### PR TITLE
 CAMEL-12588 - Improving the fix 

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -1448,6 +1448,11 @@ public class AggregateProcessor extends ServiceSupport implements AsyncProcessor
         if (recoverService != null) {
             camelContext.getExecutorServiceManager().shutdown(recoverService);
         }
+        
+        if (timeoutCheckerExecutorService != null) {
+            camelContext.getExecutorServiceManager().shutdownNow(timeoutCheckerExecutorService);
+        }
+        
         ServiceHelper.stopServices(timeoutMap, processor, deadLetterProducerTemplate);
 
         if (closedCorrelationKeys != null) {

--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -1450,7 +1450,7 @@ public class AggregateProcessor extends ServiceSupport implements AsyncProcessor
         }
         
         if (timeoutCheckerExecutorService != null) {
-            camelContext.getExecutorServiceManager().shutdownNow(timeoutCheckerExecutorService);
+            camelContext.getExecutorServiceManager().shutdown(timeoutCheckerExecutorService);
         }
         
         ServiceHelper.stopServices(timeoutMap, processor, deadLetterProducerTemplate);


### PR DESCRIPTION
doStop() method now shuts down the timeoutCheckerExecutorService pool too
Improvment - used shutdown instead of shutdownNow