### PR TITLE
CAMEL-12905: Camel context inconsistencies in Spring Cloud Environment 

### DIFF
--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -84,7 +84,7 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);
 
         // only add and start Camel if its stopped (initial state)
-        if (((ContextRefreshedEvent) event).getApplicationContext().getId().equals(this.applicationContext.getId())
+        if (event.getApplicationContext() == this.applicationContext)
                 && camelContext.getStatus().isStopped()) {
             LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
 

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -84,7 +84,8 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);
 
         // only add and start Camel if its stopped (initial state)
-        if (camelContext.getStatus().isStopped()) {
+        if (((ContextRefreshedEvent) event).getApplicationContext().getId().equals(this.applicationContext.getId())
+                && camelContext.getStatus().isStopped()) {
             LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
 
             final AntPathMatcher matcher = new AntPathMatcher();

--- a/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
+++ b/components/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/RoutesCollector.java
@@ -84,7 +84,7 @@ public class RoutesCollector implements ApplicationListener<ContextRefreshedEven
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);
 
         // only add and start Camel if its stopped (initial state)
-        if (event.getApplicationContext() == this.applicationContext)
+        if (event.getApplicationContext() == this.applicationContext
                 && camelContext.getStatus().isStopped()) {
             LOG.debug("Post-processing CamelContext bean: {}", camelContext.getName());
 

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -159,7 +159,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
     public void onApplicationEvent(ApplicationEvent event) {
         LOG.debug("onApplicationEvent: {}", event);
 
-        if (event instanceof ContextRefreshedEvent) {
+        if (event instanceof ContextRefreshedEvent && ((ContextRefreshedEvent) event).getApplicationContext().getId().equals(this.applicationContext.getId())) {
             // nominally we would prefer to use Lifecycle interface that
             // would invoke start() method, but in order to do that 
             // SpringCamelContext needs to implement SmartLifecycle

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -159,7 +159,7 @@ public class SpringCamelContext extends DefaultCamelContext implements Lifecycle
     public void onApplicationEvent(ApplicationEvent event) {
         LOG.debug("onApplicationEvent: {}", event);
 
-        if (event instanceof ContextRefreshedEvent && ((ContextRefreshedEvent) event).getApplicationContext().getId().equals(this.applicationContext.getId())) {
+        if (event instanceof ContextRefreshedEvent && ((ContextRefreshedEvent) event).getApplicationContext() == this.applicationContext) {
             // nominally we would prefer to use Lifecycle interface that
             // would invoke start() method, but in order to do that 
             // SpringCamelContext needs to implement SmartLifecycle


### PR DESCRIPTION
CAMEL-12905: The trigger that starts the SpringCamelContext and that collect to routes to the camel context, needs to be a expected ContextRefreshedEvent that has been emitted by the ApplicationContext that instantiated the SpringCamelContext instance. 

https://issues.apache.org/jira/browse/CAMEL-12905