### PR TITLE
Camel 12646 - camel-spring-boot - Auto configuration of complex types should be more tooling friendly

### DIFF
--- a/platforms/spring-boot/components-starter/camel-ahc-starter/src/main/java/org/apache/camel/component/ahc/springboot/AhcComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ahc-starter/src/main/java/org/apache/camel/component/ahc/springboot/AhcComponentConfiguration.java
@@ -17,14 +17,8 @@
 package org.apache.camel.component.ahc.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.ahc.AhcBinding;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.AsyncHttpClientConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To call external HTTP services using Async Http Client.
@@ -38,30 +32,30 @@ public class AhcComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom AsyncHttpClient
+     * To use a custom AsyncHttpClient. The option is a
+     * org.asynchttpclient.AsyncHttpClient type.
      */
-    @NestedConfigurationProperty
-    private AsyncHttpClient client;
+    private String client;
     /**
      * To use a custom AhcBinding which allows to control how to bind between
-     * AHC and Camel.
+     * AHC and Camel. The option is a org.apache.camel.component.ahc.AhcBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private AhcBinding binding;
+    private String binding;
     /**
      * To configure the AsyncHttpClient to use a custom
-     * com.ning.http.client.AsyncHttpClientConfig instance.
+     * com.ning.http.client.AsyncHttpClientConfig instance. The option is a
+     * org.asynchttpclient.AsyncHttpClientConfig type.
      */
-    @NestedConfigurationProperty
-    private AsyncHttpClientConfig clientConfig;
+    private String clientConfig;
     /**
      * Reference to a org.apache.camel.util.jsse.SSLContextParameters in the
      * Registry. Note that configuring this option will override any SSL/TLS
      * configuration options provided through the clientConfig option at the
-     * endpoint or component level.
+     * endpoint or component level. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object This is by default
@@ -76,10 +70,10 @@ public class AhcComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -87,36 +81,35 @@ public class AhcComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public AsyncHttpClient getClient() {
+    public String getClient() {
         return client;
     }
 
-    public void setClient(AsyncHttpClient client) {
+    public void setClient(String client) {
         this.client = client;
     }
 
-    public AhcBinding getBinding() {
+    public String getBinding() {
         return binding;
     }
 
-    public void setBinding(AhcBinding binding) {
+    public void setBinding(String binding) {
         this.binding = binding;
     }
 
-    public AsyncHttpClientConfig getClientConfig() {
+    public String getClientConfig() {
         return clientConfig;
     }
 
-    public void setClientConfig(AsyncHttpClientConfig clientConfig) {
+    public void setClientConfig(String clientConfig) {
         this.clientConfig = clientConfig;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -137,12 +130,11 @@ public class AhcComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ahc-ws-starter/src/main/java/org/apache/camel/component/ahc/ws/springboot/WsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ahc-ws-starter/src/main/java/org/apache/camel/component/ahc/ws/springboot/WsComponentConfiguration.java
@@ -17,14 +17,8 @@
 package org.apache.camel.component.ahc.ws.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.ahc.AhcBinding;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.AsyncHttpClientConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To exchange data with external Websocket servers using Async Http Client.
@@ -38,30 +32,30 @@ public class WsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom AsyncHttpClient
+     * To use a custom AsyncHttpClient. The option is a
+     * org.asynchttpclient.AsyncHttpClient type.
      */
-    @NestedConfigurationProperty
-    private AsyncHttpClient client;
+    private String client;
     /**
      * To use a custom AhcBinding which allows to control how to bind between
-     * AHC and Camel.
+     * AHC and Camel. The option is a org.apache.camel.component.ahc.AhcBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private AhcBinding binding;
+    private String binding;
     /**
      * To configure the AsyncHttpClient to use a custom
-     * com.ning.http.client.AsyncHttpClientConfig instance.
+     * com.ning.http.client.AsyncHttpClientConfig instance. The option is a
+     * org.asynchttpclient.AsyncHttpClientConfig type.
      */
-    @NestedConfigurationProperty
-    private AsyncHttpClientConfig clientConfig;
+    private String clientConfig;
     /**
      * Reference to a org.apache.camel.util.jsse.SSLContextParameters in the
      * Registry. Note that configuring this option will override any SSL/TLS
      * configuration options provided through the clientConfig option at the
-     * endpoint or component level.
+     * endpoint or component level. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object This is by default
@@ -76,10 +70,10 @@ public class WsComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -87,36 +81,35 @@ public class WsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public AsyncHttpClient getClient() {
+    public String getClient() {
         return client;
     }
 
-    public void setClient(AsyncHttpClient client) {
+    public void setClient(String client) {
         this.client = client;
     }
 
-    public AhcBinding getBinding() {
+    public String getBinding() {
         return binding;
     }
 
-    public void setBinding(AhcBinding binding) {
+    public void setBinding(String binding) {
         this.binding = binding;
     }
 
-    public AsyncHttpClientConfig getClientConfig() {
+    public String getClientConfig() {
         return clientConfig;
     }
 
-    public void setClientConfig(AsyncHttpClientConfig clientConfig) {
+    public void setClientConfig(String clientConfig) {
         this.clientConfig = clientConfig;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -137,12 +130,11 @@ public class WsComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-amqp-starter/src/main/java/org/apache/camel/component/amqp/springboot/AMQPComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-amqp-starter/src/main/java/org/apache/camel/component/amqp/springboot/AMQPComponentConfiguration.java
@@ -17,26 +17,12 @@
 package org.apache.camel.component.amqp.springboot;
 
 import javax.annotation.Generated;
-import javax.jms.ConnectionFactory;
-import javax.jms.ExceptionListener;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.jms.DefaultTaskExecutorType;
-import org.apache.camel.component.jms.JmsConfiguration;
-import org.apache.camel.component.jms.JmsKeyFormatStrategy;
-import org.apache.camel.component.jms.MessageCreatedStrategy;
-import org.apache.camel.component.jms.QueueBrowseStrategy;
 import org.apache.camel.component.jms.ReplyToType;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.core.task.TaskExecutor;
-import org.springframework.jms.core.JmsOperations;
-import org.springframework.jms.support.converter.MessageConverter;
-import org.springframework.jms.support.destination.DestinationResolver;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.util.ErrorHandler;
 
 /**
  * Messaging with AMQP protocol using Apache QPid Client.
@@ -50,10 +36,10 @@ public class AMQPComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a shared JMS configuration
+     * To use a shared JMS configuration. The option is a
+     * org.apache.camel.component.jms.JmsConfiguration type.
      */
-    @NestedConfigurationProperty
-    private JmsConfiguration configuration;
+    private String configuration;
     /**
      * Specifies whether the consumer accept messages while it is stopping. You
      * may consider enabling this option, if you start and stop JMS routes at
@@ -143,9 +129,10 @@ public class AMQPComponentConfiguration
     private Integer replyToConcurrentConsumers = 1;
     /**
      * The connection factory to be use. A connection factory must be configured
-     * either on the component or endpoint.
+     * either on the component or endpoint. The option is a
+     * javax.jms.ConnectionFactory type.
      */
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * Username to use with the ConnectionFactory. You can also configure
      * username/password directly on the ConnectionFactory.
@@ -172,9 +159,10 @@ public class AMQPComponentConfiguration
     private String durableSubscriptionName;
     /**
      * Specifies the JMS Exception Listener that is to be notified of any
-     * underlying JMS exceptions.
+     * underlying JMS exceptions. The option is a javax.jms.ExceptionListener
+     * type.
      */
-    private ExceptionListener exceptionListener;
+    private String exceptionListener;
     /**
      * Specifies a org.springframework.util.ErrorHandler to be invoked in case
      * of any uncaught exceptions thrown while processing a Message. By default
@@ -182,10 +170,10 @@ public class AMQPComponentConfiguration
      * been configured. You can configure logging level and whether stack traces
      * should be logged using errorHandlerLoggingLevel and
      * errorHandlerLogStackTrace options. This makes it much easier to
-     * configure, than having to code a custom errorHandler.
+     * configure, than having to code a custom errorHandler. The option is a
+     * org.springframework.util.ErrorHandler type.
      */
-    @NestedConfigurationProperty
-    private ErrorHandler errorHandler;
+    private String errorHandler;
     /**
      * Allows to configure the default errorHandler logging level for logging
      * uncaught exceptions.
@@ -253,10 +241,10 @@ public class AMQPComponentConfiguration
     /**
      * To use a custom Spring
      * org.springframework.jms.support.converter.MessageConverter so you can be
-     * in control how to map to/from a javax.jms.Message.
+     * in control how to map to/from a javax.jms.Message. The option is a
+     * org.springframework.jms.support.converter.MessageConverter type.
      */
-    @NestedConfigurationProperty
-    private MessageConverter messageConverter;
+    private String messageConverter;
     /**
      * Specifies whether Camel should auto map the received JMS message to a
      * suited payload type, such as javax.jms.TextMessage to a String etc.
@@ -312,10 +300,10 @@ public class AMQPComponentConfiguration
      */
     private Long recoveryInterval = 5000L;
     /**
-     * Allows you to specify a custom task executor for consuming messages.
+     * Allows you to specify a custom task executor for consuming messages. The
+     * option is a org.springframework.core.task.TaskExecutor type.
      */
-    @NestedConfigurationProperty
-    private TaskExecutor taskExecutor;
+    private String taskExecutor;
     /**
      * When sending messages, specifies the time-to-live of the message (in
      * milliseconds).
@@ -331,10 +319,10 @@ public class AMQPComponentConfiguration
      */
     private Boolean lazyCreateTransactionManager = true;
     /**
-     * The Spring transaction manager to use.
+     * The Spring transaction manager to use. The option is a
+     * org.springframework.transaction.PlatformTransactionManager type.
      */
-    @NestedConfigurationProperty
-    private PlatformTransactionManager transactionManager;
+    private String transactionManager;
     /**
      * The name of the transaction to use.
      */
@@ -432,18 +420,18 @@ public class AMQPComponentConfiguration
      * Allows you to use your own implementation of the
      * org.springframework.jms.core.JmsOperations interface. Camel uses
      * JmsTemplate as default. Can be used for testing purpose, but not used
-     * much as stated in the spring API docs.
+     * much as stated in the spring API docs. The option is a
+     * org.springframework.jms.core.JmsOperations type.
      */
-    @NestedConfigurationProperty
-    private JmsOperations jmsOperations;
+    private String jmsOperations;
     /**
      * A pluggable
      * org.springframework.jms.support.destination.DestinationResolver that
      * allows you to use your own resolver (for example, to lookup the real
-     * destination in a JNDI registry).
+     * destination in a JNDI registry). The option is a
+     * org.springframework.jms.support.destination.DestinationResolver type.
      */
-    @NestedConfigurationProperty
-    private DestinationResolver destinationResolver;
+    private String destinationResolver;
     /**
      * Allows for explicitly specifying which kind of strategy to use for
      * replyTo queues when doing request/reply over JMS. Possible values are:
@@ -519,10 +507,10 @@ public class AMQPComponentConfiguration
      * key as is. Can be used for JMS brokers which do not care whether JMS
      * header keys contain illegal characters. You can provide your own
      * implementation of the org.apache.camel.component.jms.JmsKeyFormatStrategy
-     * and refer to it using the notation.
+     * and refer to it using the notation. The option is a
+     * org.apache.camel.component.jms.JmsKeyFormatStrategy type.
      */
-    @NestedConfigurationProperty
-    private JmsKeyFormatStrategy jmsKeyFormatStrategy;
+    private String jmsKeyFormatStrategy;
     /**
      * This option is used to allow additional headers which may have values
      * that are invalid according to JMS specification. For example some message
@@ -533,17 +521,17 @@ public class AMQPComponentConfiguration
      */
     private String allowAdditionalHeaders;
     /**
-     * To use a custom QueueBrowseStrategy when browsing queues
+     * To use a custom QueueBrowseStrategy when browsing queues. The option is a
+     * org.apache.camel.component.jms.QueueBrowseStrategy type.
      */
-    @NestedConfigurationProperty
-    private QueueBrowseStrategy queueBrowseStrategy;
+    private String queueBrowseStrategy;
     /**
      * To use the given MessageCreatedStrategy which are invoked when Camel
      * creates new instances of javax.jms.Message objects when Camel is sending
-     * a JMS message.
+     * a JMS message. The option is a
+     * org.apache.camel.component.jms.MessageCreatedStrategy type.
      */
-    @NestedConfigurationProperty
-    private MessageCreatedStrategy messageCreatedStrategy;
+    private String messageCreatedStrategy;
     /**
      * Number of times to wait for provisional correlation id to be updated to
      * the actual correlation id when doing request/reply over JMS and when the
@@ -614,10 +602,10 @@ public class AMQPComponentConfiguration
     private Boolean formatDateHeadersToIso8601 = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -625,11 +613,11 @@ public class AMQPComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public JmsConfiguration getConfiguration() {
+    public String getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(JmsConfiguration configuration) {
+    public void setConfiguration(String configuration) {
         this.configuration = configuration;
     }
 
@@ -730,11 +718,11 @@ public class AMQPComponentConfiguration
         this.replyToConcurrentConsumers = replyToConcurrentConsumers;
     }
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
@@ -778,19 +766,19 @@ public class AMQPComponentConfiguration
         this.durableSubscriptionName = durableSubscriptionName;
     }
 
-    public ExceptionListener getExceptionListener() {
+    public String getExceptionListener() {
         return exceptionListener;
     }
 
-    public void setExceptionListener(ExceptionListener exceptionListener) {
+    public void setExceptionListener(String exceptionListener) {
         this.exceptionListener = exceptionListener;
     }
 
-    public ErrorHandler getErrorHandler() {
+    public String getErrorHandler() {
         return errorHandler;
     }
 
-    public void setErrorHandler(ErrorHandler errorHandler) {
+    public void setErrorHandler(String errorHandler) {
         this.errorHandler = errorHandler;
     }
 
@@ -877,11 +865,11 @@ public class AMQPComponentConfiguration
         this.maxMessagesPerTask = maxMessagesPerTask;
     }
 
-    public MessageConverter getMessageConverter() {
+    public String getMessageConverter() {
         return messageConverter;
     }
 
-    public void setMessageConverter(MessageConverter messageConverter) {
+    public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
 
@@ -958,11 +946,11 @@ public class AMQPComponentConfiguration
         this.recoveryInterval = recoveryInterval;
     }
 
-    public TaskExecutor getTaskExecutor() {
+    public String getTaskExecutor() {
         return taskExecutor;
     }
 
-    public void setTaskExecutor(TaskExecutor taskExecutor) {
+    public void setTaskExecutor(String taskExecutor) {
         this.taskExecutor = taskExecutor;
     }
 
@@ -991,12 +979,11 @@ public class AMQPComponentConfiguration
         this.lazyCreateTransactionManager = lazyCreateTransactionManager;
     }
 
-    public PlatformTransactionManager getTransactionManager() {
+    public String getTransactionManager() {
         return transactionManager;
     }
 
-    public void setTransactionManager(
-            PlatformTransactionManager transactionManager) {
+    public void setTransactionManager(String transactionManager) {
         this.transactionManager = transactionManager;
     }
 
@@ -1089,19 +1076,19 @@ public class AMQPComponentConfiguration
         this.transferFault = transferFault;
     }
 
-    public JmsOperations getJmsOperations() {
+    public String getJmsOperations() {
         return jmsOperations;
     }
 
-    public void setJmsOperations(JmsOperations jmsOperations) {
+    public void setJmsOperations(String jmsOperations) {
         this.jmsOperations = jmsOperations;
     }
 
-    public DestinationResolver getDestinationResolver() {
+    public String getDestinationResolver() {
         return destinationResolver;
     }
 
-    public void setDestinationResolver(DestinationResolver destinationResolver) {
+    public void setDestinationResolver(String destinationResolver) {
         this.destinationResolver = destinationResolver;
     }
 
@@ -1162,12 +1149,11 @@ public class AMQPComponentConfiguration
         this.defaultTaskExecutorType = defaultTaskExecutorType;
     }
 
-    public JmsKeyFormatStrategy getJmsKeyFormatStrategy() {
+    public String getJmsKeyFormatStrategy() {
         return jmsKeyFormatStrategy;
     }
 
-    public void setJmsKeyFormatStrategy(
-            JmsKeyFormatStrategy jmsKeyFormatStrategy) {
+    public void setJmsKeyFormatStrategy(String jmsKeyFormatStrategy) {
         this.jmsKeyFormatStrategy = jmsKeyFormatStrategy;
     }
 
@@ -1179,20 +1165,19 @@ public class AMQPComponentConfiguration
         this.allowAdditionalHeaders = allowAdditionalHeaders;
     }
 
-    public QueueBrowseStrategy getQueueBrowseStrategy() {
+    public String getQueueBrowseStrategy() {
         return queueBrowseStrategy;
     }
 
-    public void setQueueBrowseStrategy(QueueBrowseStrategy queueBrowseStrategy) {
+    public void setQueueBrowseStrategy(String queueBrowseStrategy) {
         this.queueBrowseStrategy = queueBrowseStrategy;
     }
 
-    public MessageCreatedStrategy getMessageCreatedStrategy() {
+    public String getMessageCreatedStrategy() {
         return messageCreatedStrategy;
     }
 
-    public void setMessageCreatedStrategy(
-            MessageCreatedStrategy messageCreatedStrategy) {
+    public void setMessageCreatedStrategy(String messageCreatedStrategy) {
         this.messageCreatedStrategy = messageCreatedStrategy;
     }
 
@@ -1262,12 +1247,11 @@ public class AMQPComponentConfiguration
         this.formatDateHeadersToIso8601 = formatDateHeadersToIso8601;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-apns-starter/src/main/java/org/apache/camel/component/apns/springboot/ApnsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-apns-starter/src/main/java/org/apache/camel/component/apns/springboot/ApnsComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.apns.springboot;
 
 import javax.annotation.Generated;
-import com.notnoop.apns.ApnsService;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * For sending notifications to Apple iOS devices.
@@ -36,10 +34,9 @@ public class ApnsComponentConfiguration
     /**
      * The ApnsService to use. The
      * org.apache.camel.component.apns.factory.ApnsServiceFactory can be used to
-     * build a ApnsService
+     * build a ApnsService. The option is a com.notnoop.apns.ApnsService type.
      */
-    @NestedConfigurationProperty
-    private ApnsService apnsService;
+    private String apnsService;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -47,11 +44,11 @@ public class ApnsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ApnsService getApnsService() {
+    public String getApnsService() {
         return apnsService;
     }
 
-    public void setApnsService(ApnsService apnsService) {
+    public void setApnsService(String apnsService) {
         this.apnsService = apnsService;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atmosphere-websocket-starter/src/main/java/org/apache/camel/component/atmosphere/websocket/springboot/WebsocketComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atmosphere-websocket-starter/src/main/java/org/apache/camel/component/atmosphere/websocket/springboot/WebsocketComponentConfiguration.java
@@ -17,13 +17,8 @@
 package org.apache.camel.component.atmosphere.websocket.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.servlet.HttpRegistry;
-import org.apache.camel.http.common.HttpBinding;
-import org.apache.camel.http.common.HttpConfiguration;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To exchange data with external Websocket clients using Atmosphere.
@@ -41,10 +36,10 @@ public class WebsocketComponentConfiguration
      */
     private String servletName;
     /**
-     * To use a custom org.apache.camel.component.servlet.HttpRegistry.
+     * To use a custom org.apache.camel.component.servlet.HttpRegistry. The
+     * option is a org.apache.camel.component.servlet.HttpRegistry type.
      */
-    @NestedConfigurationProperty
-    private HttpRegistry httpRegistry;
+    private String httpRegistry;
     /**
      * Whether to automatic bind multipart/form-data as attachments on the Camel
      * Exchange. The options attachmentMultipartBinding=true and
@@ -56,15 +51,15 @@ public class WebsocketComponentConfiguration
     private Boolean attachmentMultipartBinding = false;
     /**
      * To use a custom HttpBinding to control the mapping between Camel message
-     * and HttpClient.
+     * and HttpClient. The option is a org.apache.camel.http.common.HttpBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private HttpBinding httpBinding;
+    private String httpBinding;
     /**
-     * To use the shared HttpConfiguration as base configuration.
+     * To use the shared HttpConfiguration as base configuration. The option is
+     * a org.apache.camel.http.common.HttpConfiguration type.
      */
-    @NestedConfigurationProperty
-    private HttpConfiguration httpConfiguration;
+    private String httpConfiguration;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object. This is by default
@@ -75,10 +70,10 @@ public class WebsocketComponentConfiguration
     private Boolean allowJavaSerializedObject = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -94,11 +89,11 @@ public class WebsocketComponentConfiguration
         this.servletName = servletName;
     }
 
-    public HttpRegistry getHttpRegistry() {
+    public String getHttpRegistry() {
         return httpRegistry;
     }
 
-    public void setHttpRegistry(HttpRegistry httpRegistry) {
+    public void setHttpRegistry(String httpRegistry) {
         this.httpRegistry = httpRegistry;
     }
 
@@ -110,19 +105,19 @@ public class WebsocketComponentConfiguration
         this.attachmentMultipartBinding = attachmentMultipartBinding;
     }
 
-    public HttpBinding getHttpBinding() {
+    public String getHttpBinding() {
         return httpBinding;
     }
 
-    public void setHttpBinding(HttpBinding httpBinding) {
+    public void setHttpBinding(String httpBinding) {
         this.httpBinding = httpBinding;
     }
 
-    public HttpConfiguration getHttpConfiguration() {
+    public String getHttpConfiguration() {
         return httpConfiguration;
     }
 
-    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+    public void setHttpConfiguration(String httpConfiguration) {
         this.httpConfiguration = httpConfiguration;
     }
 
@@ -134,12 +129,11 @@ public class WebsocketComponentConfiguration
         this.allowJavaSerializedObject = allowJavaSerializedObject;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/map/springboot/AtomixMapComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/map/springboot/AtomixMapComponentConfiguration.java
@@ -18,13 +18,11 @@ package org.apache.camel.component.atomix.client.map.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.map.AtomixMap.Action;
 import org.apache.camel.component.atomix.client.map.AtomixMapComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-map component is used to access Atomix's distributed map.
@@ -42,10 +40,10 @@ public class AtomixMapComponentConfiguration
      */
     private AtomixMapConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -70,11 +68,11 @@ public class AtomixMapComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/messaging/springboot/AtomixMessagingComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/messaging/springboot/AtomixMessagingComponentConfiguration.java
@@ -18,14 +18,12 @@ package org.apache.camel.component.atomix.client.messaging.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.messaging.AtomixMessaging.Action;
 import org.apache.camel.component.atomix.client.messaging.AtomixMessaging.BroadcastType;
 import org.apache.camel.component.atomix.client.messaging.AtomixMessagingComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-messaging component is used to access Atomix's group messaging.
@@ -43,10 +41,10 @@ public class AtomixMessagingComponentConfiguration
      */
     private AtomixMessagingConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -71,11 +69,11 @@ public class AtomixMessagingComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/multimap/springboot/AtomixMultiMapComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/multimap/springboot/AtomixMultiMapComponentConfiguration.java
@@ -18,13 +18,11 @@ package org.apache.camel.component.atomix.client.multimap.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.multimap.AtomixMultiMap.Action;
 import org.apache.camel.component.atomix.client.multimap.AtomixMultiMapComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-multimap component is used to access Atomix's distributed multi
@@ -43,10 +41,10 @@ public class AtomixMultiMapComponentConfiguration
      */
     private AtomixMultiMapConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -71,11 +69,11 @@ public class AtomixMultiMapComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/queue/springboot/AtomixQueueComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/queue/springboot/AtomixQueueComponentConfiguration.java
@@ -18,13 +18,11 @@ package org.apache.camel.component.atomix.client.queue.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.queue.AtomixQueue.Action;
 import org.apache.camel.component.atomix.client.queue.AtomixQueueComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-queue component is used to access Atomix's distributed queue.
@@ -42,10 +40,10 @@ public class AtomixQueueComponentConfiguration
      */
     private AtomixQueueConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -70,11 +68,11 @@ public class AtomixQueueComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/set/springboot/AtomixSetComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/set/springboot/AtomixSetComponentConfiguration.java
@@ -18,13 +18,11 @@ package org.apache.camel.component.atomix.client.set.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.set.AtomixSet.Action;
 import org.apache.camel.component.atomix.client.set.AtomixSetComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-set component is used to access Atomix's distributed set.
@@ -42,10 +40,10 @@ public class AtomixSetComponentConfiguration
      */
     private AtomixSetConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -70,11 +68,11 @@ public class AtomixSetComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/value/springboot/AtomixValueComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-atomix-starter/src/main/java/org/apache/camel/component/atomix/client/value/springboot/AtomixValueComponentConfiguration.java
@@ -18,13 +18,11 @@ package org.apache.camel.component.atomix.client.value.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import io.atomix.AtomixClient;
 import io.atomix.catalyst.transport.Address;
 import org.apache.camel.component.atomix.client.value.AtomixValue.Action;
 import org.apache.camel.component.atomix.client.value.AtomixValueComponent;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The atomix-value component is used to access Atomix's distributed value.
@@ -42,10 +40,10 @@ public class AtomixValueComponentConfiguration
      */
     private AtomixValueConfigurationNestedConfiguration configuration;
     /**
-     * The shared AtomixClient instance
+     * The shared AtomixClient instance. The option is a io.atomix.AtomixClient
+     * type.
      */
-    @NestedConfigurationProperty
-    private AtomixClient atomix;
+    private String atomix;
     /**
      * The nodes the AtomixClient should connect to
      */
@@ -70,11 +68,11 @@ public class AtomixValueComponentConfiguration
         this.configuration = configuration;
     }
 
-    public AtomixClient getAtomix() {
+    public String getAtomix() {
         return atomix;
     }
 
-    public void setAtomix(AtomixClient atomix) {
+    public void setAtomix(String atomix) {
         this.atomix = atomix;
     }
 

--- a/platforms/spring-boot/components-starter/camel-beanstalk-starter/src/main/java/org/apache/camel/component/beanstalk/springboot/BeanstalkComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-beanstalk-starter/src/main/java/org/apache/camel/component/beanstalk/springboot/BeanstalkComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.beanstalk.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.beanstalk.ConnectionSettingsFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The beanstalk component is used for job retrieval and post-processing of
@@ -37,10 +35,11 @@ public class BeanstalkComponentConfiguration
     /**
      * Custom ConnectionSettingsFactory. Specify which ConnectionSettingsFactory
      * to use to make connections to Beanstalkd. Especially useful for unit
-     * testing without beanstalkd daemon (you can mock ConnectionSettings)
+     * testing without beanstalkd daemon (you can mock ConnectionSettings). The
+     * option is a
+     * org.apache.camel.component.beanstalk.ConnectionSettingsFactory type.
      */
-    @NestedConfigurationProperty
-    private ConnectionSettingsFactory connectionSettingsFactory;
+    private String connectionSettingsFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -48,12 +47,11 @@ public class BeanstalkComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ConnectionSettingsFactory getConnectionSettingsFactory() {
+    public String getConnectionSettingsFactory() {
         return connectionSettingsFactory;
     }
 
-    public void setConnectionSettingsFactory(
-            ConnectionSettingsFactory connectionSettingsFactory) {
+    public void setConnectionSettingsFactory(String connectionSettingsFactory) {
         this.connectionSettingsFactory = connectionSettingsFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-cache-starter/src/main/java/org/apache/camel/component/cache/springboot/CacheComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-cache-starter/src/main/java/org/apache/camel/component/cache/springboot/CacheComponentConfiguration.java
@@ -20,7 +20,6 @@ import javax.annotation.Generated;
 import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
 import org.apache.camel.component.cache.CacheEventListenerRegistry;
 import org.apache.camel.component.cache.CacheLoaderRegistry;
-import org.apache.camel.component.cache.CacheManagerFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
@@ -40,9 +39,10 @@ public class CacheComponentConfiguration
 
     /**
      * To use the given CacheManagerFactory for creating the CacheManager. By
-     * default the DefaultCacheManagerFactory is used.
+     * default the DefaultCacheManagerFactory is used. The option is a
+     * org.apache.camel.component.cache.CacheManagerFactory type.
      */
-    private CacheManagerFactory cacheManagerFactory;
+    private String cacheManagerFactory;
     /**
      * Sets the Cache configuration
      */
@@ -59,11 +59,11 @@ public class CacheComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public CacheManagerFactory getCacheManagerFactory() {
+    public String getCacheManagerFactory() {
         return cacheManagerFactory;
     }
 
-    public void setCacheManagerFactory(CacheManagerFactory cacheManagerFactory) {
+    public void setCacheManagerFactory(String cacheManagerFactory) {
         this.cacheManagerFactory = cacheManagerFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-cmis-starter/src/main/java/org/apache/camel/component/cmis/springboot/CMISComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-cmis-starter/src/main/java/org/apache/camel/component/cmis/springboot/CMISComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.cmis.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.cmis.CMISSessionFacadeFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The cmis component uses the Apache Chemistry client API and allows you to
@@ -36,10 +34,10 @@ public class CMISComponentConfiguration
 
     /**
      * To use a custom CMISSessionFacadeFactory to create the CMISSessionFacade
-     * instances
+     * instances. The option is a
+     * org.apache.camel.component.cmis.CMISSessionFacadeFactory type.
      */
-    @NestedConfigurationProperty
-    private CMISSessionFacadeFactory sessionFacadeFactory;
+    private String sessionFacadeFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -47,12 +45,11 @@ public class CMISComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public CMISSessionFacadeFactory getSessionFacadeFactory() {
+    public String getSessionFacadeFactory() {
         return sessionFacadeFactory;
     }
 
-    public void setSessionFacadeFactory(
-            CMISSessionFacadeFactory sessionFacadeFactory) {
+    public void setSessionFacadeFactory(String sessionFacadeFactory) {
         this.sessionFacadeFactory = sessionFacadeFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-cometd-starter/src/main/java/org/apache/camel/component/cometd/springboot/CometdComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-cometd-starter/src/main/java/org/apache/camel/component/cometd/springboot/CometdComponentConfiguration.java
@@ -19,11 +19,8 @@ package org.apache.camel.component.cometd.springboot;
 import java.util.List;
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
 import org.cometd.bayeux.server.BayeuxServer.Extension;
-import org.cometd.bayeux.server.SecurityPolicy;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The cometd component is a transport for working with the Jetty implementation
@@ -50,20 +47,20 @@ public class CometdComponentConfiguration
      */
     private String sslKeystore;
     /**
-     * To use a custom configured SecurityPolicy to control authorization
+     * To use a custom configured SecurityPolicy to control authorization. The
+     * option is a org.cometd.bayeux.server.SecurityPolicy type.
      */
-    @NestedConfigurationProperty
-    private SecurityPolicy securityPolicy;
+    private String securityPolicy;
     /**
      * To use a list of custom BayeuxServer.Extension that allows modifying
      * incoming and outgoing requests.
      */
     private List<Extension> extensions;
     /**
-     * To configure security using SSLContextParameters
+     * To configure security using SSLContextParameters. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -99,11 +96,11 @@ public class CometdComponentConfiguration
         this.sslKeystore = sslKeystore;
     }
 
-    public SecurityPolicy getSecurityPolicy() {
+    public String getSecurityPolicy() {
         return securityPolicy;
     }
 
-    public void setSecurityPolicy(SecurityPolicy securityPolicy) {
+    public void setSecurityPolicy(String securityPolicy) {
         this.securityPolicy = securityPolicy;
     }
 
@@ -115,12 +112,11 @@ public class CometdComponentConfiguration
         this.extensions = extensions;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 

--- a/platforms/spring-boot/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/ConsulComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/ConsulComponentConfiguration.java
@@ -51,10 +51,10 @@ public class ConsulComponentConfiguration
     private String datacenter;
     /**
      * SSL configuration using an
-     * org.apache.camel.util.jsse.SSLContextParameters instance.
+     * org.apache.camel.util.jsse.SSLContextParameters instance. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -98,12 +98,11 @@ public class ConsulComponentConfiguration
         this.datacenter = datacenter;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/directvm/springboot/DirectVmComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/directvm/springboot/DirectVmComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.directvm.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The direct-vm component provides direct, synchronous call to another endpoint
@@ -47,10 +45,9 @@ public class DirectVmComponentConfiguration
     /**
      * Sets a HeaderFilterStrategy that will only be applied on producer
      * endpoints (on both directions: request and response). Default value:
-     * none.
+     * none. The option is a org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether to propagate or not properties from the producer side to the
      * consumer side, and vice versa. Default value: true.
@@ -79,12 +76,11 @@ public class DirectVmComponentConfiguration
         this.timeout = timeout;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/log/springboot/LogComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/log/springboot/LogComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.log.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.spi.ExchangeFormatter;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The log component logs message exchanges to the underlying logging mechanism.
@@ -36,10 +34,10 @@ public class LogComponentConfiguration
     /**
      * Sets a custom ExchangeFormatter to convert the Exchange to a String
      * suitable for logging. If not specified, we default to
-     * DefaultExchangeFormatter.
+     * DefaultExchangeFormatter. The option is a
+     * org.apache.camel.spi.ExchangeFormatter type.
      */
-    @NestedConfigurationProperty
-    private ExchangeFormatter exchangeFormatter;
+    private String exchangeFormatter;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -47,11 +45,11 @@ public class LogComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ExchangeFormatter getExchangeFormatter() {
+    public String getExchangeFormatter() {
         return exchangeFormatter;
     }
 
-    public void setExchangeFormatter(ExchangeFormatter exchangeFormatter) {
+    public void setExchangeFormatter(String exchangeFormatter) {
         this.exchangeFormatter = exchangeFormatter;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/properties/springboot/PropertiesComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/properties/springboot/PropertiesComponentConfiguration.java
@@ -17,14 +17,10 @@
 package org.apache.camel.component.properties.springboot;
 
 import java.util.List;
-import java.util.Properties;
 import javax.annotation.Generated;
 import org.apache.camel.component.properties.PropertiesLocation;
-import org.apache.camel.component.properties.PropertiesParser;
-import org.apache.camel.component.properties.PropertiesResolver;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The properties component is used for using property placeholders in endpoint
@@ -57,15 +53,15 @@ public class PropertiesComponentConfiguration
      */
     private String encoding;
     /**
-     * To use a custom PropertiesResolver
+     * To use a custom PropertiesResolver. The option is a
+     * org.apache.camel.component.properties.PropertiesResolver type.
      */
-    @NestedConfigurationProperty
-    private PropertiesResolver propertiesResolver;
+    private String propertiesResolver;
     /**
-     * To use a custom PropertiesParser
+     * To use a custom PropertiesParser. The option is a
+     * org.apache.camel.component.properties.PropertiesParser type.
      */
-    @NestedConfigurationProperty
-    private PropertiesParser propertiesParser;
+    private String propertiesParser;
     /**
      * Whether or not to cache loaded properties. The default value is true.
      */
@@ -108,14 +104,15 @@ public class PropertiesComponentConfiguration
     private String suffixToken = "}}";
     /**
      * Sets initial properties which will be used before any locations are
-     * resolved.
+     * resolved. The option is a java.util.Properties type.
      */
-    private Properties initialProperties;
+    private String initialProperties;
     /**
      * Sets a special list of override properties that take precedence and will
-     * use first, if a property exist.
+     * use first, if a property exist. The option is a java.util.Properties
+     * type.
      */
-    private Properties overrideProperties;
+    private String overrideProperties;
     /**
      * Sets the system property mode.
      */
@@ -151,19 +148,19 @@ public class PropertiesComponentConfiguration
         this.encoding = encoding;
     }
 
-    public PropertiesResolver getPropertiesResolver() {
+    public String getPropertiesResolver() {
         return propertiesResolver;
     }
 
-    public void setPropertiesResolver(PropertiesResolver propertiesResolver) {
+    public void setPropertiesResolver(String propertiesResolver) {
         this.propertiesResolver = propertiesResolver;
     }
 
-    public PropertiesParser getPropertiesParser() {
+    public String getPropertiesParser() {
         return propertiesParser;
     }
 
-    public void setPropertiesParser(PropertiesParser propertiesParser) {
+    public void setPropertiesParser(String propertiesParser) {
         this.propertiesParser = propertiesParser;
     }
 
@@ -232,19 +229,19 @@ public class PropertiesComponentConfiguration
         this.suffixToken = suffixToken;
     }
 
-    public Properties getInitialProperties() {
+    public String getInitialProperties() {
         return initialProperties;
     }
 
-    public void setInitialProperties(Properties initialProperties) {
+    public void setInitialProperties(String initialProperties) {
         this.initialProperties = initialProperties;
     }
 
-    public Properties getOverrideProperties() {
+    public String getOverrideProperties() {
         return overrideProperties;
     }
 
-    public void setOverrideProperties(Properties overrideProperties) {
+    public void setOverrideProperties(String overrideProperties) {
         this.overrideProperties = overrideProperties;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/seda/springboot/SedaComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/seda/springboot/SedaComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.seda.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.Exchange;
-import org.apache.camel.component.seda.BlockingQueueFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The seda component provides asynchronous call to another endpoint from any
@@ -45,10 +42,11 @@ public class SedaComponentConfiguration
      */
     private Integer concurrentConsumers = 1;
     /**
-     * Sets the default queue factory.
+     * Sets the default queue factory. The option is a
+     * org.apache.camel.component
+     * .seda.BlockingQueueFactory<org.apache.camel.Exchange> type.
      */
-    @NestedConfigurationProperty
-    private BlockingQueueFactory<Exchange> defaultQueueFactory;
+    private String defaultQueueFactory;
     /**
      * Whether a thread that sends messages to a full SEDA queue will block
      * until the queue's capacity is no longer exhausted. By default, an
@@ -88,12 +86,11 @@ public class SedaComponentConfiguration
         this.concurrentConsumers = concurrentConsumers;
     }
 
-    public BlockingQueueFactory<Exchange> getDefaultQueueFactory() {
+    public String getDefaultQueueFactory() {
         return defaultQueueFactory;
     }
 
-    public void setDefaultQueueFactory(
-            BlockingQueueFactory<Exchange> defaultQueueFactory) {
+    public void setDefaultQueueFactory(String defaultQueueFactory) {
         this.defaultQueueFactory = defaultQueueFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/stub/springboot/StubComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/stub/springboot/StubComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.stub.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.Exchange;
-import org.apache.camel.component.seda.BlockingQueueFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The stub component provides a simple way to stub out any physical endpoints
@@ -45,10 +42,11 @@ public class StubComponentConfiguration
      */
     private Integer concurrentConsumers = 1;
     /**
-     * Sets the default queue factory.
+     * Sets the default queue factory. The option is a
+     * org.apache.camel.component
+     * .seda.BlockingQueueFactory<org.apache.camel.Exchange> type.
      */
-    @NestedConfigurationProperty
-    private BlockingQueueFactory<Exchange> defaultQueueFactory;
+    private String defaultQueueFactory;
     /**
      * Whether a thread that sends messages to a full SEDA queue will block
      * until the queue's capacity is no longer exhausted. By default, an
@@ -88,12 +86,11 @@ public class StubComponentConfiguration
         this.concurrentConsumers = concurrentConsumers;
     }
 
-    public BlockingQueueFactory<Exchange> getDefaultQueueFactory() {
+    public String getDefaultQueueFactory() {
         return defaultQueueFactory;
     }
 
-    public void setDefaultQueueFactory(
-            BlockingQueueFactory<Exchange> defaultQueueFactory) {
+    public void setDefaultQueueFactory(String defaultQueueFactory) {
         this.defaultQueueFactory = defaultQueueFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/validator/springboot/ValidatorComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/validator/springboot/ValidatorComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.validator.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.validator.ValidatorResourceResolverFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Validates the payload of a message using XML Schema and JAXP Validation.
@@ -35,10 +33,11 @@ public class ValidatorComponentConfiguration
 
     /**
      * To use a custom LSResourceResolver which depends on a dynamic endpoint
-     * resource URI
+     * resource URI. The option is a
+     * org.apache.camel.component.validator.ValidatorResourceResolverFactory
+     * type.
      */
-    @NestedConfigurationProperty
-    private ValidatorResourceResolverFactory resourceResolverFactory;
+    private String resourceResolverFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -46,12 +45,11 @@ public class ValidatorComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ValidatorResourceResolverFactory getResourceResolverFactory() {
+    public String getResourceResolverFactory() {
         return resourceResolverFactory;
     }
 
-    public void setResourceResolverFactory(
-            ValidatorResourceResolverFactory resourceResolverFactory) {
+    public void setResourceResolverFactory(String resourceResolverFactory) {
         this.resourceResolverFactory = resourceResolverFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/vm/springboot/VmComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/vm/springboot/VmComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.vm.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.Exchange;
-import org.apache.camel.component.seda.BlockingQueueFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The vm component provides asynchronous call to another endpoint from the same
@@ -45,10 +42,11 @@ public class VmComponentConfiguration
      */
     private Integer concurrentConsumers = 1;
     /**
-     * Sets the default queue factory.
+     * Sets the default queue factory. The option is a
+     * org.apache.camel.component
+     * .seda.BlockingQueueFactory<org.apache.camel.Exchange> type.
      */
-    @NestedConfigurationProperty
-    private BlockingQueueFactory<Exchange> defaultQueueFactory;
+    private String defaultQueueFactory;
     /**
      * Whether a thread that sends messages to a full SEDA queue will block
      * until the queue's capacity is no longer exhausted. By default, an
@@ -88,12 +86,11 @@ public class VmComponentConfiguration
         this.concurrentConsumers = concurrentConsumers;
     }
 
-    public BlockingQueueFactory<Exchange> getDefaultQueueFactory() {
+    public String getDefaultQueueFactory() {
         return defaultQueueFactory;
     }
 
-    public void setDefaultQueueFactory(
-            BlockingQueueFactory<Exchange> defaultQueueFactory) {
+    public void setDefaultQueueFactory(String defaultQueueFactory) {
         this.defaultQueueFactory = defaultQueueFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/xslt/springboot/XsltComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-core-starter/src/main/java/org/apache/camel/component/xslt/springboot/XsltComponentConfiguration.java
@@ -16,15 +16,11 @@
  */
 package org.apache.camel.component.xslt.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.URIResolver;
-import org.apache.camel.component.xslt.XsltUriResolverFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Transforms the message using a XSLT template.
@@ -44,15 +40,16 @@ public class XsltComponentConfiguration
     private XmlConverterNestedConfiguration xmlConverter;
     /**
      * To use a custom UriResolver which depends on a dynamic endpoint resource
-     * URI. Should not be used together with the option 'uriResolver'.
+     * URI. Should not be used together with the option 'uriResolver'. The
+     * option is a org.apache.camel.component.xslt.XsltUriResolverFactory type.
      */
-    @NestedConfigurationProperty
-    private XsltUriResolverFactory uriResolverFactory;
+    private String uriResolverFactory;
     /**
      * To use a custom UriResolver. Should not be used together with the option
-     * 'uriResolverFactory'.
+     * 'uriResolverFactory'. The option is a javax.xml.transform.URIResolver
+     * type.
      */
-    private URIResolver uriResolver;
+    private String uriResolver;
     /**
      * Cache for the resource content (the stylesheet file) when it is loaded.
      * If set to false Camel will reload the stylesheet file on each message
@@ -75,13 +72,15 @@ public class XsltComponentConfiguration
      */
     private String saxonExtensionFunctions;
     /**
-     * To use a custom Saxon configuration
+     * To use a custom Saxon configuration. The option is a java.lang.Object
+     * type.
      */
-    private Object saxonConfiguration;
+    private String saxonConfiguration;
     /**
-     * To set custom Saxon configuration properties
+     * To set custom Saxon configuration properties. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> saxonConfigurationProperties;
+    private String saxonConfigurationProperties;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -97,19 +96,19 @@ public class XsltComponentConfiguration
         this.xmlConverter = xmlConverter;
     }
 
-    public XsltUriResolverFactory getUriResolverFactory() {
+    public String getUriResolverFactory() {
         return uriResolverFactory;
     }
 
-    public void setUriResolverFactory(XsltUriResolverFactory uriResolverFactory) {
+    public void setUriResolverFactory(String uriResolverFactory) {
         this.uriResolverFactory = uriResolverFactory;
     }
 
-    public URIResolver getUriResolver() {
+    public String getUriResolver() {
         return uriResolver;
     }
 
-    public void setUriResolver(URIResolver uriResolver) {
+    public void setUriResolver(String uriResolver) {
         this.uriResolver = uriResolver;
     }
 
@@ -137,20 +136,20 @@ public class XsltComponentConfiguration
         this.saxonExtensionFunctions = saxonExtensionFunctions;
     }
 
-    public Object getSaxonConfiguration() {
+    public String getSaxonConfiguration() {
         return saxonConfiguration;
     }
 
-    public void setSaxonConfiguration(Object saxonConfiguration) {
+    public void setSaxonConfiguration(String saxonConfiguration) {
         this.saxonConfiguration = saxonConfiguration;
     }
 
-    public Map<String, Object> getSaxonConfigurationProperties() {
+    public String getSaxonConfigurationProperties() {
         return saxonConfigurationProperties;
     }
 
     public void setSaxonConfigurationProperties(
-            Map<String, Object> saxonConfigurationProperties) {
+            String saxonConfigurationProperties) {
         this.saxonConfigurationProperties = saxonConfigurationProperties;
     }
 

--- a/platforms/spring-boot/components-starter/camel-crypto-cms-starter/src/main/java/org/apache/camel/component/crypto/cms/springboot/CryptoCmsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-crypto-cms-starter/src/main/java/org/apache/camel/component/crypto/cms/springboot/CryptoCmsComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.crypto.cms.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.crypto.cms.crypt.EnvelopedDataDecryptorConfiguration;
-import org.apache.camel.component.crypto.cms.sig.SignedDataVerifierConfiguration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The crypto cms component is used for encrypting data in CMS Enveloped Data
@@ -38,16 +35,18 @@ public class CryptoCmsComponentConfiguration
 
     /**
      * To configure the shared SignedDataVerifierConfiguration, which determines
-     * the uri parameters for the verify operation.
+     * the uri parameters for the verify operation. The option is a
+     * org.apache.camel.component.crypto.cms.sig.SignedDataVerifierConfiguration
+     * type.
      */
-    @NestedConfigurationProperty
-    private SignedDataVerifierConfiguration signedDataVerifierConfiguration;
+    private String signedDataVerifierConfiguration;
     /**
      * To configure the shared EnvelopedDataDecryptorConfiguration, which
-     * determines the uri parameters for the decrypt operation.
+     * determines the uri parameters for the decrypt operation. The option is a
+     * org.apache.camel.component.crypto.cms.crypt.
+     * EnvelopedDataDecryptorConfiguration type.
      */
-    @NestedConfigurationProperty
-    private EnvelopedDataDecryptorConfiguration envelopedDataDecryptorConfiguration;
+    private String envelopedDataDecryptorConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -55,21 +54,21 @@ public class CryptoCmsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SignedDataVerifierConfiguration getSignedDataVerifierConfiguration() {
+    public String getSignedDataVerifierConfiguration() {
         return signedDataVerifierConfiguration;
     }
 
     public void setSignedDataVerifierConfiguration(
-            SignedDataVerifierConfiguration signedDataVerifierConfiguration) {
+            String signedDataVerifierConfiguration) {
         this.signedDataVerifierConfiguration = signedDataVerifierConfiguration;
     }
 
-    public EnvelopedDataDecryptorConfiguration getEnvelopedDataDecryptorConfiguration() {
+    public String getEnvelopedDataDecryptorConfiguration() {
         return envelopedDataDecryptorConfiguration;
     }
 
     public void setEnvelopedDataDecryptorConfiguration(
-            EnvelopedDataDecryptorConfiguration envelopedDataDecryptorConfiguration) {
+            String envelopedDataDecryptorConfiguration) {
         this.envelopedDataDecryptorConfiguration = envelopedDataDecryptorConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-cxf-starter/src/main/java/org/apache/camel/component/cxf/jaxrs/springboot/CxfRsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-cxf-starter/src/main/java/org/apache/camel/component/cxf/jaxrs/springboot/CxfRsComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.cxf.jaxrs.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The cxfrs component is used for JAX-RS REST services using Apache CXF.
@@ -39,10 +37,10 @@ public class CxfRsComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -59,12 +57,11 @@ public class CxfRsComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-cxf-starter/src/main/java/org/apache/camel/component/cxf/springboot/CxfComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-cxf-starter/src/main/java/org/apache/camel/component/cxf/springboot/CxfComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.cxf.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The cxf component is used for SOAP WebServices using Apache CXF.
@@ -46,10 +44,10 @@ public class CxfComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -74,12 +72,11 @@ public class CxfComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ehcache-starter/src/main/java/org/apache/camel/component/ehcache/springboot/EhcacheComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ehcache-starter/src/main/java/org/apache/camel/component/ehcache/springboot/EhcacheComponentConfiguration.java
@@ -28,7 +28,6 @@ import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The ehcache component enables you to perform caching operations using Ehcache
@@ -47,24 +46,25 @@ public class EhcacheComponentConfiguration
      */
     private EhcacheConfigurationNestedConfiguration configuration;
     /**
-     * The cache manager
+     * The cache manager. The option is a org.ehcache.CacheManager type.
      */
-    @NestedConfigurationProperty
-    private CacheManager cacheManager;
+    private String cacheManager;
     /**
-     * The cache manager configuration
+     * The cache manager configuration. The option is a
+     * org.ehcache.config.Configuration type.
      */
-    @NestedConfigurationProperty
-    private Configuration cacheManagerConfiguration;
+    private String cacheManagerConfiguration;
     /**
-     * The default cache configuration to be used to create caches.
+     * The default cache configuration to be used to create caches. The option
+     * is a org.ehcache.config.CacheConfiguration<?,?> type.
      */
-    @NestedConfigurationProperty
-    private CacheConfiguration<?, ?> cacheConfiguration;
+    private String cacheConfiguration;
     /**
-     * A map of caches configurations to be used to create caches.
+     * A map of caches configurations to be used to create caches. The option is
+     * a java.util.Map<java.lang.String,org.ehcache.config.CacheConfiguration<?,
+     * ?>> type.
      */
-    private Map<String, CacheConfiguration<?, ?>> cachesConfigurations;
+    private String cachesConfigurations;
     /**
      * URI pointing to the Ehcache XML configuration file's location
      */
@@ -85,38 +85,35 @@ public class EhcacheComponentConfiguration
         this.configuration = configuration;
     }
 
-    public CacheManager getCacheManager() {
+    public String getCacheManager() {
         return cacheManager;
     }
 
-    public void setCacheManager(CacheManager cacheManager) {
+    public void setCacheManager(String cacheManager) {
         this.cacheManager = cacheManager;
     }
 
-    public Configuration getCacheManagerConfiguration() {
+    public String getCacheManagerConfiguration() {
         return cacheManagerConfiguration;
     }
 
-    public void setCacheManagerConfiguration(
-            Configuration cacheManagerConfiguration) {
+    public void setCacheManagerConfiguration(String cacheManagerConfiguration) {
         this.cacheManagerConfiguration = cacheManagerConfiguration;
     }
 
-    public CacheConfiguration<?, ?> getCacheConfiguration() {
+    public String getCacheConfiguration() {
         return cacheConfiguration;
     }
 
-    public void setCacheConfiguration(
-            CacheConfiguration<?, ?> cacheConfiguration) {
+    public void setCacheConfiguration(String cacheConfiguration) {
         this.cacheConfiguration = cacheConfiguration;
     }
 
-    public Map<String, CacheConfiguration<?, ?>> getCachesConfigurations() {
+    public String getCachesConfigurations() {
         return cachesConfigurations;
     }
 
-    public void setCachesConfigurations(
-            Map<String, CacheConfiguration<?, ?>> cachesConfigurations) {
+    public void setCachesConfigurations(String cachesConfigurations) {
         this.cachesConfigurations = cachesConfigurations;
     }
 

--- a/platforms/spring-boot/components-starter/camel-elasticsearch-rest-starter/src/main/java/org/apache/camel/component/elasticsearch/springboot/ElasticsearchComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-elasticsearch-rest-starter/src/main/java/org/apache/camel/component/elasticsearch/springboot/ElasticsearchComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.elasticsearch.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.elasticsearch.client.RestClient;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The elasticsearch component is used for interfacing with ElasticSearch server
@@ -37,10 +35,9 @@ public class ElasticsearchComponentConfiguration
     /**
      * To use an existing configured Elasticsearch client, instead of creating a
      * client per endpoint. This allow to customize the client with specific
-     * settings.
+     * settings. The option is a org.elasticsearch.client.RestClient type.
      */
-    @NestedConfigurationProperty
-    private RestClient client;
+    private String client;
     /**
      * Comma separated list with ip:port formatted remote transport addresses to
      * use. The ip and port options must be left blank for hostAddresses to be
@@ -93,11 +90,11 @@ public class ElasticsearchComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public RestClient getClient() {
+    public String getClient() {
         return client;
     }
 
-    public void setClient(RestClient client) {
+    public void setClient(String client) {
         this.client = client;
     }
 

--- a/platforms/spring-boot/components-starter/camel-elasticsearch-starter/src/main/java/org/apache/camel/component/elasticsearch/springboot/ElasticsearchComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-elasticsearch-starter/src/main/java/org/apache/camel/component/elasticsearch/springboot/ElasticsearchComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.elasticsearch.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.elasticsearch.client.Client;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The elasticsearch component is used for interfacing with ElasticSearch
@@ -36,10 +34,10 @@ public class ElasticsearchComponentConfiguration
 
     /**
      * To use an existing configured Elasticsearch client, instead of creating a
-     * client per endpoint.
+     * client per endpoint. The option is a org.elasticsearch.client.Client
+     * type.
      */
-    @NestedConfigurationProperty
-    private Client client;
+    private String client;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -47,11 +45,11 @@ public class ElasticsearchComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Client getClient() {
+    public String getClient() {
         return client;
     }
 
-    public void setClient(Client client) {
+    public void setClient(String client) {
         this.client = client;
     }
 

--- a/platforms/spring-boot/components-starter/camel-elasticsearch5-starter/src/main/java/org/apache/camel/component/elasticsearch5/springboot/ElasticsearchComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-elasticsearch5-starter/src/main/java/org/apache/camel/component/elasticsearch5/springboot/ElasticsearchComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.elasticsearch5.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.elasticsearch.client.transport.TransportClient;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The elasticsearch component is used for interfacing with ElasticSearch server
@@ -37,10 +35,10 @@ public class ElasticsearchComponentConfiguration
     /**
      * To use an existing configured Elasticsearch client, instead of creating a
      * client per endpoint. This allow to customize the client with specific
-     * settings.
+     * settings. The option is a
+     * org.elasticsearch.client.transport.TransportClient type.
      */
-    @NestedConfigurationProperty
-    private TransportClient client;
+    private String client;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -48,11 +46,11 @@ public class ElasticsearchComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public TransportClient getClient() {
+    public String getClient() {
         return client;
     }
 
-    public void setClient(TransportClient client) {
+    public void setClient(String client) {
         this.client = client;
     }
 

--- a/platforms/spring-boot/components-starter/camel-elsql-starter/src/main/java/org/apache/camel/component/elsql/springboot/ElsqlComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-elsql-starter/src/main/java/org/apache/camel/component/elsql/springboot/ElsqlComponentConfiguration.java
@@ -17,12 +17,9 @@
 package org.apache.camel.component.elsql.springboot;
 
 import javax.annotation.Generated;
-import javax.sql.DataSource;
-import com.opengamma.elsql.ElSqlConfig;
 import org.apache.camel.component.elsql.ElSqlDatabaseVendor;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The elsql component is an extension to the existing SQL Component that uses
@@ -41,15 +38,16 @@ public class ElsqlComponentConfiguration
      */
     private ElSqlDatabaseVendor databaseVendor;
     /**
-     * Sets the DataSource to use to communicate with the database.
+     * Sets the DataSource to use to communicate with the database. The option
+     * is a javax.sql.DataSource type.
      */
-    private DataSource dataSource;
+    private String dataSource;
     /**
      * To use a specific configured ElSqlConfig. It may be better to use the
-     * databaseVendor option instead.
+     * databaseVendor option instead. The option is a
+     * com.opengamma.elsql.ElSqlConfig type.
      */
-    @NestedConfigurationProperty
-    private ElSqlConfig elSqlConfig;
+    private String elSqlConfig;
     /**
      * The resource file which contains the elsql SQL statements to use. You can
      * specify multiple resources separated by comma. The resources are loaded
@@ -73,19 +71,19 @@ public class ElsqlComponentConfiguration
         this.databaseVendor = databaseVendor;
     }
 
-    public DataSource getDataSource() {
+    public String getDataSource() {
         return dataSource;
     }
 
-    public void setDataSource(DataSource dataSource) {
+    public void setDataSource(String dataSource) {
         this.dataSource = dataSource;
     }
 
-    public ElSqlConfig getElSqlConfig() {
+    public String getElSqlConfig() {
         return elSqlConfig;
     }
 
-    public void setElSqlConfig(ElSqlConfig elSqlConfig) {
+    public void setElSqlConfig(String elSqlConfig) {
         this.elSqlConfig = elSqlConfig;
     }
 

--- a/platforms/spring-boot/components-starter/camel-etcd-starter/src/main/java/org/apache/camel/component/etcd/springboot/EtcdComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-etcd-starter/src/main/java/org/apache/camel/component/etcd/springboot/EtcdComponentConfiguration.java
@@ -40,10 +40,10 @@ public class EtcdComponentConfiguration
      */
     private String uris;
     /**
-     * To configure security using SSLContextParameters.
+     * To configure security using SSLContextParameters. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * The user name to use for basic authentication.
      */
@@ -75,12 +75,11 @@ public class EtcdComponentConfiguration
         this.uris = uris;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 

--- a/platforms/spring-boot/components-starter/camel-flink-starter/src/main/java/org/apache/camel/component/flink/springboot/FlinkComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-flink-starter/src/main/java/org/apache/camel/component/flink/springboot/FlinkComponentConfiguration.java
@@ -17,13 +17,8 @@
 package org.apache.camel.component.flink.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.flink.DataSetCallback;
-import org.apache.camel.component.flink.DataStreamCallback;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.flink.api.java.DataSet;
-import org.apache.flink.streaming.api.datastream.DataStream;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The flink component can be used to send DataSet jobs to Apache Flink cluster.
@@ -37,25 +32,25 @@ public class FlinkComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * DataSet to compute against.
+     * DataSet to compute against. The option is a
+     * org.apache.flink.api.java.DataSet type.
      */
-    @NestedConfigurationProperty
-    private DataSet dataSet;
+    private String dataSet;
     /**
-     * DataStream to compute against.
+     * DataStream to compute against. The option is a
+     * org.apache.flink.streaming.api.datastream.DataStream type.
      */
-    @NestedConfigurationProperty
-    private DataStream dataStream;
+    private String dataStream;
     /**
-     * Function performing action against a DataSet.
+     * Function performing action against a DataSet. The option is a
+     * org.apache.camel.component.flink.DataSetCallback type.
      */
-    @NestedConfigurationProperty
-    private DataSetCallback dataSetCallback;
+    private String dataSetCallback;
     /**
-     * Function performing action against a DataStream.
+     * Function performing action against a DataStream. The option is a
+     * org.apache.camel.component.flink.DataStreamCallback type.
      */
-    @NestedConfigurationProperty
-    private DataStreamCallback dataStreamCallback;
+    private String dataStreamCallback;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -63,35 +58,35 @@ public class FlinkComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public DataSet getDataSet() {
+    public String getDataSet() {
         return dataSet;
     }
 
-    public void setDataSet(DataSet dataSet) {
+    public void setDataSet(String dataSet) {
         this.dataSet = dataSet;
     }
 
-    public DataStream getDataStream() {
+    public String getDataStream() {
         return dataStream;
     }
 
-    public void setDataStream(DataStream dataStream) {
+    public void setDataStream(String dataStream) {
         this.dataStream = dataStream;
     }
 
-    public DataSetCallback getDataSetCallback() {
+    public String getDataSetCallback() {
         return dataSetCallback;
     }
 
-    public void setDataSetCallback(DataSetCallback dataSetCallback) {
+    public void setDataSetCallback(String dataSetCallback) {
         this.dataSetCallback = dataSetCallback;
     }
 
-    public DataStreamCallback getDataStreamCallback() {
+    public String getDataStreamCallback() {
         return dataStreamCallback;
     }
 
-    public void setDataStreamCallback(DataStreamCallback dataStreamCallback) {
+    public void setDataStreamCallback(String dataStreamCallback) {
         this.dataStreamCallback = dataStreamCallback;
     }
 

--- a/platforms/spring-boot/components-starter/camel-freemarker-starter/src/main/java/org/apache/camel/component/freemarker/springboot/FreemarkerComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-freemarker-starter/src/main/java/org/apache/camel/component/freemarker/springboot/FreemarkerComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.freemarker.springboot;
 
 import javax.annotation.Generated;
-import freemarker.template.Configuration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -34,9 +33,9 @@ public class FreemarkerComponentConfiguration
 
     /**
      * To use an existing freemarker.template.Configuration instance as the
-     * configuration.
+     * configuration. The option is a freemarker.template.Configuration type.
      */
-    private Configuration configuration;
+    private String configuration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -44,11 +43,11 @@ public class FreemarkerComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Configuration getConfiguration() {
+    public String getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(Configuration configuration) {
+    public void setConfiguration(String configuration) {
         this.configuration = configuration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-google-calendar-starter/src/main/java/org/apache/camel/component/google/calendar/springboot/GoogleCalendarComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-google-calendar-starter/src/main/java/org/apache/camel/component/google/calendar/springboot/GoogleCalendarComponentConfiguration.java
@@ -17,11 +17,9 @@
 package org.apache.camel.component.google.calendar.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.google.calendar.GoogleCalendarClientFactory;
 import org.apache.camel.component.google.calendar.internal.GoogleCalendarApiName;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The google-calendar component provides access to Google Calendar.
@@ -40,10 +38,12 @@ public class GoogleCalendarComponentConfiguration
     private GoogleCalendarConfigurationNestedConfiguration configuration;
     /**
      * To use the GoogleCalendarClientFactory as factory for creating the
-     * client. Will by default use BatchGoogleCalendarClientFactory
+     * client. Will by default use BatchGoogleCalendarClientFactory. The option
+     * is a
+     * org.apache.camel.component.google.calendar.GoogleCalendarClientFactory
+     * type.
      */
-    @NestedConfigurationProperty
-    private GoogleCalendarClientFactory clientFactory;
+    private String clientFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -60,11 +60,11 @@ public class GoogleCalendarComponentConfiguration
         this.configuration = configuration;
     }
 
-    public GoogleCalendarClientFactory getClientFactory() {
+    public String getClientFactory() {
         return clientFactory;
     }
 
-    public void setClientFactory(GoogleCalendarClientFactory clientFactory) {
+    public void setClientFactory(String clientFactory) {
         this.clientFactory = clientFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-google-drive-starter/src/main/java/org/apache/camel/component/google/drive/springboot/GoogleDriveComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-google-drive-starter/src/main/java/org/apache/camel/component/google/drive/springboot/GoogleDriveComponentConfiguration.java
@@ -18,11 +18,9 @@ package org.apache.camel.component.google.drive.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import org.apache.camel.component.google.drive.GoogleDriveClientFactory;
 import org.apache.camel.component.google.drive.internal.GoogleDriveApiName;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The google-drive component provides access to Google Drive file storage
@@ -42,10 +40,10 @@ public class GoogleDriveComponentConfiguration
     private GoogleDriveConfigurationNestedConfiguration configuration;
     /**
      * To use the GoogleCalendarClientFactory as factory for creating the
-     * client. Will by default use BatchGoogleDriveClientFactory
+     * client. Will by default use BatchGoogleDriveClientFactory. The option is
+     * a org.apache.camel.component.google.drive.GoogleDriveClientFactory type.
      */
-    @NestedConfigurationProperty
-    private GoogleDriveClientFactory clientFactory;
+    private String clientFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -62,11 +60,11 @@ public class GoogleDriveComponentConfiguration
         this.configuration = configuration;
     }
 
-    public GoogleDriveClientFactory getClientFactory() {
+    public String getClientFactory() {
         return clientFactory;
     }
 
-    public void setClientFactory(GoogleDriveClientFactory clientFactory) {
+    public void setClientFactory(String clientFactory) {
         this.clientFactory = clientFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-google-mail-starter/src/main/java/org/apache/camel/component/google/mail/springboot/GoogleMailComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-google-mail-starter/src/main/java/org/apache/camel/component/google/mail/springboot/GoogleMailComponentConfiguration.java
@@ -17,11 +17,9 @@
 package org.apache.camel.component.google.mail.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.google.mail.GoogleMailClientFactory;
 import org.apache.camel.component.google.mail.internal.GoogleMailApiName;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The google-mail component provides access to Google Mail.
@@ -40,10 +38,10 @@ public class GoogleMailComponentConfiguration
     private GoogleMailConfigurationNestedConfiguration configuration;
     /**
      * To use the GoogleCalendarClientFactory as factory for creating the
-     * client. Will by default use BatchGoogleMailClientFactory
+     * client. Will by default use BatchGoogleMailClientFactory. The option is a
+     * org.apache.camel.component.google.mail.GoogleMailClientFactory type.
      */
-    @NestedConfigurationProperty
-    private GoogleMailClientFactory clientFactory;
+    private String clientFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -60,11 +58,11 @@ public class GoogleMailComponentConfiguration
         this.configuration = configuration;
     }
 
-    public GoogleMailClientFactory getClientFactory() {
+    public String getClientFactory() {
         return clientFactory;
     }
 
-    public void setClientFactory(GoogleMailClientFactory clientFactory) {
+    public void setClientFactory(String clientFactory) {
         this.clientFactory = clientFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-google-mail-starter/src/main/java/org/apache/camel/component/google/mail/stream/springboot/GoogleMailStreamComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-google-mail-starter/src/main/java/org/apache/camel/component/google/mail/stream/springboot/GoogleMailStreamComponentConfiguration.java
@@ -18,10 +18,8 @@ package org.apache.camel.component.google.mail.stream.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import org.apache.camel.component.google.mail.GoogleMailClientFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The google-mail component provides access to Google Mail.
@@ -39,10 +37,10 @@ public class GoogleMailStreamComponentConfiguration
      */
     private GoogleMailStreamConfigurationNestedConfiguration configuration;
     /**
-     * The client Factory
+     * The client Factory. The option is a
+     * org.apache.camel.component.google.mail.GoogleMailClientFactory type.
      */
-    @NestedConfigurationProperty
-    private GoogleMailClientFactory clientFactory;
+    private String clientFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -59,11 +57,11 @@ public class GoogleMailStreamComponentConfiguration
         this.configuration = configuration;
     }
 
-    public GoogleMailClientFactory getClientFactory() {
+    public String getClientFactory() {
         return clientFactory;
     }
 
-    public void setClientFactory(GoogleMailClientFactory clientFactory) {
+    public void setClientFactory(String clientFactory) {
         this.clientFactory = clientFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-guava-eventbus-starter/src/main/java/org/apache/camel/component/guava/eventbus/springboot/GuavaEventBusComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-guava-eventbus-starter/src/main/java/org/apache/camel/component/guava/eventbus/springboot/GuavaEventBusComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.guava.eventbus.springboot;
 
 import javax.annotation.Generated;
-import com.google.common.eventbus.EventBus;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The guava-eventbus component provides integration bridge between Camel and
@@ -35,10 +33,10 @@ public class GuavaEventBusComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the given Guava EventBus instance
+     * To use the given Guava EventBus instance. The option is a
+     * com.google.common.eventbus.EventBus type.
      */
-    @NestedConfigurationProperty
-    private EventBus eventBus;
+    private String eventBus;
     /**
      * The interface with method(s) marked with the Subscribe annotation.
      * Dynamic proxy will be created over the interface so it could be
@@ -54,11 +52,11 @@ public class GuavaEventBusComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public EventBus getEventBus() {
+    public String getEventBus() {
         return eventBus;
     }
 
-    public void setEventBus(EventBus eventBus) {
+    public void setEventBus(String eventBus) {
         this.eventBus = eventBus;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/springboot/HazelcastAtomicnumberComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/springboot/HazelcastAtomicnumberComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.atomicnumber.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-atomicvalue component is used to access Hazelcast atomic
@@ -37,10 +35,10 @@ public class HazelcastAtomicnumberComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -53,11 +51,11 @@ public class HazelcastAtomicnumberComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/instance/springboot/HazelcastInstanceComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/instance/springboot/HazelcastInstanceComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.instance.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-instance component is used to consume join/leave events of the
@@ -37,10 +35,10 @@ public class HazelcastInstanceComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -53,11 +51,11 @@ public class HazelcastInstanceComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/list/springboot/HazelcastListComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/list/springboot/HazelcastListComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.list.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-list component is used to access Hazelcast distributed list.
@@ -36,10 +34,10 @@ public class HazelcastListComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastListComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/map/springboot/HazelcastMapComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/map/springboot/HazelcastMapComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.map.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-map component is used to access Hazelcast distributed map.
@@ -36,10 +34,10 @@ public class HazelcastMapComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastMapComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/multimap/springboot/HazelcastMultimapComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/multimap/springboot/HazelcastMultimapComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.multimap.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-multimap component is used to to access Hazelcast distributed
@@ -37,10 +35,10 @@ public class HazelcastMultimapComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -53,11 +51,11 @@ public class HazelcastMultimapComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/queue/springboot/HazelcastQueueComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/queue/springboot/HazelcastQueueComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.queue.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-queue component is used to access Hazelcast distributed queue.
@@ -36,10 +34,10 @@ public class HazelcastQueueComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastQueueComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/springboot/HazelcastReplicatedmapComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/springboot/HazelcastReplicatedmapComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.replicatedmap.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-replicatedmap component is used to access Hazelcast replicated
@@ -37,10 +35,10 @@ public class HazelcastReplicatedmapComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -53,11 +51,11 @@ public class HazelcastReplicatedmapComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/springboot/HazelcastRingbufferComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/springboot/HazelcastRingbufferComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.ringbuffer.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-ringbuffer component is used to access Hazelcast distributed
@@ -37,10 +35,10 @@ public class HazelcastRingbufferComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -53,11 +51,11 @@ public class HazelcastRingbufferComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/seda/springboot/HazelcastSedaComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/seda/springboot/HazelcastSedaComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.seda.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-seda component is used to access Hazelcast BlockingQueue.
@@ -36,10 +34,10 @@ public class HazelcastSedaComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastSedaComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/set/springboot/HazelcastSetComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/set/springboot/HazelcastSetComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.set.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The camel Endpoint to access Hazelcast distributed set.
@@ -36,10 +34,10 @@ public class HazelcastSetComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastSetComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/topic/springboot/HazelcastTopicComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hazelcast-starter/src/main/java/org/apache/camel/component/hazelcast/topic/springboot/HazelcastTopicComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.hazelcast.topic.springboot;
 
 import javax.annotation.Generated;
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The hazelcast-topic component is used to access Hazelcast distributed topic.
@@ -36,10 +34,10 @@ public class HazelcastTopicComponentConfiguration
     /**
      * The hazelcast instance reference which can be used for hazelcast
      * endpoint. If you don't specify the instance reference, camel use the
-     * default hazelcast instance from the camel-hazelcast instance.
+     * default hazelcast instance from the camel-hazelcast instance. The option
+     * is a com.hazelcast.core.HazelcastInstance type.
      */
-    @NestedConfigurationProperty
-    private HazelcastInstance hazelcastInstance;
+    private String hazelcastInstance;
     /**
      * The hazelcast mode reference which kind of instance should be used. If
      * you don't specify the mode, then the node mode will be the default.
@@ -52,11 +50,11 @@ public class HazelcastTopicComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HazelcastInstance getHazelcastInstance() {
+    public String getHazelcastInstance() {
         return hazelcastInstance;
     }
 
-    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+    public void setHazelcastInstance(String hazelcastInstance) {
         this.hazelcastInstance = hazelcastInstance;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hbase-starter/src/main/java/org/apache/camel/component/hbase/springboot/HBaseComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hbase-starter/src/main/java/org/apache/camel/component/hbase/springboot/HBaseComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.hbase.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.hadoop.conf.Configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * For reading/writing from/to an HBase store (Hadoop database).
@@ -34,10 +32,10 @@ public class HBaseComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the shared configuration
+     * To use the shared configuration. The option is a
+     * org.apache.hadoop.conf.Configuration type.
      */
-    @NestedConfigurationProperty
-    private Configuration configuration;
+    private String configuration;
     /**
      * Maximum number of references to keep for each table in the HTable pool.
      * The default value is 10.
@@ -50,11 +48,11 @@ public class HBaseComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Configuration getConfiguration() {
+    public String getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(Configuration configuration) {
+    public void setConfiguration(String configuration) {
         this.configuration = configuration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hdfs-starter/src/main/java/org/apache/camel/component/hdfs/springboot/HdfsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hdfs-starter/src/main/java/org/apache/camel/component/hdfs/springboot/HdfsComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.hdfs.springboot;
 
 import javax.annotation.Generated;
-import javax.security.auth.login.Configuration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -33,9 +32,10 @@ public class HdfsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the given configuration for security with JAAS.
+     * To use the given configuration for security with JAAS. The option is a
+     * javax.security.auth.login.Configuration type.
      */
-    private Configuration jAASConfiguration;
+    private String jAASConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -43,11 +43,11 @@ public class HdfsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Configuration getJAASConfiguration() {
+    public String getJAASConfiguration() {
         return jAASConfiguration;
     }
 
-    public void setJAASConfiguration(Configuration jAASConfiguration) {
+    public void setJAASConfiguration(String jAASConfiguration) {
         this.jAASConfiguration = jAASConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-hdfs2-starter/src/main/java/org/apache/camel/component/hdfs2/springboot/HdfsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-hdfs2-starter/src/main/java/org/apache/camel/component/hdfs2/springboot/HdfsComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.hdfs2.springboot;
 
 import javax.annotation.Generated;
-import javax.security.auth.login.Configuration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -33,9 +32,10 @@ public class HdfsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the given configuration for security with JAAS.
+     * To use the given configuration for security with JAAS. The option is a
+     * javax.security.auth.login.Configuration type.
      */
-    private Configuration jAASConfiguration;
+    private String jAASConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -43,11 +43,11 @@ public class HdfsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Configuration getJAASConfiguration() {
+    public String getJAASConfiguration() {
         return jAASConfiguration;
     }
 
-    public void setJAASConfiguration(Configuration jAASConfiguration) {
+    public void setJAASConfiguration(String jAASConfiguration) {
         this.jAASConfiguration = jAASConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-http-starter/src/main/java/org/apache/camel/component/http/springboot/HttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-http-starter/src/main/java/org/apache/camel/component/http/springboot/HttpComponentConfiguration.java
@@ -17,14 +17,8 @@
 package org.apache.camel.component.http.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.http.HttpClientConfigurer;
-import org.apache.camel.http.common.HttpBinding;
-import org.apache.camel.http.common.HttpConfiguration;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * For calling out to external HTTP servers using Apache HTTP Client 3.x.
@@ -39,26 +33,26 @@ public class HttpComponentConfiguration
 
     /**
      * To use the custom HttpClientConfigurer to perform configuration of the
-     * HttpClient that will be used.
+     * HttpClient that will be used. The option is a
+     * org.apache.camel.component.http.HttpClientConfigurer type.
      */
-    @NestedConfigurationProperty
-    private HttpClientConfigurer httpClientConfigurer;
+    private String httpClientConfigurer;
     /**
-     * To use a custom HttpConnectionManager to manage connections
+     * To use a custom HttpConnectionManager to manage connections. The option
+     * is a org.apache.commons.httpclient.HttpConnectionManager type.
      */
-    @NestedConfigurationProperty
-    private HttpConnectionManager httpConnectionManager;
+    private String httpConnectionManager;
     /**
      * To use a custom HttpBinding to control the mapping between Camel message
-     * and HttpClient.
+     * and HttpClient. The option is a org.apache.camel.http.common.HttpBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private HttpBinding httpBinding;
+    private String httpBinding;
     /**
-     * To use the shared HttpConfiguration as base configuration.
+     * To use the shared HttpConfiguration as base configuration. The option is
+     * a org.apache.camel.http.common.HttpConfiguration type.
      */
-    @NestedConfigurationProperty
-    private HttpConfiguration httpConfiguration;
+    private String httpConfiguration;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object This is by default
@@ -73,10 +67,10 @@ public class HttpComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -84,37 +78,35 @@ public class HttpComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HttpClientConfigurer getHttpClientConfigurer() {
+    public String getHttpClientConfigurer() {
         return httpClientConfigurer;
     }
 
-    public void setHttpClientConfigurer(
-            HttpClientConfigurer httpClientConfigurer) {
+    public void setHttpClientConfigurer(String httpClientConfigurer) {
         this.httpClientConfigurer = httpClientConfigurer;
     }
 
-    public HttpConnectionManager getHttpConnectionManager() {
+    public String getHttpConnectionManager() {
         return httpConnectionManager;
     }
 
-    public void setHttpConnectionManager(
-            HttpConnectionManager httpConnectionManager) {
+    public void setHttpConnectionManager(String httpConnectionManager) {
         this.httpConnectionManager = httpConnectionManager;
     }
 
-    public HttpBinding getHttpBinding() {
+    public String getHttpBinding() {
         return httpBinding;
     }
 
-    public void setHttpBinding(HttpBinding httpBinding) {
+    public void setHttpBinding(String httpBinding) {
         this.httpBinding = httpBinding;
     }
 
-    public HttpConfiguration getHttpConfiguration() {
+    public String getHttpConfiguration() {
         return httpConfiguration;
     }
 
-    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+    public void setHttpConfiguration(String httpConfiguration) {
         this.httpConfiguration = httpConfiguration;
     }
 
@@ -135,12 +127,11 @@ public class HttpComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-http4-starter/src/main/java/org/apache/camel/component/http4/springboot/HttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-http4-starter/src/main/java/org/apache/camel/component/http4/springboot/HttpComponentConfiguration.java
@@ -17,18 +17,8 @@
 package org.apache.camel.component.http4.springboot;
 
 import javax.annotation.Generated;
-import javax.net.ssl.HostnameVerifier;
-import org.apache.camel.component.http4.HttpClientConfigurer;
-import org.apache.camel.http.common.HttpBinding;
-import org.apache.camel.http.common.HttpConfiguration;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
-import org.apache.http.client.CookieStore;
-import org.apache.http.conn.HttpClientConnectionManager;
-import org.apache.http.protocol.HttpContext;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * For calling out to external HTTP servers using Apache HTTP Client 4.x.
@@ -43,40 +33,40 @@ public class HttpComponentConfiguration
 
     /**
      * To use the custom HttpClientConfigurer to perform configuration of the
-     * HttpClient that will be used.
+     * HttpClient that will be used. The option is a
+     * org.apache.camel.component.http4.HttpClientConfigurer type.
      */
-    @NestedConfigurationProperty
-    private HttpClientConfigurer httpClientConfigurer;
+    private String httpClientConfigurer;
     /**
      * To use a custom and shared HttpClientConnectionManager to manage
      * connections. If this has been configured then this is always used for all
-     * endpoints created by this component.
+     * endpoints created by this component. The option is a
+     * org.apache.http.conn.HttpClientConnectionManager type.
      */
-    @NestedConfigurationProperty
-    private HttpClientConnectionManager clientConnectionManager;
+    private String clientConnectionManager;
     /**
      * To use a custom org.apache.http.protocol.HttpContext when executing
-     * requests.
+     * requests. The option is a org.apache.http.protocol.HttpContext type.
      */
-    @NestedConfigurationProperty
-    private HttpContext httpContext;
+    private String httpContext;
     /**
      * To configure security using SSLContextParameters. Important: Only one
      * instance of org.apache.camel.util.jsse.SSLContextParameters is supported
      * per HttpComponent. If you need to use 2 or more different instances, you
-     * need to define a new HttpComponent per instance you need.
+     * need to define a new HttpComponent per instance you need. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom X509HostnameVerifier such as DefaultHostnameVerifier or
-     * org.apache.http.conn.ssl.NoopHostnameVerifier.
+     * org.apache.http.conn.ssl.NoopHostnameVerifier. The option is a
+     * javax.net.ssl.HostnameVerifier type.
      */
-    private HostnameVerifier x509HostnameVerifier;
+    private String x509HostnameVerifier;
     /**
      * The maximum number of connections.
      */
@@ -95,10 +85,10 @@ public class HttpComponentConfiguration
      * org.apache.http.impl.client.BasicCookieStore is used which is an
      * in-memory only cookie store. Notice if bridgeEndpoint=true then the
      * cookie store is forced to be a noop cookie store as cookie shouldn't be
-     * stored as we are just bridging (eg acting as a proxy).
+     * stored as we are just bridging (eg acting as a proxy). The option is a
+     * org.apache.http.client.CookieStore type.
      */
-    @NestedConfigurationProperty
-    private CookieStore cookieStore;
+    private String cookieStore;
     /**
      * The timeout in milliseconds used when requesting a connection from the
      * connection manager. A timeout value of zero is interpreted as an infinite
@@ -124,15 +114,15 @@ public class HttpComponentConfiguration
     private Integer socketTimeout = -1;
     /**
      * To use a custom HttpBinding to control the mapping between Camel message
-     * and HttpClient.
+     * and HttpClient. The option is a org.apache.camel.http.common.HttpBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private HttpBinding httpBinding;
+    private String httpBinding;
     /**
-     * To use the shared HttpConfiguration as base configuration.
+     * To use the shared HttpConfiguration as base configuration. The option is
+     * a org.apache.camel.http.common.HttpConfiguration type.
      */
-    @NestedConfigurationProperty
-    private HttpConfiguration httpConfiguration;
+    private String httpConfiguration;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object. This is by default
@@ -143,10 +133,10 @@ public class HttpComponentConfiguration
     private Boolean allowJavaSerializedObject = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -154,38 +144,35 @@ public class HttpComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HttpClientConfigurer getHttpClientConfigurer() {
+    public String getHttpClientConfigurer() {
         return httpClientConfigurer;
     }
 
-    public void setHttpClientConfigurer(
-            HttpClientConfigurer httpClientConfigurer) {
+    public void setHttpClientConfigurer(String httpClientConfigurer) {
         this.httpClientConfigurer = httpClientConfigurer;
     }
 
-    public HttpClientConnectionManager getClientConnectionManager() {
+    public String getClientConnectionManager() {
         return clientConnectionManager;
     }
 
-    public void setClientConnectionManager(
-            HttpClientConnectionManager clientConnectionManager) {
+    public void setClientConnectionManager(String clientConnectionManager) {
         this.clientConnectionManager = clientConnectionManager;
     }
 
-    public HttpContext getHttpContext() {
+    public String getHttpContext() {
         return httpContext;
     }
 
-    public void setHttpContext(HttpContext httpContext) {
+    public void setHttpContext(String httpContext) {
         this.httpContext = httpContext;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -198,11 +185,11 @@ public class HttpComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HostnameVerifier getX509HostnameVerifier() {
+    public String getX509HostnameVerifier() {
         return x509HostnameVerifier;
     }
 
-    public void setX509HostnameVerifier(HostnameVerifier x509HostnameVerifier) {
+    public void setX509HostnameVerifier(String x509HostnameVerifier) {
         this.x509HostnameVerifier = x509HostnameVerifier;
     }
 
@@ -230,11 +217,11 @@ public class HttpComponentConfiguration
         this.connectionTimeToLive = connectionTimeToLive;
     }
 
-    public CookieStore getCookieStore() {
+    public String getCookieStore() {
         return cookieStore;
     }
 
-    public void setCookieStore(CookieStore cookieStore) {
+    public void setCookieStore(String cookieStore) {
         this.cookieStore = cookieStore;
     }
 
@@ -262,19 +249,19 @@ public class HttpComponentConfiguration
         this.socketTimeout = socketTimeout;
     }
 
-    public HttpBinding getHttpBinding() {
+    public String getHttpBinding() {
         return httpBinding;
     }
 
-    public void setHttpBinding(HttpBinding httpBinding) {
+    public void setHttpBinding(String httpBinding) {
         this.httpBinding = httpBinding;
     }
 
-    public HttpConfiguration getHttpConfiguration() {
+    public String getHttpConfiguration() {
         return httpConfiguration;
     }
 
-    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+    public void setHttpConfiguration(String httpConfiguration) {
         this.httpConfiguration = httpConfiguration;
     }
 
@@ -286,12 +273,11 @@ public class HttpComponentConfiguration
         this.allowJavaSerializedObject = allowJavaSerializedObject;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/cache/springboot/IgniteCacheComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/cache/springboot/IgniteCacheComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.cache.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Cache endpoint is one of camel-ignite endpoints which allows you
@@ -36,20 +33,19 @@ public class IgniteCacheComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteCacheComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/compute/springboot/IgniteComputeComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/compute/springboot/IgniteComputeComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.compute.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Compute endpoint is one of camel-ignite endpoints which allows you
@@ -38,20 +35,19 @@ public class IgniteComputeComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -59,27 +55,27 @@ public class IgniteComputeComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/events/springboot/IgniteEventsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/events/springboot/IgniteEventsComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.events.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Events endpoint is one of camel-ignite endpoints which allows you
@@ -36,20 +33,19 @@ public class IgniteEventsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteEventsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/idgen/springboot/IgniteIdGenComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/idgen/springboot/IgniteIdGenComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.idgen.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite ID Generator endpoint is one of camel-ignite endpoints which
@@ -36,20 +33,19 @@ public class IgniteIdGenComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteIdGenComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/messaging/springboot/IgniteMessagingComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/messaging/springboot/IgniteMessagingComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.messaging.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Messaging endpoint is one of camel-ignite endpoints which allows
@@ -36,20 +33,19 @@ public class IgniteMessagingComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteMessagingComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/queue/springboot/IgniteQueueComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/queue/springboot/IgniteQueueComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.queue.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Queue endpoint is one of camel-ignite endpoints which allows you
@@ -36,20 +33,19 @@ public class IgniteQueueComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteQueueComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/set/springboot/IgniteSetComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ignite-starter/src/main/java/org/apache/camel/component/ignite/set/springboot/IgniteSetComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.ignite.set.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Ignite Sets endpoint is one of camel-ignite endpoints which allows you to
@@ -36,20 +33,19 @@ public class IgniteSetComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the Ignite instance.
+     * Sets the Ignite instance. The option is a org.apache.ignite.Ignite type.
      */
-    @NestedConfigurationProperty
-    private Ignite ignite;
+    private String ignite;
     /**
      * Sets the resource from where to load the configuration. It can be a: URI,
-     * String (URI) or an InputStream.
+     * String (URI) or an InputStream. The option is a java.lang.Object type.
      */
-    private Object configurationResource;
+    private String configurationResource;
     /**
-     * Allows the user to set a programmatic IgniteConfiguration.
+     * Allows the user to set a programmatic IgniteConfiguration. The option is
+     * a org.apache.ignite.configuration.IgniteConfiguration type.
      */
-    @NestedConfigurationProperty
-    private IgniteConfiguration igniteConfiguration;
+    private String igniteConfiguration;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -57,27 +53,27 @@ public class IgniteSetComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Ignite getIgnite() {
+    public String getIgnite() {
         return ignite;
     }
 
-    public void setIgnite(Ignite ignite) {
+    public void setIgnite(String ignite) {
         this.ignite = ignite;
     }
 
-    public Object getConfigurationResource() {
+    public String getConfigurationResource() {
         return configurationResource;
     }
 
-    public void setConfigurationResource(Object configurationResource) {
+    public void setConfigurationResource(String configurationResource) {
         this.configurationResource = configurationResource;
     }
 
-    public IgniteConfiguration getIgniteConfiguration() {
+    public String getIgniteConfiguration() {
         return igniteConfiguration;
     }
 
-    public void setIgniteConfiguration(IgniteConfiguration igniteConfiguration) {
+    public void setIgniteConfiguration(String igniteConfiguration) {
         this.igniteConfiguration = igniteConfiguration;
     }
 

--- a/platforms/spring-boot/components-starter/camel-infinispan-starter/src/main/java/org/apache/camel/component/infinispan/springboot/InfinispanComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-infinispan-starter/src/main/java/org/apache/camel/component/infinispan/springboot/InfinispanComponentConfiguration.java
@@ -28,7 +28,6 @@ import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.context.Flag;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * For reading/writing from/to Infinispan distributed key/value store and data
@@ -47,10 +46,10 @@ public class InfinispanComponentConfiguration
      */
     private InfinispanConfigurationNestedConfiguration configuration;
     /**
-     * The default cache container.
+     * The default cache container. The option is a
+     * org.infinispan.commons.api.BasicCacheContainer type.
      */
-    @NestedConfigurationProperty
-    private BasicCacheContainer cacheContainer;
+    private String cacheContainer;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -67,11 +66,11 @@ public class InfinispanComponentConfiguration
         this.configuration = configuration;
     }
 
-    public BasicCacheContainer getCacheContainer() {
+    public String getCacheContainer() {
         return cacheContainer;
     }
 
-    public void setCacheContainer(BasicCacheContainer cacheContainer) {
+    public void setCacheContainer(String cacheContainer) {
         this.cacheContainer = cacheContainer;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jcache-starter/src/main/java/org/apache/camel/component/jcache/springboot/JCacheComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jcache-starter/src/main/java/org/apache/camel/component/jcache/springboot/JCacheComponentConfiguration.java
@@ -16,9 +16,7 @@
  */
 package org.apache.camel.component.jcache.springboot;
 
-import java.util.Properties;
 import javax.annotation.Generated;
-import javax.cache.configuration.Configuration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -39,14 +37,15 @@ public class JCacheComponentConfiguration
      */
     private String cachingProvider;
     /**
-     * A Configuration for the Cache
+     * A Configuration for the Cache. The option is a
+     * javax.cache.configuration.Configuration type.
      */
-    private Configuration cacheConfiguration;
+    private String cacheConfiguration;
     /**
      * The Properties for the javax.cache.spi.CachingProvider to create the
-     * CacheManager
+     * CacheManager. The option is a java.util.Properties type.
      */
-    private Properties cacheConfigurationProperties;
+    private String cacheConfigurationProperties;
     /**
      * An implementation specific URI for the CacheManager
      */
@@ -66,20 +65,20 @@ public class JCacheComponentConfiguration
         this.cachingProvider = cachingProvider;
     }
 
-    public Configuration getCacheConfiguration() {
+    public String getCacheConfiguration() {
         return cacheConfiguration;
     }
 
-    public void setCacheConfiguration(Configuration cacheConfiguration) {
+    public void setCacheConfiguration(String cacheConfiguration) {
         this.cacheConfiguration = cacheConfiguration;
     }
 
-    public Properties getCacheConfigurationProperties() {
+    public String getCacheConfigurationProperties() {
         return cacheConfigurationProperties;
     }
 
     public void setCacheConfigurationProperties(
-            Properties cacheConfigurationProperties) {
+            String cacheConfigurationProperties) {
         this.cacheConfigurationProperties = cacheConfigurationProperties;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jdbc-starter/src/main/java/org/apache/camel/component/jdbc/springboot/JdbcComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jdbc-starter/src/main/java/org/apache/camel/component/jdbc/springboot/JdbcComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.jdbc.springboot;
 
 import javax.annotation.Generated;
-import javax.sql.DataSource;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -35,9 +34,9 @@ public class JdbcComponentConfiguration
 
     /**
      * To use the DataSource instance instead of looking up the data source by
-     * name from the registry.
+     * name from the registry. The option is a javax.sql.DataSource type.
      */
-    private DataSource dataSource;
+    private String dataSource;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -45,11 +44,11 @@ public class JdbcComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public DataSource getDataSource() {
+    public String getDataSource() {
         return dataSource;
     }
 
-    public void setDataSource(DataSource dataSource) {
+    public void setDataSource(String dataSource) {
         this.dataSource = dataSource;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jetty9-starter/src/main/java/org/apache/camel/component/jetty9/springboot/JettyHttpComponentConfiguration9.java
+++ b/platforms/spring-boot/components-starter/camel-jetty9-starter/src/main/java/org/apache/camel/component/jetty9/springboot/JettyHttpComponentConfiguration9.java
@@ -16,20 +16,9 @@
  */
 package org.apache.camel.component.jetty9.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
-import org.apache.camel.component.jetty.JettyHttpBinding;
-import org.apache.camel.http.common.HttpBinding;
-import org.apache.camel.http.common.HttpConfiguration;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
-import org.eclipse.jetty.jmx.MBeanContainer;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.util.thread.ThreadPool;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The jetty component provides HTTP-based endpoints for consuming and producing
@@ -61,19 +50,22 @@ public class JettyHttpComponentConfiguration9
      */
     private String keystore;
     /**
-     * This option is used to set the ErrorHandler that Jetty server uses.
+     * This option is used to set the ErrorHandler that Jetty server uses. The
+     * option is a org.eclipse.jetty.server.handler.ErrorHandler type.
      */
-    @NestedConfigurationProperty
-    private ErrorHandler errorHandler;
+    private String errorHandler;
     /**
-     * A map which contains per port number specific SSL connectors.
+     * A map which contains per port number specific SSL connectors. The option
+     * is a java.util.Map<java.lang.Integer,org.eclipse.jetty.server.Connector>
+     * type.
      */
-    private Map<Integer, Connector> sslSocketConnectors;
+    private String sslSocketConnectors;
     /**
      * A map which contains per port number specific HTTP connectors. Uses the
-     * same principle as sslSocketConnectors.
+     * same principle as sslSocketConnectors. The option is a
+     * java.util.Map<java.lang.Integer,org.eclipse.jetty.server.Connector> type.
      */
-    private Map<Integer, Connector> socketConnectors;
+    private String socketConnectors;
     /**
      * To set a value for minimum number of threads in HttpClient thread pool.
      * Notice that both a min and max size must be configured.
@@ -96,10 +88,10 @@ public class JettyHttpComponentConfiguration9
     private Integer maxThreads;
     /**
      * To use a custom thread pool for the server. This option should only be
-     * used in special circumstances.
+     * used in special circumstances. The option is a
+     * org.eclipse.jetty.util.thread.ThreadPool type.
      */
-    @NestedConfigurationProperty
-    private ThreadPool threadPool;
+    private String threadPool;
     /**
      * If this option is true, Jetty JMX support will be enabled for this
      * endpoint.
@@ -108,34 +100,36 @@ public class JettyHttpComponentConfiguration9
     /**
      * To use a custom org.apache.camel.component.jetty.JettyHttpBinding, which
      * are used to customize how a response should be written for the producer.
+     * The option is a org.apache.camel.component.jetty.JettyHttpBinding type.
      */
-    @NestedConfigurationProperty
-    private JettyHttpBinding jettyHttpBinding;
+    private String jettyHttpBinding;
     /**
-     * Not to be used - use JettyHttpBinding instead.
+     * Not to be used - use JettyHttpBinding instead. The option is a
+     * org.apache.camel.http.common.HttpBinding type.
      */
-    @NestedConfigurationProperty
-    private HttpBinding httpBinding;
+    private String httpBinding;
     /**
-     * Jetty component does not use HttpConfiguration.
+     * Jetty component does not use HttpConfiguration. The option is a
+     * org.apache.camel.http.common.HttpConfiguration type.
      */
-    @NestedConfigurationProperty
-    private HttpConfiguration httpConfiguration;
+    private String httpConfiguration;
     /**
      * To use a existing configured org.eclipse.jetty.jmx.MBeanContainer if JMX
-     * is enabled that Jetty uses for registering mbeans.
+     * is enabled that Jetty uses for registering mbeans. The option is a
+     * org.eclipse.jetty.jmx.MBeanContainer type.
      */
-    @NestedConfigurationProperty
-    private MBeanContainer mbContainer;
+    private String mbContainer;
     /**
-     * A map which contains general SSL connector properties.
+     * A map which contains general SSL connector properties. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> sslSocketConnectorProperties;
+    private String sslSocketConnectorProperties;
     /**
      * A map which contains general HTTP connector properties. Uses the same
-     * principle as sslSocketConnectorProperties.
+     * principle as sslSocketConnectorProperties. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> socketConnectorProperties;
+    private String socketConnectorProperties;
     /**
      * Allows to set a timeout in millis when using Jetty as consumer (server).
      * By default Jetty uses 30000. You can use a value of = 0 to never expire.
@@ -149,10 +143,10 @@ public class JettyHttpComponentConfiguration9
      */
     private Boolean useContinuation = true;
     /**
-     * To configure security using SSLContextParameters
+     * To configure security using SSLContextParameters. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters
      */
@@ -206,10 +200,10 @@ public class JettyHttpComponentConfiguration9
     private Boolean allowJavaSerializedObject = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -241,28 +235,27 @@ public class JettyHttpComponentConfiguration9
         this.keystore = keystore;
     }
 
-    public ErrorHandler getErrorHandler() {
+    public String getErrorHandler() {
         return errorHandler;
     }
 
-    public void setErrorHandler(ErrorHandler errorHandler) {
+    public void setErrorHandler(String errorHandler) {
         this.errorHandler = errorHandler;
     }
 
-    public Map<Integer, Connector> getSslSocketConnectors() {
+    public String getSslSocketConnectors() {
         return sslSocketConnectors;
     }
 
-    public void setSslSocketConnectors(
-            Map<Integer, Connector> sslSocketConnectors) {
+    public void setSslSocketConnectors(String sslSocketConnectors) {
         this.sslSocketConnectors = sslSocketConnectors;
     }
 
-    public Map<Integer, Connector> getSocketConnectors() {
+    public String getSocketConnectors() {
         return socketConnectors;
     }
 
-    public void setSocketConnectors(Map<Integer, Connector> socketConnectors) {
+    public void setSocketConnectors(String socketConnectors) {
         this.socketConnectors = socketConnectors;
     }
 
@@ -298,11 +291,11 @@ public class JettyHttpComponentConfiguration9
         this.maxThreads = maxThreads;
     }
 
-    public ThreadPool getThreadPool() {
+    public String getThreadPool() {
         return threadPool;
     }
 
-    public void setThreadPool(ThreadPool threadPool) {
+    public void setThreadPool(String threadPool) {
         this.threadPool = threadPool;
     }
 
@@ -314,53 +307,52 @@ public class JettyHttpComponentConfiguration9
         this.enableJmx = enableJmx;
     }
 
-    public JettyHttpBinding getJettyHttpBinding() {
+    public String getJettyHttpBinding() {
         return jettyHttpBinding;
     }
 
-    public void setJettyHttpBinding(JettyHttpBinding jettyHttpBinding) {
+    public void setJettyHttpBinding(String jettyHttpBinding) {
         this.jettyHttpBinding = jettyHttpBinding;
     }
 
-    public HttpBinding getHttpBinding() {
+    public String getHttpBinding() {
         return httpBinding;
     }
 
-    public void setHttpBinding(HttpBinding httpBinding) {
+    public void setHttpBinding(String httpBinding) {
         this.httpBinding = httpBinding;
     }
 
-    public HttpConfiguration getHttpConfiguration() {
+    public String getHttpConfiguration() {
         return httpConfiguration;
     }
 
-    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+    public void setHttpConfiguration(String httpConfiguration) {
         this.httpConfiguration = httpConfiguration;
     }
 
-    public MBeanContainer getMbContainer() {
+    public String getMbContainer() {
         return mbContainer;
     }
 
-    public void setMbContainer(MBeanContainer mbContainer) {
+    public void setMbContainer(String mbContainer) {
         this.mbContainer = mbContainer;
     }
 
-    public Map<String, Object> getSslSocketConnectorProperties() {
+    public String getSslSocketConnectorProperties() {
         return sslSocketConnectorProperties;
     }
 
     public void setSslSocketConnectorProperties(
-            Map<String, Object> sslSocketConnectorProperties) {
+            String sslSocketConnectorProperties) {
         this.sslSocketConnectorProperties = sslSocketConnectorProperties;
     }
 
-    public Map<String, Object> getSocketConnectorProperties() {
+    public String getSocketConnectorProperties() {
         return socketConnectorProperties;
     }
 
-    public void setSocketConnectorProperties(
-            Map<String, Object> socketConnectorProperties) {
+    public void setSocketConnectorProperties(String socketConnectorProperties) {
         this.socketConnectorProperties = socketConnectorProperties;
     }
 
@@ -380,12 +372,11 @@ public class JettyHttpComponentConfiguration9
         this.useContinuation = useContinuation;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -470,12 +461,11 @@ public class JettyHttpComponentConfiguration9
         this.allowJavaSerializedObject = allowJavaSerializedObject;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jgroups-starter/src/main/java/org/apache/camel/component/jgroups/springboot/JGroupsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jgroups-starter/src/main/java/org/apache/camel/component/jgroups/springboot/JGroupsComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.jgroups.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.jgroups.JChannel;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The jgroups component provides exchange of messages between Camel and JGroups
@@ -35,10 +33,9 @@ public class JGroupsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Channel to use
+     * Channel to use. The option is a org.jgroups.JChannel type.
      */
-    @NestedConfigurationProperty
-    private JChannel channel;
+    private String channel;
     /**
      * Specifies configuration properties of the JChannel used by the endpoint.
      */
@@ -56,11 +53,11 @@ public class JGroupsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public JChannel getChannel() {
+    public String getChannel() {
         return channel;
     }
 
-    public void setChannel(JChannel channel) {
+    public void setChannel(String channel) {
         this.channel = channel;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jms-starter/src/main/java/org/apache/camel/component/jms/springboot/JmsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jms-starter/src/main/java/org/apache/camel/component/jms/springboot/JmsComponentConfiguration.java
@@ -28,9 +28,7 @@ import org.apache.camel.component.jms.JmsMessageType;
 import org.apache.camel.component.jms.JmsProviderMetadata;
 import org.apache.camel.component.jms.MessageCreatedStrategy;
 import org.apache.camel.component.jms.MessageListenerContainerFactory;
-import org.apache.camel.component.jms.QueueBrowseStrategy;
 import org.apache.camel.component.jms.ReplyToType;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
@@ -147,9 +145,10 @@ public class JmsComponentConfiguration
     private Integer replyToConcurrentConsumers = 1;
     /**
      * The connection factory to be use. A connection factory must be configured
-     * either on the component or endpoint.
+     * either on the component or endpoint. The option is a
+     * javax.jms.ConnectionFactory type.
      */
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * Username to use with the ConnectionFactory. You can also configure
      * username/password directly on the ConnectionFactory.
@@ -177,9 +176,10 @@ public class JmsComponentConfiguration
     private String durableSubscriptionName;
     /**
      * Specifies the JMS Exception Listener that is to be notified of any
-     * underlying JMS exceptions.
+     * underlying JMS exceptions. The option is a javax.jms.ExceptionListener
+     * type.
      */
-    private ExceptionListener exceptionListener;
+    private String exceptionListener;
     /**
      * Specifies a org.springframework.util.ErrorHandler to be invoked in case
      * of any uncaught exceptions thrown while processing a Message. By default
@@ -187,10 +187,10 @@ public class JmsComponentConfiguration
      * been configured. You can configure logging level and whether stack traces
      * should be logged using errorHandlerLoggingLevel and
      * errorHandlerLogStackTrace options. This makes it much easier to
-     * configure, than having to code a custom errorHandler.
+     * configure, than having to code a custom errorHandler. The option is a
+     * org.springframework.util.ErrorHandler type.
      */
-    @NestedConfigurationProperty
-    private ErrorHandler errorHandler;
+    private String errorHandler;
     /**
      * Allows to configure the default errorHandler logging level for logging
      * uncaught exceptions.
@@ -258,10 +258,10 @@ public class JmsComponentConfiguration
     /**
      * To use a custom Spring
      * org.springframework.jms.support.converter.MessageConverter so you can be
-     * in control how to map to/from a javax.jms.Message.
+     * in control how to map to/from a javax.jms.Message. The option is a
+     * org.springframework.jms.support.converter.MessageConverter type.
      */
-    @NestedConfigurationProperty
-    private MessageConverter messageConverter;
+    private String messageConverter;
     /**
      * Specifies whether Camel should auto map the received JMS message to a
      * suited payload type, such as javax.jms.TextMessage to a String etc. See
@@ -315,10 +315,10 @@ public class JmsComponentConfiguration
      */
     private Long recoveryInterval = 5000L;
     /**
-     * Allows you to specify a custom task executor for consuming messages.
+     * Allows you to specify a custom task executor for consuming messages. The
+     * option is a org.springframework.core.task.TaskExecutor type.
      */
-    @NestedConfigurationProperty
-    private TaskExecutor taskExecutor;
+    private String taskExecutor;
     /**
      * When sending messages, specifies the time-to-live of the message (in
      * milliseconds).
@@ -334,10 +334,10 @@ public class JmsComponentConfiguration
      */
     private Boolean lazyCreateTransactionManager = true;
     /**
-     * The Spring transaction manager to use.
+     * The Spring transaction manager to use. The option is a
+     * org.springframework.transaction.PlatformTransactionManager type.
      */
-    @NestedConfigurationProperty
-    private PlatformTransactionManager transactionManager;
+    private String transactionManager;
     /**
      * The name of the transaction to use.
      */
@@ -435,18 +435,18 @@ public class JmsComponentConfiguration
      * Allows you to use your own implementation of the
      * org.springframework.jms.core.JmsOperations interface. Camel uses
      * JmsTemplate as default. Can be used for testing purpose, but not used
-     * much as stated in the spring API docs.
+     * much as stated in the spring API docs. The option is a
+     * org.springframework.jms.core.JmsOperations type.
      */
-    @NestedConfigurationProperty
-    private JmsOperations jmsOperations;
+    private String jmsOperations;
     /**
      * A pluggable
      * org.springframework.jms.support.destination.DestinationResolver that
      * allows you to use your own resolver (for example, to lookup the real
-     * destination in a JNDI registry).
+     * destination in a JNDI registry). The option is a
+     * org.springframework.jms.support.destination.DestinationResolver type.
      */
-    @NestedConfigurationProperty
-    private DestinationResolver destinationResolver;
+    private String destinationResolver;
     /**
      * Allows for explicitly specifying which kind of strategy to use for
      * replyTo queues when doing request/reply over JMS. Possible values are:
@@ -522,10 +522,10 @@ public class JmsComponentConfiguration
      * key as is. Can be used for JMS brokers which do not care whether JMS
      * header keys contain illegal characters. You can provide your own
      * implementation of the org.apache.camel.component.jms.JmsKeyFormatStrategy
-     * and refer to it using the notation.
+     * and refer to it using the notation. The option is a
+     * org.apache.camel.component.jms.JmsKeyFormatStrategy type.
      */
-    @NestedConfigurationProperty
-    private JmsKeyFormatStrategy jmsKeyFormatStrategy;
+    private String jmsKeyFormatStrategy;
     /**
      * This option is used to allow additional headers which may have values
      * that are invalid according to JMS specification. For example some message
@@ -536,17 +536,17 @@ public class JmsComponentConfiguration
      */
     private String allowAdditionalHeaders;
     /**
-     * To use a custom QueueBrowseStrategy when browsing queues
+     * To use a custom QueueBrowseStrategy when browsing queues. The option is a
+     * org.apache.camel.component.jms.QueueBrowseStrategy type.
      */
-    @NestedConfigurationProperty
-    private QueueBrowseStrategy queueBrowseStrategy;
+    private String queueBrowseStrategy;
     /**
      * To use the given MessageCreatedStrategy which are invoked when Camel
      * creates new instances of javax.jms.Message objects when Camel is sending
-     * a JMS message.
+     * a JMS message. The option is a
+     * org.apache.camel.component.jms.MessageCreatedStrategy type.
      */
-    @NestedConfigurationProperty
-    private MessageCreatedStrategy messageCreatedStrategy;
+    private String messageCreatedStrategy;
     /**
      * Number of times to wait for provisional correlation id to be updated to
      * the actual correlation id when doing request/reply over JMS and when the
@@ -617,10 +617,10 @@ public class JmsComponentConfiguration
     private Boolean formatDateHeadersToIso8601 = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -734,11 +734,11 @@ public class JmsComponentConfiguration
         this.replyToConcurrentConsumers = replyToConcurrentConsumers;
     }
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
@@ -782,19 +782,19 @@ public class JmsComponentConfiguration
         this.durableSubscriptionName = durableSubscriptionName;
     }
 
-    public ExceptionListener getExceptionListener() {
+    public String getExceptionListener() {
         return exceptionListener;
     }
 
-    public void setExceptionListener(ExceptionListener exceptionListener) {
+    public void setExceptionListener(String exceptionListener) {
         this.exceptionListener = exceptionListener;
     }
 
-    public ErrorHandler getErrorHandler() {
+    public String getErrorHandler() {
         return errorHandler;
     }
 
-    public void setErrorHandler(ErrorHandler errorHandler) {
+    public void setErrorHandler(String errorHandler) {
         this.errorHandler = errorHandler;
     }
 
@@ -881,11 +881,11 @@ public class JmsComponentConfiguration
         this.maxMessagesPerTask = maxMessagesPerTask;
     }
 
-    public MessageConverter getMessageConverter() {
+    public String getMessageConverter() {
         return messageConverter;
     }
 
-    public void setMessageConverter(MessageConverter messageConverter) {
+    public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
 
@@ -962,11 +962,11 @@ public class JmsComponentConfiguration
         this.recoveryInterval = recoveryInterval;
     }
 
-    public TaskExecutor getTaskExecutor() {
+    public String getTaskExecutor() {
         return taskExecutor;
     }
 
-    public void setTaskExecutor(TaskExecutor taskExecutor) {
+    public void setTaskExecutor(String taskExecutor) {
         this.taskExecutor = taskExecutor;
     }
 
@@ -995,12 +995,11 @@ public class JmsComponentConfiguration
         this.lazyCreateTransactionManager = lazyCreateTransactionManager;
     }
 
-    public PlatformTransactionManager getTransactionManager() {
+    public String getTransactionManager() {
         return transactionManager;
     }
 
-    public void setTransactionManager(
-            PlatformTransactionManager transactionManager) {
+    public void setTransactionManager(String transactionManager) {
         this.transactionManager = transactionManager;
     }
 
@@ -1093,19 +1092,19 @@ public class JmsComponentConfiguration
         this.transferFault = transferFault;
     }
 
-    public JmsOperations getJmsOperations() {
+    public String getJmsOperations() {
         return jmsOperations;
     }
 
-    public void setJmsOperations(JmsOperations jmsOperations) {
+    public void setJmsOperations(String jmsOperations) {
         this.jmsOperations = jmsOperations;
     }
 
-    public DestinationResolver getDestinationResolver() {
+    public String getDestinationResolver() {
         return destinationResolver;
     }
 
-    public void setDestinationResolver(DestinationResolver destinationResolver) {
+    public void setDestinationResolver(String destinationResolver) {
         this.destinationResolver = destinationResolver;
     }
 
@@ -1166,12 +1165,11 @@ public class JmsComponentConfiguration
         this.defaultTaskExecutorType = defaultTaskExecutorType;
     }
 
-    public JmsKeyFormatStrategy getJmsKeyFormatStrategy() {
+    public String getJmsKeyFormatStrategy() {
         return jmsKeyFormatStrategy;
     }
 
-    public void setJmsKeyFormatStrategy(
-            JmsKeyFormatStrategy jmsKeyFormatStrategy) {
+    public void setJmsKeyFormatStrategy(String jmsKeyFormatStrategy) {
         this.jmsKeyFormatStrategy = jmsKeyFormatStrategy;
     }
 
@@ -1183,20 +1181,19 @@ public class JmsComponentConfiguration
         this.allowAdditionalHeaders = allowAdditionalHeaders;
     }
 
-    public QueueBrowseStrategy getQueueBrowseStrategy() {
+    public String getQueueBrowseStrategy() {
         return queueBrowseStrategy;
     }
 
-    public void setQueueBrowseStrategy(QueueBrowseStrategy queueBrowseStrategy) {
+    public void setQueueBrowseStrategy(String queueBrowseStrategy) {
         this.queueBrowseStrategy = queueBrowseStrategy;
     }
 
-    public MessageCreatedStrategy getMessageCreatedStrategy() {
+    public String getMessageCreatedStrategy() {
         return messageCreatedStrategy;
     }
 
-    public void setMessageCreatedStrategy(
-            MessageCreatedStrategy messageCreatedStrategy) {
+    public void setMessageCreatedStrategy(String messageCreatedStrategy) {
         this.messageCreatedStrategy = messageCreatedStrategy;
     }
 
@@ -1266,12 +1263,11 @@ public class JmsComponentConfiguration
         this.formatDateHeadersToIso8601 = formatDateHeadersToIso8601;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jolt-starter/src/main/java/org/apache/camel/component/jolt/springboot/JoltComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jolt-starter/src/main/java/org/apache/camel/component/jolt/springboot/JoltComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.jolt.springboot;
 
 import javax.annotation.Generated;
-import com.bazaarvoice.jolt.Transform;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The jolt component allows you to process a JSON messages using an JOLT
@@ -36,10 +34,10 @@ public class JoltComponentConfiguration
 
     /**
      * Explicitly sets the Transform to use. If not set a Transform specified by
-     * the transformDsl will be created
+     * the transformDsl will be created. The option is a
+     * com.bazaarvoice.jolt.Transform type.
      */
-    @NestedConfigurationProperty
-    private Transform transform;
+    private String transform;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -47,11 +45,11 @@ public class JoltComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public Transform getTransform() {
+    public String getTransform() {
         return transform;
     }
 
-    public void setTransform(Transform transform) {
+    public void setTransform(String transform) {
         this.transform = transform;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jpa-starter/src/main/java/org/apache/camel/component/jpa/springboot/JpaComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jpa-starter/src/main/java/org/apache/camel/component/jpa/springboot/JpaComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.jpa.springboot;
 
 import javax.annotation.Generated;
-import javax.persistence.EntityManagerFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * The jpa component enables you to store and retrieve Java objects from
@@ -37,14 +34,15 @@ public class JpaComponentConfiguration
 
     /**
      * To use the EntityManagerFactory. This is strongly recommended to
-     * configure.
+     * configure. The option is a javax.persistence.EntityManagerFactory type.
      */
-    private EntityManagerFactory entityManagerFactory;
+    private String entityManagerFactory;
     /**
-     * To use the PlatformTransactionManager for managing transactions.
+     * To use the PlatformTransactionManager for managing transactions. The
+     * option is a org.springframework.transaction.PlatformTransactionManager
+     * type.
      */
-    @NestedConfigurationProperty
-    private PlatformTransactionManager transactionManager;
+    private String transactionManager;
     /**
      * The camel-jpa component will join transaction by default. You can use
      * this option to turn this off, for example if you use LOCAL_RESOURCE and
@@ -66,21 +64,19 @@ public class JpaComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public EntityManagerFactory getEntityManagerFactory() {
+    public String getEntityManagerFactory() {
         return entityManagerFactory;
     }
 
-    public void setEntityManagerFactory(
-            EntityManagerFactory entityManagerFactory) {
+    public void setEntityManagerFactory(String entityManagerFactory) {
         this.entityManagerFactory = entityManagerFactory;
     }
 
-    public PlatformTransactionManager getTransactionManager() {
+    public String getTransactionManager() {
         return transactionManager;
     }
 
-    public void setTransactionManager(
-            PlatformTransactionManager transactionManager) {
+    public void setTransactionManager(String transactionManager) {
         this.transactionManager = transactionManager;
     }
 

--- a/platforms/spring-boot/components-starter/camel-jt400-starter/src/main/java/org/apache/camel/component/jt400/springboot/Jt400ComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-jt400-starter/src/main/java/org/apache/camel/component/jt400/springboot/Jt400ComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.jt400.springboot;
 
 import javax.annotation.Generated;
-import com.ibm.as400.access.AS400ConnectionPool;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The jt400 component allows you to exchanges messages with an AS/400 system
@@ -35,10 +33,10 @@ public class Jt400ComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Returns the default connection pool used by this component.
+     * Returns the default connection pool used by this component. The option is
+     * a com.ibm.as400.access.AS400ConnectionPool type.
      */
-    @NestedConfigurationProperty
-    private AS400ConnectionPool connectionPool;
+    private String connectionPool;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -46,11 +44,11 @@ public class Jt400ComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public AS400ConnectionPool getConnectionPool() {
+    public String getConnectionPool() {
         return connectionPool;
     }
 
-    public void setConnectionPool(AS400ConnectionPool connectionPool) {
+    public void setConnectionPool(String connectionPool) {
         this.connectionPool = connectionPool;
     }
 

--- a/platforms/spring-boot/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/KafkaComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/KafkaComponentConfiguration.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.kafka.springboot;
 
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Generated;
-import org.apache.camel.component.kafka.KafkaManualCommitFactory;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.StateRepository;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
@@ -55,9 +54,10 @@ public class KafkaComponentConfiguration
      * kafka server has acknowledge the message that was sent to it from
      * KafkaProducer using asynchronous non-blocking processing. If using this
      * option then you must handle the lifecycle of the thread pool to shut the
-     * pool down when no longer needed.
+     * pool down when no longer needed. The option is a
+     * java.util.concurrent.ExecutorService type.
      */
-    private ExecutorService workerPool;
+    private String workerPool;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -84,10 +84,10 @@ public class KafkaComponentConfiguration
      * Factory to use for creating KafkaManualCommit instances. This allows to
      * plugin a custom factory to create custom KafkaManualCommit instances in
      * case special logic is needed when doing manual commits that deviates from
-     * the default implementation that comes out of the box.
+     * the default implementation that comes out of the box. The option is a
+     * org.apache.camel.component.kafka.KafkaManualCommitFactory type.
      */
-    @NestedConfigurationProperty
-    private KafkaManualCommitFactory kafkaManualCommitFactory;
+    private String kafkaManualCommitFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -112,11 +112,11 @@ public class KafkaComponentConfiguration
         this.brokers = brokers;
     }
 
-    public ExecutorService getWorkerPool() {
+    public String getWorkerPool() {
         return workerPool;
     }
 
-    public void setWorkerPool(ExecutorService workerPool) {
+    public void setWorkerPool(String workerPool) {
         this.workerPool = workerPool;
     }
 
@@ -145,12 +145,11 @@ public class KafkaComponentConfiguration
         this.allowManualCommit = allowManualCommit;
     }
 
-    public KafkaManualCommitFactory getKafkaManualCommitFactory() {
+    public String getKafkaManualCommitFactory() {
         return kafkaManualCommitFactory;
     }
 
-    public void setKafkaManualCommitFactory(
-            KafkaManualCommitFactory kafkaManualCommitFactory) {
+    public void setKafkaManualCommitFactory(String kafkaManualCommitFactory) {
         this.kafkaManualCommitFactory = kafkaManualCommitFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-lumberjack-starter/src/main/java/org/apache/camel/component/lumberjack/springboot/LumberjackComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-lumberjack-starter/src/main/java/org/apache/camel/component/lumberjack/springboot/LumberjackComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.lumberjack.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The lumberjack retrieves logs sent over the network using the Lumberjack
@@ -36,10 +34,10 @@ public class LumberjackComponentConfiguration
 
     /**
      * Sets the default SSL configuration to use for all the endpoints. You can
-     * also configure it directly at the endpoint level.
+     * also configure it directly at the endpoint level. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -51,12 +49,11 @@ public class LumberjackComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 

--- a/platforms/spring-boot/components-starter/camel-mail-starter/src/main/java/org/apache/camel/component/mail/springboot/MailComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-mail-starter/src/main/java/org/apache/camel/component/mail/springboot/MailComponentConfiguration.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 import javax.annotation.Generated;
 import javax.mail.Session;
 import org.apache.camel.component.mail.AttachmentsContentTransferEncodingResolver;
-import org.apache.camel.component.mail.ContentTypeResolver;
 import org.apache.camel.component.mail.JavaMailSender;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.apache.camel.util.jsse.SSLContextParameters;
@@ -43,10 +42,10 @@ public class MailComponentConfiguration
      */
     private MailConfigurationNestedConfiguration configuration;
     /**
-     * Resolver to determine Content-Type for file attachments.
+     * Resolver to determine Content-Type for file attachments. The option is a
+     * org.apache.camel.component.mail.ContentTypeResolver type.
      */
-    @NestedConfigurationProperty
-    private ContentTypeResolver contentTypeResolver;
+    private String contentTypeResolver;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -67,11 +66,11 @@ public class MailComponentConfiguration
         this.configuration = configuration;
     }
 
-    public ContentTypeResolver getContentTypeResolver() {
+    public String getContentTypeResolver() {
         return contentTypeResolver;
     }
 
-    public void setContentTypeResolver(ContentTypeResolver contentTypeResolver) {
+    public void setContentTypeResolver(String contentTypeResolver) {
         this.contentTypeResolver = contentTypeResolver;
     }
 

--- a/platforms/spring-boot/components-starter/camel-master-starter/src/main/java/org/apache/camel/component/master/springboot/MasterComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-master-starter/src/main/java/org/apache/camel/component/master/springboot/MasterComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.master.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.cluster.CamelClusterService;
-import org.apache.camel.cluster.CamelClusterService.Selector;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Represents an endpoint which only becomes active when the CamelClusterView
@@ -36,16 +33,16 @@ public class MasterComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Inject the service to use.
+     * Inject the service to use. The option is a
+     * org.apache.camel.cluster.CamelClusterService type.
      */
-    @NestedConfigurationProperty
-    private CamelClusterService service;
+    private String service;
     /**
      * Inject the service selector used to lookup the CamelClusterService to
-     * use.
+     * use. The option is a
+     * org.apache.camel.cluster.CamelClusterService.Selector type.
      */
-    @NestedConfigurationProperty
-    private Selector serviceSelector;
+    private String serviceSelector;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -53,19 +50,19 @@ public class MasterComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public CamelClusterService getService() {
+    public String getService() {
         return service;
     }
 
-    public void setService(CamelClusterService service) {
+    public void setService(String service) {
         this.service = service;
     }
 
-    public Selector getServiceSelector() {
+    public String getServiceSelector() {
         return serviceSelector;
     }
 
-    public void setServiceSelector(Selector serviceSelector) {
+    public void setServiceSelector(String serviceSelector) {
         this.serviceSelector = serviceSelector;
     }
 

--- a/platforms/spring-boot/components-starter/camel-metrics-starter/src/main/java/org/apache/camel/component/metrics/springboot/MetricsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-metrics-starter/src/main/java/org/apache/camel/component/metrics/springboot/MetricsComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.metrics.springboot;
 
 import javax.annotation.Generated;
-import com.codahale.metrics.MetricRegistry;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To collect various metrics directly from Camel routes using the DropWizard
@@ -35,10 +33,10 @@ public class MetricsComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom configured MetricRegistry.
+     * To use a custom configured MetricRegistry. The option is a
+     * com.codahale.metrics.MetricRegistry type.
      */
-    @NestedConfigurationProperty
-    private MetricRegistry metricRegistry;
+    private String metricRegistry;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -46,11 +44,11 @@ public class MetricsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public MetricRegistry getMetricRegistry() {
+    public String getMetricRegistry() {
         return metricRegistry;
     }
 
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
+    public void setMetricRegistry(String metricRegistry) {
         this.metricRegistry = metricRegistry;
     }
 

--- a/platforms/spring-boot/components-starter/camel-micrometer-starter/src/main/java/org/apache/camel/component/micrometer/springboot/MicrometerComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-micrometer-starter/src/main/java/org/apache/camel/component/micrometer/springboot/MicrometerComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.micrometer.springboot;
 
 import javax.annotation.Generated;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To collect various metrics directly from Camel routes using the Micrometer
@@ -35,10 +33,10 @@ public class MicrometerComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom configured MetricRegistry.
+     * To use a custom configured MetricRegistry. The option is a
+     * io.micrometer.core.instrument.MeterRegistry type.
      */
-    @NestedConfigurationProperty
-    private MeterRegistry metricsRegistry;
+    private String metricsRegistry;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -46,11 +44,11 @@ public class MicrometerComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public MeterRegistry getMetricsRegistry() {
+    public String getMetricsRegistry() {
         return metricsRegistry;
     }
 
-    public void setMetricsRegistry(MeterRegistry metricsRegistry) {
+    public void setMetricsRegistry(String metricsRegistry) {
         this.metricsRegistry = metricsRegistry;
     }
 

--- a/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/server/springboot/MiloServerComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-milo-starter/src/main/java/org/apache/camel/component/milo/server/springboot/MiloServerComponentConfiguration.java
@@ -18,17 +18,10 @@ package org.apache.camel.component.milo.server.springboot;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.Set;
-import java.util.function.Supplier;
 import javax.annotation.Generated;
-import org.apache.camel.component.milo.KeyStoreLoader.Result;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.eclipse.milo.opcua.stack.core.application.CertificateManager;
-import org.eclipse.milo.opcua.stack.core.application.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
-import org.eclipse.milo.opcua.stack.core.types.structured.BuildInfo;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Make telemetry data available as an OPC UA server
@@ -74,9 +67,11 @@ public class MiloServerComponentConfiguration
      */
     private String hostname;
     /**
-     * Security policies
+     * Security policies. The option is a
+     * java.util.Set<org.eclipse.milo.opcua.stack.core.security.SecurityPolicy>
+     * type.
      */
-    private Set<SecurityPolicy> securityPolicies;
+    private String securityPolicies;
     /**
      * Security policies by URI or name
      */
@@ -99,24 +94,27 @@ public class MiloServerComponentConfiguration
      */
     private String bindAddresses;
     /**
-     * Server build info
+     * Server build info. The option is a
+     * org.eclipse.milo.opcua.stack.core.types.structured.BuildInfo type.
      */
-    @NestedConfigurationProperty
-    private BuildInfo buildInfo;
+    private String buildInfo;
     /**
-     * Server certificate
+     * Server certificate. The option is a
+     * org.apache.camel.component.milo.KeyStoreLoader.Result type.
      */
-    @NestedConfigurationProperty
-    private Result serverCertificate;
+    private String serverCertificate;
     /**
-     * Server certificate manager
+     * Server certificate manager. The option is a
+     * org.eclipse.milo.opcua.stack.core.application.CertificateManager type.
      */
-    @NestedConfigurationProperty
-    private CertificateManager certificateManager;
+    private String certificateManager;
     /**
-     * Validator for client certificates
+     * Validator for client certificates. The option is a
+     * java.util.function.Supplier
+     * <org.eclipse.milo.opcua.stack.core.application.CertificateValidator>
+     * type.
      */
-    private Supplier<CertificateValidator> certificateValidator;
+    private String certificateValidator;
     /**
      * Validator for client certificates using default file based approach
      */
@@ -192,11 +190,11 @@ public class MiloServerComponentConfiguration
         this.hostname = hostname;
     }
 
-    public Set<SecurityPolicy> getSecurityPolicies() {
+    public String getSecurityPolicies() {
         return securityPolicies;
     }
 
-    public void setSecurityPolicies(Set<SecurityPolicy> securityPolicies) {
+    public void setSecurityPolicies(String securityPolicies) {
         this.securityPolicies = securityPolicies;
     }
 
@@ -243,36 +241,35 @@ public class MiloServerComponentConfiguration
         this.bindAddresses = bindAddresses;
     }
 
-    public BuildInfo getBuildInfo() {
+    public String getBuildInfo() {
         return buildInfo;
     }
 
-    public void setBuildInfo(BuildInfo buildInfo) {
+    public void setBuildInfo(String buildInfo) {
         this.buildInfo = buildInfo;
     }
 
-    public Result getServerCertificate() {
+    public String getServerCertificate() {
         return serverCertificate;
     }
 
-    public void setServerCertificate(Result serverCertificate) {
+    public void setServerCertificate(String serverCertificate) {
         this.serverCertificate = serverCertificate;
     }
 
-    public CertificateManager getCertificateManager() {
+    public String getCertificateManager() {
         return certificateManager;
     }
 
-    public void setCertificateManager(CertificateManager certificateManager) {
+    public void setCertificateManager(String certificateManager) {
         this.certificateManager = certificateManager;
     }
 
-    public Supplier<CertificateValidator> getCertificateValidator() {
+    public String getCertificateValidator() {
         return certificateValidator;
     }
 
-    public void setCertificateValidator(
-            Supplier<CertificateValidator> certificateValidator) {
+    public void setCertificateValidator(String certificateValidator) {
         this.certificateValidator = certificateValidator;
     }
 

--- a/platforms/spring-boot/components-starter/camel-msv-starter/src/main/java/org/apache/camel/component/validator/msv/springboot/MsvComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-msv-starter/src/main/java/org/apache/camel/component/validator/msv/springboot/MsvComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.validator.msv.springboot;
 
 import javax.annotation.Generated;
-import javax.xml.validation.SchemaFactory;
-import org.apache.camel.component.validator.ValidatorResourceResolverFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Validates the payload of a message using the MSV Library.
@@ -35,15 +32,17 @@ public class MsvComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the javax.xml.validation.SchemaFactory.
+     * To use the javax.xml.validation.SchemaFactory. The option is a
+     * javax.xml.validation.SchemaFactory type.
      */
-    private SchemaFactory schemaFactory;
+    private String schemaFactory;
     /**
      * To use a custom LSResourceResolver which depends on a dynamic endpoint
-     * resource URI
+     * resource URI. The option is a
+     * org.apache.camel.component.validator.ValidatorResourceResolverFactory
+     * type.
      */
-    @NestedConfigurationProperty
-    private ValidatorResourceResolverFactory resourceResolverFactory;
+    private String resourceResolverFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -51,20 +50,19 @@ public class MsvComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SchemaFactory getSchemaFactory() {
+    public String getSchemaFactory() {
         return schemaFactory;
     }
 
-    public void setSchemaFactory(SchemaFactory schemaFactory) {
+    public void setSchemaFactory(String schemaFactory) {
         this.schemaFactory = schemaFactory;
     }
 
-    public ValidatorResourceResolverFactory getResourceResolverFactory() {
+    public String getResourceResolverFactory() {
         return resourceResolverFactory;
     }
 
-    public void setResourceResolverFactory(
-            ValidatorResourceResolverFactory resourceResolverFactory) {
+    public void setResourceResolverFactory(String resourceResolverFactory) {
         this.resourceResolverFactory = resourceResolverFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-mustache-starter/src/main/java/org/apache/camel/component/mustache/springboot/MustacheComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-mustache-starter/src/main/java/org/apache/camel/component/mustache/springboot/MustacheComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.mustache.springboot;
 
 import javax.annotation.Generated;
-import com.github.mustachejava.MustacheFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Transforms the message using a Mustache template.
@@ -34,10 +32,10 @@ public class MustacheComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom MustacheFactory
+     * To use a custom MustacheFactory. The option is a
+     * com.github.mustachejava.MustacheFactory type.
      */
-    @NestedConfigurationProperty
-    private MustacheFactory mustacheFactory;
+    private String mustacheFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -45,11 +43,11 @@ public class MustacheComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public MustacheFactory getMustacheFactory() {
+    public String getMustacheFactory() {
         return mustacheFactory;
     }
 
-    public void setMustacheFactory(MustacheFactory mustacheFactory) {
+    public void setMustacheFactory(String mustacheFactory) {
         this.mustacheFactory = mustacheFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-mybatis-starter/src/main/java/org/apache/camel/component/mybatis/springboot/MyBatisBeanComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-mybatis-starter/src/main/java/org/apache/camel/component/mybatis/springboot/MyBatisBeanComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.mybatis.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Performs a query, insert, update or delete in a relational database using
@@ -35,10 +33,10 @@ public class MyBatisBeanComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the SqlSessionFactory
+     * To use the SqlSessionFactory. The option is a
+     * org.apache.ibatis.session.SqlSessionFactory type.
      */
-    @NestedConfigurationProperty
-    private SqlSessionFactory sqlSessionFactory;
+    private String sqlSessionFactory;
     /**
      * Location of MyBatis xml configuration file. The default value is:
      * SqlMapConfig.xml loaded from the classpath
@@ -51,11 +49,11 @@ public class MyBatisBeanComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SqlSessionFactory getSqlSessionFactory() {
+    public String getSqlSessionFactory() {
         return sqlSessionFactory;
     }
 
-    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+    public void setSqlSessionFactory(String sqlSessionFactory) {
         this.sqlSessionFactory = sqlSessionFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-mybatis-starter/src/main/java/org/apache/camel/component/mybatis/springboot/MyBatisComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-mybatis-starter/src/main/java/org/apache/camel/component/mybatis/springboot/MyBatisComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.mybatis.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Performs a query, poll, insert, update or delete in a relational database
@@ -35,10 +33,10 @@ public class MyBatisComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the SqlSessionFactory
+     * To use the SqlSessionFactory. The option is a
+     * org.apache.ibatis.session.SqlSessionFactory type.
      */
-    @NestedConfigurationProperty
-    private SqlSessionFactory sqlSessionFactory;
+    private String sqlSessionFactory;
     /**
      * Location of MyBatis xml configuration file. The default value is:
      * SqlMapConfig.xml loaded from the classpath
@@ -51,11 +49,11 @@ public class MyBatisComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SqlSessionFactory getSqlSessionFactory() {
+    public String getSqlSessionFactory() {
         return sqlSessionFactory;
     }
 
-    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+    public void setSqlSessionFactory(String sqlSessionFactory) {
         this.sqlSessionFactory = sqlSessionFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-netty-http-starter/src/main/java/org/apache/camel/component/netty/http/springboot/NettyHttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-netty-http-starter/src/main/java/org/apache/camel/component/netty/http/springboot/NettyHttpComponentConfiguration.java
@@ -18,13 +18,10 @@ package org.apache.camel.component.netty.http.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.LoggingLevel;
-import org.apache.camel.component.netty.http.NettyHttpBinding;
 import org.apache.camel.component.netty.http.SecurityAuthenticator;
 import org.apache.camel.component.netty.http.SecurityConstraint;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Netty HTTP server and client using the Netty 3.x library.
@@ -39,20 +36,19 @@ public class NettyHttpComponentConfiguration
 
     /**
      * To use a custom org.apache.camel.component.netty.http.NettyHttpBinding
-     * for binding to/from Netty and Camel Message API.
+     * for binding to/from Netty and Camel Message API. The option is a
+     * org.apache.camel.component.netty.http.NettyHttpBinding type.
      */
-    @NestedConfigurationProperty
-    private NettyHttpBinding nettyHttpBinding;
+    private String nettyHttpBinding;
     /**
      * To use the NettyConfiguration as configuration when creating endpoints.
      */
     private NettyHttpConfigurationNestedConfiguration configuration;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * headers.
+     * headers. The option is a org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Refers to a
      * org.apache.camel.component.netty.http.NettyHttpSecurityConfiguration for
@@ -75,11 +71,11 @@ public class NettyHttpComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public NettyHttpBinding getNettyHttpBinding() {
+    public String getNettyHttpBinding() {
         return nettyHttpBinding;
     }
 
-    public void setNettyHttpBinding(NettyHttpBinding nettyHttpBinding) {
+    public void setNettyHttpBinding(String nettyHttpBinding) {
         this.nettyHttpBinding = nettyHttpBinding;
     }
 
@@ -92,12 +88,11 @@ public class NettyHttpComponentConfiguration
         this.configuration = configuration;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-netty4-http-starter/src/main/java/org/apache/camel/component/netty4/http/springboot/NettyHttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-netty4-http-starter/src/main/java/org/apache/camel/component/netty4/http/springboot/NettyHttpComponentConfiguration.java
@@ -17,15 +17,11 @@
 package org.apache.camel.component.netty4.http.springboot;
 
 import javax.annotation.Generated;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.camel.LoggingLevel;
-import org.apache.camel.component.netty4.http.NettyHttpBinding;
 import org.apache.camel.component.netty4.http.SecurityAuthenticator;
 import org.apache.camel.component.netty4.http.SecurityConstraint;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Netty HTTP server and client using the Netty 4.x library.
@@ -40,20 +36,19 @@ public class NettyHttpComponentConfiguration
 
     /**
      * To use a custom org.apache.camel.component.netty4.http.NettyHttpBinding
-     * for binding to/from Netty and Camel Message API.
+     * for binding to/from Netty and Camel Message API. The option is a
+     * org.apache.camel.component.netty4.http.NettyHttpBinding type.
      */
-    @NestedConfigurationProperty
-    private NettyHttpBinding nettyHttpBinding;
+    private String nettyHttpBinding;
     /**
      * To use the NettyConfiguration as configuration when creating endpoints.
      */
     private NettyHttpConfigurationNestedConfiguration configuration;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * headers.
+     * headers. The option is a org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Refers to a
      * org.apache.camel.component.netty4.http.NettyHttpSecurityConfiguration for
@@ -70,10 +65,10 @@ public class NettyHttpComponentConfiguration
      */
     private Integer maximumPoolSize = 16;
     /**
-     * To use the given EventExecutorGroup.
+     * To use the given EventExecutorGroup. The option is a
+     * io.netty.util.concurrent.EventExecutorGroup type.
      */
-    @NestedConfigurationProperty
-    private EventExecutorGroup executorService;
+    private String executorService;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -81,11 +76,11 @@ public class NettyHttpComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public NettyHttpBinding getNettyHttpBinding() {
+    public String getNettyHttpBinding() {
         return nettyHttpBinding;
     }
 
-    public void setNettyHttpBinding(NettyHttpBinding nettyHttpBinding) {
+    public void setNettyHttpBinding(String nettyHttpBinding) {
         this.nettyHttpBinding = nettyHttpBinding;
     }
 
@@ -98,12 +93,11 @@ public class NettyHttpComponentConfiguration
         this.configuration = configuration;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 
@@ -133,11 +127,11 @@ public class NettyHttpComponentConfiguration
         this.maximumPoolSize = maximumPoolSize;
     }
 
-    public EventExecutorGroup getExecutorService() {
+    public String getExecutorService() {
         return executorService;
     }
 
-    public void setExecutorService(EventExecutorGroup executorService) {
+    public void setExecutorService(String executorService) {
         this.executorService = executorService;
     }
 

--- a/platforms/spring-boot/components-starter/camel-netty4-starter/src/main/java/org/apache/camel/component/netty4/springboot/NettyComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-netty4-starter/src/main/java/org/apache/camel/component/netty4/springboot/NettyComponentConfiguration.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.component.netty4.ClientInitializerFactory;
 import org.apache.camel.component.netty4.NettyCamelStateCorrelationManager;
@@ -59,10 +58,10 @@ public class NettyComponentConfiguration
      */
     private NettyConfigurationNestedConfiguration configuration;
     /**
-     * To use the given EventExecutorGroup.
+     * To use the given EventExecutorGroup. The option is a
+     * io.netty.util.concurrent.EventExecutorGroup type.
      */
-    @NestedConfigurationProperty
-    private EventExecutorGroup executorService;
+    private String executorService;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -91,11 +90,11 @@ public class NettyComponentConfiguration
         this.configuration = configuration;
     }
 
-    public EventExecutorGroup getExecutorService() {
+    public String getExecutorService() {
         return executorService;
     }
 
-    public void setExecutorService(EventExecutorGroup executorService) {
+    public void setExecutorService(String executorService) {
         this.executorService = executorService;
     }
 

--- a/platforms/spring-boot/components-starter/camel-paho-starter/src/main/java/org/apache/camel/component/paho/springboot/PahoComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-paho-starter/src/main/java/org/apache/camel/component/paho/springboot/PahoComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.paho.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Component for communicating with MQTT M2M message brokers using Eclipse Paho
@@ -43,10 +41,10 @@ public class PahoComponentConfiguration
      */
     private String clientId;
     /**
-     * Client connection options
+     * Client connection options. The option is a
+     * org.eclipse.paho.client.mqttv3.MqttConnectOptions type.
      */
-    @NestedConfigurationProperty
-    private MqttConnectOptions connectOptions;
+    private String connectOptions;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -70,11 +68,11 @@ public class PahoComponentConfiguration
         this.clientId = clientId;
     }
 
-    public MqttConnectOptions getConnectOptions() {
+    public String getConnectOptions() {
         return connectOptions;
     }
 
-    public void setConnectOptions(MqttConnectOptions connectOptions) {
+    public void setConnectOptions(String connectOptions) {
         this.connectOptions = connectOptions;
     }
 

--- a/platforms/spring-boot/components-starter/camel-quartz2-starter/src/main/java/org/apache/camel/component/quartz2/springboot/QuartzComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-quartz2-starter/src/main/java/org/apache/camel/component/quartz2/springboot/QuartzComponentConfiguration.java
@@ -16,13 +16,9 @@
  */
 package org.apache.camel.component.quartz2.springboot;
 
-import java.util.Properties;
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Provides a scheduled delivery of messages using the Quartz 2.x scheduler.
@@ -55,9 +51,10 @@ public class QuartzComponentConfiguration
      */
     private Boolean enableJmx = true;
     /**
-     * Properties to configure the Quartz scheduler.
+     * Properties to configure the Quartz scheduler. The option is a
+     * java.util.Properties type.
      */
-    private Properties properties;
+    private String properties;
     /**
      * File name of the properties to load from the classpath
      */
@@ -78,15 +75,14 @@ public class QuartzComponentConfiguration
     private Boolean interruptJobsOnShutdown = false;
     /**
      * To use the custom SchedulerFactory which is used to create the Scheduler.
+     * The option is a org.quartz.SchedulerFactory type.
      */
-    @NestedConfigurationProperty
-    private SchedulerFactory schedulerFactory;
+    private String schedulerFactory;
     /**
      * To use the custom configured Quartz scheduler, instead of creating a new
-     * Scheduler.
+     * Scheduler. The option is a org.quartz.Scheduler type.
      */
-    @NestedConfigurationProperty
-    private Scheduler scheduler;
+    private String scheduler;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -127,11 +123,11 @@ public class QuartzComponentConfiguration
         this.enableJmx = enableJmx;
     }
 
-    public Properties getProperties() {
+    public String getProperties() {
         return properties;
     }
 
-    public void setProperties(Properties properties) {
+    public void setProperties(String properties) {
         this.properties = properties;
     }
 
@@ -159,19 +155,19 @@ public class QuartzComponentConfiguration
         this.interruptJobsOnShutdown = interruptJobsOnShutdown;
     }
 
-    public SchedulerFactory getSchedulerFactory() {
+    public String getSchedulerFactory() {
         return schedulerFactory;
     }
 
-    public void setSchedulerFactory(SchedulerFactory schedulerFactory) {
+    public void setSchedulerFactory(String schedulerFactory) {
         this.schedulerFactory = schedulerFactory;
     }
 
-    public Scheduler getScheduler() {
+    public String getScheduler() {
         return scheduler;
     }
 
-    public void setScheduler(Scheduler scheduler) {
+    public void setScheduler(String scheduler) {
         this.scheduler = scheduler;
     }
 

--- a/platforms/spring-boot/components-starter/camel-quickfix-starter/src/main/java/org/apache/camel/component/quickfixj/springboot/QuickfixjComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-quickfix-starter/src/main/java/org/apache/camel/component/quickfixj/springboot/QuickfixjComponentConfiguration.java
@@ -16,15 +16,9 @@
  */
 package org.apache.camel.component.quickfixj.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
-import org.apache.camel.component.quickfixj.QuickfixjConfiguration;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import quickfix.LogFactory;
-import quickfix.MessageFactory;
-import quickfix.MessageStoreFactory;
 
 /**
  * The quickfix component allows to send Financial Interchange (FIX) messages to
@@ -39,25 +33,26 @@ public class QuickfixjComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the given MessageFactory
+     * To use the given MessageFactory. The option is a quickfix.MessageFactory
+     * type.
      */
-    @NestedConfigurationProperty
-    private MessageFactory messageFactory;
+    private String messageFactory;
     /**
-     * To use the given LogFactory
+     * To use the given LogFactory. The option is a quickfix.LogFactory type.
      */
-    @NestedConfigurationProperty
-    private LogFactory logFactory;
+    private String logFactory;
     /**
-     * To use the given MessageStoreFactory
+     * To use the given MessageStoreFactory. The option is a
+     * quickfix.MessageStoreFactory type.
      */
-    @NestedConfigurationProperty
-    private MessageStoreFactory messageStoreFactory;
+    private String messageStoreFactory;
     /**
      * To use the given map of pre configured QuickFix configurations mapped to
-     * the key
+     * the key. The option is a
+     * java.util.Map<java.lang.String,org.apache.camel.component
+     * .quickfixj.QuickfixjConfiguration> type.
      */
-    private Map<String, QuickfixjConfiguration> configurations;
+    private String configurations;
     /**
      * If set to true, the engines will be created and started when needed (when
      * first message is send)
@@ -70,36 +65,35 @@ public class QuickfixjComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public MessageFactory getMessageFactory() {
+    public String getMessageFactory() {
         return messageFactory;
     }
 
-    public void setMessageFactory(MessageFactory messageFactory) {
+    public void setMessageFactory(String messageFactory) {
         this.messageFactory = messageFactory;
     }
 
-    public LogFactory getLogFactory() {
+    public String getLogFactory() {
         return logFactory;
     }
 
-    public void setLogFactory(LogFactory logFactory) {
+    public void setLogFactory(String logFactory) {
         this.logFactory = logFactory;
     }
 
-    public MessageStoreFactory getMessageStoreFactory() {
+    public String getMessageStoreFactory() {
         return messageStoreFactory;
     }
 
-    public void setMessageStoreFactory(MessageStoreFactory messageStoreFactory) {
+    public void setMessageStoreFactory(String messageStoreFactory) {
         this.messageStoreFactory = messageStoreFactory;
     }
 
-    public Map<String, QuickfixjConfiguration> getConfigurations() {
+    public String getConfigurations() {
         return configurations;
     }
 
-    public void setConfigurations(
-            Map<String, QuickfixjConfiguration> configurations) {
+    public void setConfigurations(String configurations) {
         this.configurations = configurations;
     }
 

--- a/platforms/spring-boot/components-starter/camel-rabbitmq-starter/src/main/java/org/apache/camel/component/rabbitmq/springboot/RabbitMQComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-rabbitmq-starter/src/main/java/org/apache/camel/component/rabbitmq/springboot/RabbitMQComponentConfiguration.java
@@ -16,13 +16,9 @@
  */
 package org.apache.camel.component.rabbitmq.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
-import javax.net.ssl.TrustManager;
-import com.rabbitmq.client.ConnectionFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The rabbitmq component allows you produce and consume messages from RabbitMQ
@@ -65,10 +61,9 @@ public class RabbitMQComponentConfiguration
     /**
      * To use a custom RabbitMQ connection factory. When this option is set, all
      * connection options (connectionTimeout, requestedChannelMax...) set on URI
-     * are not used
+     * are not used. The option is a com.rabbitmq.client.ConnectionFactory type.
      */
-    @NestedConfigurationProperty
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * The consumer uses a Thread Pool Executor with a fixed number of threads.
      * This setting allows you to set that number of threads.
@@ -199,23 +194,25 @@ public class RabbitMQComponentConfiguration
      * different prefix is required for each: Exchange: arg.exchange. Queue:
      * arg.queue. Binding: arg.binding. For example to declare a queue with
      * message ttl argument:
-     * http://localhost:5672/exchange/queueargs=arg.queue.x-message-ttl=60000
+     * http://localhost:5672/exchange/queueargs=arg.queue.x-message-ttl=60000.
+     * The option is a java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> args;
+    private String args;
     /**
      * Connection client properties (client info used in negotiating with the
-     * server)
+     * server). The option is a java.util.Map<java.lang.String,java.lang.Object>
+     * type.
      */
-    private Map<String, Object> clientProperties;
+    private String clientProperties;
     /**
      * Enables SSL on connection, accepted value are true, TLS and 'SSLv3
      */
     private String sslProtocol;
     /**
      * Configure SSL trust manager, SSL should be enabled for this option to be
-     * effective
+     * effective. The option is a javax.net.ssl.TrustManager type.
      */
-    private TrustManager trustManager;
+    private String trustManager;
     /**
      * If messages should be auto acknowledged
      */
@@ -334,11 +331,11 @@ public class RabbitMQComponentConfiguration
         this.addresses = addresses;
     }
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
@@ -529,19 +526,19 @@ public class RabbitMQComponentConfiguration
         this.immediate = immediate;
     }
 
-    public Map<String, Object> getArgs() {
+    public String getArgs() {
         return args;
     }
 
-    public void setArgs(Map<String, Object> args) {
+    public void setArgs(String args) {
         this.args = args;
     }
 
-    public Map<String, Object> getClientProperties() {
+    public String getClientProperties() {
         return clientProperties;
     }
 
-    public void setClientProperties(Map<String, Object> clientProperties) {
+    public void setClientProperties(String clientProperties) {
         this.clientProperties = clientProperties;
     }
 
@@ -553,11 +550,11 @@ public class RabbitMQComponentConfiguration
         this.sslProtocol = sslProtocol;
     }
 
-    public TrustManager getTrustManager() {
+    public String getTrustManager() {
         return trustManager;
     }
 
-    public void setTrustManager(TrustManager trustManager) {
+    public void setTrustManager(String trustManager) {
         this.trustManager = trustManager;
     }
 

--- a/platforms/spring-boot/components-starter/camel-restlet-starter/src/main/java/org/apache/camel/component/restlet/springboot/RestletComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-restlet-starter/src/main/java/org/apache/camel/component/restlet/springboot/RestletComponentConfiguration.java
@@ -18,10 +18,8 @@ package org.apache.camel.component.restlet.springboot;
 
 import java.util.List;
 import javax.annotation.Generated;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Component for consuming and producing Restful resources using Restlet.
@@ -45,10 +43,10 @@ public class RestletComponentConfiguration
     private Integer controllerSleepTimeMs;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * The size of the buffer when reading messages.
      */
@@ -166,12 +164,11 @@ public class RestletComponentConfiguration
         this.controllerSleepTimeMs = controllerSleepTimeMs;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-salesforce-starter/src/main/java/org/apache/camel/component/salesforce/springboot/SalesforceComponentConfiguration.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.salesforce.springboot;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Generated;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.component.salesforce.AuthenticationType;
@@ -33,7 +32,6 @@ import org.apache.camel.component.salesforce.internal.dto.NotifyForFieldsEnum;
 import org.apache.camel.component.salesforce.internal.dto.NotifyForOperationsEnum;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.apache.camel.util.jsse.KeyStoreParameters;
-import org.apache.camel.util.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -87,10 +85,10 @@ public class SalesforceComponentConfiguration
      * only one entry with private key and certificate. Salesforce does not
      * verify the certificate chain, so this can easily be a selfsigned
      * certificate. Make sure that you upload the certificate to the
-     * corresponding connected app.
+     * corresponding connected app. The option is a
+     * org.apache.camel.util.jsse.KeyStoreParameters type.
      */
-    @NestedConfigurationProperty
-    private KeyStoreParameters keystore;
+    private String keystore;
     /**
      * Refresh token already obtained in the refresh token OAuth flow. One needs
      * to setup a web application and configure a callback URL to receive the
@@ -130,21 +128,23 @@ public class SalesforceComponentConfiguration
     /**
      * Used to set any properties that can be configured on the underlying HTTP
      * client. Have a look at properties of SalesforceHttpClient and the Jetty
-     * HttpClient for all available options.
+     * HttpClient for all available options. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> httpClientProperties;
+    private String httpClientProperties;
     /**
      * Used to set any properties that can be configured on the
      * LongPollingTransport used by the BayeuxClient (CometD) used by the
-     * streaming api
+     * streaming api. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> longPollingTransportProperties;
+    private String longPollingTransportProperties;
     /**
      * SSL parameters to use, see SSLContextParameters class for all available
-     * options.
+     * options. The option is a org.apache.camel.util.jsse.SSLContextParameters
+     * type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters
      */
@@ -174,13 +174,15 @@ public class SalesforceComponentConfiguration
      */
     private Boolean isHttpProxySecure = true;
     /**
-     * A list of addresses for which HTTP proxy server should be used.
+     * A list of addresses for which HTTP proxy server should be used. The
+     * option is a java.util.Set<java.lang.String> type.
      */
-    private Set<String> httpProxyIncludedAddresses;
+    private String httpProxyIncludedAddresses;
     /**
-     * A list of addresses for which HTTP proxy server should not be used.
+     * A list of addresses for which HTTP proxy server should not be used. The
+     * option is a java.util.Set<java.lang.String> type.
      */
-    private Set<String> httpProxyExcludedAddresses;
+    private String httpProxyExcludedAddresses;
     /**
      * Used in authentication against the HTTP proxy server, needs to match the
      * URI of the proxy server in order for the httpProxyUsername and
@@ -260,11 +262,11 @@ public class SalesforceComponentConfiguration
         this.clientSecret = clientSecret;
     }
 
-    public KeyStoreParameters getKeystore() {
+    public String getKeystore() {
         return keystore;
     }
 
-    public void setKeystore(KeyStoreParameters keystore) {
+    public void setKeystore(String keystore) {
         this.keystore = keystore;
     }
 
@@ -308,29 +310,28 @@ public class SalesforceComponentConfiguration
         this.config = config;
     }
 
-    public Map<String, Object> getHttpClientProperties() {
+    public String getHttpClientProperties() {
         return httpClientProperties;
     }
 
-    public void setHttpClientProperties(Map<String, Object> httpClientProperties) {
+    public void setHttpClientProperties(String httpClientProperties) {
         this.httpClientProperties = httpClientProperties;
     }
 
-    public Map<String, Object> getLongPollingTransportProperties() {
+    public String getLongPollingTransportProperties() {
         return longPollingTransportProperties;
     }
 
     public void setLongPollingTransportProperties(
-            Map<String, Object> longPollingTransportProperties) {
+            String longPollingTransportProperties) {
         this.longPollingTransportProperties = longPollingTransportProperties;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -391,21 +392,19 @@ public class SalesforceComponentConfiguration
         this.isHttpProxySecure = isHttpProxySecure;
     }
 
-    public Set<String> getHttpProxyIncludedAddresses() {
+    public String getHttpProxyIncludedAddresses() {
         return httpProxyIncludedAddresses;
     }
 
-    public void setHttpProxyIncludedAddresses(
-            Set<String> httpProxyIncludedAddresses) {
+    public void setHttpProxyIncludedAddresses(String httpProxyIncludedAddresses) {
         this.httpProxyIncludedAddresses = httpProxyIncludedAddresses;
     }
 
-    public Set<String> getHttpProxyExcludedAddresses() {
+    public String getHttpProxyExcludedAddresses() {
         return httpProxyExcludedAddresses;
     }
 
-    public void setHttpProxyExcludedAddresses(
-            Set<String> httpProxyExcludedAddresses) {
+    public void setHttpProxyExcludedAddresses(String httpProxyExcludedAddresses) {
         this.httpProxyExcludedAddresses = httpProxyExcludedAddresses;
     }
 

--- a/platforms/spring-boot/components-starter/camel-saxon-starter/src/main/java/org/apache/camel/component/xquery/springboot/XQueryComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-saxon-starter/src/main/java/org/apache/camel/component/xquery/springboot/XQueryComponentConfiguration.java
@@ -16,13 +16,9 @@
  */
 package org.apache.camel.component.xquery.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
-import net.sf.saxon.Configuration;
-import net.sf.saxon.lib.ModuleURIResolver;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Transforms the message using a XQuery template using Saxon.
@@ -36,19 +32,20 @@ public class XQueryComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the custom ModuleURIResolver
+     * To use the custom ModuleURIResolver. The option is a
+     * net.sf.saxon.lib.ModuleURIResolver type.
      */
-    @NestedConfigurationProperty
-    private ModuleURIResolver moduleURIResolver;
+    private String moduleURIResolver;
     /**
-     * To use a custom Saxon configuration
+     * To use a custom Saxon configuration. The option is a
+     * net.sf.saxon.Configuration type.
      */
-    @NestedConfigurationProperty
-    private Configuration configuration;
+    private String configuration;
     /**
-     * To set custom Saxon configuration properties
+     * To set custom Saxon configuration properties. The option is a
+     * java.util.Map<java.lang.String,java.lang.Object> type.
      */
-    private Map<String, Object> configurationProperties;
+    private String configurationProperties;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -56,28 +53,27 @@ public class XQueryComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ModuleURIResolver getModuleURIResolver() {
+    public String getModuleURIResolver() {
         return moduleURIResolver;
     }
 
-    public void setModuleURIResolver(ModuleURIResolver moduleURIResolver) {
+    public void setModuleURIResolver(String moduleURIResolver) {
         this.moduleURIResolver = moduleURIResolver;
     }
 
-    public Configuration getConfiguration() {
+    public String getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(Configuration configuration) {
+    public void setConfiguration(String configuration) {
         this.configuration = configuration;
     }
 
-    public Map<String, Object> getConfigurationProperties() {
+    public String getConfigurationProperties() {
         return configurationProperties;
     }
 
-    public void setConfigurationProperties(
-            Map<String, Object> configurationProperties) {
+    public void setConfigurationProperties(String configurationProperties) {
         this.configurationProperties = configurationProperties;
     }
 

--- a/platforms/spring-boot/components-starter/camel-service-starter/src/main/java/org/apache/camel/component/service/springboot/ServiceComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-service-starter/src/main/java/org/apache/camel/component/service/springboot/ServiceComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.service.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.cloud.ServiceRegistry;
-import org.apache.camel.cloud.ServiceRegistry.Selector;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Represents an endpoint which is registered to a Service Registry such as
@@ -36,15 +33,15 @@ public class ServiceComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Inject the service to use.
+     * Inject the service to use. The option is a
+     * org.apache.camel.cloud.ServiceRegistry type.
      */
-    @NestedConfigurationProperty
-    private ServiceRegistry service;
+    private String service;
     /**
      * Inject the service selector used to lookup the ServiceRegistry to use.
+     * The option is a org.apache.camel.cloud.ServiceRegistry.Selector type.
      */
-    @NestedConfigurationProperty
-    private Selector serviceSelector;
+    private String serviceSelector;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -52,19 +49,19 @@ public class ServiceComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ServiceRegistry getService() {
+    public String getService() {
         return service;
     }
 
-    public void setService(ServiceRegistry service) {
+    public void setService(String service) {
         this.service = service;
     }
 
-    public Selector getServiceSelector() {
+    public String getServiceSelector() {
         return serviceSelector;
     }
 
-    public void setServiceSelector(Selector serviceSelector) {
+    public void setServiceSelector(String serviceSelector) {
         this.serviceSelector = serviceSelector;
     }
 

--- a/platforms/spring-boot/components-starter/camel-servlet-starter/src/main/java/org/apache/camel/component/servlet/springboot/ServletComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-servlet-starter/src/main/java/org/apache/camel/component/servlet/springboot/ServletComponentConfiguration.java
@@ -17,13 +17,8 @@
 package org.apache.camel.component.servlet.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.servlet.HttpRegistry;
-import org.apache.camel.http.common.HttpBinding;
-import org.apache.camel.http.common.HttpConfiguration;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * To use a HTTP Servlet as entry for Camel routes when running in a servlet
@@ -42,10 +37,10 @@ public class ServletComponentConfiguration
      */
     private String servletName;
     /**
-     * To use a custom org.apache.camel.component.servlet.HttpRegistry.
+     * To use a custom org.apache.camel.component.servlet.HttpRegistry. The
+     * option is a org.apache.camel.component.servlet.HttpRegistry type.
      */
-    @NestedConfigurationProperty
-    private HttpRegistry httpRegistry;
+    private String httpRegistry;
     /**
      * Whether to automatic bind multipart/form-data as attachments on the Camel
      * Exchange. The options attachmentMultipartBinding=true and
@@ -57,15 +52,15 @@ public class ServletComponentConfiguration
     private Boolean attachmentMultipartBinding = false;
     /**
      * To use a custom HttpBinding to control the mapping between Camel message
-     * and HttpClient.
+     * and HttpClient. The option is a org.apache.camel.http.common.HttpBinding
+     * type.
      */
-    @NestedConfigurationProperty
-    private HttpBinding httpBinding;
+    private String httpBinding;
     /**
-     * To use the shared HttpConfiguration as base configuration.
+     * To use the shared HttpConfiguration as base configuration. The option is
+     * a org.apache.camel.http.common.HttpConfiguration type.
      */
-    @NestedConfigurationProperty
-    private HttpConfiguration httpConfiguration;
+    private String httpConfiguration;
     /**
      * Whether to allow java serialization when a request uses
      * context-type=application/x-java-serialized-object. This is by default
@@ -76,10 +71,10 @@ public class ServletComponentConfiguration
     private Boolean allowJavaSerializedObject = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -95,11 +90,11 @@ public class ServletComponentConfiguration
         this.servletName = servletName;
     }
 
-    public HttpRegistry getHttpRegistry() {
+    public String getHttpRegistry() {
         return httpRegistry;
     }
 
-    public void setHttpRegistry(HttpRegistry httpRegistry) {
+    public void setHttpRegistry(String httpRegistry) {
         this.httpRegistry = httpRegistry;
     }
 
@@ -111,19 +106,19 @@ public class ServletComponentConfiguration
         this.attachmentMultipartBinding = attachmentMultipartBinding;
     }
 
-    public HttpBinding getHttpBinding() {
+    public String getHttpBinding() {
         return httpBinding;
     }
 
-    public void setHttpBinding(HttpBinding httpBinding) {
+    public void setHttpBinding(String httpBinding) {
         this.httpBinding = httpBinding;
     }
 
-    public HttpConfiguration getHttpConfiguration() {
+    public String getHttpConfiguration() {
         return httpConfiguration;
     }
 
-    public void setHttpConfiguration(HttpConfiguration httpConfiguration) {
+    public void setHttpConfiguration(String httpConfiguration) {
         this.httpConfiguration = httpConfiguration;
     }
 
@@ -135,12 +130,11 @@ public class ServletComponentConfiguration
         this.allowJavaSerializedObject = allowJavaSerializedObject;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-sjms-starter/src/main/java/org/apache/camel/component/sjms/batch/springboot/SjmsBatchComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-sjms-starter/src/main/java/org/apache/camel/component/sjms/batch/springboot/SjmsBatchComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.sjms.batch.springboot;
 
 import javax.annotation.Generated;
-import javax.jms.ConnectionFactory;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The sjms-batch component is a specialized for highly performant,
@@ -36,9 +33,10 @@ public class SjmsBatchComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * A ConnectionFactory is required to enable the SjmsBatchComponent.
+     * A ConnectionFactory is required to enable the SjmsBatchComponent. The
+     * option is a javax.jms.ConnectionFactory type.
      */
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * Whether to startup the consumer message listener asynchronously, when
      * starting a route. For example if a JmsConsumer cannot get a connection to
@@ -60,10 +58,10 @@ public class SjmsBatchComponentConfiguration
     private Integer recoveryInterval = 5000;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -71,11 +69,11 @@ public class SjmsBatchComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
@@ -95,12 +93,11 @@ public class SjmsBatchComponentConfiguration
         this.recoveryInterval = recoveryInterval;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-sjms-starter/src/main/java/org/apache/camel/component/sjms/springboot/SjmsComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-sjms-starter/src/main/java/org/apache/camel/component/sjms/springboot/SjmsComponentConfiguration.java
@@ -17,16 +17,8 @@
 package org.apache.camel.component.sjms.springboot;
 
 import javax.annotation.Generated;
-import javax.jms.ConnectionFactory;
-import org.apache.camel.component.sjms.TransactionCommitStrategy;
-import org.apache.camel.component.sjms.jms.ConnectionResource;
-import org.apache.camel.component.sjms.jms.DestinationCreationStrategy;
-import org.apache.camel.component.sjms.jms.JmsKeyFormatStrategy;
-import org.apache.camel.component.sjms.jms.MessageCreatedStrategy;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The sjms component (simple jms) allows messages to be sent to (or consumed
@@ -42,16 +34,17 @@ public class SjmsComponentConfiguration
 
     /**
      * A ConnectionFactory is required to enable the SjmsComponent. It can be
-     * set directly or set set as part of a ConnectionResource.
+     * set directly or set set as part of a ConnectionResource. The option is a
+     * javax.jms.ConnectionFactory type.
      */
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * A ConnectionResource is an interface that allows for customization and
      * container control of the ConnectionFactory. See Plugable Connection
-     * Resource Management for further details.
+     * Resource Management for further details. The option is a
+     * org.apache.camel.component.sjms.jms.ConnectionResource type.
      */
-    @NestedConfigurationProperty
-    private ConnectionResource connectionResource;
+    private String connectionResource;
     /**
      * The maximum number of connections available to endpoints started under
      * this component
@@ -65,21 +58,21 @@ public class SjmsComponentConfiguration
      * whether JMS header keys contain illegal characters. You can provide your
      * own implementation of the
      * org.apache.camel.component.jms.JmsKeyFormatStrategy and refer to it using
-     * the notation.
+     * the notation. The option is a
+     * org.apache.camel.component.sjms.jms.JmsKeyFormatStrategy type.
      */
-    @NestedConfigurationProperty
-    private JmsKeyFormatStrategy jmsKeyFormatStrategy;
+    private String jmsKeyFormatStrategy;
     /**
      * To configure which kind of commit strategy to use. Camel provides two
-     * implementations out of the box, default and batch.
+     * implementations out of the box, default and batch. The option is a
+     * org.apache.camel.component.sjms.TransactionCommitStrategy type.
      */
-    @NestedConfigurationProperty
-    private TransactionCommitStrategy transactionCommitStrategy;
+    private String transactionCommitStrategy;
     /**
-     * To use a custom DestinationCreationStrategy.
+     * To use a custom DestinationCreationStrategy. The option is a
+     * org.apache.camel.component.sjms.jms.DestinationCreationStrategy type.
      */
-    @NestedConfigurationProperty
-    private DestinationCreationStrategy destinationCreationStrategy;
+    private String destinationCreationStrategy;
     /**
      * To use a custom TimedTaskManager
      */
@@ -87,10 +80,10 @@ public class SjmsComponentConfiguration
     /**
      * To use the given MessageCreatedStrategy which are invoked when Camel
      * creates new instances of javax.jms.Message objects when Camel is sending
-     * a JMS message.
+     * a JMS message. The option is a
+     * org.apache.camel.component.sjms.jms.MessageCreatedStrategy type.
      */
-    @NestedConfigurationProperty
-    private MessageCreatedStrategy messageCreatedStrategy;
+    private String messageCreatedStrategy;
     /**
      * When using the default
      * org.apache.camel.component.sjms.jms.ConnectionFactoryResource then should
@@ -121,10 +114,10 @@ public class SjmsComponentConfiguration
     private Long connectionMaxWait = 5000L;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -132,19 +125,19 @@ public class SjmsComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
-    public ConnectionResource getConnectionResource() {
+    public String getConnectionResource() {
         return connectionResource;
     }
 
-    public void setConnectionResource(ConnectionResource connectionResource) {
+    public void setConnectionResource(String connectionResource) {
         this.connectionResource = connectionResource;
     }
 
@@ -156,30 +149,28 @@ public class SjmsComponentConfiguration
         this.connectionCount = connectionCount;
     }
 
-    public JmsKeyFormatStrategy getJmsKeyFormatStrategy() {
+    public String getJmsKeyFormatStrategy() {
         return jmsKeyFormatStrategy;
     }
 
-    public void setJmsKeyFormatStrategy(
-            JmsKeyFormatStrategy jmsKeyFormatStrategy) {
+    public void setJmsKeyFormatStrategy(String jmsKeyFormatStrategy) {
         this.jmsKeyFormatStrategy = jmsKeyFormatStrategy;
     }
 
-    public TransactionCommitStrategy getTransactionCommitStrategy() {
+    public String getTransactionCommitStrategy() {
         return transactionCommitStrategy;
     }
 
-    public void setTransactionCommitStrategy(
-            TransactionCommitStrategy transactionCommitStrategy) {
+    public void setTransactionCommitStrategy(String transactionCommitStrategy) {
         this.transactionCommitStrategy = transactionCommitStrategy;
     }
 
-    public DestinationCreationStrategy getDestinationCreationStrategy() {
+    public String getDestinationCreationStrategy() {
         return destinationCreationStrategy;
     }
 
     public void setDestinationCreationStrategy(
-            DestinationCreationStrategy destinationCreationStrategy) {
+            String destinationCreationStrategy) {
         this.destinationCreationStrategy = destinationCreationStrategy;
     }
 
@@ -192,12 +183,11 @@ public class SjmsComponentConfiguration
         this.timedTaskManager = timedTaskManager;
     }
 
-    public MessageCreatedStrategy getMessageCreatedStrategy() {
+    public String getMessageCreatedStrategy() {
         return messageCreatedStrategy;
     }
 
-    public void setMessageCreatedStrategy(
-            MessageCreatedStrategy messageCreatedStrategy) {
+    public void setMessageCreatedStrategy(String messageCreatedStrategy) {
         this.messageCreatedStrategy = messageCreatedStrategy;
     }
 
@@ -241,12 +231,11 @@ public class SjmsComponentConfiguration
         this.connectionMaxWait = connectionMaxWait;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-sjms2-starter/src/main/java/org/apache/camel/component/sjms2/springboot/Sjms2ComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-sjms2-starter/src/main/java/org/apache/camel/component/sjms2/springboot/Sjms2ComponentConfiguration.java
@@ -17,17 +17,8 @@
 package org.apache.camel.component.sjms2.springboot;
 
 import javax.annotation.Generated;
-import javax.jms.ConnectionFactory;
-import org.apache.camel.component.sjms.TransactionCommitStrategy;
-import org.apache.camel.component.sjms.jms.ConnectionResource;
-import org.apache.camel.component.sjms.jms.DestinationCreationStrategy;
-import org.apache.camel.component.sjms.jms.JmsKeyFormatStrategy;
-import org.apache.camel.component.sjms.jms.MessageCreatedStrategy;
-import org.apache.camel.component.sjms.taskmanager.TimedTaskManager;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The sjms2 component (simple jms) allows messages to be sent to (or consumed
@@ -43,16 +34,17 @@ public class Sjms2ComponentConfiguration
 
     /**
      * A ConnectionFactory is required to enable the SjmsComponent. It can be
-     * set directly or set set as part of a ConnectionResource.
+     * set directly or set set as part of a ConnectionResource. The option is a
+     * javax.jms.ConnectionFactory type.
      */
-    private ConnectionFactory connectionFactory;
+    private String connectionFactory;
     /**
      * A ConnectionResource is an interface that allows for customization and
      * container control of the ConnectionFactory. See Plugable Connection
-     * Resource Management for further details.
+     * Resource Management for further details. The option is a
+     * org.apache.camel.component.sjms.jms.ConnectionResource type.
      */
-    @NestedConfigurationProperty
-    private ConnectionResource connectionResource;
+    private String connectionResource;
     /**
      * The maximum number of connections available to endpoints started under
      * this component
@@ -66,33 +58,33 @@ public class Sjms2ComponentConfiguration
      * whether JMS header keys contain illegal characters. You can provide your
      * own implementation of the
      * org.apache.camel.component.jms.JmsKeyFormatStrategy and refer to it using
-     * the notation.
+     * the notation. The option is a
+     * org.apache.camel.component.sjms.jms.JmsKeyFormatStrategy type.
      */
-    @NestedConfigurationProperty
-    private JmsKeyFormatStrategy jmsKeyFormatStrategy;
+    private String jmsKeyFormatStrategy;
     /**
      * To configure which kind of commit strategy to use. Camel provides two
-     * implementations out of the box, default and batch.
+     * implementations out of the box, default and batch. The option is a
+     * org.apache.camel.component.sjms.TransactionCommitStrategy type.
      */
-    @NestedConfigurationProperty
-    private TransactionCommitStrategy transactionCommitStrategy;
+    private String transactionCommitStrategy;
     /**
-     * To use a custom DestinationCreationStrategy.
+     * To use a custom DestinationCreationStrategy. The option is a
+     * org.apache.camel.component.sjms.jms.DestinationCreationStrategy type.
      */
-    @NestedConfigurationProperty
-    private DestinationCreationStrategy destinationCreationStrategy;
+    private String destinationCreationStrategy;
     /**
-     * To use a custom TimedTaskManager
+     * To use a custom TimedTaskManager. The option is a
+     * org.apache.camel.component.sjms.taskmanager.TimedTaskManager type.
      */
-    @NestedConfigurationProperty
-    private TimedTaskManager timedTaskManager;
+    private String timedTaskManager;
     /**
      * To use the given MessageCreatedStrategy which are invoked when Camel
      * creates new instances of javax.jms.Message objects when Camel is sending
-     * a JMS message.
+     * a JMS message. The option is a
+     * org.apache.camel.component.sjms.jms.MessageCreatedStrategy type.
      */
-    @NestedConfigurationProperty
-    private MessageCreatedStrategy messageCreatedStrategy;
+    private String messageCreatedStrategy;
     /**
      * When using the default
      * org.apache.camel.component.sjms.jms.ConnectionFactoryResource then should
@@ -123,10 +115,10 @@ public class Sjms2ComponentConfiguration
     private Long connectionMaxWait = 5000L;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -134,19 +126,19 @@ public class Sjms2ComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ConnectionFactory getConnectionFactory() {
+    public String getConnectionFactory() {
         return connectionFactory;
     }
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
-    public ConnectionResource getConnectionResource() {
+    public String getConnectionResource() {
         return connectionResource;
     }
 
-    public void setConnectionResource(ConnectionResource connectionResource) {
+    public void setConnectionResource(String connectionResource) {
         this.connectionResource = connectionResource;
     }
 
@@ -158,47 +150,44 @@ public class Sjms2ComponentConfiguration
         this.connectionCount = connectionCount;
     }
 
-    public JmsKeyFormatStrategy getJmsKeyFormatStrategy() {
+    public String getJmsKeyFormatStrategy() {
         return jmsKeyFormatStrategy;
     }
 
-    public void setJmsKeyFormatStrategy(
-            JmsKeyFormatStrategy jmsKeyFormatStrategy) {
+    public void setJmsKeyFormatStrategy(String jmsKeyFormatStrategy) {
         this.jmsKeyFormatStrategy = jmsKeyFormatStrategy;
     }
 
-    public TransactionCommitStrategy getTransactionCommitStrategy() {
+    public String getTransactionCommitStrategy() {
         return transactionCommitStrategy;
     }
 
-    public void setTransactionCommitStrategy(
-            TransactionCommitStrategy transactionCommitStrategy) {
+    public void setTransactionCommitStrategy(String transactionCommitStrategy) {
         this.transactionCommitStrategy = transactionCommitStrategy;
     }
 
-    public DestinationCreationStrategy getDestinationCreationStrategy() {
+    public String getDestinationCreationStrategy() {
         return destinationCreationStrategy;
     }
 
     public void setDestinationCreationStrategy(
-            DestinationCreationStrategy destinationCreationStrategy) {
+            String destinationCreationStrategy) {
         this.destinationCreationStrategy = destinationCreationStrategy;
     }
 
-    public TimedTaskManager getTimedTaskManager() {
+    public String getTimedTaskManager() {
         return timedTaskManager;
     }
 
-    public void setTimedTaskManager(TimedTaskManager timedTaskManager) {
+    public void setTimedTaskManager(String timedTaskManager) {
         this.timedTaskManager = timedTaskManager;
     }
 
-    public MessageCreatedStrategy getMessageCreatedStrategy() {
+    public String getMessageCreatedStrategy() {
         return messageCreatedStrategy;
     }
 
-    public void setMessageCreatedStrategy(
-            MessageCreatedStrategy messageCreatedStrategy) {
+    public void setMessageCreatedStrategy(String messageCreatedStrategy) {
         this.messageCreatedStrategy = messageCreatedStrategy;
     }
 
@@ -242,12 +231,11 @@ public class Sjms2ComponentConfiguration
         this.connectionMaxWait = connectionMaxWait;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-spark-starter/src/main/java/org/apache/camel/component/spark/springboot/SparkComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-spark-starter/src/main/java/org/apache/camel/component/spark/springboot/SparkComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.spark.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.spark.RddCallback;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.spark.api.java.JavaRDDLike;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The spark component can be used to send RDD or DataFrame jobs to Apache Spark
@@ -36,15 +33,15 @@ public class SparkComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * RDD to compute against.
+     * RDD to compute against. The option is a
+     * org.apache.spark.api.java.JavaRDDLike type.
      */
-    @NestedConfigurationProperty
-    private JavaRDDLike rdd;
+    private String rdd;
     /**
-     * Function performing action against an RDD.
+     * Function performing action against an RDD. The option is a
+     * org.apache.camel.component.spark.RddCallback type.
      */
-    @NestedConfigurationProperty
-    private RddCallback rddCallback;
+    private String rddCallback;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -52,19 +49,19 @@ public class SparkComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public JavaRDDLike getRdd() {
+    public String getRdd() {
         return rdd;
     }
 
-    public void setRdd(JavaRDDLike rdd) {
+    public void setRdd(String rdd) {
         this.rdd = rdd;
     }
 
-    public RddCallback getRddCallback() {
+    public String getRddCallback() {
         return rddCallback;
     }
 
-    public void setRddCallback(RddCallback rddCallback) {
+    public void setRddCallback(String rddCallback) {
         this.rddCallback = rddCallback;
     }
 

--- a/platforms/spring-boot/components-starter/camel-splunk-starter/src/main/java/org/apache/camel/component/splunk/springboot/SplunkComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-splunk-starter/src/main/java/org/apache/camel/component/splunk/springboot/SplunkComponentConfiguration.java
@@ -17,10 +17,8 @@
 package org.apache.camel.component.splunk.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.splunk.SplunkConfigurationFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The splunk component allows to publish or search for events in Splunk.
@@ -34,10 +32,10 @@ public class SplunkComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the SplunkConfigurationFactory
+     * To use the SplunkConfigurationFactory. The option is a
+     * org.apache.camel.component.splunk.SplunkConfigurationFactory type.
      */
-    @NestedConfigurationProperty
-    private SplunkConfigurationFactory splunkConfigurationFactory;
+    private String splunkConfigurationFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -45,12 +43,11 @@ public class SplunkComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public SplunkConfigurationFactory getSplunkConfigurationFactory() {
+    public String getSplunkConfigurationFactory() {
         return splunkConfigurationFactory;
     }
 
-    public void setSplunkConfigurationFactory(
-            SplunkConfigurationFactory splunkConfigurationFactory) {
+    public void setSplunkConfigurationFactory(String splunkConfigurationFactory) {
         this.splunkConfigurationFactory = splunkConfigurationFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-spring-batch-starter/src/main/java/org/apache/camel/component/spring/batch/springboot/SpringBatchComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-spring-batch-starter/src/main/java/org/apache/camel/component/spring/batch/springboot/SpringBatchComponentConfiguration.java
@@ -18,10 +18,7 @@ package org.apache.camel.component.spring.batch.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.springframework.batch.core.configuration.JobRegistry;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The spring-batch component allows to send messages to Spring Batch for
@@ -36,15 +33,15 @@ public class SpringBatchComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Explicitly specifies a JobLauncher to be used.
+     * Explicitly specifies a JobLauncher to be used. The option is a
+     * org.springframework.batch.core.launch.JobLauncher type.
      */
-    @NestedConfigurationProperty
-    private JobLauncher jobLauncher;
+    private String jobLauncher;
     /**
-     * Explicitly specifies a JobRegistry to be used.
+     * Explicitly specifies a JobRegistry to be used. The option is a
+     * org.springframework.batch.core.configuration.JobRegistry type.
      */
-    @NestedConfigurationProperty
-    private JobRegistry jobRegistry;
+    private String jobRegistry;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -52,19 +49,19 @@ public class SpringBatchComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public JobLauncher getJobLauncher() {
+    public String getJobLauncher() {
         return jobLauncher;
     }
 
-    public void setJobLauncher(JobLauncher jobLauncher) {
+    public void setJobLauncher(String jobLauncher) {
         this.jobLauncher = jobLauncher;
     }
 
-    public JobRegistry getJobRegistry() {
+    public String getJobRegistry() {
         return jobRegistry;
     }
 
-    public void setJobRegistry(JobRegistry jobRegistry) {
+    public void setJobRegistry(String jobRegistry) {
         this.jobRegistry = jobRegistry;
     }
 

--- a/platforms/spring-boot/components-starter/camel-sql-starter/src/main/java/org/apache/camel/component/sql/springboot/SqlComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-sql-starter/src/main/java/org/apache/camel/component/sql/springboot/SqlComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.sql.springboot;
 
 import javax.annotation.Generated;
-import javax.sql.DataSource;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -33,9 +32,10 @@ public class SqlComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the DataSource to use to communicate with the database.
+     * Sets the DataSource to use to communicate with the database. The option
+     * is a javax.sql.DataSource type.
      */
-    private DataSource dataSource;
+    private String dataSource;
     /**
      * Sets whether to use placeholder and replace all placeholder characters
      * with sign in the SQL queries. This option is default true
@@ -48,11 +48,11 @@ public class SqlComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public DataSource getDataSource() {
+    public String getDataSource() {
         return dataSource;
     }
 
-    public void setDataSource(DataSource dataSource) {
+    public void setDataSource(String dataSource) {
         this.dataSource = dataSource;
     }
 

--- a/platforms/spring-boot/components-starter/camel-sql-starter/src/main/java/org/apache/camel/component/sql/stored/springboot/SqlStoredComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-sql-starter/src/main/java/org/apache/camel/component/sql/stored/springboot/SqlStoredComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.sql.stored.springboot;
 
 import javax.annotation.Generated;
-import javax.sql.DataSource;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -34,9 +33,10 @@ public class SqlStoredComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * Sets the DataSource to use to communicate with the database.
+     * Sets the DataSource to use to communicate with the database. The option
+     * is a javax.sql.DataSource type.
      */
-    private DataSource dataSource;
+    private String dataSource;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -44,11 +44,11 @@ public class SqlStoredComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public DataSource getDataSource() {
+    public String getDataSource() {
         return dataSource;
     }
 
-    public void setDataSource(DataSource dataSource) {
+    public void setDataSource(String dataSource) {
         this.dataSource = dataSource;
     }
 

--- a/platforms/spring-boot/components-starter/camel-ssh-starter/src/main/java/org/apache/camel/component/ssh/springboot/SshComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-ssh-starter/src/main/java/org/apache/camel/component/ssh/springboot/SshComponentConfiguration.java
@@ -21,7 +21,6 @@ import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The ssh component enables access to SSH servers such that you can send an SSH
@@ -65,10 +64,10 @@ public class SshComponentConfiguration
     private String pollCommand;
     /**
      * Sets the KeyPairProvider reference to use when connecting using
-     * Certificates to the remote SSH Server.
+     * Certificates to the remote SSH Server. The option is a
+     * org.apache.sshd.common.keyprovider.KeyPairProvider type.
      */
-    @NestedConfigurationProperty
-    private KeyPairProvider keyPairProvider;
+    private String keyPairProvider;
     /**
      * Sets the key type to pass to the KeyPairProvider as part of
      * authentication. KeyPairProvider.loadKey(...) will be passed this value.
@@ -162,11 +161,11 @@ public class SshComponentConfiguration
         this.pollCommand = pollCommand;
     }
 
-    public KeyPairProvider getKeyPairProvider() {
+    public String getKeyPairProvider() {
         return keyPairProvider;
     }
 
-    public void setKeyPairProvider(KeyPairProvider keyPairProvider) {
+    public void setKeyPairProvider(String keyPairProvider) {
         this.keyPairProvider = keyPairProvider;
     }
 

--- a/platforms/spring-boot/components-starter/camel-stomp-starter/src/main/java/org/apache/camel/component/stomp/springboot/StompComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-stomp-starter/src/main/java/org/apache/camel/component/stomp/springboot/StompComponentConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.stomp.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.apache.camel.util.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -61,10 +60,10 @@ public class StompComponentConfiguration
     private Boolean useGlobalSslContextParameters = false;
     /**
      * To use a custom org.apache.camel.spi.HeaderFilterStrategy to filter
-     * header to and from Camel message.
+     * header to and from Camel message. The option is a
+     * org.apache.camel.spi.HeaderFilterStrategy type.
      */
-    @NestedConfigurationProperty
-    private HeaderFilterStrategy headerFilterStrategy;
+    private String headerFilterStrategy;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -122,12 +121,11 @@ public class StompComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public HeaderFilterStrategy getHeaderFilterStrategy() {
+    public String getHeaderFilterStrategy() {
         return headerFilterStrategy;
     }
 
-    public void setHeaderFilterStrategy(
-            HeaderFilterStrategy headerFilterStrategy) {
+    public void setHeaderFilterStrategy(String headerFilterStrategy) {
         this.headerFilterStrategy = headerFilterStrategy;
     }
 

--- a/platforms/spring-boot/components-starter/camel-twilio-starter/src/main/java/org/apache/camel/component/twilio/springboot/TwilioComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-twilio-starter/src/main/java/org/apache/camel/component/twilio/springboot/TwilioComponentConfiguration.java
@@ -17,11 +17,9 @@
 package org.apache.camel.component.twilio.springboot;
 
 import javax.annotation.Generated;
-import com.twilio.http.TwilioRestClient;
 import org.apache.camel.component.twilio.internal.TwilioApiName;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The Twilio component allows you to interact with the Twilio REST APIs using
@@ -40,10 +38,10 @@ public class TwilioComponentConfiguration
      */
     private TwilioConfigurationNestedConfiguration configuration;
     /**
-     * To use the shared REST client
+     * To use the shared REST client. The option is a
+     * com.twilio.http.TwilioRestClient type.
      */
-    @NestedConfigurationProperty
-    private TwilioRestClient restClient;
+    private String restClient;
     /**
      * The account to use.
      */
@@ -72,11 +70,11 @@ public class TwilioComponentConfiguration
         this.configuration = configuration;
     }
 
-    public TwilioRestClient getRestClient() {
+    public String getRestClient() {
         return restClient;
     }
 
-    public void setRestClient(TwilioRestClient restClient) {
+    public void setRestClient(String restClient) {
         this.restClient = restClient;
     }
 

--- a/platforms/spring-boot/components-starter/camel-undertow-starter/src/main/java/org/apache/camel/component/undertow/springboot/UndertowComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-undertow-starter/src/main/java/org/apache/camel/component/undertow/springboot/UndertowComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.undertow.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.undertow.UndertowHttpBinding;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The undertow component provides HTTP and WebSocket based endpoints for
@@ -37,15 +34,15 @@ public class UndertowComponentConfiguration
 
     /**
      * To use a custom HttpBinding to control the mapping between Camel message
-     * and HttpClient.
+     * and HttpClient. The option is a
+     * org.apache.camel.component.undertow.UndertowHttpBinding type.
      */
-    @NestedConfigurationProperty
-    private UndertowHttpBinding undertowHttpBinding;
+    private String undertowHttpBinding;
     /**
-     * To configure security using SSLContextParameters
+     * To configure security using SSLContextParameters. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -61,20 +58,19 @@ public class UndertowComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public UndertowHttpBinding getUndertowHttpBinding() {
+    public String getUndertowHttpBinding() {
         return undertowHttpBinding;
     }
 
-    public void setUndertowHttpBinding(UndertowHttpBinding undertowHttpBinding) {
+    public void setUndertowHttpBinding(String undertowHttpBinding) {
         this.undertowHttpBinding = undertowHttpBinding;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 

--- a/platforms/spring-boot/components-starter/camel-velocity-starter/src/main/java/org/apache/camel/component/velocity/springboot/VelocityComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-velocity-starter/src/main/java/org/apache/camel/component/velocity/springboot/VelocityComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.velocity.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.velocity.app.VelocityEngine;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Transforms the message using a Velocity template.
@@ -34,10 +32,10 @@ public class VelocityComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use the VelocityEngine otherwise a new engine is created
+     * To use the VelocityEngine otherwise a new engine is created. The option
+     * is a org.apache.velocity.app.VelocityEngine type.
      */
-    @NestedConfigurationProperty
-    private VelocityEngine velocityEngine;
+    private String velocityEngine;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -45,11 +43,11 @@ public class VelocityComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public VelocityEngine getVelocityEngine() {
+    public String getVelocityEngine() {
         return velocityEngine;
     }
 
-    public void setVelocityEngine(VelocityEngine velocityEngine) {
+    public void setVelocityEngine(String velocityEngine) {
         this.velocityEngine = velocityEngine;
     }
 

--- a/platforms/spring-boot/components-starter/camel-vertx-starter/src/main/java/org/apache/camel/component/vertx/springboot/VertxComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-vertx-starter/src/main/java/org/apache/camel/component/vertx/springboot/VertxComponentConfiguration.java
@@ -17,12 +17,8 @@
 package org.apache.camel.component.vertx.springboot;
 
 import javax.annotation.Generated;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.spi.VertxFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The vertx component is used for sending and receive messages from a vertx
@@ -37,10 +33,10 @@ public class VertxComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom VertxFactory implementation
+     * To use a custom VertxFactory implementation. The option is a
+     * io.vertx.core.spi.VertxFactory type.
      */
-    @NestedConfigurationProperty
-    private VertxFactory vertxFactory;
+    private String vertxFactory;
     /**
      * Hostname for creating an embedded clustered EventBus
      */
@@ -50,16 +46,15 @@ public class VertxComponentConfiguration
      */
     private Integer port;
     /**
-     * Options to use for creating vertx
+     * Options to use for creating vertx. The option is a
+     * io.vertx.core.VertxOptions type.
      */
-    @NestedConfigurationProperty
-    private VertxOptions vertxOptions;
+    private String vertxOptions;
     /**
      * To use the given vertx EventBus instead of creating a new embedded
-     * EventBus
+     * EventBus. The option is a io.vertx.core.Vertx type.
      */
-    @NestedConfigurationProperty
-    private Vertx vertx;
+    private String vertx;
     /**
      * Timeout in seconds to wait for clustered Vertx EventBus to be ready. The
      * default value is 60.
@@ -72,11 +67,11 @@ public class VertxComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public VertxFactory getVertxFactory() {
+    public String getVertxFactory() {
         return vertxFactory;
     }
 
-    public void setVertxFactory(VertxFactory vertxFactory) {
+    public void setVertxFactory(String vertxFactory) {
         this.vertxFactory = vertxFactory;
     }
 
@@ -96,19 +91,19 @@ public class VertxComponentConfiguration
         this.port = port;
     }
 
-    public VertxOptions getVertxOptions() {
+    public String getVertxOptions() {
         return vertxOptions;
     }
 
-    public void setVertxOptions(VertxOptions vertxOptions) {
+    public void setVertxOptions(String vertxOptions) {
         this.vertxOptions = vertxOptions;
     }
 
-    public Vertx getVertx() {
+    public String getVertx() {
         return vertx;
     }
 
-    public void setVertx(Vertx vertx) {
+    public void setVertx(String vertx) {
         this.vertx = vertx;
     }
 

--- a/platforms/spring-boot/components-starter/camel-websocket-starter/src/main/java/org/apache/camel/component/websocket/springboot/WebsocketComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-websocket-starter/src/main/java/org/apache/camel/component/websocket/springboot/WebsocketComponentConfiguration.java
@@ -16,14 +16,9 @@
  */
 package org.apache.camel.component.websocket.springboot;
 
-import java.util.Map;
 import javax.annotation.Generated;
-import org.apache.camel.component.websocket.WebSocketFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.camel.util.jsse.SSLContextParameters;
-import org.eclipse.jetty.util.thread.ThreadPool;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The websocket component provides websocket endpoints with Jetty for
@@ -85,15 +80,15 @@ public class WebsocketComponentConfiguration
     private Integer maxThreads;
     /**
      * To use a custom thread pool for the server. MaxThreads/minThreads or
-     * threadPool fields are required due to switch to Jetty9.
+     * threadPool fields are required due to switch to Jetty9. The option is a
+     * org.eclipse.jetty.util.thread.ThreadPool type.
      */
-    @NestedConfigurationProperty
-    private ThreadPool threadPool;
+    private String threadPool;
     /**
-     * To configure security using SSLContextParameters
+     * To configure security using SSLContextParameters. The option is a
+     * org.apache.camel.util.jsse.SSLContextParameters type.
      */
-    @NestedConfigurationProperty
-    private SSLContextParameters sslContextParameters;
+    private String sslContextParameters;
     /**
      * Enable usage of global SSL context parameters.
      */
@@ -101,9 +96,11 @@ public class WebsocketComponentConfiguration
     /**
      * To configure a map which contains custom WebSocketFactory for sub
      * protocols. The key in the map is the sub protocol. The default key is
-     * reserved for the default implementation.
+     * reserved for the default implementation. The option is a
+     * java.util.Map<java
+     * .lang.String,org.apache.camel.component.websocket.WebSocketFactory> type.
      */
-    private Map<String, WebSocketFactory> socketFactory;
+    private String socketFactory;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -183,20 +180,19 @@ public class WebsocketComponentConfiguration
         this.maxThreads = maxThreads;
     }
 
-    public ThreadPool getThreadPool() {
+    public String getThreadPool() {
         return threadPool;
     }
 
-    public void setThreadPool(ThreadPool threadPool) {
+    public void setThreadPool(String threadPool) {
         this.threadPool = threadPool;
     }
 
-    public SSLContextParameters getSslContextParameters() {
+    public String getSslContextParameters() {
         return sslContextParameters;
     }
 
-    public void setSslContextParameters(
-            SSLContextParameters sslContextParameters) {
+    public void setSslContextParameters(String sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
     }
 
@@ -209,11 +205,11 @@ public class WebsocketComponentConfiguration
         this.useGlobalSslContextParameters = useGlobalSslContextParameters;
     }
 
-    public Map<String, WebSocketFactory> getSocketFactory() {
+    public String getSocketFactory() {
         return socketFactory;
     }
 
-    public void setSocketFactory(Map<String, WebSocketFactory> socketFactory) {
+    public void setSocketFactory(String socketFactory) {
         this.socketFactory = socketFactory;
     }
 

--- a/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/XStreamDataFormatConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-xstream-starter/src/main/java/org/apache/camel/dataformat/xstream/springboot/XStreamDataFormatConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.camel.dataformat.xstream.springboot;
 
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.DataFormatConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -76,20 +75,23 @@ public class XStreamDataFormatConfiguration
      */
     private List<String> converters;
     /**
-     * Alias a Class to a shorter name to be used in XML elements.
+     * Alias a Class to a shorter name to be used in XML elements. The option is
+     * a java.util.Map<java.lang.String,java.lang.String> type.
      */
-    private Map<String, String> aliases;
+    private String aliases;
     /**
      * Prevents a field from being serialized. To omit a field you must always
      * provide the declaring type and not necessarily the type that is
-     * converted.
+     * converted. The option is a
+     * java.util.Map<java.lang.String,java.lang.String[]> type.
      */
-    private Map<String, String[]> omitFields;
+    private String omitFields;
     /**
      * Adds a default implicit collection which is used for any unmapped XML
-     * tag.
+     * tag. The option is a java.util.Map<java.lang.String,java.lang.String[]>
+     * type.
      */
-    private Map<String, String[]> implicitCollections;
+    private String implicitCollections;
     /**
      * Whether the data format should set the Content-Type header with the type
      * from the data format if the data format is capable of doing so. For
@@ -146,27 +148,27 @@ public class XStreamDataFormatConfiguration
         this.converters = converters;
     }
 
-    public Map<String, String> getAliases() {
+    public String getAliases() {
         return aliases;
     }
 
-    public void setAliases(Map<String, String> aliases) {
+    public void setAliases(String aliases) {
         this.aliases = aliases;
     }
 
-    public Map<String, String[]> getOmitFields() {
+    public String getOmitFields() {
         return omitFields;
     }
 
-    public void setOmitFields(Map<String, String[]> omitFields) {
+    public void setOmitFields(String omitFields) {
         this.omitFields = omitFields;
     }
 
-    public Map<String, String[]> getImplicitCollections() {
+    public String getImplicitCollections() {
         return implicitCollections;
     }
 
-    public void setImplicitCollections(Map<String, String[]> implicitCollections) {
+    public void setImplicitCollections(String implicitCollections) {
         this.implicitCollections = implicitCollections;
     }
 

--- a/platforms/spring-boot/components-starter/camel-yql-starter/src/main/java/org/apache/camel/component/yql/springboot/YqlComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-yql-starter/src/main/java/org/apache/camel/component/yql/springboot/YqlComponentConfiguration.java
@@ -18,9 +18,7 @@ package org.apache.camel.component.yql.springboot;
 
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.http.conn.HttpClientConnectionManager;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * The YQL (Yahoo! Query Language) platform enables you to query, filter, and
@@ -35,10 +33,10 @@ public class YqlComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom configured HttpClientConnectionManager.
+     * To use a custom configured HttpClientConnectionManager. The option is a
+     * org.apache.http.conn.HttpClientConnectionManager type.
      */
-    @NestedConfigurationProperty
-    private HttpClientConnectionManager connectionManager;
+    private String connectionManager;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -46,12 +44,11 @@ public class YqlComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public HttpClientConnectionManager getConnectionManager() {
+    public String getConnectionManager() {
         return connectionManager;
     }
 
-    public void setConnectionManager(
-            HttpClientConnectionManager connectionManager) {
+    public void setConnectionManager(String connectionManager) {
         this.connectionManager = connectionManager;
     }
 

--- a/platforms/spring-boot/components-starter/camel-zendesk-starter/src/main/java/org/apache/camel/component/zendesk/springboot/ZendeskComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-zendesk-starter/src/main/java/org/apache/camel/component/zendesk/springboot/ZendeskComponentConfiguration.java
@@ -19,8 +19,6 @@ package org.apache.camel.component.zendesk.springboot;
 import javax.annotation.Generated;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.zendesk.client.v2.Zendesk;
 
 /**
  * Allows producing messages to manage Zendesk ticket, user, organization, etc.
@@ -38,10 +36,10 @@ public class ZendeskComponentConfiguration
      */
     private ZendeskConfigurationNestedConfiguration configuration;
     /**
-     * To use a shared Zendesk instance.
+     * To use a shared Zendesk instance. The option is a
+     * org.zendesk.client.v2.Zendesk type.
      */
-    @NestedConfigurationProperty
-    private Zendesk zendesk;
+    private String zendesk;
     /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
@@ -58,11 +56,11 @@ public class ZendeskComponentConfiguration
         this.configuration = configuration;
     }
 
-    public Zendesk getZendesk() {
+    public String getZendesk() {
         return zendesk;
     }
 
-    public void setZendesk(Zendesk zendesk) {
+    public void setZendesk(String zendesk) {
         this.zendesk = zendesk;
     }
 

--- a/platforms/spring-boot/components-starter/camel-zookeeper-master-starter/src/main/java/org/apache/camel/component/zookeepermaster/springboot/MasterComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-zookeeper-master-starter/src/main/java/org/apache/camel/component/zookeepermaster/springboot/MasterComponentConfiguration.java
@@ -17,11 +17,8 @@
 package org.apache.camel.component.zookeepermaster.springboot;
 
 import javax.annotation.Generated;
-import org.apache.camel.component.zookeepermaster.ContainerIdFactory;
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
-import org.apache.curator.framework.CuratorFramework;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Represents an endpoint which only becomes active when it obtains the master
@@ -36,10 +33,10 @@ public class MasterComponentConfiguration
             ComponentConfigurationPropertiesCommon {
 
     /**
-     * To use a custom ContainerIdFactory for creating container ids.
+     * To use a custom ContainerIdFactory for creating container ids. The option
+     * is a org.apache.camel.component.zookeepermaster.ContainerIdFactory type.
      */
-    @NestedConfigurationProperty
-    private ContainerIdFactory containerIdFactory;
+    private String containerIdFactory;
     /**
      * The root path to use in zookeeper where information is stored which nodes
      * are master/slave etc. Will by default use:
@@ -48,10 +45,10 @@ public class MasterComponentConfiguration
     private String zkRoot = "/camel/zookeepermaster/clusters/master";
     /**
      * To use a custom configured CuratorFramework as connection to zookeeper
-     * ensemble.
+     * ensemble. The option is a org.apache.curator.framework.CuratorFramework
+     * type.
      */
-    @NestedConfigurationProperty
-    private CuratorFramework curator;
+    private String curator;
     /**
      * Timeout in millis to use when connecting to the zookeeper ensemble
      */
@@ -71,11 +68,11 @@ public class MasterComponentConfiguration
      */
     private Boolean resolvePropertyPlaceholders = true;
 
-    public ContainerIdFactory getContainerIdFactory() {
+    public String getContainerIdFactory() {
         return containerIdFactory;
     }
 
-    public void setContainerIdFactory(ContainerIdFactory containerIdFactory) {
+    public void setContainerIdFactory(String containerIdFactory) {
         this.containerIdFactory = containerIdFactory;
     }
 
@@ -87,11 +84,11 @@ public class MasterComponentConfiguration
         this.zkRoot = zkRoot;
     }
 
-    public CuratorFramework getCurator() {
+    public String getCurator() {
         return curator;
     }
 
-    public void setCurator(CuratorFramework curator) {
+    public void setCurator(String curator) {
         this.curator = curator;
     }
 


### PR DESCRIPTION
The camel maven plugin for spring boot auto configuration source code generation now generates complex types as String types so we can use them via spring boot and its tooling, eg they are listed in the spring-configuration-metadata.json file.

See ticket: https://issues.apache.org/jira/browse/CAMEL-12646