### PR TITLE
CAMEL-12880 : Atom consumer stops polling

### DIFF
--- a/components/camel-atom/src/main/java/org/apache/camel/component/atom/AtomUtils.java
+++ b/components/camel-atom/src/main/java/org/apache/camel/component/atom/AtomUtils.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 
 import org.apache.abdera.Abdera;
 import org.apache.abdera.model.Document;
@@ -53,7 +54,11 @@ public final class AtomUtils {
      * @throws ParseException is thrown if the parsing failed
      */
     public static Document<Feed> parseDocument(String uri) throws IOException, ParseException {
-        InputStream in = new URL(uri).openStream();
+        URL feedUrl = new URL(uri);
+        URLConnection urlConn = feedUrl.openConnection();
+        urlConn.setConnectTimeout(60000);
+        urlConn.setReadTimeout(60000);
+        InputStream in = urlConn.getInputStream();
         return parseInputStream(in);
     }
 

--- a/components/camel-atom/src/main/java/org/apache/camel/component/atom/AtomUtils.java
+++ b/components/camel-atom/src/main/java/org/apache/camel/component/atom/AtomUtils.java
@@ -60,6 +60,8 @@ public final class AtomUtils {
     public static Document<Feed> parseDocument(String uri, String username, String password) throws IOException {
         URL feedUrl = new URL(uri);
         HttpURLConnection httpcon = (HttpURLConnection) feedUrl.openConnection();
+        httpcon.setConnectTimeout(60000);
+        httpcon.setReadTimeout(60000);
         String encoding = Base64.encodeBase64String(username.concat(":").concat(password).getBytes());
         httpcon.setRequestProperty("Authorization", "Basic " + encoding);
         InputStream in = httpcon.getInputStream();


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/CAMEL-12880. 
Setting a timeout value of 60 seconds to throw exception if connection not successful so that the scheduled poll consumer restart polling.

Thanks,
Saravanakumar