### PR TITLE
Update: Fix Maven integration test profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5679,6 +5679,39 @@
       </dependencies>
     </profile>
 
+    <profile>
+      <id>integration</id>
+      <!--The profile for running the unit and integration test -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin-version}</version>
+            <configuration>
+              <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+              <childDelegation>false</childDelegation>
+              <useFile>true</useFile>
+              <failIfNoTests>false</failIfNoTests>
+              <runOrder>alphabetical</runOrder>
+              <rerunFailingTestsCount>0</rerunFailingTestsCount>
+              <systemPropertyVariables>
+                <derby.stream.error.file>target/derby.log</derby.stream.error.file>
+                <java.awt.headless>${java.awt.headless}</java.awt.headless>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*Test.*</include>
+                <include>**/*IntegrationTest.*</include>
+              </includes>
+              <excludes>
+                <exclude>**/*XXXTest.*</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- experimental profile to activate ekstazi http://www.ekstazi.org -->
     <profile>
       <id>ekstazi</id>

--- a/pom.xml
+++ b/pom.xml
@@ -561,35 +561,6 @@
     </profile>
 
     <profile>
-      <id>integration</id>
-      <!--The profile for running the unit and integration test -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin-version}</version>
-            <configuration>
-              <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
-              <childDelegation>false</childDelegation>
-              <useFile>true</useFile>
-              <failIfNoTests>false</failIfNoTests>
-              <runOrder>alphabetical</runOrder>
-              <systemPropertyVariables>
-                <derby.stream.error.file>target/derby.log</derby.stream.error.file>
-                <java.awt.headless>${java.awt.headless}</java.awt.headless>
-              </systemPropertyVariables>
-              <includes>
-                <include>**/*Test.*</include>
-                <include>**/*IntegrationTest.*</include>
-              </includes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>deploy</id>
       <build>
         <defaultGoal>deploy</defaultGoal>


### PR DESCRIPTION
Some components use `*IntegrationTest` tests that are not included in surefire plugin execution by default. The tests are explicitly enabled with `integration` Maven profile. 

The `integration` profile should be located in the `camel-parent` pom.xml though in order to ensure proper configuration and inheritance to component modules. Currently `-Pintegration` has no effect in component modules as profile configuration in root pom.xml is overwritten.

- Moved integration profile from root pom.xml to camel-parent pom.xml
- Added `<rerunFailingTestsCount>0</rerunFailingTestsCount>` to integration profile as multiple executions in integration tests leads to long running builds.
- Added explicit exclude section to integration profile in order to ensure `**/*IntegrationTest.*` inclusion when profile is active