### PR TITLE
Fix for CAMEL-12746 (temp reply queue autoAck)

### DIFF
--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/services/KubernetesServicesConsumer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/services/KubernetesServicesConsumer.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -91,7 +92,7 @@ public class KubernetesServicesConsumer extends DefaultConsumer {
         
         @Override
         public void run() {
-            MixedOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> w = getEndpoint().getKubernetesClient().services();
+            MixedOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> w = getEndpoint().getKubernetesClient().services();
             if (ObjectHelper.isNotEmpty(getEndpoint().getKubernetesConfiguration().getNamespace())) {
                 w.inNamespace(getEndpoint().getKubernetesConfiguration().getNamespace());
             }

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/services/KubernetesServicesProducer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/services/KubernetesServicesProducer.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.kubernetes.AbstractKubernetesEndpoint;
@@ -117,7 +118,7 @@ public class KubernetesServicesProducer extends DefaultProducer {
         String namespaceName = exchange.getIn().getHeader(
                 KubernetesConstants.KUBERNETES_NAMESPACE_NAME, String.class);
         if (!ObjectHelper.isEmpty(namespaceName)) {
-            NonNamespaceOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> services; 
+            NonNamespaceOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> services; 
             services = getEndpoint().getKubernetesClient().services()
                     .inNamespace(namespaceName);
             for (Map.Entry<String, String> entry : labels.entrySet()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12746

This is a fix for the above issue of temporary reply queues getting stale un-acked messages. The fix ensures that temp reply queues will be always created with the autoAck setting set to true.