### PR TITLE
CAMEL-12649: camel-braintree - Upgraded Braintree Java SDK to 2.83.1 and exposed transaction level fees API

### DIFF
--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -226,6 +226,11 @@
                   <fromJavadoc/>
                 </api>
                 <api>
+                  <apiName>report</apiName>
+                  <proxyClass>com.braintreegateway.ReportGateway</proxyClass>
+                  <fromJavadoc/>
+                </api>
+                <api>
                   <apiName>settlementBatchSummary</apiName>
                   <proxyClass>com.braintreegateway.SettlementBatchSummaryGateway</proxyClass>
                   <fromJavadoc/>

--- a/components/camel-braintree/src/main/docs/braintree-component.adoc
+++ b/components/camel-braintree/src/main/docs/braintree-component.adoc
@@ -121,6 +121,7 @@ Endpoint prefix can be one of:
 * paymentmethod
 * paymentmethodNonce
 * plan
+* report
 * settlementBatchSummary
 * subscription
 * transaction
@@ -568,7 +569,32 @@ braintree://plan/endpoint
 |all |  |  |List<com.braintreegateway.Plan>
 |====================================================
 
- 
+
+#### Endpoint prefix _report_
+
+The following endpoints can be invoked with the prefix *report* as
+follows:
+
+[source,java]
+---------------------------------
+braintree://plan/report?[options]
+---------------------------------
+
+[cols="<,<,<,<",options="header",]
+|==============================================================================================================
+|Endpoint |Shorthand Alias |Options |Result Body Type
+|transactionLevelFees |  | request |com.braintreegateway.Result<com.braintreegateway.TransactionLevelFeeReport>
+|==============================================================================================================
+
+[[Braintree-URIOptionsfortreport]]
+URI Options for _report_
+
+[cols="<,<",options="header",]
+|==============================================================
+|Name |Type
+|request |com.braintreegateway.TransactionLevelFeeReportRequest
+|==============================================================
+
 
 #### Endpoint prefix _settlementBatchSummary_
 

--- a/components/camel-braintree/src/test/java/org/apache/camel/component/braintree/ReportGatewayIntegrationTest.java
+++ b/components/camel-braintree/src/test/java/org/apache/camel/component/braintree/ReportGatewayIntegrationTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.braintree;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
+
+import com.braintreegateway.TransactionLevelFeeReport;
+import com.braintreegateway.TransactionLevelFeeReportRequest;
+import com.braintreegateway.TransactionLevelFeeReportRow;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.braintree.internal.BraintreeApiCollection;
+import org.apache.camel.component.braintree.internal.ReportGatewayApiMethod;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test class for {@link com.braintreegateway.ReportGateway} APIs.
+ */
+public class ReportGatewayIntegrationTest extends AbstractBraintreeTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReportGatewayIntegrationTest.class);
+    private static final String PATH_PREFIX = BraintreeApiCollection.getCollection().getApiName(ReportGatewayApiMethod.class).getName();
+
+    @Test
+    public void testTransactionLevelFees() throws Exception {
+        String merchantAccountId = System.getenv("CAMEL_BRAINTREE_MERCHANT_ACCOUNT_ID");
+        String reportDateString = System.getenv("CAMEL_BRAINTREE_REPORT_DATE");
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar reportDate = Calendar.getInstance();
+        reportDate.setTime(sdf.parse(reportDateString));
+
+        TransactionLevelFeeReportRequest request = new TransactionLevelFeeReportRequest()
+                .date(reportDate)
+                .merchantAccountId(merchantAccountId);
+
+        final com.braintreegateway.Result<TransactionLevelFeeReport> result = requestBody(
+                "direct://TRANSACTIONLEVELFEES",
+                request
+        );
+
+        assertNotNull("transactionLevelFees result", result);
+        assertTrue("transactionLevelFees success", result.isSuccess());
+        List<TransactionLevelFeeReportRow> rows = result.getTarget().getRows();
+        assertTrue("transactionLevelFeeRows found", rows.size() > 0);
+
+        LOG.debug("transactionLevelFees: " + result);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                // test route for transactionLevelFees
+                from("direct://TRANSACTIONLEVELFEES")
+                    .to("braintree://" + PATH_PREFIX + "/transactionLevelFees?inBody=request");
+
+            }
+        };
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,7 +98,7 @@
     <bouncycastle-version>1.57</bouncycastle-version>
     <boxjavalibv2.version>3.2.1</boxjavalibv2.version>
     <box-java-sdk-version>2.10.0</box-java-sdk-version>
-    <braintree-gateway-version>2.81.0</braintree-gateway-version>
+    <braintree-gateway-version>2.83.1</braintree-gateway-version>
     <brave-zipkin-version>5.1.2</brave-zipkin-version>
     <build-helper-maven-plugin-version>1.10</build-helper-maven-plugin-version>
     <c3p0-version>0.9.5.2</c3p0-version>


### PR DESCRIPTION
Upgraded Braintree Java SDK to 2.83.1 and exposed transaction level fees API