### PR TITLE
CAMEL-13033: Memory leak in ReactiveHelper class

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/support/ReactiveHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/support/ReactiveHelper.java
@@ -52,7 +52,7 @@ public final class ReactiveHelper {
     }
 
     public static void scheduleLast(Runnable runnable, String description) {
-        WORKERS.get().schedule(describe(runnable, description), false, false, false);
+        WORKERS.get().schedule(describe(runnable, description), false, true, false);
     }
 
     public static void scheduleSync(Runnable runnable, String description) {


### PR DESCRIPTION
It seems that, in some cases, we are never polling from the back list of work in org.apache.camel.support.ReactiveHelper.Work and this leads to OOM error. 

This is a test case (try to set numOfRecords=1000000 and maxWaitTime=20000):
https://github.com/fvaleri/camel/tree/bigxml-split-example/examples/camel-example-bigxml-split

I tried to set the "main" parameter to true in the schedule call inside ReactiveHelper.scheduleLast. If I understand correctly, this avoids the accumulation of after processor work from CamelInternalProcessor by executing it in the route's main execution thread.

After this change I see the after processor TRACE log (CamelInternalProcessor line 232) and I have similar test results as with 2.23.0, even if I have to increase maxWaitTime a little for the 1.3GB test.

I'm not completely aware of the implications of this change in other parts of the code, so I need a double check from you.
