### PR TITLE
CAMEL-12895: TransactionErrorHandler fails if UnitOfWork is null

### DIFF
--- a/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandler.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandler.java
@@ -95,7 +95,7 @@ public class TransactionErrorHandler extends RedeliveryErrorHandler {
     public void process(Exchange exchange) throws Exception {
         // we have to run this synchronously as Spring Transaction does *not* support
         // using multiple threads to span a transaction
-        if (transactionTemplate.getPropagationBehavior() != TransactionDefinition.PROPAGATION_REQUIRES_NEW && exchange.getUnitOfWork().isTransactedBy(transactionKey)) {
+        if (transactionTemplate.getPropagationBehavior() != TransactionDefinition.PROPAGATION_REQUIRES_NEW && exchange.getUnitOfWork() != null && exchange.getUnitOfWork().isTransactedBy(transactionKey)) {
             // already transacted by this transaction template
             // so lets just let the error handler process it
             processByErrorHandler(exchange);
@@ -129,7 +129,8 @@ public class TransactionErrorHandler extends RedeliveryErrorHandler {
 
         try {
             // mark the beginning of this transaction boundary
-            exchange.getUnitOfWork().beginTransactedBy(transactionKey);
+            if (exchange.getUnitOfWork() != null)
+                exchange.getUnitOfWork().beginTransactedBy(transactionKey);
 
             // do in transaction
             logTransactionBegin(redelivered, ids);
@@ -144,7 +145,8 @@ public class TransactionErrorHandler extends RedeliveryErrorHandler {
             logTransactionRollback(redelivered, ids, e, false);
         } finally {
             // mark the end of this transaction boundary
-            exchange.getUnitOfWork().endTransactedBy(transactionKey);
+            if (exchange.getUnitOfWork() != null)
+                exchange.getUnitOfWork().endTransactedBy(transactionKey);
         }
 
         // if it was a local rollback only then remove its marker so outer transaction wont see the marker

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/TransactedInterceptUsingAdviceWithSendToEndpointTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/TransactedInterceptUsingAdviceWithSendToEndpointTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.interceptor;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.spring.SpringRouteBuilder;
+import org.junit.Test;
+
+/**
+ * Easier transaction configuration as we do not have to setup a transaction error handler
+ */
+public class TransactedInterceptUsingAdviceWithSendToEndpointTest extends TransactionalClientDataSourceTest {
+
+    @Test
+    public void testTransactionSuccess() throws Exception {
+        MockEndpoint intercepted = getMockEndpoint("mock:intercepted");
+        
+        addInterceptor("ok_route");
+        
+        intercepted.expectedBodiesReceived("Hello World");
+
+        super.testTransactionSuccess();
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testTransactionRollback() throws Exception {
+        MockEndpoint intercepted = getMockEndpoint("mock:intercepted");
+        
+        addInterceptor("fail_route");
+        
+        intercepted.expectedBodiesReceived("Tiger in Action");
+
+        super.testTransactionRollback();
+
+        assertMockEndpointsSatisfied();
+    }
+    
+    private void addInterceptor(String routeId) throws Exception {
+        context.getRouteDefinition(routeId).adviceWith(context, new SpringRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                interceptSendToEndpoint("direct:(foo|bar)")
+                    .to("mock:intercepted");
+            }
+        });
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new SpringRouteBuilder() {
+            public void configure() throws Exception {
+                from("direct:okay")
+                    .routeId("ok_route")
+                    .transacted()
+                    .enrich("direct:foo", (oldExchange, newExchange) -> {
+                        return newExchange;
+                    })
+                    .setBody(constant("Tiger in Action")).bean("bookService")
+                    .setBody(constant("Elephant in Action")).bean("bookService");
+
+                from("direct:fail")
+                    .routeId("fail_route")
+                    .transacted()
+                    .setBody(constant("Tiger in Action")).bean("bookService")
+                    .enrich("direct:bar", (oldExchange, newExchange) -> {
+                        return newExchange;
+                    })
+                    .setBody(constant("Donkey in Action")).bean("bookService");
+
+                from("direct:foo").to("log:okay");
+
+                from("direct:bar").to("mock:fail");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12985