### PR TITLE
CAMEL-12666: Create push tag operation

### DIFF
--- a/components/camel-git/src/main/docs/git-component.adoc
+++ b/components/camel-git/src/main/docs/git-component.adoc
@@ -116,6 +116,8 @@ from("direct:start")
         .setHeader(GitConstants.GIT_COMMIT_MESSAGE, constant("first commit"))
         .to("git:///tmp/testRepo?operation=commit")
         .to("git:///tmp/testRepo?operation=push&remotePath=https://foo.com/test/test.git&username=xxx&password=xxx")
+        .to("git:///tmp/testRepo?operation=createTag&tagName=myTag")
+        .to("git:///tmp/testRepo?operation=pushTag&tagName=myTag&remoteName=origin")
 --------------------------------------------------------------------------------------------------------------------
 
 ### Consumer Example

--- a/components/camel-git/src/main/java/org/apache/camel/component/git/producer/GitOperation.java
+++ b/components/camel-git/src/main/java/org/apache/camel/component/git/producer/GitOperation.java
@@ -31,6 +31,7 @@ public interface GitOperation {
     String STATUS_OPERATION = "status";
     String LOG_OPERATION = "log";
     String PUSH_OPERATION = "push";
+    String PUSH_TAG_OPERATION = "pushTag";
     String PULL_OPERATION = "pull";
     String MERGE_OPERATION = "merge";
     String SHOW_BRANCHES_OPERATION = "showBranches";


### PR DESCRIPTION
Operation "createTag" must be able to work with mandatory parameters tagName and remoteName. Example section documentation was updated.