### PR TITLE
CAMEL-12685: fix xslt nested relative refs

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/xml/XsltUriResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/xml/XsltUriResolver.java
@@ -91,7 +91,7 @@ public class XsltUriResolver implements URIResolver {
             } catch (IOException e) {
                 throw new TransformerException(e);
             }
-            return new StreamSource(is);
+            return new StreamSource(is, href);
         }
 
         // if href and location is the same, then its the initial resolve
@@ -100,8 +100,8 @@ public class XsltUriResolver implements URIResolver {
             return resolve(path, base);
         }
 
-        // okay then its relative to the starting location from the XSLT component
-        String path = FileUtil.onlyPath(location);
+        // okay then its relative to the starting location from the XSLT importing this one
+        String path = FileUtil.onlyPath(base);
         if (ObjectHelper.isEmpty(path)) {
             path = baseScheme + href;
             return resolve(path, base);

--- a/camel-core/src/main/java/org/apache/camel/component/xslt/XsltEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/component/xslt/XsltEndpoint.java
@@ -416,7 +416,6 @@ public class XsltEndpoint extends ProcessorEndpoint {
         if (source == null) {
             throw new IOException("Cannot load schema resource " + resourceUri);
         } else {
-            source.setSystemId(resourceUri);
             xslt.setTransformerSource(source);
         }
         // now loaded so clear flag

--- a/camel-core/src/test/java/org/apache/camel/component/xslt/XsltIncludeRelativeNestedTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/xslt/XsltIncludeRelativeNestedTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.xslt;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+
+/**
+ *
+ */
+public class XsltIncludeRelativeNestedTest extends ContextTestSupport {
+
+    public void testXsltIncludeRelativeNested() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("file:src/test/data/?fileName=staff.xml&noop=true&initialDelay=0&delay=10")
+                    .to("xslt:org/apache/camel/component/xslt/staff_include_relative_nested.xsl")
+                    .to("log:foo")
+                    .to("mock:result");
+            }
+        };
+    }
+}

--- a/camel-core/src/test/resources/org/apache/camel/component/xslt/included/staff_included_nested_level_1.xsl
+++ b/camel-core/src/test/resources/org/apache/camel/component/xslt/included/staff_included_nested_level_1.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:include href="../staff_included_nested_level_2.xsl" />
+
+    <xsl:template match="staff/programmer">
+        <html>
+            <body>
+                <xsl:apply-templates select="age"/>
+                <br/>
+            </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="age">
+        AGE:
+        <span style="color:yellow;">
+            <xsl:value-of select="."/>
+        </span>
+        <br/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/camel-core/src/test/resources/org/apache/camel/component/xslt/staff_include_relative_nested.xsl
+++ b/camel-core/src/test/resources/org/apache/camel/component/xslt/staff_include_relative_nested.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:include href="included/staff_included_nested_level_1.xsl"/>
+
+    <xsl:template match="staff/programmer" priority="2">
+        <html>
+            <body>
+                <xsl:apply-templates select="age"/>
+                <br/>
+            </body>
+        </html>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/camel-core/src/test/resources/org/apache/camel/component/xslt/staff_included_nested_level_2.xsl
+++ b/camel-core/src/test/resources/org/apache/camel/component/xslt/staff_included_nested_level_2.xsl
@@ -1,0 +1,26 @@
+<?xml version = "1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="hello">
+    <goodbye/>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
If an XSLT A includes XSLT B which includes XSLT C using relative references, XSLT C is resolved relative to A instead of B.
An example is added in unit test XsltIncludeRelativeNestedTest.

This PR changes this behavior to the expected one, i.e. resolve relative references based on the location of the direct parent XSLT. 

