### PR TITLE
CAMEL-12740: HttpAsyncClientBuilder is now used when no ClientBuilder…

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
@@ -176,6 +176,8 @@ public class Olingo2Component extends AbstractApiComponent<Olingo2ApiName, Oling
             } catch (IOException e) {
                 throw ObjectHelper.wrapRuntimeCamelException(e);
             }
+
+            clientBuilder = asyncClientBuilder;
         }
 
         Olingo2AppImpl olingo2App;

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
@@ -162,6 +162,8 @@ public class Olingo4Component extends AbstractApiComponent<Olingo4ApiName, Oling
             } catch (IOException e) {
                 throw ObjectHelper.wrapRuntimeCamelException(e);
             }
+
+            clientBuilder = asyncClientBuilder;
         }
 
         Olingo4AppImpl olingo4App;


### PR DESCRIPTION
I have changed the Olingo2 and Olingo4 components do use the created HttpAsyncClientBuilder when no builder is specified. In the previous scenario the created HttpAsyncClientBuilder was ignored.

See CAMEL-12740