### PR TITLE
Up to latest version

### DIFF
--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisTestSupport.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisTestSupport.java
@@ -79,7 +79,7 @@ public abstract class MyBatisTestSupport extends CamelTestSupport {
 
     protected Connection createConnection() throws Exception {
         MyBatisComponent component = context.getComponent("mybatis", MyBatisComponent.class);
-        return component.createSqlSessionFactory().getConfiguration().getEnvironment().getDataSource().getConnection();
+        return component.getSqlSessionFactory().getConfiguration().getEnvironment().getDataSource().getConnection();
     }
 
 }


### PR DESCRIPTION
I don't know if is relevant but i'm using the latest camel version (2.22.1) and the method `component.createSqlSessionFactory()` is now protected so you should use `component.getSqlSessionFactory()` instead (i did not run the test)