### PR TITLE
CAMEL-12852 - use minimum expected message count

### DIFF
--- a/components/camel-pubnub/src/test/java/org/apache/camel/component/pubnub/PubNubPresenceTest.java
+++ b/components/camel-pubnub/src/test/java/org/apache/camel/component/pubnub/PubNubPresenceTest.java
@@ -48,7 +48,7 @@ public class PubNubPresenceTest extends PubNubTestBase {
                           + "{\"a\":\"4\",\"f\":512,\"p\":{\"t\":\"14637536741726901\",\"r\":1},\"k\":\"demo-36\",\"c\":\"mychannel-pnpres\",\"d\":{\"action\": \"state-change\", "
                           + "\"timestamp\": 1463753674, \"data\": {\"state\": \"cool\"}, \"uuid\": \"24c9bb19-1fcd-4c40-a6f1-522a8a1329ef\", \"occupancy\": 3},\"b\":\"mychannel-pnpres\"}]}")));
         context.startRoute("presence-route");
-        mockResult.expectedMessageCount(1);
+        mockResult.expectedMinimumMessageCount(1);
         mockResult.expectedHeaderReceived(PubNubConstants.CHANNEL, "mychannel");
         assertMockEndpointsSatisfied();
         PNPresenceEventResult presence = mockResult.getReceivedExchanges().get(0).getIn().getBody(PNPresenceEventResult.class);
@@ -67,7 +67,7 @@ public class PubNubPresenceTest extends PubNubTestBase {
                           + "\"d\":{\"action\": \"interval\", \"timestamp\": 1490124758, \"occupancy\": 2, \"here_now_refresh\": true, "
                           + "\"join\": [\"2220E216-5A30-49AD-A89C-1E0B5AE26AD7\", \"4262AE3F-3202-4487-BEE0-1A0D91307DEB\"]},\"b\":\"mychannel-pnpres\"}]}")));
         context.startRoute("presence-route");
-        mockResult.expectedMessageCount(1);
+        mockResult.expectedMinimumMessageCount(1);
         assertMockEndpointsSatisfied();
         PNPresenceEventResult presence = mockResult.getReceivedExchanges().get(0).getIn().getBody(PNPresenceEventResult.class);
         assertThat(presence.getHereNowRefresh(), equalTo(true));


### PR DESCRIPTION
a lot of messages are generated, only the first oen is checked.

please check comments on https://issues.apache.org/jira/browse/CAMEL-12852
this PR is in case the tested routes is expected to generate several messages. If it is not normal, the fix will need to be different.