### PR TITLE
CAMEL-12713 - XsltUriResolver fix: relative imports can ignore URI scheme 

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/xml/XsltUriResolver.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/xml/XsltUriResolver.java
@@ -27,6 +27,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.ResourceHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,14 +75,16 @@ public class XsltUriResolver implements URIResolver {
         LOG.trace("Resolving URI with href: {} and base: {}", href, base);
 
         String scheme = ResourceHelper.getScheme(href);
+
         if (scheme != null) {
             // need to compact paths for file/classpath as it can be relative paths using .. to go backwards
+            String hrefPath = StringHelper.after(href, scheme);
             if ("file:".equals(scheme)) {
                 // compact path use file OS separator
-                href = FileUtil.compactPath(href);
+                href = scheme + FileUtil.compactPath(hrefPath);
             } else if ("classpath:".equals(scheme)) {
                 // for classpath always use /
-                href = FileUtil.compactPath(href, '/');
+                href = scheme + FileUtil.compactPath(hrefPath, '/');
             }
             LOG.debug("Resolving URI from {}: {}", scheme, href);
 

--- a/camel-core/src/test/java/org/apache/camel/builder/xml/XsltUriResolverTest.java
+++ b/camel-core/src/test/java/org/apache/camel/builder/xml/XsltUriResolverTest.java
@@ -1,0 +1,18 @@
+package org.apache.camel.builder.xml;
+
+import junit.framework.TestCase;
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+
+import javax.xml.transform.Source;
+
+public class XsltUriResolverTest extends TestCase {
+
+    public void testResolveUri() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        XsltUriResolver xsltUriResolver = new XsltUriResolver(context, "classpath:xslt/staff/staff.xsl");
+        Source source = xsltUriResolver.resolve("../../xslt/common/staff_template.xsl", "classpath:xslt/staff/staff.xsl");
+        assertNotNull(source);
+        assertEquals("classpath:xslt/common/staff_template.xsl", source.getSystemId());
+    }
+}


### PR DESCRIPTION
fix for CAMEL-12713

FileUtil.compactPath() is used to calculate the relative URI, but this call ignores the colon separator and considers "classpath:directory" as a single path part. 

This patch passes the URI without its scheme to FileUtil.compactPath() and attaches it again to the result. 