### PR TITLE
mongodb3 - adds example of iterating over a DBCursor

### DIFF
--- a/components/camel-mongodb3/src/main/docs/mongodb3-component.adoc
+++ b/components/camel-mongodb3/src/main/docs/mongodb3-component.adoc
@@ -670,8 +670,7 @@ Example with option outputType=MongoIterable and batch size:
 
 [source,java]
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-// route: from("direct:aggregate").to("mongodb3:myDb?database=science&collection=notableScientists&operation=aggregate&outputType=MongoIterable");
-List<Bson> aggregate = Arrays.asList(match(or(eq("scientist", "Darwin"), eq("scientist", 
+List<Bson> aggregate = Arrays.asList(match(or(eq("scientist", "Darwin"), eq("scientist",
         group("$scientist", sum("count", 1)));
 from("direct:aggregate")
     .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
@@ -680,6 +679,20 @@ from("direct:aggregate")
     .to("mock:resultAggregate");
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+Example with outputType=DBCursor and batch size showing how to iterate over the cursor's data:
+
+[source,java]
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+List<Bson> aggregate = Arrays.asList(match(or(eq("scientist", "Darwin"), eq("scientist",
+        group("$scientist", sum("count", 1)));
+from("direct:aggregate")
+    .setHeader(MongoDbConstants.BATCH_SIZE).constant(10)
+    .setBody().constant(aggregate)
+    .to("mongodb3:myDb?database=science&collection=notableScientists&operation=aggregate&outputType=MongoIterable")
+    .split(body())
+    .streaming()
+    .to("mock:resultAggregate");
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ===== getDbStats
 


### PR DESCRIPTION
The documentation says one can return a `DBCursor` but doesn't show an example how to iterate over it in order to work with the actual data. I found this way of doing it based on [this gist](https://gist.github.com/padewitte/1e159475b0ae7a9b6b8e) and thought future readers might appreciate the concrete example.

If the correct way to iterate is different I'll gladly update the PR or close this one if a different PR solves my case.