### PR TITLE
CAMEL-12989 Allow Endpoint to set the key that ProducerCache uses

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/Endpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/Endpoint.java
@@ -60,6 +60,14 @@ public interface Endpoint extends IsSingleton, Service {
     String getEndpointKey();
 
     /**
+     * Key that allows multiple endpoints to be associated with the same URI
+     * Allows for different configurations on the same endpoint e.g. multiple SSL certificates
+     * @return
+     */
+    String getProducerCacheKey();
+    void setProducerCacheKey(String key);
+	
+	/**
      * Create a new exchange for communicating with this endpoint
      *
      * @return a new exchange

--- a/camel-core/src/main/java/org/apache/camel/Endpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/Endpoint.java
@@ -66,8 +66,8 @@ public interface Endpoint extends IsSingleton, Service {
      */
     String getProducerCacheKey();
     void setProducerCacheKey(String key);
-	
-	/**
+
+    /**
      * Create a new exchange for communicating with this endpoint
      *
      * @return a new exchange

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultEndpoint.java
@@ -88,11 +88,11 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
     private int pollingConsumerQueueSize = 1000;
     private boolean pollingConsumerBlockWhenFull = true;
     private long pollingConsumerBlockTimeout;
-	
+
     // key that producer cache will use
-	private String producerCacheKey;
+    private String producerCacheKey;
     
-	/**
+    /**
      * Constructs a fully-initialized DefaultEndpoint instance. This is the
      * preferred method of constructing an object from Java code (as opposed to
      * Spring beans, etc.).
@@ -551,19 +551,18 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
     protected void doStop() throws Exception {
         // noop
     }
-	
-	@Override
-	public String getProducerCacheKey() {
-		if (producerCacheKey == null) {
-			// return URI as the default if no key is set
-			return getEndpointUri();
-		}
-		return this.producerCacheKey;
-	}
 
-	@Override
-	public void setProducerCacheKey(String key) {
-		this.producerCacheKey = key;
-		
-	}	
+    @Override
+    public String getProducerCacheKey() {
+        if (producerCacheKey == null) {
+        // return URI as the default if no key is set
+            return getEndpointUri();
+        }
+        return this.producerCacheKey;
+    }
+
+    @Override
+    public void setProducerCacheKey(String key) {
+        this.producerCacheKey = key;
+    }
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultEndpoint.java
@@ -88,8 +88,11 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
     private int pollingConsumerQueueSize = 1000;
     private boolean pollingConsumerBlockWhenFull = true;
     private long pollingConsumerBlockTimeout;
-
-    /**
+	
+    // key that producer cache will use
+	private String producerCacheKey;
+    
+	/**
      * Constructs a fully-initialized DefaultEndpoint instance. This is the
      * preferred method of constructing an object from Java code (as opposed to
      * Spring beans, etc.).
@@ -548,4 +551,19 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
     protected void doStop() throws Exception {
         // noop
     }
+	
+	@Override
+	public String getProducerCacheKey() {
+		if (producerCacheKey == null) {
+			// return URI as the default if no key is set
+			return getEndpointUri();
+		}
+		return this.producerCacheKey;
+	}
+
+	@Override
+	public void setProducerCacheKey(String key) {
+		this.producerCacheKey = key;
+		
+	}	
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/InterceptSendToEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/InterceptSendToEndpoint.java
@@ -149,14 +149,13 @@ public class InterceptSendToEndpoint implements Endpoint, ShutdownableService {
         return delegate.toString();
     }
 
-	@Override
-	public String getProducerCacheKey() {
-		return delegate.getProducerCacheKey();
-	}
-	
-	@Override
-	public void setProducerCacheKey(String key) {
-		delegate.setProducerCacheKey(key);
-	}
-	
+    @Override
+    public String getProducerCacheKey() {
+        return delegate.getProducerCacheKey();
+    }
+
+    @Override
+    public void setProducerCacheKey(String key) {
+        delegate.setProducerCacheKey(key);
+    }
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/InterceptSendToEndpoint.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/InterceptSendToEndpoint.java
@@ -148,4 +148,15 @@ public class InterceptSendToEndpoint implements Endpoint, ShutdownableService {
     public String toString() {
         return delegate.toString();
     }
+
+	@Override
+	public String getProducerCacheKey() {
+		return delegate.getProducerCacheKey();
+	}
+	
+	@Override
+	public void setProducerCacheKey(String key) {
+		delegate.setProducerCacheKey(key);
+	}
+	
 }

--- a/camel-core/src/main/java/org/apache/camel/impl/ProducerCache.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/ProducerCache.java
@@ -560,7 +560,7 @@ public class ProducerCache extends ServiceSupport {
     }
 
     protected synchronized Producer doGetProducer(Endpoint endpoint, boolean pooled) {
-        String key = endpoint.getEndpointUri();
+        String key = endpoint.getProducerCacheKey();
         Producer answer = producers.get(key);
         if (pooled && answer == null) {
             // try acquire from connection pool


### PR DESCRIPTION
ProducerCache is heavily tied to Endpoint URIs. Using the Endpoint URI as the key to the cache does not allow for the creation of Endpoints with the same URI but with different configurations. For example, using a RecipientList to call the same SOAP endpoint but with different SSL certificates isn't currently possible. As the URI is always the same the ProducerCache will always use the first Endpoint it added to the map, even if multiple Endpoints are added to the CamelContext with different keys.

Endpoint interface has 2 new methods: getProducerCacheKey & setProducerCacheKey
ProducerCache.doGetProducer uses the getProducerCacheKey method instead of getEndpointUri.
DefaultEndpoint has a new member variable producerCacheKey and implements the 2 new Endpoint methods. The getter returns getEndpointUri() if the producerCacheKey member is null.

InterceptSendToEndpoint also implements the new methods but simply forwards to the delegate.