### PR TITLE
CAMEL-13054: Olingo4Endpoint - avoid swallowing consumer options

### DIFF
--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
@@ -196,6 +196,14 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
             final Map.Entry<String, Object> entry = it.next();
             final String paramName = entry.getKey();
 
+            /**
+             * Avoid swallowing consumer scheduler properties, which
+             * get processed in configureProperties()
+             */
+            if (paramName.startsWith("consumer.")) {
+                continue;
+            }
+
             if (!endpointPropertyNames.contains(paramName)) {
 
                 // add to query params


### PR DESCRIPTION
* Those options prefixed with 'consumer' are required to be processed by
  Olingo4Endpoint's parent class. However, they are getting added to the
  query options instead and never applied to the scheduling consumer.