### PR TITLE
Change download previous file version endpoint

### DIFF
--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -352,7 +352,7 @@ box:files/endpoint?[options]
 
 |getFileVersions |versions |fileId |java.util.Collection
 
-|downloadPreviousFileVersions |downloadVersion |fileId, version, output, [listener] |java.io.OutputStream
+|downloadPreviousFileVersion |downloadVersion |fileId, version, output, [listener] |java.io.OutputStream
 
 |deleteFileVersion |deleteVersion |fileId, version |
 


### PR DESCRIPTION
Shorthand Alias will remain nonfunctional until changes are made on backend mapping. 

The real working endpoint is downloadPreviousFileVersion (singular form), on backend downloadVersion is mapped with downloadPreviousFileVersions (plural form) which not exists.