### PR TITLE
CAMEL-12650 Log messages that do not match with their method function

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/ConsumerCache.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ConsumerCache.java
@@ -177,7 +177,7 @@ public class ConsumerCache extends ServiceSupport {
                 throw new FailedToCreateConsumerException(endpoint, e);
             }
             if (pooled && answer instanceof ServicePoolAware) {
-                LOG.debug("Adding to producer service pool with key: {} for producer: {}", endpoint, answer);
+                LOG.debug("Adding to consumer service pool with key: {} for consumer: {}", endpoint, answer);
                 answer = pool.addAndAcquire(endpoint, answer);
             } else {
                 boolean singleton = false;

--- a/components/camel-atomix/src/main/java/org/apache/camel/component/atomix/client/value/AtomixValueConsumer.java
+++ b/components/camel-atomix/src/main/java/org/apache/camel/component/atomix/client/value/AtomixValueConsumer.java
@@ -56,7 +56,7 @@ final class AtomixValueConsumer extends AbstractAtomixClientConsumer<AtomixValue
             .join();
 
 
-        LOGGER.debug("Subscribe to events for queue: {}", resourceName);
+        LOGGER.debug("Subscribe to events for value: {}", resourceName);
         this.listeners.add(this.value.onChange(this::onEvent).join());
     }
 

--- a/components/camel-aws/src/main/java/org/apache/camel/component/aws/mq/MQProducer.java
+++ b/components/camel-aws/src/main/java/org/apache/camel/component/aws/mq/MQProducer.java
@@ -177,7 +177,7 @@ public class MQProducer extends DefaultProducer {
         try {
             result = mqClient.rebootBroker(request);
         } catch (AmazonServiceException ase) {
-            LOG.trace("Delete Broker command returned the error code {}", ase.getErrorCode());
+            LOG.trace("Reboot Broker command returned the error code {}", ase.getErrorCode());
             throw ase;
         }
         Message message = getMessageForResponse(exchange);

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanDropletsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanDropletsProducer.java
@@ -330,7 +330,7 @@ public class DigitalOceanDropletsProducer extends DigitalOceanProducer {
         }
 
         Action action = getEndpoint().getDigitalOceanClient().changeDropletKernel(dropletId, exchange.getIn().getHeader(DigitalOceanHeaders.KERNEL_ID, Integer.class));
-        LOG.trace("Rename Droplet {} : [{}] ", dropletId, action);
+        LOG.trace("Change Droplet {} : [{}] ", dropletId, action);
         exchange.getOut().setBody(action);
     }
 

--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/DockerProducer.java
@@ -1019,7 +1019,7 @@ public class DockerProducer extends DefaultProducer {
      */
     private StopContainerCmd executeStopContainerRequest(DockerClient client, Message message) {
 
-        LOGGER.debug("Executing Docker Kill Container Request");
+        LOGGER.debug("Executing Docker Stop Container Request");
 
         String containerId = DockerHelper.getProperty(DockerConstants.DOCKER_CONTAINER_ID, configuration, message, String.class);
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsEndpoint.java
@@ -197,7 +197,7 @@ public class FtpsEndpoint extends FtpEndpoint<FTPFile> {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Created FTPClient [connectTimeout: {}, soTimeout: {}, dataTimeout: {}, bufferSize: {}"
+            log.debug("Created FTPSClient [connectTimeout: {}, soTimeout: {}, dataTimeout: {}, bufferSize: {}"
                             + ", receiveDataSocketBufferSize: {}, sendDataSocketBufferSize: {}]: {}",
                     new Object[]{client.getConnectTimeout(), getSoTimeout(), dataTimeout, client.getBufferSize(),
                             client.getReceiveDataSocketBufferSize(), client.getSendDataSocketBufferSize(), client});

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/deployments/KubernetesDeploymentsProducer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/deployments/KubernetesDeploymentsProducer.java
@@ -149,11 +149,11 @@ public class KubernetesDeploymentsProducer extends DefaultProducer {
         DeploymentSpec deSpec = exchange.getIn().getHeader(KubernetesConstants.KUBERNETES_DEPLOYMENT_SPEC, DeploymentSpec.class);
         if (ObjectHelper.isEmpty(deploymentName)) {
             LOG.error("Create a specific Deployment require specify a Deployment name");
-            throw new IllegalArgumentException("Create a specific pod require specify a pod name");
+            throw new IllegalArgumentException("Create a specific Deployment require specify a pod name");
         }
         if (ObjectHelper.isEmpty(namespaceName)) {
-            LOG.error("Create a specific pod require specify a namespace name");
-            throw new IllegalArgumentException("Create a specific pod require specify a namespace name");
+            LOG.error("Create a specific Deployment require specify a namespace name");
+            throw new IllegalArgumentException("Create a specific Deployment require specify a namespace name");
         }
         if (ObjectHelper.isEmpty(deSpec)) {
             LOG.error("Create a specific Deployment require specify a Deployment spec bean");

--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/handlers/ClientChannelHandler.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/handlers/ClientChannelHandler.java
@@ -126,7 +126,7 @@ public class ClientChannelHandler extends SimpleChannelInboundHandler<Object> {
                 // and could not return a response. We should count down to stop waiting for a response
                 String address = configuration.getAddress();
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Channel closed but no message received from address: {}", address);
+                    LOG.debug("Channel is inactive but no message received from address: {}", address);
                 }
                 // don't fail the exchange if we actually specify to disconnect
                 if (!configuration.isDisconnect()) {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
@@ -352,7 +352,7 @@ public class RabbitMQProducer extends DefaultAsyncProducer {
         try {
             if (replyManager != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Stopping JmsReplyManager: {} from processing replies from: {}", replyManager,
+                    log.debug("Stopping RabbitMQReplyManager: {} from processing replies from: {}", replyManager,
                                     getEndpoint().getReplyTo() != null ? getEndpoint().getReplyTo() : "temporary queue");
                 }
                 ServiceHelper.stopService(replyManager);

--- a/components/camel-sip/src/main/java/org/apache/camel/component/sip/listener/SipPresenceAgentListener.java
+++ b/components/camel-sip/src/main/java/org/apache/camel/component/sip/listener/SipPresenceAgentListener.java
@@ -189,7 +189,7 @@ public class SipPresenceAgentListener implements SipListener, SipMessageCodes {
 
     public void processTimeout(javax.sip.TimeoutEvent timeoutEvent) {
         if (LOG.isWarnEnabled()) {
-            LOG.warn("TimeoutEvent received at Sip Subscription Listener");
+            LOG.warn("TimeoutEvent received at Sip Presence Agent Listener");
         }
     }
 

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/producer/WordpressUserProducer.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/producer/WordpressUserProducer.java
@@ -37,7 +37,7 @@ public class WordpressUserProducer extends AbstractWordpressProducer<User> {
     }
 
     protected User processUpdate(Exchange exchange) {
-        LOG.debug("Trying to update the post {} with id {}", exchange.getIn().getBody(), this.getConfiguration().getId());
+        LOG.debug("Trying to update the user {} with id {}", exchange.getIn().getBody(), this.getConfiguration().getId());
         return serviceUsers.update(getConfiguration().getId(), exchange.getIn().getBody(User.class));
     }
 

--- a/platforms/camel-catalog-nexus/src/main/java/org/apache/camel/catalog/nexus/ConnectorCatalogNexusRepository.java
+++ b/platforms/camel-catalog-nexus/src/main/java/org/apache/camel/catalog/nexus/ConnectorCatalogNexusRepository.java
@@ -125,7 +125,7 @@ public class ConnectorCatalogNexusRepository extends BaseNexusRepository {
                 addConnector(dto, name, scheme, javaType, description, csb.toString(), json[0], json[1], json[2]);
             }
         } catch (IOException e) {
-            logger.warn("Error scanning JAR for custom Camel components", e);
+            logger.warn("Error scanning JAR for custom Camel connectors", e);
         }
     }
 


### PR DESCRIPTION
The description of the issue:
https://issues.apache.org/jira/browse/CAMEL-12650

There are some possible copy and paste errors in the log messages (The logging statement was copied from an old place to a new place, but the message wasn't changed to adapt to the function of the new place. The issue report shows the pairs of original places where the logging statements might be copied from, and the new places that copied to) which may cause confusion when operators are reading the log messages.  I changed the logging messages to make them more adaptive