### PR TITLE
CAMEL-12873: camel-servlet - Example for HttpRegistry no longer works…

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/CamelServlet.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/CamelServlet.java
@@ -71,7 +71,7 @@ public class CamelServlet extends HttpServlet {
     }
 
     @Override
-    protected final void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         if (isAsync()) {
             final AsyncContext context = req.startAsync();
             //run async

--- a/components/camel-servlet/src/main/docs/servlet-component.adoc
+++ b/components/camel-servlet/src/main/docs/servlet-component.adoc
@@ -325,79 +325,71 @@ like this:
 
 From *Camel 2.6.0*, you can publish the
 https://github.com/apache/camel/blob/master/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/CamelHttpTransportServlet.java[CamelHttpTransportServlet]
-as an OSGi service with help of SpringDM like this:
+as an OSGi service with Blueprint like this:
 
 [source,xml]
 -------------------------------------------------------------------------
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:osgi="http://www.springframework.org/schema/osgi"
-       xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/osgi  http://www.springframework.org/schema/osgi/spring-osgi.xsd">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
-    <bean id="camelServlet" class="org.apache.camel.component.servlet.CamelHttpTransportServlet">
-    </bean>
+    <bean id="camelServlet" class="org.apache.camel.component.servlet.CamelHttpTransportServlet" />
 
     <!--
-        Enlist it in OSGi service registry
+        Enlist it in OSGi service registry.
         This will cause two things:
         1) As the pax web whiteboard extender is running the CamelServlet will
            be registered with the OSGi HTTP Service
         2) It will trigger the HttpRegistry in other bundles so the servlet is
            made known there too
     -->
-    <osgi:service ref="camelServlet">
-        <osgi:interfaces>
+    <service ref="camelServlet">
+        <interfaces>
             <value>javax.servlet.Servlet</value>
-            <value>org.apache.camel.component.http.CamelServlet</value>
-        </osgi:interfaces>
-        <osgi:service-properties>
+            <value>org.apache.camel.http.common.CamelServlet</value>
+        </interfaces>
+        <service-properties>
             <entry key="alias" value="/camel/services" />
             <entry key="matchOnUriPrefix" value="true" />
-            <entry key="servlet-name" value="CamelServlet"/>
-        </osgi:service-properties>
-    </osgi:service>
+            <entry key="servlet-name" value="CamelServlet" />
+        </service-properties>
+    </service>
 
-</beans>
+</blueprint>
 -------------------------------------------------------------------------
 
-Then use this service in your camel route like this:
+Then use this service in your Camel route like this:
 
 [source,xml]
 -------------------------------------------------------------------------
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:camel="http://camel.apache.org/schema/spring"
-       xmlns:osgi="http://www.springframework.org/schema/osgi"
-       xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/osgi  http://www.springframework.org/schema/osgi/spring-osgi.xsd
-       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
-    <osgi:reference id="servletref" interface="org.apache.camel.component.http.CamelServlet">
-        <osgi:listener bind-method="register" unbind-method="unregister">
-            <ref bean="httpRegistry"/>
-        </osgi:listener>
-    </osgi:reference>
+    <reference id="servletref" ext:proxy-method="classes" interface="org.apache.camel.http.common.CamelServlet">
+        <reference-listener ref="httpRegistry" bind-method="register" unbind-method="unregister" />
+    </reference>
 
-    <bean id="httpRegistry" class="org.apache.camel.component.servlet.DefaultHttpRegistry"/>
+    <bean id="httpRegistry" class="org.apache.camel.component.servlet.DefaultHttpRegistry" />
 
     <bean id="servlet" class="org.apache.camel.component.servlet.ServletComponent">
         <property name="httpRegistry" ref="httpRegistry" />
     </bean>
 
-    <bean id="servletProcessor" class="org.apache.camel.itest.osgi.servlet.ServletProcessor" />
+    <bean id="servletProcessor" class="org.apache.camel.example.servlet.ServletProcessor" />
 
-    <camelContext xmlns="http://camel.apache.org/schema/spring">
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint">
         <route>
-            <!-- notice how we can use the servlet scheme which is that osgi:reference above -->
-            <from uri="servlet:///hello"/>
-            <process ref="servletProcessor"/>
+            <!-- Notice how we can use the servlet scheme which is that reference above -->
+            <from uri="servlet://hello" />
+            <process ref="servletProcessor" />
         </route>
     </camelContext>
 
-</beans>
+</blueprint>
 -------------------------------------------------------------------------
 
 For versions prior to Camel 2.6 you can use an `Activator` to publish

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/HttpRegistry.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/HttpRegistry.java
@@ -20,14 +20,15 @@ import org.apache.camel.http.common.CamelServlet;
 import org.apache.camel.http.common.HttpConsumer;
 
 /**
- * Keeps track of HttpConsumers and CamelServlets and 
+ * Keeps track of HttpConsumers and CamelServlets and
  * connects them to each other. In OSGi there should
  * be one HttpRegistry per bundle.
  * 
  * A CamelServlet that should serve more than one
  * bundle should be registered as an OSGi service.
- * The HttpRegistryImpl can then be configured to listen
- * to service changes. See /tests/camel-itest-osgi/../servlet
+ * The {@link DefaultHttpRegistry} can then be configured to listen
+ * to service changes.
+ * See /examples/camel-example-servlet-httpregistry-blueprint
  * for an example how to use this.
  */
 public interface HttpRegistry {

--- a/examples/camel-example-servlet-httpregistry-blueprint/README.md
+++ b/examples/camel-example-servlet-httpregistry-blueprint/README.md
@@ -1,0 +1,55 @@
+# Camel Servlet HttpRegistry Blueprint example
+
+### Introduction
+
+This example shows how to use `camel-servlet` [HttpRegistry](https://github.com/apache/camel/blob/master/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/HttpRegistry.java) so that a `CamelServlet` can serve multiple OSGi bundles.
+
+### Build
+
+You will need to compile this example first:
+
+    mvn install
+
+### Run
+
+To install Apache Camel in Karaf you type in the shell (we use version ${project.version}):
+
+    feature:repo-add camel ${project.version}
+    feature:install camel
+
+First you need to install the following features in Karaf/ServiceMix with:
+
+    feature:install camel-servlet
+    feature:install war
+
+Then you can install the example:
+
+    install -s mvn:org.apache.camel.example/camel-example-servlet-httpregistry-blueprint/${project.version}
+
+And you can see the application running by tailing the logs
+
+    log:tail
+
+And you can use <kbd>ctrl</kbd>+<kbd>c</kbd> to stop tailing the log.
+
+There is a servlet that supports the following operation:
+
+- POST /camel/services/hello - to echo the request body
+
+From the command shell you can use `curl` to post a request to the servlet as shown below:
+
+    curl -X POST -H "Content-Type: text/plain" -d "Hello World" http://localhost:8181/camel/services/hello
+
+
+### Configuration
+
+This example is implemented in XML DSL in the [src/main/resources/OSGI-INF/blueprint/camel-context.xml](src/main/resources/OSGI-INF/blueprint/camel-context.xml) file.
+
+
+### Forum, Help, etc
+
+If you hit problems please let us know on the Camel Forums:
+    <http://camel.apache.org/discussion-forums.html>
+
+Please help us make Apache Camel better - we appreciate any feedback you may
+have.  Enjoy!

--- a/examples/camel-example-servlet-httpregistry-blueprint/pom.xml
+++ b/examples/camel-example-servlet-httpregistry-blueprint/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel.example</groupId>
+    <artifactId>examples</artifactId>
+    <version>2.23.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-example-servlet-httpregistry-blueprint</artifactId>
+  <name>Camel :: Example :: Servlet HttpRegistry Blueprint</name>
+  <description>An example using Servlet and HttpRegistry with OSGi Blueprint</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <category>OSGi</category>
+    <title>Servlet HttpRegistry Blueprint</title>
+
+    <camel.osgi.import.pkg>
+      *
+    </camel.osgi.import.pkg>
+    <camel.osgi.export.pkg>
+      *
+    </camel.osgi.export.pkg>
+  </properties>
+
+  <dependencies>
+
+    <!-- camel -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-blueprint</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-servlet</artifactId>
+    </dependency>
+    
+    <!-- logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/java/org/apache/camel/example/servlet/ServletProcessor.java
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/java/org/apache/camel/example/servlet/ServletProcessor.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.servlet;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServletProcessor implements Processor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServletProcessor.class);
+
+    public void process(Exchange exchange) throws Exception {
+        String request = exchange.getIn().getBody(String.class);
+        LOG.info("The request is: {}", request);
+        exchange.getOut().setBody("Echo " + request);
+    }
+
+}

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/META-INF/LICENSE.txt
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/META-INF/NOTICE.txt
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/OSGI-INF/blueprint/camel-context.xml
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/OSGI-INF/blueprint/camel-context.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <!-- availability="optional" is required only when the servlet service is packaged in the same bundle -->
+    <reference id="servletRef" ext:proxy-method="classes" interface="org.apache.camel.http.common.CamelServlet"
+        availability="optional">
+        <reference-listener ref="httpRegistry" bind-method="register" unbind-method="unregister" />
+    </reference>
+
+    <bean id="httpRegistry" class="org.apache.camel.component.servlet.DefaultHttpRegistry" />
+
+    <bean id="servlet" class="org.apache.camel.component.servlet.ServletComponent">
+        <property name="httpRegistry" ref="httpRegistry" />
+    </bean>
+
+    <bean id="servletProcessor" class="org.apache.camel.example.servlet.ServletProcessor" />
+
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+        <route>
+            <!-- Notice how we can use the servlet scheme which is that reference above -->
+            <from uri="servlet://hello" />
+            <process ref="servletProcessor" />
+        </route>
+    </camelContext>
+
+</blueprint>

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/OSGI-INF/blueprint/servlet-service.xml
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/OSGI-INF/blueprint/servlet-service.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="camelServlet" class="org.apache.camel.component.servlet.CamelHttpTransportServlet" />
+
+    <!--
+        Enlist it in OSGi service registry.
+        This will cause two things:
+        1) As the pax web whiteboard extender is running the CamelServlet will
+           be registered with the OSGi HTTP Service
+        2) It will trigger the HttpRegistry in other bundles so the servlet is
+           made known there too
+    -->
+    <service ref="camelServlet">
+        <interfaces>
+            <value>javax.servlet.Servlet</value>
+            <value>org.apache.camel.http.common.CamelServlet</value>
+        </interfaces>
+        <service-properties>
+            <entry key="alias" value="/camel/services" />
+            <entry key="matchOnUriPrefix" value="true" />
+            <entry key="servlet-name" value="CamelServlet" />
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/log4j2.properties
+++ b/examples/camel-example-servlet-httpregistry-blueprint/src/main/resources/log4j2.properties
@@ -1,0 +1,23 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = console

--- a/examples/camel-example-servlet-rest-blueprint/README.md
+++ b/examples/camel-example-servlet-rest-blueprint/README.md
@@ -1,5 +1,4 @@
 # Camel Servlet REST and OSGi Blueprint example
-=============================================
 
 ### Introduction
 This example shows how to use Servlet REST to define REST endpoints in Camel routes using the Rest DSL
@@ -11,7 +10,7 @@ You will need to compile this example first:
 	mvn install
 
 
-### run
+### Run
 To install Apache Camel in Karaf you type in the shell (we use version ${project.version}):
 
 	feature:repo-add camel ${project.version}
@@ -35,9 +34,9 @@ And you can use <kbd>ctrl</kbd>+<kbd>c</kbd> to stop tailing the log.
 
 There is a user REST service that supports the following operations
 
- - GET /user/{id} - to view a user with the given id </li>
- - GET /user/final - to view all users</li>
- - PUT /user - to update/create an user</li>
+ - GET /user/{id} - to view a user with the given id
+ - GET /user/final - to view all users
+ - PUT /user - to update/create an user
 
 The view operations are HTTP GET, and update is using HTTP PUT.
 
@@ -54,12 +53,12 @@ From the command shell you can use curl to access the service as shown below:
 
 
 ### Configuration
-This example is implemented in XML DSL in the `src/main/resources/OSGI-INF/bluepring/camel.xml` file.
+This example is implemented in XML DSL in the `src/main/resources/OSGI-INF/blueprint/camel.xml` file.
 
 
 ### Forum, Help, etc
 
-If you hit an problems please let us know on the Camel Forums
+If you hit problems please let us know on the Camel Forums
 	<http://camel.apache.org/discussion-forums.html>
 
 Please help us make Apache Camel better - we appreciate any feedback you may

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -97,6 +97,7 @@
     <module>camel-example-restlet-jdbc</module>
     <module>camel-example-route-throttling</module>
     <module>camel-example-scala</module>
+    <module>camel-example-servlet-httpregistry-blueprint</module>
     <module>camel-example-servlet-rest-blueprint</module>
     <module>camel-example-servlet-tomcat</module>
     <module>camel-example-servlet-tomcat-no-spring</module>


### PR DESCRIPTION
… throwing FinalModifierException

It also recovers an example test which existed under `tests/camel-itest-osgi/src/test/java/org/apache/camel/itest/osgi/servlet/` as an example.