### PR TITLE
Update aws-kinesis-component.adoc

### DIFF
--- a/components/camel-aws/src/main/docs/aws-kinesis-component.adoc
+++ b/components/camel-aws/src/main/docs/aws-kinesis-component.adoc
@@ -207,7 +207,7 @@ however, a
 different http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSCredentialsProvider.html[AWSCredentialsProvider]
 can be specified when calling createClient(...).
 
-#### Message headers used by the Kinesis producer to write to Kinesis.  The producer expects that the message body is a `ByteBuffer`.
+#### Message headers used by the Kinesis producer to write to Kinesis.  The producer expects that the message body is a `byte[]`.
 
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================


### PR DESCRIPTION
The AWS Kinesis Producer actually requires a byte[] instead of a ByteBuffer.