### PR TITLE
CAMEL-12741: type conversion with SjmsMessage

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
@@ -94,6 +94,18 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
             if (answer != null) {
                 return answer;
             }
+        } else if (camelContext != null) {
+            TypeConverter converter = camelContext.getTypeConverter();
+
+            T answer = converter.convertTo(type, body);
+            if (answer != null) {
+                return answer;
+            }
+
+            answer = converter.tryConvertTo(type, this);
+            if (answer != null) {
+                return answer;
+            }
         }
 
         // not possible to convert

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
@@ -101,6 +101,8 @@ public class SjmsMessage extends DefaultMessage {
         if (that.hasAttachments()) {
             getAttachmentObjects().putAll(that.getAttachmentObjects());
         }
+
+        setExchange(that.getExchange());
     }
 
     public JmsBinding getBinding() {


### PR DESCRIPTION
If we don't copy Exchange in `SjmsMessage::copyFrom` then type conversion doesn't work.

I'm not sure what approach to take for resolving [CAMEL-12741](https://issues.apache.org/jira/browse/CAMEL-12741). 

I've created two commits with two options that could help here, not sure what option (or both?) should we implement.