### PR TITLE
Fixed typo in Azure blob storage URI example

### DIFF
--- a/components/camel-azure/src/main/docs/azure-blob-component.adoc
+++ b/components/camel-azure/src/main/docs/azure-blob-component.adoc
@@ -221,7 +221,7 @@ and refer to it in your Camel azure-blob component configuration:
 
 [source,java]
 --------------------------------------------------------------------------------
-from("azure-blob:/camelazure/container1/blockBlob?azureBlobClient=#client")
+from("azure-blob://camelazure/container1/blockBlob?azureBlobClient=#client")
 .to("mock:result");
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The example in the docs only has a single slash after `azure-blob:` when there should be two.