### PR TITLE
if channel.getExistStatus() is null, then calling

### DIFF
--- a/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshResult.java
+++ b/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshResult.java
@@ -36,13 +36,13 @@ public class SshResult {
     
     private final String command;
     
-    private final int exitValue;
+    private final Integer exitValue;
 
     private final InputStream stdout;
 
     private final InputStream stderr;
     
-    public SshResult(String command, int exitValue, InputStream out, InputStream err) {
+    public SshResult(String command, Integer exitValue, InputStream out, InputStream err) {
         this.command = command;
         this.exitValue = exitValue;
         this.stdout = out;
@@ -53,7 +53,7 @@ public class SshResult {
         return command;
     }
 
-    public int getExitValue() {
+    public Integer getExitValue() {
         return exitValue;
     }
 


### PR DESCRIPTION
this constructor may fail due to auto-unboxing with potential NullPointerException