### PR TITLE
CAMEL-12785: ServletComponent ignores HttpBinding

### DIFF
--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
@@ -320,7 +320,7 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
         ServletEndpoint endpoint = camelContext.getEndpoint(url, ServletEndpoint.class);
         setProperties(camelContext, endpoint, parameters);
 
-        if (!map.containsKey("httpBindingRef")) {
+        if (!map.containsKey("httpBinding")) {
             // use the rest binding, if not using a custom http binding
             HttpBinding binding = new ServletRestHttpBinding();
             binding.setHeaderFilterStrategy(endpoint.getHeaderFilterStrategy());


### PR DESCRIPTION
We dropped the **httpBindingRef** in http common and servlet component some time back. The Servlet Component had a regression where it wasn't taking into consideration a custom **httpBinding**, and instead always initialized a default instance of **ServletRestHttpBinding**, thereby ignoring the custom config. 
This change now takes into effect **user's custom httpBinding**. 