### PR TITLE
CAMEL-12656: Fixed root span id for multiple routes.

### DIFF
--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinTracer.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinTracer.java
@@ -757,24 +757,16 @@ public class ZipkinTracer extends ServiceSupport implements RoutePolicyFactory, 
                     serverRequest(brave, serviceName, exchange);
                 }
             }
+        }
 
-            // add on completion after the route is done, but before the consumer writes the response
-            // this allows us to track the zipkin event before returning the response which is the right time
-            exchange.addOnCompletion(new SynchronizationAdapter() {
-                @Override
-                public void onAfterRoute(Route route, Exchange exchange) {
-                    String serviceName = getServiceName(exchange, route.getEndpoint(), true, false);
-                    Brave brave = getBrave(serviceName);
-                    if (brave != null) {
-                        serverResponse(brave, serviceName, exchange);
-                    }
-                }
-
-                @Override
-                public String toString() {
-                    return "ZipkinTracerOnCompletion[" + routeId + "]";
-                }
-            });
+        // Report Server send after route has completed processing of the exchange.
+        @Override
+        public void onExchangeDone(Route route, Exchange exchange) {
+            String serviceName = getServiceName(exchange, route.getEndpoint(), true, false);
+            Brave brave = getBrave(serviceName);
+            if (brave != null) {
+                serverResponse(brave, serviceName, exchange);
+            }
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12656
I have added screenshots in Jira already.
Camel-Zipkin does not report traces with root span id when there are multiple routes. 

For example: 
```
from("direct:foo")
        .delay(1000)
        .to("direct:bar")
        .to("direct:moo")
        .to("direct:tar");

from("direct:bar")
        .delay(2000);

from("direct:moo")
        .delay(1000);

from("direct:tar")
        .delay(3000);
```

Root SpanId(TraceId) should be for service-name = direct:foo and the trace in UI should show all the 4 routes in one sequence. But it breaks. Check the attached screenshot: Traces Breaking.png

I looked into the code and figured out why its happening. Here is the code which is breaking the functionality.

Class Name: ZipkinTracer.ZipkinRoutePolicy
Inside onExchangeBegin() method 

 

```
// add on completion after the route is done, but before the consumer writes the response
// this allows us to track the zipkin event before returning the response which is the right time
exchange.addOnCompletion(new SynchronizationAdapter() {
    @Override
    public void onAfterRoute(Route route, Exchange exchange) {
        String serviceName = getServiceName(exchange, route.getEndpoint(), true, false);
        Brave brave = getBrave(serviceName);
        if (brave != null) {
            serverResponse(brave, serviceName, exchange);
        }
    }

    @Override
    public String toString() {
        return "ZipkinTracerOnCompletion[" + routeId + "]";
    }
});
```
 


Using onAfterRoute() :  if the exchange is being routed through multiple routes, there will be callbacks for each route.

I have fix for it: 
If I use onExchangeDone() instead of above code. The traces are reported properly.  Check screenshots.

https://zipkin.io/pages/instrumenting.html

Note This process must be repeated if the service makes multiple downstream calls. That is each subsequent span will have the same trace id and parent id, but a new and different span id.