### PR TITLE
CAMEL-12730: Fix FindBugs warnings: Suspicious reference comparison

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/processor/Throttler.java
+++ b/camel-core/src/main/java/org/apache/camel/processor/Throttler.java
@@ -309,7 +309,7 @@ public class Throttler extends DelegateAsyncProcessor implements Traceable, IdAw
             }
 
             if (newThrottle != null) {
-                if (newThrottle != throttleRate) {
+                if (!newThrottle.equals(throttleRate)) {
                     // get the queue from the cache
                     // decrease
                     if (throttleRate > newThrottle) {
@@ -357,7 +357,7 @@ public class Throttler extends DelegateAsyncProcessor implements Traceable, IdAw
             }
 
             if (newThrottle != null) {
-                if (newThrottle != throttleRatesMap.get(key)) {
+                if (!newThrottle.equals(throttleRatesMap.get(key))) {
                     // get the queue from the cache
                     // decrease
                     if (throttleRatesMap.get(key) > newThrottle) {


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported 2 RC_REF_COMPARISON warnings on master:
```
H C RC: Suspicious comparison of Integer references in org.apache.camel.processor.Throttler.calculateAndSetMaxRequestsPerPeriod(Exchange)  At Throttler.java:[line 312]
H C RC: Suspicious comparison of Integer references in org.apache.camel.processor.Throttler.calculateAndSetMaxRequestsPerPeriod(DelayQueue, Exchange, Integer)  At Throttler.java:[line 360]
```
The description of the bug is as follows:
> **RC: Suspicious reference comparison (RC_REF_COMPARISON)**
> This method compares two reference values using the == or != operator, where the correct way to compare instances of this type is generally with the equals() method. It is possible to create distinct instances that are equal but do not compare as == since they are different objects. Examples of classes which should generally not be compared by reference are java.lang.Integer, java.lang.Float, etc.
> [http://findbugs.sourceforge.net/bugDescriptions.html#RC_REF_COMPARISON](http://findbugs.sourceforge.net/bugDescriptions.html#RC_REF_COMPARISON)