### PR TITLE
Schematron component supports class `javax.xml.transform.Source`

### DIFF
--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/SchematronProcessor.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/SchematronProcessor.java
@@ -52,7 +52,6 @@ public class SchematronProcessor {
      * @param templates
      */
     public SchematronProcessor(XMLReader reader, Templates templates) {
-
         this.reader = reader;
         this.templates = templates;
     }
@@ -64,9 +63,18 @@ public class SchematronProcessor {
      * @return
      */
     public String validate(final String xml) {
+        final Source source = new SAXSource(reader, new InputSource(IOUtils.toInputStream(xml)));
+        return validate(source);
+    }
 
+    /**
+     * Validates the given XML for given Rules.
+     *
+     * @param source
+     * @return
+     */
+    public String validate(Source source) {
         try {
-            final Source source = new SAXSource(reader, new InputSource(IOUtils.toInputStream(xml)));
             final StringWriter writer = new StringWriter();
             templates.newTransformer().transform(source, new StreamResult(writer));
             return writer.toString();


### PR DESCRIPTION
We use the Schematron component in one of our projects - and I'd like to micro-optimize on this code.

Our XMLs came in the [Fast InfoSet](https://en.wikipedia.org/wiki/Fast_Infoset) format as a byte array, and it's more efficient to create a `javax.xml.transform.Source` object from the byte array and let the Schematron run on that than unmarshal the XML to String and let Schematron parse that String again.

