### PR TITLE
Fix some log messages that do not match with their method function

### DIFF
--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/AsyncDockerProducer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/producer/AsyncDockerProducer.java
@@ -487,7 +487,7 @@ public class AsyncDockerProducer extends DefaultAsyncProducer {
      */
     private ExecStartCmd executeExecStartRequest(DockerClient client, Message message) {
 
-        LOGGER.debug("Executing Docker Exec Create Request");
+        LOGGER.debug("Executing Docker Exec Start Request");
 
         String execId = DockerHelper.getProperty(DockerConstants.DOCKER_EXEC_ID, configuration, message, String.class);
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
@@ -113,7 +113,7 @@ public abstract class RemoteFileConsumer<T> extends GenericFileConsumer<T> {
             exchange.addOnCompletion(new SynchronizationAdapter() {
                 @Override
                 public void onDone(Exchange exchange) {
-                    log.trace("postPollCheck disconnect from: {}", getEndpoint());
+                    log.trace("processExchange disconnect from: {}", getEndpoint());
                     disconnect();
                 }
 


### PR DESCRIPTION
An extension to this pull request:
https://github.com/apache/camel/pull/2426

There are some possible copy and paste errors in the log messages (The logging statement was copied from an old place to a new place, but the message wasn't changed to adapt to the function of the new place). I found two more instances which are suffering from this problem and changed the logging messages to make them more adaptive to record the actual behavior.