### PR TITLE
[CAMEL-12593] Active deploy profile when deploying

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh "./mvnw $MAVEN_PARAMS -Dmaven.test.skip.exec=true clean deploy"
+                sh "./mvnw $MAVEN_PARAMS -Dmaven.test.skip.exec=true -Pdeploy clean deploy"
             }
         }
 


### PR DESCRIPTION
The deploy profile attaches javadoc and sources: https://github.com/apache/camel/blob/master/pom.xml#L591

Note that I can't test this myself since this runs on Jenkins and publishes to the ASF repo, neither of which I can access :)

https://issues.apache.org/jira/browse/CAMEL-12593