### PR TITLE
CAMEL-12726: Fix FindBugs warnings: Invocation of toString on an array

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRemoveHeaders.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRemoveHeaders.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.management.mbean;
 
+import java.util.Arrays;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.api.management.mbean.ManagedRemoveHeadersMBean;
@@ -34,7 +36,7 @@ public class ManagedRemoveHeaders extends ManagedProcessor implements ManagedRem
         super(context, processor, definition);
         this.processor = processor;
         if (processor.getExcludePattern() != null) {
-            exclude = processor.getExcludePattern().toString();
+            exclude = Arrays.toString(processor.getExcludePattern());
         } else {
             exclude = null;
         }

--- a/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRemoveProperties.java
+++ b/camel-core/src/main/java/org/apache/camel/management/mbean/ManagedRemoveProperties.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.management.mbean;
 
+import java.util.Arrays;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.api.management.mbean.ManagedRemovePropertiesMBean;
@@ -34,7 +36,7 @@ public class ManagedRemoveProperties extends ManagedProcessor implements Managed
         super(context, processor, definition);
         this.processor = processor;
         if (processor.getExcludePattern() != null) {
-            exclude = processor.getExcludePattern().toString();
+            exclude = Arrays.toString(processor.getExcludePattern());
         } else {
             exclude = null;
         }

--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxFoldersManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxFoldersManager.java
@@ -201,7 +201,7 @@ public class BoxFoldersManager {
      */
     public BoxFolder createFolder(String parentFolderId, String... path) {
         try {
-            LOG.debug("Creating folder with path '" + path + "' in parent_folder(id=" + parentFolderId + ")");
+            LOG.debug("Creating folder with path '" + Arrays.toString(path) + "' in parent_folder(id=" + parentFolderId + ")");
             if (parentFolderId == null) {
                 throw new IllegalArgumentException("Parameter 'parentFolderId' can not be null");
             }

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -259,7 +260,7 @@ public class ScpOperations implements RemoteFileOperations<ScpFile> {
                 try {
                     jsch.addIdentity("camel-jsch", data, null, pkfp != null ? pkfp.getBytes() : null);
                 } catch (Exception e) {
-                    throw new GenericFileOperationFailedException("Cannot load private key bytes: " + config.getPrivateKeyBytes(), e);
+                    throw new GenericFileOperationFailedException("Cannot load private key bytes: " + Arrays.toString(config.getPrivateKeyBytes()), e);
                 }                
             }
 


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported 4 DMI_INVOKING_TOSTRING_ON_ARRAY warnings on master:
```
H C USELESS_STRING: Invocation of toString on org.apache.camel.processor.RemoveHeadersProcessor.getExcludePattern() in new org.apache.camel.management.mbean.ManagedRemoveHeaders(CamelContext, RemoveHeadersProcessor, ProcessorDefinition)  At ManagedRemoveHeaders.java:[line 37]
H C USELESS_STRING: Invocation of toString on org.apache.camel.processor.RemovePropertiesProcessor.getExcludePattern() in new org.apache.camel.management.mbean.ManagedRemoveProperties(CamelContext, RemovePropertiesProcessor, ProcessorDefinition)  At ManagedRemoveProperties.java:[line 37]
M C USELESS_STRING: Invocation of toString on ScpConfiguration.getPrivateKeyBytes() in org.apache.camel.component.scp.ScpOperations.createSession(ScpConfiguration)  At ScpOperations.java:[line 262]
M C USELESS_STRING: Invocation of toString on path in org.apache.camel.component.box.api.BoxFoldersManager.createFolder(String, String[])  At BoxFoldersManager.java:[line 204]
```
The description of the bug is as follows:
> USELESS_STRING: Invocation of toString on an array (DMI_INVOKING_TOSTRING_ON_ARRAY)
>  The code invokes toString on an array, which will generate a fairly useless result such as [C@16f0472. Consider using Arrays.toString to convert the array into a readable String that gives the contents of the array. See Programming Puzzlers, chapter 3, puzzle 12.
 [http://findbugs.sourceforge.net/bugDescriptions.html#DMI_INVOKING_TOSTRING_ON_ARRAY](http://findbugs.sourceforge.net/bugDescriptions.html#DMI_INVOKING_TOSTRING_ON_ARRAY)