### PR TITLE
CAMEL-12853 - disable SftpConsumerDisconnectTest

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpConsumerDisconnectTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpConsumerDisconnectTest.java
@@ -24,21 +24,15 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class SftpConsumerDisconnectTest extends SftpServerTestSupport {
     private static final String SAMPLE_FILE_NAME_1 = String.format("sample-1-%s.txt", SftpConsumerDisconnectTest.class.getSimpleName());
     private static final String SAMPLE_FILE_NAME_2 = String.format("sample-2-%s.txt", SftpConsumerDisconnectTest.class.getSimpleName());
     private static final String SAMPLE_FILE_CHARSET = "iso-8859-1";
     private static final String SAMPLE_FILE_PAYLOAD = "abc";
-
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        context.stopRoute("foo");
-        context.stopRoute("bar");
-    }
 
     @Test
     public void testConsumeDelete() throws Exception {
@@ -58,25 +52,12 @@ public class SftpConsumerDisconnectTest extends SftpServerTestSupport {
 
         // Check that expectations are satisfied
         assertMockEndpointsSatisfied();
+        
+        Thread.sleep(250);
 
         // File is deleted
-        assertTrue(fileRemovedEventually(FTP_ROOT_DIR + "/" + SAMPLE_FILE_NAME_1));
-    }
-
-    public boolean fileRemovedEventually(String fileName) throws InterruptedException {
-        // try up to 10 seconds
-        for (int i = 0; i < 10; i++) {
-            // Give it a second to delete the file
-            Thread.sleep(1000);
-
-            // File is deleted
-            File file = new File(FTP_ROOT_DIR + "/" + SAMPLE_FILE_NAME_1);
-            if (!file.exists()) {
-                return true;
-            }
-        }
-
-        return false;
+        File deletedFile = new File(FTP_ROOT_DIR + "/" + SAMPLE_FILE_NAME_1);
+        assertFalse("File should have been deleted: " + deletedFile, deletedFile.exists());
     }
 
     @Test
@@ -109,21 +90,25 @@ public class SftpConsumerDisconnectTest extends SftpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("sftp://localhost:" + getPort() + "/" + FTP_ROOT_DIR + "?username=admin&password=admin&delete=true").routeId("foo").noAutoStartup().process(new Processor() {
-                    @Override
-                    public void process(Exchange exchange) throws Exception {
-                        disconnectAllSessions(); // disconnect all Sessions from
-                                                 // the SFTP server
-                    }
-                }).to("mock:result");
-                from("sftp://localhost:" + getPort() + "/" + FTP_ROOT_DIR + "?username=admin&password=admin&noop=false&move=.camel").routeId("bar").noAutoStartup()
+                from("sftp://localhost:" + getPort() + "/" + FTP_ROOT_DIR + "?username=admin&password=admin&delete=true")
+                    .routeId("foo")
+                    .noAutoStartup()
                     .process(new Processor() {
                         @Override
                         public void process(Exchange exchange) throws Exception {
-                            disconnectAllSessions(); // disconnect all Sessions
-                                                     // from the SFTP server
+                            disconnectAllSessions(); // disconnect all Sessions from
+                                                     // the SFTP server
                         }
                     }).to("mock:result");
+                from("sftp://localhost:" + getPort() + "/" + FTP_ROOT_DIR + "?username=admin&password=admin&noop=false&move=.camel")
+                    .routeId("bar")
+                    .noAutoStartup().process(new Processor() {
+                        @Override
+                        public void process(Exchange exchange) throws Exception {
+                           disconnectAllSessions(); // disconnect all Sessions
+                                                    // from the SFTP server
+                       }
+                   }).to("mock:result");
             }
         };
     }


### PR DESCRIPTION
I think it will be better to mark this test case as ignore.
the reason for this is that the error case is simulated with processor to disconnect all sessions and exchange often does not reach to an end and session is closed and leaving with closed input stream as indicated in the log entry of the issue. Because in 
https://github.com/apache/camel/blob/master/camel-core/src/main/java/org/apache/camel/component/file/GenericFileOnCompletion.java#L127

where the deletion is handle over GenericFileDeleteProcessStrategy which runs after exchange is completed and ftp sessions are disconnected before it really does moving or deleting.

Even though test almost fails on Linux VM (whereas it sometimes flakes and passes), it almost run with no failure on windows. Apparently it also runs on CI as well.

Please let me know your ideas if disabling makes sense or not.
