### PR TITLE
Fix param type

### DIFF
--- a/components/camel-jackson/src/main/docs/json-jackson-dataformat.adoc
+++ b/components/camel-jackson/src/main/docs/json-jackson-dataformat.adoc
@@ -25,7 +25,7 @@ The JSon Jackson dataformat supports 19 options, which are listed below.
 [width="100%",cols="2s,1m,1m,6",options="header"]
 |===
 | Name | Default | Java Type | Description
-| objectMapper |  | String | Lookup and use the existing ObjectMapper with the given id when using Jackson.
+| objectMapper |  | ObjectMapper | A com.fasterxml.jackson.databind.ObjectMapper instance.
 | useDefaultObjectMapper | true | Boolean | Whether to lookup and use default Jackson ObjectMapper from the registry.
 | prettyPrint | false | Boolean | To enable pretty printing output nicely formatted. Is by default false.
 | library | XStream | JsonLibrary | Which json library to use.


### PR DESCRIPTION
ObjectMapper has  wrong param type (maybe it will be a good idea to unify this with [jackson-xml component](https://github.com/apache/camel/blob/master/components/camel-jacksonxml/src/main/docs/jacksonxml-dataformat.adoc)