### PR TITLE
feat: Add default implementation of a RouteBuilder

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/Routes.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/Routes.java
@@ -1,0 +1,21 @@
+package org.apache.camel.builder;
+
+/**
+ * No-op implementation of a RouteBuilder which can be easily used for initialization
+ * via object initialisers.
+ *
+ * An easy usage would be
+ *
+ * <pre>
+ *   camelContext.add(new Routes {{
+ *
+ *       from("file:data/inbox?noop=true")
+ *         .to("file:data/outbox");
+ *
+ *   }});
+ * </pre>
+ */
+public class Routes extends RouteBuilder {
+    @Override
+    public void configure() throws Exception { }
+}

--- a/camel-core/src/test/java/org/apache/camel/builder/RouteBuilderAddRoutesTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/RouteBuilderAddRoutesTest.java
@@ -19,20 +19,17 @@ package org.apache.camel.builder;
 import org.apache.camel.ContextTestSupport;
 
 /**
- * @version 
+ * @version
  */
 public class RouteBuilderAddRoutesTest extends ContextTestSupport {
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                includeRoutes(new MyExtraRoute());
+        return new Routes() {{
+            includeRoutes(new MyExtraRoute());
 
-                from("direct:start").to("mock:result");
-            }
-        };
+            from("direct:start").to("mock:result");
+        }};
     }
 
     public void testAddRoutes() throws Exception {


### PR DESCRIPTION
So that you can easily use object initializers for initialising routes
like in

ctx.add(new Routes {{
      from("file:data/inbox?noop=true")
        .to("file:data/outbox");
}});


This is a POC, and *not* meant to be merged but trigger some discussions around this idea
which btw was 'borrowed' from JMockit. Its IMO the simplest way with the less of boilerplate
to introduce a Java DSL.

If interested I could elaborate on it and add some tests and/or docs.