### PR TITLE
CAMEL-12643: Inadequate information for handling catch clauses

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -268,7 +268,7 @@ class RabbitConsumer implements com.rabbitmq.client.Consumer {
                     reconnect();
                     connected = true;
                 } catch (IOException | TimeoutException e) {
-                    log.warn("Unable to obtain a RabbitMQ channel. Will try again", e);
+                    log.warn("Unable to obtain a RabbitMQ channel. Will try again." + " Caused by: " + e.getMessage());
 
                     Integer networkRecoveryInterval = consumer.getEndpoint().getNetworkRecoveryInterval();
                     final long connectionRetryInterval = networkRecoveryInterval != null && networkRecoveryInterval > 0

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -268,7 +268,7 @@ class RabbitConsumer implements com.rabbitmq.client.Consumer {
                     reconnect();
                     connected = true;
                 } catch (IOException | TimeoutException e) {
-                    log.warn("Unable to obtain a RabbitMQ channel. Will try again");
+                    log.warn("Unable to obtain a RabbitMQ channel. Will try again", e);
 
                     Integer networkRecoveryInterval = consumer.getEndpoint().getNetworkRecoveryInterval();
                     final long connectionRetryInterval = networkRecoveryInterval != null && networkRecoveryInterval > 0


### PR DESCRIPTION
The description of the problem:
https://issues.apache.org/jira/browse/CAMEL-12643
I added a full stack trace information to the logging statement, so that the exception type can be generated to the logs.