### PR TITLE
Updated documentation and feature files for examples

### DIFF
--- a/examples/camel-example-aggregate/src/main/resources/features.xml
+++ b/examples/camel-example-aggregate/src/main/resources/features.xml
@@ -24,7 +24,7 @@
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-stream</feature>
         <feature version="${project.version}">camel-hawtdb</feature>
-        <bundle>mvn:org.apache.camel/camel-example-aggregate/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-aggregate/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-cafe/src/main/resources/features.xml
+++ b/examples/camel-example-cafe/src/main/resources/features.xml
@@ -22,7 +22,7 @@
 
     <feature name='camel-example-cafe' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
-        <bundle>mvn:org.apache.camel/camel-example-cafe/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-cafe/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-cxf-blueprint/README.md
+++ b/examples/camel-example-cxf-blueprint/README.md
@@ -40,7 +40,7 @@ Add features required
 #### Step 3: Deploy
 Deploy the example
 
-	install -s mvn:org.apache.camel/camel-example-cxf-blueprint/${version}
+	install -s mvn:org.apache.camel.example/camel-example-cxf-blueprint/${version}
 
 #### Step 4: Verify that your service is available using the following url in the browser.
 

--- a/examples/camel-example-loan-broker-cxf/src/main/resources/features.xml
+++ b/examples/camel-example-loan-broker-cxf/src/main/resources/features.xml
@@ -24,7 +24,7 @@
   <feature name='camel-example-loan-broker' version='${project.version}'>
     <feature version="${project.version}">camel</feature>
     <feature version="${project.version}">camel-cxf</feature>
-    <bundle>mvn:org.apache.camel/camel-example-loan-broker/${project.version}
+    <bundle>mvn:org.apache.camel.example/camel-example-loan-broker-cxf/${project.version}
     </bundle>
   </feature>
 

--- a/examples/camel-example-loan-broker-jms/src/main/resources/features.xml
+++ b/examples/camel-example-loan-broker-jms/src/main/resources/features.xml
@@ -37,7 +37,7 @@
     <feature name='camel-example-loan-broker' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-loan-broker/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-loan-broker-jms/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-management/src/main/resources/features.xml
+++ b/examples/camel-example-management/src/main/resources/features.xml
@@ -37,7 +37,7 @@
     <feature name='camel-example-management' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-management/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-management/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-pojo-messaging/src/main/resources/features.xml
+++ b/examples/camel-example-pojo-messaging/src/main/resources/features.xml
@@ -37,7 +37,7 @@
     <feature name='camel-example-pojo-messaging' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-pojo-messaging/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-pojo-messaging/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-route-throttling/src/main/resources/features.xml
+++ b/examples/camel-example-route-throttling/src/main/resources/features.xml
@@ -37,7 +37,7 @@
     <feature name='camel-example-route-throttling' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-route-throttling/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-route-throttling/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-spring-jms/src/main/resources/features.xml
+++ b/examples/camel-example-spring-jms/src/main/resources/features.xml
@@ -26,7 +26,7 @@
         <feature>activemq-camel</feature>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-spring-jms/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-spring-jms/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-spring-xquery/src/main/resources/features.xml
+++ b/examples/camel-example-spring-xquery/src/main/resources/features.xml
@@ -38,7 +38,7 @@
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
         <feature version="${project.version}">camel-saxon</feature>
-        <bundle>mvn:org.apache.camel/camel-example-spring-xquery/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-spring-xquery/${project.version}</bundle>
     </feature>
 
 </features>

--- a/examples/camel-example-spring/src/main/resources/features.xml
+++ b/examples/camel-example-spring/src/main/resources/features.xml
@@ -37,7 +37,7 @@
     <feature name='camel-example-spring' version='${project.version}'>
         <feature version="${project.version}">camel</feature>
         <feature version="${project.version}">camel-jms</feature>
-        <bundle>mvn:org.apache.camel/camel-example-spring/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.example/camel-example-spring/${project.version}</bundle>
     </feature>
 
 </features>


### PR DESCRIPTION
 Most cases wrong groupId. Changed from org.apache.camel to org.apache.camel.example.