### PR TITLE
CAMEL-12587: camel-zipkin-starter fails mapping service names

### DIFF
--- a/examples/camel-example-zipkin/service1/src/main/resources/application.properties
+++ b/examples/camel-example-zipkin/service1/src/main/resources/application.properties
@@ -23,8 +23,8 @@ camel.springboot.main-run-controller=true
 camel.zipkin.endpoint=http://localhost:9411/api/v2/spans
 
 # the zipkin service name
-camel.zipkin.server-service-mappings.*=service1
-camel.zipkin.client-service-mappings.*=service2
+camel.zipkin.server-service-mappings.[*]=service1
+camel.zipkin.client-service-mappings.[*]=service2
 
 # include message bodies in the traces (not recommended for production)
 camel.zipkin.include-message-body-streams=true


### PR DESCRIPTION
I also encountered the same issue while running the camel-zipkin example quickstart. Made changes as per this issue, https://github.com/spring-projects/spring-boot/issues/13506 we can see the quickstart working as expected. 