### PR TITLE
CAMEL-12588 AggregateProcessor does not stop AggregateTimeoutChecker

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -1448,6 +1448,13 @@ public class AggregateProcessor extends ServiceSupport implements AsyncProcessor
         if (recoverService != null) {
             camelContext.getExecutorServiceManager().shutdown(recoverService);
         }
+
+        if (shutdownTimeoutCheckerExecutorService && timeoutCheckerExecutorService != null) {
+            camelContext.getExecutorServiceManager().shutdown(timeoutCheckerExecutorService);
+            timeoutCheckerExecutorService = null;
+            shutdownTimeoutCheckerExecutorService = false;
+        }
+
         ServiceHelper.stopServices(timeoutMap, processor, deadLetterProducerTemplate);
 
         if (closedCorrelationKeys != null) {


### PR DESCRIPTION
threads on stop call

doStart()  starts back timeoutCheckerExecutorService  only if it is null (it does not consider the
state of the pool)

So, I have set timeoutCheckerExecutorService to null in doStop() (like in doShutDown()) 