### PR TITLE
 CAMEL-12723 - camel-ftp add IPv6 support

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -549,7 +549,7 @@ public final class URISupport {
             path = path.substring(0, idx);
         }
 
-        if (u.getScheme().startsWith("http") || u.getScheme().startsWith("ftp")) {
+        if (u.getScheme().startsWith("http") || u.getScheme().contains("ftp")) {
             path = UnsafeUriCharactersEncoder.encodeHttpURI(path);
         } else {
             path = UnsafeUriCharactersEncoder.encode(path);

--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -549,7 +549,11 @@ public final class URISupport {
             path = path.substring(0, idx);
         }
 
-        path = UnsafeUriCharactersEncoder.encodeHttpURI(path);
+        if (u.getScheme().startsWith("http") || u.getScheme().startsWith("ftp")) {
+            path = UnsafeUriCharactersEncoder.encodeHttpURI(path);
+        } else {
+            path = UnsafeUriCharactersEncoder.encode(path);
+        }
 
         // okay if we have user info in the path and they use @ in username or password,
         // then we need to encode them (but leave the last @ sign before the hostname)

--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -549,11 +549,7 @@ public final class URISupport {
             path = path.substring(0, idx);
         }
 
-        if (u.getScheme().startsWith("http")) {
-            path = UnsafeUriCharactersEncoder.encodeHttpURI(path);
-        } else {
-            path = UnsafeUriCharactersEncoder.encode(path);
-        }
+        path = UnsafeUriCharactersEncoder.encodeHttpURI(path);
 
         // okay if we have user info in the path and they use @ in username or password,
         // then we need to encode them (but leave the last @ sign before the hostname)

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpComponent.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpComponent.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.util.IntrospectionSupport;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.apache.commons.net.ftp.FTPFile;
 
 /**
@@ -36,6 +37,11 @@ public class FtpComponent extends RemoteFileComponent<FTPFile> {
     public FtpComponent(CamelContext context) {
         super(context);
         setEndpointClass(FtpEndpoint.class);
+    }
+    
+    @Override
+    protected String preProcessUri(String uri) {
+        return UnsafeUriCharactersEncoder.encodeHttpURI(uri);
     }
 
     @Override

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsComponent.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsComponent.java
@@ -24,6 +24,7 @@ import org.apache.camel.SSLContextParametersAware;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.util.IntrospectionSupport;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.apache.commons.net.ftp.FTPFile;
 
 /**
@@ -45,6 +46,11 @@ public class FtpsComponent extends FtpComponent implements SSLContextParametersA
     public FtpsComponent(CamelContext context) {
         super(context);
         setEndpointClass(FtpsEndpoint.class);
+    }
+    
+    @Override
+    protected String preProcessUri(String uri) {
+        return UnsafeUriCharactersEncoder.encodeHttpURI(uri);
     }
 
     @Override

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpComponent.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpComponent.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.file.GenericFileEndpoint;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
 /**
  * Secure FTP Component
@@ -34,6 +35,11 @@ public class SftpComponent extends RemoteFileComponent<SftpRemoteFile> {
     public SftpComponent(CamelContext context) {
         super(context);
         setEndpointClass(SftpEndpoint.class);
+    }
+    
+    @Override
+    protected String preProcessUri(String uri) {
+        return UnsafeUriCharactersEncoder.encodeHttpURI(uri);
     }
 
     @Override

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FileToFtpsWithDefaultSettingsIPV6Test.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FileToFtpsWithDefaultSettingsIPV6Test.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -26,7 +25,6 @@ import org.junit.Test;
  * 
  * @version 
  */
-@Ignore
 public class FileToFtpsWithDefaultSettingsIPV6Test extends FtpsServerExplicitTLSWithoutClientAuthTestSupport {
     
     private String getFtpUrl() {

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpConsumerIPV6BodyAsStringTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpConsumerIPV6BodyAsStringTest.java
@@ -23,13 +23,11 @@ import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @version 
  */
-@Ignore
 public class FtpConsumerIPV6BodyAsStringTest extends FtpServerTestSupport {
 
     private String getFtpUrl() {

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpSimpleIPV6ConsumeTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpSimpleIPV6ConsumeTest.java
@@ -19,13 +19,11 @@ package org.apache.camel.component.file.remote.sftp;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @version 
  */
-@Ignore
 public class SftpSimpleIPV6ConsumeTest extends SftpServerTestSupport {
 
     @Test


### PR DESCRIPTION
the second commit makes PR less sensitive because the change in URISupport in the first commit have higher impact even though all UTs are OK without this second commit.