### PR TITLE
CAMEL-12731: Fix FindBugs warnings: Array formatted in useless way us…

### DIFF
--- a/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/operations/FutureEventDrivenOperation.java
+++ b/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/operations/FutureEventDrivenOperation.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.zookeeper.operations;
 
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +70,7 @@ public abstract class FutureEventDrivenOperation<ResultType> extends ZooKeeperOp
             if (b.length() > 0) {
                 b.setLength(b.length() - 2);
             }
-            LOG.trace(String.format("Recieved event of type %s did not match any watched types %s", received, awaitedTypes));
+            LOG.trace(String.format("Recieved event of type %s did not match any watched types %s", received, Arrays.toString(awaitedTypes)));
         }
     }
 


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported a VA_FORMAT_STRING_BAD_CONVERSION_FROM_ARRAY warning on master:
```
H C USELESS_STRING: Argument of type org.apache.zookeeper.Watcher$Event$EventType[] formatted in useless way in org.apache.camel.component.zookeeper.operations.FutureEventDrivenOperation.process(WatchedEvent)  At FutureEventDrivenOperation.java:[line 72]
```
The description of the bug is as follows:
> **USELESS_STRING: Array formatted in useless way using format string (VA_FORMAT_STRING_BAD_CONVERSION_FROM_ARRAY)**
> One of the arguments being formatted with a format string is an array. This will be formatted using a fairly useless format, such as [I@304282, which doesn't actually show the contents of the array. Consider wrapping the array using Arrays.asList(...)before handling it off to a formatted.
> [http://findbugs.sourceforge.net/bugDescriptions.html#VA_FORMAT_STRING_BAD_CONVERSION_FROM_ARRAY](http://findbugs.sourceforge.net/bugDescriptions.html#VA_FORMAT_STRING_BAD_CONVERSION_FROM_ARRAY)