### PR TITLE
CAMEL-12503 : support for propagating camel headers to kafka 

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -72,7 +72,7 @@ with the following path and query parameters:
 |===
 
 
-==== Query Parameters (90 parameters):
+==== Query Parameters (91 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -80,6 +80,7 @@ with the following path and query parameters:
 | Name | Description | Default | Type
 | *brokers* (common) | URL of the Kafka brokers to use. The format is host1:port1,host2:port2, and the list can be a subset of brokers or a VIP pointing to a subset of brokers. This option is known as bootstrap.servers in the Kafka documentation. |  | String
 | *clientId* (common) | The client id is a user-specified string sent in each request to help trace calls. It should logically identify the application making the request. |  | String
+| *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | *reconnectBackoffMaxMs* (common) | The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms. | 1000 | Integer
 | *allowManualCommit* (consumer) | Whether to allow doing manual commits via KafkaManualCommit. If this option is enabled then an instance of KafkaManualCommit is stored on the Exchange message header, which allows end users to access this API and perform manual offset commits via the Kafka consumer. | false | boolean
 | *autoCommitEnable* (consumer) | If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer. This committed offset will be used when the process fails as the position from which the new consumer will begin. | true | Boolean
@@ -417,3 +418,25 @@ This will force a synchronous commit which will block until the commit is acknow
 
 If you want to use a custom implementation of `KafkaManualCommit` then you can configure a custom `KafkaManualCommitFactory`
 on the `KafkaComponent` that creates instances of your custom implementation.
+
+=== Kafka Headers propagation
+*Available as of Camel 2.22*
+
+When consuming messages from Kafka, headers will be propagated to camel exchange headers automatically.
+Producing flow backed by same behaviour - camel headers of particular exchange will be propagated to kafka message headers.
+
+Since kafka headers allows only `byte[]` values, in order camel exchnage header to be propagated its value should be serialized to `bytes[]`,
+otherwise header will be skipped.
+Following header value types are supported: `String`, `Integer`, `Long`, `Double`, `byte[]`.
+Note: all headers propagated *from* kafka *to* camel exchange will contain `byte[]` value.
+
+By default all headers are being filtered by `KafkaHeaderFilterStrategy`.
+Strategy filters out headers which start with `Camel` or `org.apache.camel` prefixes.
+Default strategy can be overridden by using `headerFilterStrategy` uri parameter in both `to` and `from` routes:
+```
+from("kafka:my_topic?headerFilterStrategy=#myStrategy")
+...
+.to("kafka:my_topic?headerFilterStrategy=#myStrategy")
+```
+
+`myStrategy` object should be subclass of `HeaderFilterStrategy` and must be placed in the Camel registry, either manually or by registration as a bean in Spring/Blueprint, as it is `CamelContext` aware.

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka;
+
+import org.apache.camel.impl.DefaultHeaderFilterStrategy;
+
+public class KafkaHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+
+    public KafkaHeaderFilterStrategy() {
+        initialize();  
+    }
+
+    protected void initialize() {
+        // filter out kafka record metadata
+        getInFilter().add("org.apache.kafka.clients.producer.RecordMetadata");
+
+        // filter headers begin with "Camel" or "org.apache.camel"
+        setOutFilterPattern("(?i)(Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
+        setInFilterPattern("(?i)(Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
+    }
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerFullTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerFullTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kafka;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.StreamSupport;
 
@@ -25,6 +26,7 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -71,20 +73,30 @@ public class KafkaConsumerFullTest extends BaseEmbeddedKafkaTest {
 
     @Test
     public void kafkaMessageIsConsumedByCamel() throws InterruptedException, IOException {
+        String propagatedHeaderKey = "PropagatedCustomHeader";
+        byte[] propagatedHeaderValue = "propagated header value".getBytes();
+        String skippedHeaderKey = "CamelSkippedHeader";
         to.expectedMessageCount(5);
         to.expectedBodiesReceivedInAnyOrder("message-0", "message-1", "message-2", "message-3", "message-4");
         // The LAST_RECORD_BEFORE_COMMIT header should not be configured on any exchange because autoCommitEnable=true
         to.expectedHeaderValuesReceivedInAnyOrder(KafkaConstants.LAST_RECORD_BEFORE_COMMIT, null, null, null, null, null);
+        to.expectedHeaderReceived(propagatedHeaderKey, propagatedHeaderValue);
 
         for (int k = 0; k < 5; k++) {
             String msg = "message-" + k;
-            ProducerRecord<String, String> data = new ProducerRecord<String, String>(TOPIC, "1", msg);
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, "1", msg);
+            data.headers().add(new RecordHeader("CamelSkippedHeader", "skipped header value".getBytes()));
+            data.headers().add(new RecordHeader(propagatedHeaderKey, propagatedHeaderValue));
             producer.send(data);
         }
 
         to.assertIsSatisfied(3000);
 
         assertEquals(5, StreamSupport.stream(MockConsumerInterceptor.recordsCaptured.get(0).records(TOPIC).spliterator(), false).count());
+
+        Map<String, Object> headers = to.getExchanges().get(0).getIn().getHeaders();
+        assertFalse("Should not receive skipped header", headers.containsKey(skippedHeaderKey));
+        assertTrue("Should receive propagated header", headers.containsKey(propagatedHeaderKey));
     }
 
     @Test

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerFullTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerFullTest.java
@@ -17,14 +17,18 @@
 package org.apache.camel.component.kafka;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
@@ -33,9 +37,14 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultHeaderFilterStrategy;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,23 +57,31 @@ public class KafkaProducerFullTest extends BaseEmbeddedKafkaTest {
     private static final String TOPIC_BYTES = "testBytes";
     private static final String TOPIC_BYTES_IN_HEADER = "testBytesHeader";
     private static final String GROUP_BYTES = "groupStrings";
+    private static final String TOPIC_PROPAGATED_HEADERS = "testPropagatedHeaders";
 
     private static KafkaConsumer<String, String> stringsConsumerConn;
     private static KafkaConsumer<byte[], byte[]> bytesConsumerConn;
 
     @EndpointInject(uri = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1")
     private Endpoint toStrings;
+
     @EndpointInject(uri = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1&partitionKey=1")
     private Endpoint toStrings2;
+
     @EndpointInject(uri = "kafka:" + TOPIC_INTERCEPTED + "?requestRequiredAcks=-1"
             + "&interceptorClasses=org.apache.camel.component.kafka.MockProducerInterceptor")
     private Endpoint toStringsWithInterceptor;
+
     @EndpointInject(uri = "mock:kafkaAck")
     private MockEndpoint mockEndpoint;
+
     @EndpointInject(uri = "kafka:" + TOPIC_BYTES + "?requestRequiredAcks=-1"
             + "&serializerClass=org.apache.kafka.common.serialization.ByteArraySerializer&"
             + "keySerializerClass=org.apache.kafka.common.serialization.ByteArraySerializer")
     private Endpoint toBytes;
+
+    @EndpointInject(uri = "kafka:" + TOPIC_PROPAGATED_HEADERS + "?requestRequiredAcks=-1")
+    private Endpoint toPropagatedHeaders;
 
     @Produce(uri = "direct:startStrings")
     private ProducerTemplate stringsTemplate;
@@ -77,6 +94,16 @@ public class KafkaProducerFullTest extends BaseEmbeddedKafkaTest {
 
     @Produce(uri = "direct:startTraced")
     private ProducerTemplate interceptedTemplate;
+
+    @Produce(uri = "direct:propagatedHeaders")
+    private ProducerTemplate propagatedHeadersTemplate;
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+        jndi.bind("myStrategy", new MyHeaderFilterStrategy());
+        return jndi;
+    }
 
     @BeforeClass
     public static void before() {
@@ -118,6 +145,8 @@ public class KafkaProducerFullTest extends BaseEmbeddedKafkaTest {
                 from("direct:startBytes").to(toBytes).to(mockEndpoint);
 
                 from("direct:startTraced").to(toStringsWithInterceptor).to(mockEndpoint);
+
+                from("direct:propagatedHeaders").to(toPropagatedHeaders).to(mockEndpoint);
             }
         };
     }
@@ -271,6 +300,89 @@ public class KafkaProducerFullTest extends BaseEmbeddedKafkaTest {
         }
     }
 
+    @Test
+    public void propagatedHeaderIsReceivedByKafka() throws Exception {
+        String propagatedStringHeaderKey = "PROPAGATED_STRING_HEADER";
+        String propagatedStringHeaderValue = "propagated string header value";
+
+        String propagatedIntegerHeaderKey = "PROPAGATED_INTEGER_HEADER";
+        Integer propagatedIntegerHeaderValue = 54545;
+
+        String propagatedLongHeaderKey = "PROPAGATED_LONG_HEADER";
+        Long propagatedLongHeaderValue = 5454545454545L;
+
+        String propagatedDoubleHeaderKey = "PROPAGATED_DOUBLE_HEADER";
+        Double propagatedDoubleHeaderValue = 43434.545D;
+
+        String propagatedBytesHeaderKey = "PROPAGATED_BYTES_HEADER";
+        byte[] propagatedBytesHeaderValue = new byte[]{121, 34, 34, 54, 5, 3, 54, -34};
+
+        Map<String, Object> camelHeaders = new HashMap<>();
+        camelHeaders.put(propagatedStringHeaderKey, propagatedStringHeaderValue);
+        camelHeaders.put(propagatedIntegerHeaderKey, propagatedIntegerHeaderValue);
+        camelHeaders.put(propagatedLongHeaderKey, propagatedLongHeaderValue);
+        camelHeaders.put(propagatedDoubleHeaderKey, propagatedDoubleHeaderValue);
+        camelHeaders.put(propagatedBytesHeaderKey, propagatedBytesHeaderValue);
+        camelHeaders.put("CustomObjectHeader", new Object());
+        camelHeaders.put("CamelFilteredHeader", "CamelFilteredHeader value");
+
+        CountDownLatch messagesLatch = new CountDownLatch(1);
+        propagatedHeadersTemplate.sendBodyAndHeaders("Some test message", camelHeaders);
+
+        List<ConsumerRecord<String, String>> records = pollForRecords(stringsConsumerConn, TOPIC_PROPAGATED_HEADERS, messagesLatch);
+        boolean allMessagesReceived = messagesLatch.await(10_000, TimeUnit.MILLISECONDS);
+
+        assertTrue("Not all messages were published to the kafka topics. Not received: " + messagesLatch.getCount(), allMessagesReceived);
+
+        ConsumerRecord<String, String> record = records.get(0);
+        Headers headers = record.headers();
+        assertNotNull("Kafka Headers should not be null.", headers);
+        // we have 5 headers and 1 header with breadcrumbId
+        assertEquals("Six propagated headers are expected.", 6, headers.toArray().length);
+        assertEquals("Propagated string value received", propagatedStringHeaderValue,
+                new String(getHeaderValue(propagatedStringHeaderKey, headers)));
+        assertEquals("Propagated integer value received", propagatedIntegerHeaderValue,
+                new Integer(ByteBuffer.wrap(getHeaderValue(propagatedIntegerHeaderKey, headers)).getInt()));
+        assertEquals("Propagated long value received", propagatedLongHeaderValue,
+                new Long(ByteBuffer.wrap(getHeaderValue(propagatedLongHeaderKey, headers)).getLong()));
+        assertEquals("Propagated double value received", propagatedDoubleHeaderValue,
+                new Double(ByteBuffer.wrap(getHeaderValue(propagatedDoubleHeaderKey, headers)).getDouble()));
+        assertArrayEquals("Propagated byte array value received", propagatedBytesHeaderValue, getHeaderValue(propagatedBytesHeaderKey, headers));
+    }
+
+    @Test
+    public void headerFilterStrategyCouldBeOverridden() {
+        KafkaEndpoint kafkaEndpoint = context.getEndpoint("kafka:TOPIC_PROPAGATED_HEADERS?headerFilterStrategy=#myStrategy", KafkaEndpoint.class);
+        assertIsInstanceOf(MyHeaderFilterStrategy.class, kafkaEndpoint.getConfiguration().getHeaderFilterStrategy());
+    }
+
+    private byte[] getHeaderValue(String headerKey, Headers headers) {
+        Header foundHeader = StreamSupport.stream(headers.spliterator(), false)
+                .filter(header -> header.key().equals(headerKey))
+                .findFirst()
+                .orElse(null);
+        assertNotNull("Header should be sent", foundHeader);
+        return foundHeader.value();
+    }
+
+    private List<ConsumerRecord<String, String>> pollForRecords(KafkaConsumer<String, String> consumerConn,
+                                                                String topic, CountDownLatch messagesLatch) {
+
+        List<ConsumerRecord<String, String>> consumedRecords = new ArrayList<>();
+        consumerConn.subscribe(Collections.singletonList(topic));
+
+        new Thread(() -> {
+            while (messagesLatch.getCount() != 0) {
+                for (ConsumerRecord<String, String> record : consumerConn.poll(100)) {
+                    consumedRecords.add(record);
+                    messagesLatch.countDown();
+                }
+            }
+        }).start();
+
+        return consumedRecords;
+    }
+
     private void createKafkaMessageConsumer(KafkaConsumer<String, String> consumerConn,
                                             String topic, String topicInHeader, CountDownLatch messagesLatch) {
 
@@ -321,6 +433,9 @@ public class KafkaProducerFullTest extends BaseEmbeddedKafkaTest {
         for (int k = 0; k < messages; k++) {
             template.sendBodyAndHeaders(bodyOther, headerMap);
         }
+    }
+
+    private static class MyHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
     }
 
 }

--- a/platforms/spring-boot/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/KafkaComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/KafkaComponentConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.kafka.springboot;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Generated;
 import org.apache.camel.component.kafka.KafkaManualCommitFactory;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.StateRepository;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.apache.camel.util.jsse.SSLContextParameters;
@@ -751,6 +752,11 @@ public class KafkaComponentConfiguration
          * increase, 20% random jitter is added to avoid connection storms.
          */
         private Integer reconnectBackoffMaxMs = 1000;
+        /**
+         * To use a custom HeaderFilterStrategy to filter header to and from
+         * Camel message.
+         */
+        private HeaderFilterStrategy headerFilterStrategy;
 
         public Boolean getTopicIsPattern() {
             return topicIsPattern;
@@ -1451,6 +1457,15 @@ public class KafkaComponentConfiguration
 
         public void setReconnectBackoffMaxMs(Integer reconnectBackoffMaxMs) {
             this.reconnectBackoffMaxMs = reconnectBackoffMaxMs;
+        }
+
+        public HeaderFilterStrategy getHeaderFilterStrategy() {
+            return headerFilterStrategy;
+        }
+
+        public void setHeaderFilterStrategy(
+                HeaderFilterStrategy headerFilterStrategy) {
+            this.headerFilterStrategy = headerFilterStrategy;
         }
     }
 }


### PR DESCRIPTION
As part of https://issues.apache.org/jira/browse/CAMEL-12503

the main point why I ported feature to 2.21.x branch is to support 1.5.x Spring boot, we've discussed earlier in gitter about this with members.

cherry picked from 2.22.0 commit ee29789