### PR TITLE
changed csv unmarshalling to only strip quotes if quoting is set to "true"

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
@@ -753,6 +753,10 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
         return quote;
     }
 
+    public Boolean getQuoting() {
+        return quoting;
+    }
+
     public int getMaxpos() {
         return maxpos;
     }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyCsvFactory.java
@@ -75,6 +75,7 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
     private boolean allowEmptyStream;
     private boolean quotingEscaped;
     private boolean endWithLineBreak;
+    private boolean removeQuotes;
 
     public BindyCsvFactory(Class<?> type) throws Exception {
         super(type);
@@ -665,6 +666,9 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
                     // Get endWithLineBreak parameter
                     endWithLineBreak = record.endWithLineBreak();
                     LOG.debug("End with line break: {}", endWithLineBreak);
+
+                    removeQuotes = record.removeQuotes();
+                    LOG.debug("Remove quotes: {}", removeQuotes);
                 }
 
                 if (section != null) {
@@ -753,8 +757,8 @@ public class BindyCsvFactory extends BindyAbstractFactory implements BindyFactor
         return quote;
     }
 
-    public Boolean getQuoting() {
-        return quoting;
+    public Boolean getRemoveQuotes() {
+        return removeQuotes;
     }
 
     public int getMaxpos() {

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/annotation/CsvRecord.java
@@ -107,4 +107,9 @@ public @interface CsvRecord {
      */
     boolean endWithLineBreak() default true;
 
+    /**
+     * The remove quotes parameter flags if unmarshalling should try to remove quotes for each field
+     */
+    boolean removeQuotes() default true;
+
 }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -155,6 +155,7 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
             // Retrieve the separator defined to split the record
             String separator = factory.getSeparator();
             String quote = factory.getQuote();
+            Boolean quoting = factory.getQuoting();
             ObjectHelper.notNull(separator, "The separator has not been defined in the annotation @CsvRecord or not instantiated during initModel.");
     
             int count = 0;
@@ -202,7 +203,9 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
                 String[] tokens = pattern.split(line, factory.getAutospanLine() ? factory.getMaxpos() : -1);
                 List<String> result = Arrays.asList(tokens);
                 // must unquote tokens before use
-                result = unquoteTokens(result, separators, quote);
+                if(quoting) {
+                    result = unquoteTokens(result, separators, quote);
+                }
     
                 if (result.size() == 0 || result.isEmpty()) {
                     throw new java.lang.IllegalArgumentException("No records have been defined in the CSV");

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -155,7 +155,7 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
             // Retrieve the separator defined to split the record
             String separator = factory.getSeparator();
             String quote = factory.getQuote();
-            Boolean quoting = factory.getQuoting();
+            Boolean removeQuotes = factory.getRemoveQuotes();
             ObjectHelper.notNull(separator, "The separator has not been defined in the annotation @CsvRecord or not instantiated during initModel.");
     
             int count = 0;
@@ -203,7 +203,7 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
                 String[] tokens = pattern.split(line, factory.getAutospanLine() ? factory.getMaxpos() : -1);
                 List<String> result = Arrays.asList(tokens);
                 // must unquote tokens before use
-                if(quoting) {
+                if(removeQuotes) {
                     result = unquoteTokens(result, separators, quote);
                 }
     

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyDoNotRemoveQuotesCsvUnmarshallTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/csv/BindyDoNotRemoveQuotesCsvUnmarshallTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.csv;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.dataformat.bindy.annotation.CsvRecord;
+import org.apache.camel.dataformat.bindy.annotation.DataField;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Assert;
+
+@ContextConfiguration
+public class BindyDoNotRemoveQuotesCsvUnmarshallTest extends AbstractJUnit4SpringContextTests {
+
+    private static final String URI_MOCK_RESULT = "mock:result";
+    private static final String URI_DIRECT_START = "direct:start";
+
+    @Produce(uri = URI_DIRECT_START)
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = URI_MOCK_RESULT)
+    private MockEndpoint result;
+
+    private String expected;
+
+    //Without removesQuotes=false annotation on product this will fail to unmarshall properly
+    @Test
+    @DirtiesContext
+    public void testUnMarshallMessage() throws Exception {
+
+        expected = "apple,\"bright red\" apple,a fruit";
+
+        template.sendBody(expected);
+
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+        BindyDoNotRemoveQuotesCsvUnmarshallTest.Product product = result.getReceivedExchanges().get(0).getIn().getBody(BindyDoNotRemoveQuotesCsvUnmarshallTest.Product.class);
+        Assert.assertEquals("apple", product.getName());
+        Assert.assertEquals("\"bright red\" apple", product.getDescription1());
+        Assert.assertEquals("a fruit", product.getDescription2());
+    }
+
+    public static class ContextConfig extends RouteBuilder {
+        BindyCsvDataFormat camelDataFormat = new BindyCsvDataFormat(BindyDoNotRemoveQuotesCsvUnmarshallTest.Product.class);
+
+        public void configure() {
+            from(URI_DIRECT_START).unmarshal(camelDataFormat).to(URI_MOCK_RESULT);
+        }
+    }
+
+    @CsvRecord(separator = ",",removeQuotes = false)
+    public static class Product {
+
+        @DataField(pos = 1)
+        private String name;
+
+        @DataField(pos = 2)
+        private String description1;
+
+        @DataField(pos = 3)
+        private String description2;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription1() {
+            return description1;
+        }
+
+        public void setDescription1(String description1) {
+            this.description1 = description1;
+        }
+
+        public String getDescription2() {
+            return description2;
+        }
+
+        public void setDescription2(String description2) {
+            this.description2 = description2;
+        }
+
+        @Override
+        public String toString() {
+            return "Product{" +
+                    "name='" + name + '\'' +
+                    ", description1='" + description1 + '\'' +
+                    ", description2='" + description2 + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyDoNotRemoveQuotesCsvUnmarshallTest-context.xml
+++ b/components/camel-bindy/src/test/resources/org/apache/camel/dataformat/bindy/csv/BindyDoNotRemoveQuotesCsvUnmarshallTest-context.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+     http://www.springframework.org/schema/beans
+     http://www.springframework.org/schema/beans/spring-beans.xsd
+     http://camel.apache.org/schema/spring
+     http://camel.apache.org/schema/spring/camel-spring.xsd">
+     
+	<camelContext xmlns="http://camel.apache.org/schema/spring">
+		<routeBuilder ref="myBuilder" /> 
+	</camelContext>
+	
+	<bean id="myBuilder" class="org.apache.camel.dataformat.bindy.csv.BindyDoNotRemoveQuotesCsvUnmarshallTest$ContextConfig"/>
+	
+</beans>


### PR DESCRIPTION
When unmarshalling a tsv file where the individual fields are not quoted, the unmarshaller still tries to strip the quotes.   For a field such as:    , "Amazing" field,     , the unmarshaller will see the first quote and try to strip it off expecting another quote at the end of the field.  The end result is bindy unmarshaller completely fails for the whole record.   The fix is to look at the  "quoting" field and if qoutes are not expected, do not try to strip them.