### PR TITLE
CAMEL-12943: Rest DSL generates invalid swagger operation Id

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
@@ -142,6 +142,19 @@ public final class RouteDefinitionHelper {
                     });
                 }
                 customIds.add(id);
+            } else {
+                RestDefinition rest = route.getRestDefinition();
+                if (rest != null && route.isRest()) {
+                    VerbDefinition verb = findVerbDefinition(rest, route.getInputs().get(0).getUri());
+                    if (verb != null) {
+                        String id = verb.getId();
+                        if (verb.hasCustomIdAssigned() && ObjectHelper.isNotEmpty(id) && !customIds.contains(id)) {
+                            route.setId(id);
+                            customIds.add(id);
+                            break;
+                        }
+                    }
+                }
             }
         }
 
@@ -169,7 +182,8 @@ public final class RouteDefinitionHelper {
             }
             RestDefinition rest = route.getRestDefinition();
             if (rest != null && route.isRest()) {
-                for (VerbDefinition verb : rest.getVerbs()) {
+                VerbDefinition verb = findVerbDefinition(rest, route.getInputs().get(0).getUri());
+                if (verb != null) {
                     String id = verb.idOrCreate(context.getNodeIdFactory());
                     if (!verb.getUsedForGeneratingNodeId()) {
                         id = route.getId();
@@ -194,6 +208,19 @@ public final class RouteDefinitionHelper {
                 }
             }
         }
+    }
+    
+    /**
+     * Find verb associated with the route by mapping uri
+     */
+    private static VerbDefinition findVerbDefinition(RestDefinition rest, String endpointUri) {
+        for (VerbDefinition verb : rest.getVerbs()) {
+            String verbUri = rest.buildFromUri(verb);
+            if (endpointUri.startsWith(verbUri)) {
+                return verb;
+            }
+        }
+        return null;
     }
 
     /**

--- a/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -658,6 +658,13 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         verb.setRoute(route);
         return route;
     }
+    
+    /**
+     * Build the from endpoint uri for the verb
+     */
+    public String buildFromUri(VerbDefinition verb) {
+        return "rest:" + verb.asVerb() + ":" + buildUri(verb);
+    }
 
     // Implementation
     //-------------------------------------------------------------------------
@@ -799,6 +806,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         return answer;
     }
 
+    @SuppressWarnings("rawtypes")
     private void addRouteDefinition(CamelContext camelContext, List<RouteDefinition> answer, String component) {
         for (VerbDefinition verb : getVerbs()) {
             // either the verb has a singular to or a embedded route
@@ -877,7 +885,7 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
             route.setRestBindingDefinition(binding);
 
             // create the from endpoint uri which is using the rest component
-            String from = "rest:" + verb.asVerb() + ":" + buildUri(verb);
+            String from = buildFromUri(verb);
 
             // append options
             Map<String, Object> options = new HashMap<>();

--- a/camel-core/src/test/java/org/apache/camel/impl/RouteIdRestDefinitionTest.java
+++ b/camel-core/src/test/java/org/apache/camel/impl/RouteIdRestDefinitionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.rest.DummyRestConsumerFactory;
+import org.apache.camel.component.rest.DummyRestProcessorFactory;
+import org.junit.Test;
+
+public class RouteIdRestDefinitionTest extends ContextTestSupport {
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+        jndi.bind("dummy-rest", new DummyRestConsumerFactory());
+        jndi.bind("dummy-rest-api", new DummyRestProcessorFactory());
+        return jndi;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start1?timeout=30000").to("mock:result");
+                from("direct:start2").to("mock:result");
+                rest("/say/hello").get("/bar").id("getSayHelloBar").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testSayHelloBar() {
+        assertEquals("getSayHelloBar", context.getRouteDefinitions().get(2).getId());
+    }
+    
+}

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEnableVendorExtensionTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEnableVendorExtensionTest.java
@@ -58,7 +58,7 @@ public class RestSwaggerReaderEnableVendorExtensionTest extends CamelTestSupport
                         .param().name("body").type(RestParamType.body).description("The user to update or create").endParam()
                         .to("bean:userService?method=updateUser")
 
-                    .get("/findAll").description("Find all users").outTypeList(User.class)
+                    .get("/findAll").description("Find all users").outType(User[].class)
                         .responseMessage().message("All the found users").endResponseMessage()
                         .to("bean:userService?method=listUsers");
             }


### PR DESCRIPTION
@tdiesler , could you please to look at the PR, but RestSwaggerReaderEnableVendorExtensionTest which was failing also seem to be this issue test.