### PR TITLE
CAMEL-12714 - support handlers in cxf payload mode without SEI

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfSpringEndpoint.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfSpringEndpoint.java
@@ -47,23 +47,6 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
     public CxfSpringEndpoint() {
     }
 
-    /**
-     * 
-     * A help to get the service class.  The serviceClass classname in URI 
-     * query takes precedence over the serviceClass in CxfEndpointBean.
-     */
-    private Class<?> getSEIClass() throws ClassNotFoundException {
-        
-        // get service class
-        Class<?> answer = null;
-        if (getServiceClass() != null) {
-            // classname is specified in URI which overrides the bean properties
-            answer = getServiceClass();
-        }
-        return answer;
-    }
-    
-
     // Package private methods
     // -------------------------------------------------------------------------
 
@@ -74,7 +57,7 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
     Client createClient() throws Exception {
         
         // get service class
-        Class<?> cls = getSEIClass();    
+        Class<?> cls = getServiceClass();    
         
         if (getDataFormat().equals(DataFormat.POJO)) { 
             ObjectHelper.notNull(cls, CxfConstants.SERVICE_CLASS);
@@ -88,61 +71,44 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
             if (getDataFormat().equals(DataFormat.PAYLOAD)) { 
                 setSkipPayloadMessagePartCheck(true);
             }
-            cls = getSEIClass();
+            cls = getServiceClass();
         }
         
+        ClientFactoryBean factoryBean;
         if (cls != null) {
             // create client factory bean
-            ClientFactoryBean factoryBean = createClientFactoryBean(cls);
-
-            // setup client factory bean
-            setupClientFactoryBean(factoryBean, cls);
-
-            // fill in values that have not been filled.
-            QName serviceQName = null;
-            try {
-                serviceQName = factoryBean.getServiceName();
-            } catch (IllegalStateException e) {
-                // It throws IllegalStateException if serviceName has not been set.
-            }
-
-            if (serviceQName == null && getServiceLocalName() != null) {
-                factoryBean.setServiceName(new QName(getServiceNamespace(), getServiceLocalName()));
-            }
-            if (factoryBean.getEndpointName() == null && getEndpointLocalName() != null) {
-                factoryBean.setEndpointName(new QName(getEndpointNamespace(), getEndpointLocalName()));
-            }
-
-            Client client = factoryBean.create();
-            // setup the handlers
-            setupHandlers(factoryBean, client);
-            return client;
+            factoryBean = createClientFactoryBean(cls);
         } else {
-            
-            ClientFactoryBean factoryBean = createClientFactoryBean();
+            factoryBean = createClientFactoryBean();
+        }
 
-            // setup client factory bean
-            setupClientFactoryBean(factoryBean, null);
-            
-            // fill in values that have not been filled.
-            QName serviceQName = null;
-            try {
-                serviceQName = factoryBean.getServiceName();
-            } catch (IllegalStateException e) {
-                // It throws IllegalStateException if serviceName has not been set.
-            }
-            
-            if (serviceQName == null && getServiceLocalName() != null) {
-                factoryBean.setServiceName(new QName(getServiceNamespace(), getServiceLocalName()));
-            }
-            if (factoryBean.getEndpointName() == null && getEndpointLocalName() != null) {
-                factoryBean.setEndpointName(new QName(getEndpointNamespace(), getEndpointLocalName()));
-            }
-            
+        // setup client factory bean
+        setupClientFactoryBean(factoryBean, cls);
+
+        // fill in values that have not been filled.
+        QName serviceQName = null;
+        try {
+            serviceQName = factoryBean.getServiceName();
+        } catch (IllegalStateException e) {
+            // It throws IllegalStateException if serviceName has not been set.
+        }
+
+        if (serviceQName == null && getServiceLocalName() != null) {
+            factoryBean.setServiceName(new QName(getServiceNamespace(), getServiceLocalName()));
+        }
+        if (factoryBean.getEndpointName() == null && getEndpointLocalName() != null) {
+            factoryBean.setEndpointName(new QName(getEndpointNamespace(), getEndpointLocalName()));
+        }
+        
+        if (cls == null) {
             checkName(factoryBean.getEndpointName(), "endpoint/port name");
             checkName(factoryBean.getServiceName(), "service name");
-            return factoryBean.create();
         }
+
+        Client client = factoryBean.create();
+        // setup the handlers
+        setupHandlers(factoryBean, client);
+        return client;
     }
 
 
@@ -153,7 +119,7 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
     ServerFactoryBean createServerFactoryBean() throws Exception  {
         
         // get service class
-        Class<?> cls = getSEIClass();                
+        Class<?> cls = getServiceClass();                
         
         if (getWsdlURL() == null && cls == null) {
             // no WSDL and serviceClass specified, set our default serviceClass
@@ -170,11 +136,7 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
 
         if (cls == null) {
             if (!getDataFormat().equals(DataFormat.POJO)) {
-                answer = new JaxWsServerFactoryBean(new WSDLServiceFactoryBean()) {
-                    {
-                        doInit = false;
-                    }
-                };
+                answer = new JaxWsServerFactoryBean(new WSDLServiceFactoryBean());
                 cls = Provider.class;
             } else {
                 ObjectHelper.notNull(cls, CxfConstants.SERVICE_CLASS);

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/WSDLServiceFactoryBean.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/WSDLServiceFactoryBean.java
@@ -26,8 +26,8 @@ import javax.xml.ws.Provider;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.endpoint.EndpointException;
-import org.apache.cxf.endpoint.EndpointImpl;
 import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.jaxws.support.JaxWsEndpointImpl;
 import org.apache.cxf.jaxws.support.JaxWsServiceFactoryBean;
 import org.apache.cxf.service.factory.FactoryBeanListener.Event;
 import org.apache.cxf.service.invoker.Invoker;
@@ -102,7 +102,7 @@ public class WSDLServiceFactoryBean extends JaxWsServiceFactoryBean {
         super.buildServiceFromWSDL(url);
     }
     public Endpoint createEndpoint(EndpointInfo ei) throws EndpointException {
-        Endpoint ep = new EndpointImpl(getBus(), getService(), ei);
+        Endpoint ep = new JaxWsEndpointImpl(getBus(), getService(), ei);
         sendEvent(Event.ENDPOINT_CREATED, ei, ep, getServiceClass());
         return ep;
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEITest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEITest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cxf;
+
+import javax.xml.ws.Endpoint;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
+import org.apache.camel.wsdl_first.PersonImpl;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class CxfPayloadWsdlWithoutSEITest extends AbstractCxfWsdlFirstTest {
+
+    @BeforeClass
+    public static void startService() {
+        Object implementor = new PersonImpl();
+        String address = "http://localhost:" + getPort1() + "/CxfPayloadWsdlWithoutSEITest/PersonService/";
+        Endpoint.publish(address, implementor);
+    }
+
+    @Override
+    protected ClassPathXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEI.xml");
+    }
+
+    @Test
+    @Override
+    public void testInvokingServiceWithCamelProducer() {
+        Exchange exchange = sendJaxWsMessage("hello");
+        assertEquals("The request should be handled sucessfully ", exchange.isFailed(), false);
+        org.apache.camel.Message out = exchange.getOut();
+        String result =  out.getBody(String.class);
+        assertStringContains(result, "Bonjour");
+
+        exchange = sendJaxWsMessage("");
+        assertEquals("We should get a fault here", exchange.isFailed(), true);
+        Throwable ex = exchange.getException();
+        assertTrue("We should get a SoapFault here", ex instanceof SoapFault);
+    }
+
+    private Exchange sendJaxWsMessage(final String personIdString) {
+        Exchange exchange = template.send("direct:producer", new Processor() {
+            public void process(final Exchange exchange) {
+                String body = "<GetPerson xmlns=\"http://camel.apache.org/wsdl-first/types\"><personId>" + personIdString + "</personId></GetPerson>\n";
+                exchange.getIn().setBody(body);
+                exchange.getIn().setHeader(CxfConstants.OPERATION_NAME, "GetPerson");
+            }
+        });
+        return exchange;
+    }
+
+}

--- a/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEI.xml
+++ b/components/camel-cxf/src/test/resources/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEI.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
+	distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under 
+	the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
+	obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+	in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+	ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+	the License. -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xmlns:cxf="http://camel.apache.org/schema/cxf"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd       http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd              http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd     ">
+    
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+    
+    <cxf:cxfEndpoint
+        address="http://localhost:${CXFTestSupport.port2}/CxfPayloadWsdlWithoutSEITest/PersonService/"
+        endpointName="person:soap" id="routerEndpoint"
+        serviceName="person:PersonService"
+        wsdlURL="classpath:person.wsdl" xmlns:person="http://camel.apache.org/wsdl-first">
+        <cxf:properties>
+            <entry key="schema-validation-enabled" value="true"/>
+        </cxf:properties>
+        <cxf:handlers>
+            <ref bean="fromEndpointJaxwsHandler"/>
+        </cxf:handlers>
+    </cxf:cxfEndpoint>
+    
+    <cxf:cxfEndpoint
+        address="http://localhost:${CXFTestSupport.port1}/CxfPayloadWsdlWithoutSEITest/PersonService/"
+        endpointName="person:soap" id="serviceEndpoint"
+        serviceName="person:PersonService" xmlns:person="http://camel.apache.org/wsdl-first"
+        wsdlURL="classpath:person.wsdl">
+        <cxf:handlers>
+            <ref bean="toEndpointJaxwsHandler"/>
+        </cxf:handlers>
+    </cxf:cxfEndpoint>
+    
+    <bean class="org.apache.camel.builder.NoErrorHandlerBuilder" id="noErrorHandler"/>
+    
+    <bean class="org.apache.camel.wsdl_first.JaxwsTestHandler" id="fromEndpointJaxwsHandler"/>
+    <bean class="org.apache.camel.wsdl_first.JaxwsTestHandler" id="toEndpointJaxwsHandler"/>
+    
+    <camelContext errorHandlerRef="noErrorHandler" id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="cxf:bean:routerEndpoint?dataFormat=PAYLOAD"/>
+            <to uri="cxf:bean:serviceEndpoint?dataFormat=PAYLOAD"/>
+        </route>
+        <route>
+            <from uri="direct:producer"/>
+            <to uri="cxf:bean:serviceEndpoint?dataFormat=PAYLOAD"/>
+        </route>
+    </camelContext>
+    
+</beans>


### PR DESCRIPTION
Support JAX-WS handlers for cxf endpoint in payload mode with a WSDL specified and without service class by using a JaxWsEndpointImpl instead of EndpointImpl and removing some checks that avoid the handlers being set.

I removed the CxfSpringEndpoint.getSEIClass() method as it did the same as getServiceClass().