### PR TITLE
CAMEL-12741: The copy method on Message should by default set the exc…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/Message.java
+++ b/camel-core/src/main/java/org/apache/camel/Message.java
@@ -270,7 +270,10 @@ public interface Message {
 
     /**
      * Creates a copy of this message so that it can be used and possibly
-     * modified further in another exchange
+     * modified further in another exchange.
+     * <p/>
+     * The returned {@link Message} copy will have its {@link Exchange} set
+     * to the same {@link Exchange} instance as from the source.
      *
      * @return a new message instance copied from this message
      */
@@ -281,6 +284,9 @@ public interface Message {
      * <p/>
      * If you need to do a copy and then set a new body,
      * then use {@link #copyFromWithNewBody(Message, Object)} method instead.
+     * <p/>
+     * The returned {@link Message} copy will have its {@link Exchange} set
+     * to the same {@link Exchange} instance as from the source.
      *
      * @param message the other message
      * @see #copyFromWithNewBody(Message, Object)
@@ -289,6 +295,9 @@ public interface Message {
     
     /**
      * Copies the contents (except the body) of the other message into this message and uses the provided new body instead
+     * <p/>
+     * The returned {@link Message} copy will have its {@link Exchange} set
+     * to the same {@link Exchange} instance as from the source.
      *
      * @param message the other message
      * @param newBody the new body to use

--- a/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/MessageSupport.java
@@ -187,6 +187,10 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         if (that instanceof DataTypeAware && ((DataTypeAware) that).hasDataType()) {
             setDataType(((DataTypeAware)that).getDataType());
         }
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
 
         copyFromWithNewBody(that, that.getBody());
     }
@@ -202,6 +206,11 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
         if (that instanceof CamelContextAware) {
             setCamelContext(((CamelContextAware) that).getCamelContext());
         }
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
+
         // should likely not set DataType as the new body may be a different type than the original body
 
         setMessageId(that.getMessageId());

--- a/camel-core/src/test/java/org/apache/camel/impl/MessageSupportTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/MessageSupportTest.java
@@ -83,4 +83,18 @@ public class MessageSupportTest extends ContextTestSupport {
         assertEquals(123, in.getHeader("foo"));
         assertEquals(123, out.getHeader("foo"));
     }
+
+    public void testCopyOverExchange() throws Exception {
+        Exchange exchange = new DefaultExchange(context);
+        Message in = exchange.getIn();
+        in.setBody("Bye World");
+
+        Message two = in.copy();
+        assertSame(exchange, two.getExchange());
+
+        Message three = new DefaultMessage(context);
+        three.copyFrom(two);
+        assertSame(exchange, three.getExchange());
+    }
+
 }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
@@ -91,6 +91,11 @@ public class JmsMessage extends DefaultMessage {
             setMessageId(that.getMessageId());
         }
 
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
+
         // copy body and fault flag
         setBody(that.getBody());
         setFault(that.isFault());

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailMessage.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailMessage.java
@@ -152,6 +152,10 @@ public class MailMessage extends DefaultMessage {
             this.mailMessage = mailMessage.mailMessage;
             this.mapMailMessage = mailMessage.mapMailMessage;
         }
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
     }
 
 }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
@@ -88,6 +88,11 @@ public class SjmsMessage extends DefaultMessage {
             setMessageId(that.getMessageId());
         }
 
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
+
         // copy body and fault flag
         setBody(that.getBody());
         setFault(that.isFault());

--- a/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationMessage.java
+++ b/components/camel-spring-integration/src/main/java/org/apache/camel/component/spring/integration/SpringIntegrationMessage.java
@@ -56,6 +56,11 @@ public class SpringIntegrationMessage extends DefaultMessage {
             this.setCamelContext(((CamelContextAware) that).getCamelContext());
         }
 
+        // cover over exchange if none has been assigned
+        if (getExchange() == null) {
+            setExchange(that.getExchange());
+        }
+
         setMessageId(that.getMessageId());
         setBody(that.getBody());
         super.getHeaders().putAll(that.getHeaders());


### PR DESCRIPTION
…hange on the copied message to the same instance as from the source. If the copied message is re-attached to another exchange it will reset the exchange anyway.