### PR TITLE
Avoid potentially conflicting jetty port during test execution

### DIFF
--- a/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringBeanServiceCallRouteTest.java
+++ b/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringBeanServiceCallRouteTest.java
@@ -42,5 +42,13 @@ public class SpringBeanServiceCallRouteTest extends SpringRibbonServiceCallRoute
         RibbonServiceLoadBalancer loadBalancer = (RibbonServiceLoadBalancer)processor.getLoadBalancer();
         Assert.assertTrue(loadBalancer.getServiceDiscovery() instanceof StaticServiceDiscovery);
     }
+    
+    protected String getFirstPort() {
+        return "9092";
+    }
+    
+    protected String getSecondPort() {
+        return "9093";
+    }
 }
 

--- a/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringDslRibbonPropertiesServiceCallRouteTest.java
+++ b/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringDslRibbonPropertiesServiceCallRouteTest.java
@@ -41,5 +41,14 @@ public class SpringDslRibbonPropertiesServiceCallRouteTest extends SpringRibbonS
         RibbonServiceLoadBalancer loadBalancer = (RibbonServiceLoadBalancer)processor.getLoadBalancer();
         Assert.assertNull(loadBalancer.getServiceDiscovery());
     }
+
+    protected String getFirstPort() {
+        return "9094";
+    }
+    
+    protected String getSecondPort() {
+        return "9095";
+    }
+
 }
 

--- a/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringDslRibbonServiceCallRouteTest.java
+++ b/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringDslRibbonServiceCallRouteTest.java
@@ -42,5 +42,13 @@ public class SpringDslRibbonServiceCallRouteTest extends SpringRibbonServiceCall
         RibbonServiceLoadBalancer loadBalancer = (RibbonServiceLoadBalancer)processor.getLoadBalancer();
         Assert.assertTrue(loadBalancer.getServiceDiscovery() instanceof StaticServiceDiscovery);
     }
+    
+    protected String getFirstPort() {
+        return "9096";
+    }
+    
+    protected String getSecondPort() {
+        return "9097";
+    }
 }
 

--- a/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringRibbonServiceCallRouteTest.java
+++ b/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/SpringRibbonServiceCallRouteTest.java
@@ -32,17 +32,21 @@ import org.springframework.test.annotation.DirtiesContext;
 public abstract class SpringRibbonServiceCallRouteTest extends CamelSpringTestSupport {
     @Test
     public void testServiceCall() throws Exception {
-        getMockEndpoint("mock:9090").expectedMessageCount(1);
-        getMockEndpoint("mock:9091").expectedMessageCount(1);
+        getMockEndpoint("mock:"+getFirstPort()).expectedMessageCount(1);
+        getMockEndpoint("mock:"+getSecondPort()).expectedMessageCount(1);
         getMockEndpoint("mock:result").expectedMessageCount(2);
 
         String out = template.requestBody("direct:start", null, String.class);
         String out2 = template.requestBody("direct:start", null, String.class);
-        assertEquals("9091", out);
-        assertEquals("9090", out2);
+        assertEquals(getSecondPort(), out);
+        assertEquals(getFirstPort(), out2);
 
         assertMockEndpointsSatisfied();
     }
+
+    protected abstract String getSecondPort();
+
+    protected abstract String getFirstPort();
 
     // ************************************
     // Helpers

--- a/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringBeanRibbonServiceCallRouteTest.xml
+++ b/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringBeanRibbonServiceCallRouteTest.xml
@@ -27,7 +27,7 @@
 
   <!-- setup a static ribbon server list with these 2 servers to start with -->
   <bean id="discovery" class="org.apache.camel.impl.cloud.StaticServiceDiscovery">
-    <property name="servers" value="localhost:9090,localhost:9091"/>
+    <property name="servers" value="localhost:9092,localhost:9093"/>
   </bean>
 
   <bean id="balancer" class="org.apache.camel.component.ribbon.cloud.RibbonServiceLoadBalancer">
@@ -48,18 +48,18 @@
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9090"/>
-      <to uri="mock:9090"/>
+      <from uri="jetty:http://localhost:9092"/>
+      <to uri="mock:9092"/>
       <transform>
-        <constant>9090</constant>
+        <constant>9092</constant>
       </transform>
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9091"/>
-      <to uri="mock:9091"/>
+      <from uri="jetty:http://localhost:9093"/>
+      <to uri="mock:9093"/>
       <transform>
-        <constant>9091</constant>
+        <constant>9093</constant>
       </transform>
     </route>
   </camelContext>

--- a/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringDslRibbonPropertiesServiceCallRouteTest.xml
+++ b/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringDslRibbonPropertiesServiceCallRouteTest.xml
@@ -31,25 +31,25 @@
       <serviceCall name="myService" component="jetty">
         <!-- enable ribbon load balancer -->
         <ribbonLoadBalancer clientName="myClient">
-          <properties key="listOfServers" value="localhost:9090,localhost:9091"/>
+          <properties key="listOfServers" value="localhost:9094,localhost:9095"/>
         </ribbonLoadBalancer>
       </serviceCall>
       <to uri="mock:result"/>
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9090"/>
-      <to uri="mock:9090"/>
+      <from uri="jetty:http://localhost:9094"/>
+      <to uri="mock:9094"/>
       <transform>
-        <constant>9090</constant>
+        <constant>9094</constant>
       </transform>
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9091"/>
-      <to uri="mock:9091"/>
+      <from uri="jetty:http://localhost:9095"/>
+      <to uri="mock:9095"/>
       <transform>
-        <constant>9091</constant>
+        <constant>9095</constant>
       </transform>
     </route>
   </camelContext>

--- a/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringDslRibbonServiceCallRouteTest.xml
+++ b/components/camel-ribbon/src/test/resources/org/apache/camel/component/ribbon/cloud/SpringDslRibbonServiceCallRouteTest.xml
@@ -31,7 +31,7 @@
       <serviceCall name="myService" component="jetty">
         <!-- static list of servers -->
         <staticServiceDiscovery>
-          <servers>localhost:9090,localhost:9091</servers>
+          <servers>localhost:9096,localhost:9097</servers>
         </staticServiceDiscovery>
 
         <!-- enable ribbon load balancer -->
@@ -41,18 +41,18 @@
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9090"/>
-      <to uri="mock:9090"/>
+      <from uri="jetty:http://localhost:9096"/>
+      <to uri="mock:9096"/>
       <transform>
-        <constant>9090</constant>
+        <constant>9096</constant>
       </transform>
     </route>
 
     <route>
-      <from uri="jetty:http://localhost:9091"/>
-      <to uri="mock:9091"/>
+      <from uri="jetty:http://localhost:9097"/>
+      <to uri="mock:9097"/>
       <transform>
-        <constant>9091</constant>
+        <constant>9097</constant>
       </transform>
     </route>
   </camelContext>


### PR DESCRIPTION
in case tests are not cleaning correctly the Jetty server or are
launched in parallel, having different ports will avoid to have port
still occupied for other tests

Signed-off-by: Aurélien Pupier <apupier@redhat.com>