### PR TITLE
CAMEL-12966: camel-netty4-http use relative path by default

### DIFF
--- a/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
+++ b/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
@@ -174,7 +174,7 @@ with the following path and query parameters:
 | *producerPoolMaxIdle* (producer) | Sets the cap on the number of idle instances in the pool. | 100 | int
 | *producerPoolMinEvictable Idle* (producer) | Sets the minimum amount of time (value in millis) an object may sit idle in the pool before it is eligible for eviction by the idle object evictor. | 300000 | long
 | *producerPoolMinIdle* (producer) | Sets the minimum number of instances allowed in the producer pool before the evictor thread (if active) spawns new objects. |  | int
-| *useRelativePath* (producer) | Sets whether to use a relative path in HTTP requests. | false | boolean
+| *useRelativePath* (producer) | Sets whether to use a relative path in HTTP requests. (Note: This applies only for requests which are non GET. For GET requests, we use relative path) | false | boolean
 | *allowSerializedHeaders* (advanced) | Only used for TCP when transferExchange is true. When set to true, serializable objects in headers and properties will be added to the exchange. Otherwise Camel will exclude any non-serializable objects and log it at WARN level. | false | boolean
 | *bootstrapConfiguration* (advanced) | To use a custom configured NettyServerBootstrapConfiguration for configuring this endpoint. |  | NettyServerBootstrap Configuration
 | *channelGroup* (advanced) | To use a explicit ChannelGroup. |  | ChannelGroup

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/DefaultNettyHttpBinding.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/DefaultNettyHttpBinding.java
@@ -506,6 +506,15 @@ public class DefaultNettyHttpBinding implements NettyHttpBinding, Cloneable {
         HttpMethod method = NettyHttpHelper.createMethod(message, body != null);
         request.setMethod(method);
         
+        // we use the relative path by default for GET Requests
+        if (request.method().equals(HttpMethod.GET)) {
+            int indexOfPath = uri.indexOf((new URI(uri)).getPath());
+            if (indexOfPath > 0) {
+                uriForRequest = uri.substring(indexOfPath);
+            }
+            request.setUri(uriForRequest);
+        }
+ 
         TypeConverter tc = message.getExchange().getContext().getTypeConverter();
 
         // if we bridge endpoint then we need to skip matching headers with the HTTP_QUERY to avoid sending

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConfiguration.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConfiguration.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.netty4.http;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import io.netty.channel.ChannelHandler;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.netty4.NettyConfiguration;


### PR DESCRIPTION
Make useRelativePath to true, to get the relative path by default.