### PR TITLE
CAMEL-12708: Fix atx-style section titles in docs

### DIFF
--- a/camel-core/readme-eip.adoc
+++ b/camel-core/readme-eip.adoc
@@ -1,5 +1,4 @@
-Enterprise Integration Patterns
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Enterprise Integration Patterns
 
 Camel supports most of the link:http://www.eaipatterns.com/toc.html[Enterprise Integration Patterns] from the excellent book by link:http://www.amazon.com/exec/obidos/search-handle-url/105-9796798-8100401?%5Fencoding=UTF8&search-type=ss&index=books&field-author=Gregor%20Hohpe[Gregor Hohpe] and link:http://www.amazon.com/exec/obidos/search-handle-url/105-9796798-8100401?%5Fencoding=UTF8&search-type=ss&index=books&field-author=Bobby%20Woolf[Bobby Woolf].
 

--- a/camel-core/readme.adoc
+++ b/camel-core/readme.adoc
@@ -1,5 +1,4 @@
-Components
-^^^^^^^^^^
+==== Components
 
 
 
@@ -95,8 +94,7 @@ Number of Components: 25 in 1 JAR artifacts (0 deprecated)
 
 
 
-Data Formats
-^^^^^^^^^^^^
+==== Data Formats
 
 
 
@@ -125,8 +123,7 @@ Number of Data Formats: 4 in 35 JAR artifacts (0 deprecated)
 
 
 
-Expression Languages
-^^^^^^^^^^^^^^^^^^^^
+==== Expression Languages
 
 
 

--- a/components/camel-cxf-transport/src/main/docs/cxf-transport.adoc
+++ b/components/camel-cxf-transport/src/main/docs/cxf-transport.adoc
@@ -18,15 +18,13 @@ use Camel's routing engine and integration patterns support together
 with your CXF services.
 
 [[CamelTransportforCXF-IntegrateCamelintoCXFtransportlayer]]
-Integrate Camel into CXF transport layer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Integrate Camel into CXF transport layer
 
 To include the Camel Tranport into your CXF bus you use the
 CamelTransportFactory. You can do this in Java as well as in Spring.
 
 [[CamelTransportforCXF-SettinguptheCamelTransportinSpring]]
-Setting up the Camel Transport in Spring
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Setting up the Camel Transport in Spring
 
 You can use the following snippet in your applicationcontext if you want
 to configure anything special. If you only want to activate the camel
@@ -57,8 +55,7 @@ jar and load a CamelTransportFactory for you.
 --------------------------------------------------------------------------------------------------------
 
 [[CamelTransportforCXF-IntegratingtheCamelTransportinaprogrammaticway]]
-Integrating the Camel Transport in a programmatic way
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Integrating the Camel Transport in a programmatic way
 
 Camel transport provides a setContext method that you could use to set
 the Camel context into the transport factory. If you want this factory
@@ -93,12 +90,10 @@ BusFactory.setDefaultBus(bus);
 ------------------------------------------------------------------------------------------------------------------
 
 [[CamelTransportforCXF-ConfigurethedestinationandconduitwithSpring]]
-Configure the destination and conduit with Spring
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Configure the destination and conduit with Spring
 
 [[CamelTransportforCXF-Namespace]]
-Namespace
-^^^^^^^^^
+==== Namespace
 
 The elements used to configure an Camel transport endpoint are defined
 in the namespace `http://cxf.apache.org/transports/camel`. It is
@@ -122,8 +117,7 @@ the `xsi:schemaLocation` attribute.
 ---------------------------------------------------------------------
 
 [[CamelTransportforCXF-Thedestinationelement]]
-The `destination` element
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== The `destination` element
 
 You configure an Camel transport server endpoint using the
 `camel:destination` element and its children. The `camel:destination`
@@ -172,8 +166,7 @@ You can specify the camel context in the camel destination
 The camel context id which you want inject into the camel destination
 
 [[CamelTransportforCXF-Theconduitelement]]
-The `conduit` element
-^^^^^^^^^^^^^^^^^^^^^
+==== The `conduit` element
 
 You configure a Camel transport client using the `camel:conduit` element
 and its children. The `camel:conduit` element takes a single attribute,
@@ -228,8 +221,7 @@ You can specify the camel context in the camel conduit
 The camel context id which you want inject into the camel conduit
 
 [[CamelTransportforCXF-ConfigurethedestinationandconduitwithBlueprint]]
-Configure the destination and conduit with Blueprint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Configure the destination and conduit with Blueprint
 
 From *Camel 2.11.x*, Camel Transport supports to be configured with
 Blueprint.
@@ -262,16 +254,14 @@ context in the camel destination.
 ------------------------------------------------------------------------
 
 [[CamelTransportforCXF-ExampleUsingCamelasaloadbalancerforCXF]]
-Example Using Camel as a load balancer for CXF
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Example Using Camel as a load balancer for CXF
 
 This example shows how to use the camel load balancing feature in CXF.
 You need to load the configuration file in CXF and publish the endpoints
 on the address "camel://direct:EndpointA" and "camel://direct:EndpointB"
 
 [[CamelTransportforCXF-CompleteHowtoandExampleforattachingCameltoCXF]]
-Complete Howto and Example for attaching Camel to CXF
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Complete Howto and Example for attaching Camel to CXF
 
 link:better-jms-transport-for-cxf-webservice-using-apache-camel.html[Better
 JMS Transport for CXF Webservice using Apache Camel] 

--- a/components/camel-kura/src/main/docs/kura.adoc
+++ b/components/camel-kura/src/main/docs/kura.adoc
@@ -13,8 +13,7 @@ services and finally forward the current temperature value to your data
 center service using Camel EIP and components.
 
 [[Kura-KuraRouteractivator]]
-KuraRouter activator
-^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter activator
 
 Bundles deployed to the Eclipse Kura are usually
 http://eclipse.github.io/kura/doc/hello-example.html#create-java-class[developed
@@ -47,8 +46,7 @@ every class extending `KuraRouter`, there will be a dedicated
 per OSGi bundle.
 
 [[Kura-DeployingKuraRouter]]
-Deploying KuraRouter
-^^^^^^^^^^^^^^^^^^^^
+==== Deploying KuraRouter
 
 Bundle containing your Kura router class should import the following
 packages in the OSGi manifest:
@@ -96,15 +94,13 @@ start <your-bundle-id>
 ----------------------------------------------------------------------------------
 
 [[Kura-KuraRouterutilities]]
-KuraRouter utilities 
-^^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter utilities 
 
  Kura router base class provides many useful utilities. This section
 explores each of them.
 
 [[Kura-SLF4Jlogger]]
-SLF4J logger
-++++++++++++
+===== SLF4J logger
 
 Kura uses SLF4J facade for logging purposes. Protected member `log`
 returns SLF4J logger instance associated with the given Kura router.
@@ -123,8 +119,7 @@ public class MyKuraRouter extends KuraRouter {
 ----------------------------------------------
 
 [[Kura-BundleContext]]
-BundleContext
-+++++++++++++
+===== BundleContext
 
 Protected member `bundleContext` returns bundle context associated with
 the given Kura router.
@@ -144,8 +139,7 @@ public class MyKuraRouter extends KuraRouter {
 ---------------------------------------------------------------------------------------------------------------
 
 [[Kura-CamelContext]]
-CamelContext
-++++++++++++
+===== CamelContext
 
 Protected member `camelContext` is the `CamelContext` associated with
 the given Kura router.
@@ -164,8 +158,7 @@ public class MyKuraRouter extends KuraRouter {
 ----------------------------------------------
 
 [[Kura-ProducerTemplate]]
-ProducerTemplate
-++++++++++++++++
+===== ProducerTemplate
 
 Protected member `producerTemplate` is the `ProducerTemplate` instance
 associated with the given Camel context.
@@ -184,8 +177,7 @@ public class MyKuraRouter extends KuraRouter {
 -----------------------------------------------------------
 
 [[Kura-ConsumerTemplate]]
-ConsumerTemplate
-++++++++++++++++
+===== ConsumerTemplate
 
 Protected member `consumerTemplate` is the `ConsumerTemplate` instance
 associated with the given Camel context.
@@ -204,8 +196,7 @@ public class MyKuraRouter extends KuraRouter {
 --------------------------------------------------------------------------------------------------
 
 [[Kura-OSGiserviceresolver]]
-OSGi service resolver
-+++++++++++++++++++++
+===== OSGi service resolver
 
 OSGi service resolver (`service(Class<T> serviceType)`) can be used to
 easily retrieve service by type from the OSGi bundle context.
@@ -242,8 +233,7 @@ public class MyKuraRouter extends KuraRouter {
 ---------------------------------------------------------------
 
 [[Kura-KuraRouteractivatorcallbacks]]
-KuraRouter activator callbacks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter activator callbacks
 
 Kura router comes with the lifecycle callbacks that can be used to
 customize the way the Camel router works. For example to configure the
@@ -266,8 +256,7 @@ public class MyKuraRouter extends KuraRouter {
 --------------------------------------------------------------------------
 
 [[Kura-LoadingXMLroutesfromConfigurationAdmin]]
-Loading XML routes from ConfigurationAdmin
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Loading XML routes from ConfigurationAdmin
 
 Sometimes it is desired to read the XML definition of the routes from
 the server configuration. This a common scenario for IoT gateways where
@@ -294,8 +283,7 @@ Camel XML route file, for example:
  
 
 [[Kura-DeployingKurarouterasadeclarativeOSGiservice]]
-Deploying Kura router as a declarative OSGi service
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Deploying Kura router as a declarative OSGi service
 
 If you would like to deploy your Kura router as a declarative OSGi
 service, you can use `activate` and `deactivate` methods provided by
@@ -309,8 +297,7 @@ service, you can use `activate` and `deactivate` methods provided by
 ----------------------------------------------------------------------------------------------------------------------------------------------
 
 [[Kura-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/components/camel-leveldb/src/main/docs/leveldb.adoc
+++ b/components/camel-leveldb/src/main/docs/leveldb.adoc
@@ -13,8 +13,7 @@ Current features it provides:
 * LevelDBAggregationRepository
 
 [[LevelDB-UsingLevelDBAggregationRepository]]
-Using LevelDBAggregationRepository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using LevelDBAggregationRepository
 
 `LevelDBAggregationRepository` is an `AggregationRepository` which on
 the fly persists the aggregated messages. This ensures that you will not
@@ -70,8 +69,7 @@ The `repositoryName` option must be provided. Then either the
 `persistentFileName` or the `levelDBFile` must be provided.
 
 [[LevelDB-Whatispreservedwhenpersisting]]
-What is preserved when persisting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== What is preserved when persisting
 
 `LevelDBAggregationRepository` will only preserve any `Serializable`
 compatible message body data types. Message headers must be primitive /
@@ -80,8 +78,7 @@ and a `WARN` is logged. And it only persists the `Message` body and the
 `Message` headers. The `Exchange` properties are *not* persisted.
 
 [[LevelDB-Recovery]]
-Recovery
-^^^^^^^^
+==== Recovery
 
 The `LevelDBAggregationRepository` will by default recover any failed
 Exchange. It does this by having a background tasks
@@ -123,21 +120,18 @@ https://svn.apache.org/repos/asf/camel/trunk/components/camel-leveldb/src/test/j
 test].
 
 [[LevelDB-UsingLevelDBAggregationRepositoryinJavaDSL]]
-Using LevelDBAggregationRepository in Java DSL
-++++++++++++++++++++++++++++++++++++++++++++++
+===== Using LevelDBAggregationRepository in Java DSL
 
 In this example we want to persist aggregated messages in the
 `target/data/leveldb.dat` file.
 
 [[LevelDB-UsingLevelDBAggregationRepositoryinSpringXML]]
-Using LevelDBAggregationRepository in Spring XML
-++++++++++++++++++++++++++++++++++++++++++++++++
+===== Using LevelDBAggregationRepository in Spring XML
 
 The same example but using Spring XML instead:
 
 [[LevelDB-Dependencies]]
-Dependencies
-^^^^^^^^^^^^
+==== Dependencies
 
 To use LevelDB in your camel routes you need to add
 the a dependency on *camel-leveldb*.
@@ -156,8 +150,7 @@ the download page for the latest versions).
 ----------------------------------------
 
 [[LevelDB-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/components/camel-script/src/main/docs/script.adoc
+++ b/components/camel-script/src/main/docs/script.adoc
@@ -14,8 +14,7 @@ return value should be used as a changed message body then
 use Message Translator EIP instead.
 
 [[Script-UsingfromJavaDSL]]
-Using from Java DSL
-^^^^^^^^^^^^^^^^^^^
+==== Using from Java DSL
 
 The route below will read the file contents and validate them against a
 regular expression.
@@ -28,8 +27,7 @@ from("file://inbox")
 ---------------------------------------------------
 
 [[Script-UsingfromSpringDSL]]
-Using from Spring DSL
-^^^^^^^^^^^^^^^^^^^^^
+==== Using from Spring DSL
 
 And from XML its easy as well
 
@@ -64,8 +62,7 @@ Mind that you can use CDATA in XML if the groovy scrip uses < > etc
 -------------------------------------------------------------------------------------------------
 
 [[Script-Usingexternalscriptfiles]]
-Using external script files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using external script files
 
 You can refer to external script files instead of inlining the script.
 For example to load a groovy script from the classpath you need to
@@ -90,8 +87,7 @@ of classpath: such as file:/var/myscript.groovy
  
 
 [[Script-UsingThisPattern]]
-Using This Pattern
-++++++++++++++++++
+===== Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
 Getting Started, you may also find the

--- a/components/camel-shiro/src/main/docs/shiro.adoc
+++ b/components/camel-shiro/src/main/docs/shiro.adoc
@@ -37,8 +37,7 @@ for this component:
 ------------------------------------------------------------
 
 [[ShiroSecurity-ShiroSecurityBasics]]
-Shiro Security Basics
-^^^^^^^^^^^^^^^^^^^^^
+==== Shiro Security Basics
 
 To employ Shiro security on a camel route, a ShiroSecurityPolicy object
 must be instantiated with security configuration details (including
@@ -75,8 +74,7 @@ sec-level1 = zone1:readonly:*
 ------------------------------------------------------------------
 
 [[ShiroSecurity-InstantiatingaShiroSecurityPolicyObject]]
-Instantiating a ShiroSecurityPolicy Object
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Instantiating a ShiroSecurityPolicy Object
 
 A ShiroSecurityPolicy object is instantiated as follows
 
@@ -97,8 +95,7 @@ A ShiroSecurityPolicy object is instantiated as follows
 ----------------------------------------------------------------------------------------
 
 [[ShiroSecurity-ShiroSecurityPolicyOptions]]
-ShiroSecurityPolicy Options
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== ShiroSecurityPolicy Options
 
 [width="100%",cols="10%,10%,10%,90%",options="header",]
 |=======================================================================
@@ -147,8 +144,7 @@ require all of the roles to be met.
 |=======================================================================
 
 [[ShiroSecurity-ApplyingShiroAuthenticationonaCamelRoute]]
-Applying Shiro Authentication on a Camel Route
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Applying Shiro Authentication on a Camel Route
 
 The ShiroSecurityPolicy, tests and permits incoming message exchanges
 containing a encrypted SecurityToken in the Message Header to proceed
@@ -183,8 +179,7 @@ the user is a valid user.
 -----------------------------------------------------------------------
 
 [[ShiroSecurity-ApplyingShiroAuthorizationonaCamelRoute]]
-Applying Shiro Authorization on a Camel Route
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Applying Shiro Authorization on a Camel Route
 
 Authorization can be applied on a camel route by associating a
 Permissions List with the ShiroSecurityPolicy. The Permissions List
@@ -219,8 +214,7 @@ permission set, the request is not authorized to continue any further.
 -------------------------------------------------------------------------------------------
 
 [[ShiroSecurity-CreatingaShiroSecurityTokenandinjectingitintoaMessageExchange]]
-Creating a ShiroSecurityToken and injecting it into a Message Exchange
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Creating a ShiroSecurityToken and injecting it into a Message Exchange
 
 A ShiroSecurityToken object may be created and injected into a Message
 Exchange using a Shiro Processor called ShiroSecurityTokenInjector. An
@@ -239,8 +233,7 @@ ShiroSecurityTokenInjector in the client is shown below
 -------------------------------------------------------------------------------------
 
 [[ShiroSecurity-SendingMessagestoroutessecuredbyaShiroSecurityPolicy]]
-Sending Messages to routes secured by a ShiroSecurityPolicy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Sending Messages to routes secured by a ShiroSecurityPolicy
 
 Messages and Message Exchanges sent along the camel route where the
 security policy is applied need to be accompanied by a SecurityToken in
@@ -274,15 +267,13 @@ ProducerTemplate in Camel along with a SecurityToken
 -------------------------------------------------------------------------------------------------
 
 [[ShiroSecurity-SendingMessagestoroutessecuredbyaShiroSecurityPolicymucheasierfromCamel2.12onwards]]
-Sending Messages to routes secured by a ShiroSecurityPolicy (much easier from Camel 2.12 onwards)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Sending Messages to routes secured by a ShiroSecurityPolicy (much easier from Camel 2.12 onwards)
 
 From *Camel 2.12* onwards its even easier as you can provide the subject
 in two different ways.
 
 [[ShiroSecurity-UsingShiroSecurityToken]]
-Using ShiroSecurityToken
-++++++++++++++++++++++++
+===== Using ShiroSecurityToken
 
 You can send a message to a Camel route with a header of key
 `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` of the type

--- a/components/camel-spring-cloud/src/main/docs/spring-cloud.adoc
+++ b/components/camel-spring-cloud/src/main/docs/spring-cloud.adoc
@@ -22,8 +22,7 @@ soon as you add that dependency into your classpath, Spring Boot will
 automatically auto-configure Camel for you.
 
 [[SpringCloud-CamelSpringCloudStarter]]
-Camel Spring Cloud Starter
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Camel Spring Cloud Starter
 
 *Available as of Camel 2.19*
 

--- a/components/camel-spring-javaconfig/src/main/docs/spring-javaconfig.adoc
+++ b/components/camel-spring-javaconfig/src/main/docs/spring-javaconfig.adoc
@@ -10,8 +10,7 @@ You can use either the XML or Java config approaches with Camel; its
 your choice really on which you prefer.
 
 [[SpringJavaConfig-UsingSpringJavaConfig]]
-Using Spring Java Config
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using Spring Java Config
 
 To use Spring Java Config in your Camel project the easiest thing to do
 is add the following to your pom.xml
@@ -32,8 +31,7 @@ Note that this library is totally optional; you could just wire Camel
 together yourself with Java Config.
 
 [[SpringJavaConfig-Configuration]]
-Configuration
-^^^^^^^^^^^^^
+==== Configuration
 
 The most common case of using JavaConfig with Camel would be to create
 configuration with defined list of routes to be used by router.
@@ -69,8 +67,7 @@ public class MyRouteConfiguration extends CamelConfiguration {
 --------------------------------------------------------------
 
 [[SpringJavaConfig-Testing]]
-Testing
-^^^^^^^
+==== Testing
 
 Since *Camel 2.11.0* you can use the `CamelSpringJUnit4ClassRunner` with
 `CamelSpringDelegatingTestContextLoader`. This is the recommended way to

--- a/components/camel-test-cdi/src/main/docs/test-cdi.adoc
+++ b/components/camel-test-cdi/src/main/docs/test-cdi.adoc
@@ -65,8 +65,7 @@ containers].
 |=======================================================================
 
 [[CDITesting-CamelCDITest]]
-Camel CDI Test
-^^^^^^^^^^^^^^
+==== Camel CDI Test
 
 With this approach, your test classes use the JUnit runner provided in
 Camel CDI test. This runner manages the lifecycle of a standalone CDI
@@ -202,8 +201,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Arquillian]]
-Arquillian
-^^^^^^^^^^
+==== Arquillian
 
 With this approach, you use the JUnit runner or TestNG support provided
 by Arquillian to delegate the bootstrap of the CDI container. You need
@@ -368,8 +366,7 @@ for a complete working example of testing a Camel CDI application using
 the REST DSL and deployed as a WAR in Jetty.
 
 [[CDITesting-PAXExam]]
-PAX Exam
-^^^^^^^^
+==== PAX Exam
 
 If you target OSGi as runtime environment for your Camel CDI
 applications, you can use PAX Exam to automate the deployment of your
@@ -427,8 +424,7 @@ complete working example of testing a Camel CDI application deployed in
 an OSGi container using PAX Exam.
 
 [[CDITesting-TestingPatterns]]
-Testing Patterns
-^^^^^^^^^^^^^^^^
+==== Testing Patterns
 
 You can see the tests in the `camel-example-cdi-test` example for a
 thorough overview of the following testing patterns for Camel CDI
@@ -439,8 +435,7 @@ module, they should equally work with Arquillian and PAX Exam unless
 otherwise stated or illustrated with a specific example.
 
 [[CDITesting-Testroutes]]
-Test routes
-+++++++++++
+===== Test routes
 
 You may want to add some Camel routes to your Camel CDI applications for
 testing purpose. For example to route some exchanges to a `MockEndpoint`
@@ -487,8 +482,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Beanalternatives]]
-Bean alternatives
-+++++++++++++++++
+===== Bean alternatives
 
 You may want to replace a bean that is used in your Camel routes by
 another bean for testing purpose, for example to mock it or change the
@@ -601,8 +595,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Camelcontextcustomization]]
-Camel context customization
-+++++++++++++++++++++++++++
+===== Camel context customization
 
 You may need to customize your Camel contexts for testing purpose, for
 example disabling JMX management to avoid TCP port allocation conflict.
@@ -632,8 +625,7 @@ class will be used during the test execution instead of the default
 Camel context bean provided by the Camel CDI component.
 
 [[CDITesting-RoutesadvisingwithadviceWith]]
-Routes advising with `adviceWith`
-+++++++++++++++++++++++++++++++++
+===== Routes advising with `adviceWith`
 
 `AdviceWith` is used for testing Camel routes where you
 can _advice_ an existing route before its being tested. It allows to
@@ -667,8 +659,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-JUnitrules]]
-JUnit rules
-+++++++++++
+===== JUnit rules
 
 Camel CDI test starts the CDI container after all the JUnit class rules
 have executed.
@@ -736,8 +727,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * CDI component
 * http://arquillian.org[Arquillian Web site]

--- a/components/camel-test/src/main/docs/test.adoc
+++ b/components/camel-test/src/main/docs/test.adoc
@@ -39,8 +39,7 @@ From Camel 2.9 onwards the <<test-component,Test>> component is provided
 directly in the camel-core.
 
 [[Test-URIformat]]
-URI format
-^^^^^^^^^^
+==== URI format
 
 [source,java]
 --------------------------------
@@ -52,8 +51,7 @@ Component URI that the expected message bodies are
 pulled from before starting the test.
 
 [[Test-URIOptions]]
-URI Options
-^^^^^^^^^^^
+==== URI Options
 
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
@@ -77,8 +75,7 @@ expression.
 |=======================================================================
 
 [[Test-Example]]
-Example
-^^^^^^^
+==== Example
 
 For example, you could write a test case as follows:
 
@@ -96,8 +93,7 @@ To see how you can set other expectations on the test endpoint, see the
 <<mock-component,Mock>> component.
 
 [[Test-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -1,5 +1,4 @@
-Components
-^^^^^^^^^^
+==== Components
 
 // components: START
 Number of Components: 289 in 191 JAR artifacts (0 deprecated)
@@ -879,8 +878,7 @@ Number of Components: 289 in 191 JAR artifacts (0 deprecated)
 // components: END
 
 
-Data Formats
-^^^^^^^^^^^^
+==== Data Formats
 
 // dataformats: START
 Number of Data Formats: 45 in 35 JAR artifacts (0 deprecated)
@@ -982,8 +980,7 @@ Number of Data Formats: 45 in 35 JAR artifacts (0 deprecated)
 // dataformats: END
 
 
-Expression Languages
-^^^^^^^^^^^^^^^^^^^^
+==== Expression Languages
 
 // languages: START
 Number of Languages: 18 in 9 JAR artifacts (1 deprecated)
@@ -1031,8 +1028,7 @@ Number of Languages: 18 in 9 JAR artifacts (1 deprecated)
 // languages: END
 
 
-Miscellaneous Components
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Miscellaneous Components
 
 // others: START
 Number of Miscellaneous Components: 31 in 31 JAR artifacts (0 deprecated)

--- a/docs/components/modules/ROOT/pages/cxf-transport.adoc
+++ b/docs/components/modules/ROOT/pages/cxf-transport.adoc
@@ -18,15 +18,13 @@ use Camel's routing engine and integration patterns support together
 with your CXF services.
 
 [[CamelTransportforCXF-IntegrateCamelintoCXFtransportlayer]]
-Integrate Camel into CXF transport layer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Integrate Camel into CXF transport layer
 
 To include the Camel Tranport into your CXF bus you use the
 CamelTransportFactory. You can do this in Java as well as in Spring.
 
 [[CamelTransportforCXF-SettinguptheCamelTransportinSpring]]
-Setting up the Camel Transport in Spring
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Setting up the Camel Transport in Spring
 
 You can use the following snippet in your applicationcontext if you want
 to configure anything special. If you only want to activate the camel
@@ -57,8 +55,7 @@ jar and load a CamelTransportFactory for you.
 --------------------------------------------------------------------------------------------------------
 
 [[CamelTransportforCXF-IntegratingtheCamelTransportinaprogrammaticway]]
-Integrating the Camel Transport in a programmatic way
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Integrating the Camel Transport in a programmatic way
 
 Camel transport provides a setContext method that you could use to set
 the Camel context into the transport factory. If you want this factory
@@ -93,12 +90,10 @@ BusFactory.setDefaultBus(bus);
 ------------------------------------------------------------------------------------------------------------------
 
 [[CamelTransportforCXF-ConfigurethedestinationandconduitwithSpring]]
-Configure the destination and conduit with Spring
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Configure the destination and conduit with Spring
 
 [[CamelTransportforCXF-Namespace]]
-Namespace
-^^^^^^^^^
+==== Namespace
 
 The elements used to configure an Camel transport endpoint are defined
 in the namespace `http://cxf.apache.org/transports/camel`. It is
@@ -122,8 +117,7 @@ the `xsi:schemaLocation` attribute.
 ---------------------------------------------------------------------
 
 [[CamelTransportforCXF-Thedestinationelement]]
-The `destination` element
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== The `destination` element
 
 You configure an Camel transport server endpoint using the
 `camel:destination` element and its children. The `camel:destination`
@@ -172,8 +166,7 @@ You can specify the camel context in the camel destination
 The camel context id which you want inject into the camel destination
 
 [[CamelTransportforCXF-Theconduitelement]]
-The `conduit` element
-^^^^^^^^^^^^^^^^^^^^^
+==== The `conduit` element
 
 You configure a Camel transport client using the `camel:conduit` element
 and its children. The `camel:conduit` element takes a single attribute,
@@ -228,8 +221,7 @@ You can specify the camel context in the camel conduit
 The camel context id which you want inject into the camel conduit
 
 [[CamelTransportforCXF-ConfigurethedestinationandconduitwithBlueprint]]
-Configure the destination and conduit with Blueprint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Configure the destination and conduit with Blueprint
 
 From *Camel 2.11.x*, Camel Transport supports to be configured with
 Blueprint.
@@ -262,16 +254,14 @@ context in the camel destination.
 ------------------------------------------------------------------------
 
 [[CamelTransportforCXF-ExampleUsingCamelasaloadbalancerforCXF]]
-Example Using Camel as a load balancer for CXF
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Example Using Camel as a load balancer for CXF
 
 This example shows how to use the camel load balancing feature in CXF.
 You need to load the configuration file in CXF and publish the endpoints
 on the address "camel://direct:EndpointA" and "camel://direct:EndpointB"
 
 [[CamelTransportforCXF-CompleteHowtoandExampleforattachingCameltoCXF]]
-Complete Howto and Example for attaching Camel to CXF
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Complete Howto and Example for attaching Camel to CXF
 
 link:better-jms-transport-for-cxf-webservice-using-apache-camel.html[Better
 JMS Transport for CXF Webservice using Apache Camel] 

--- a/docs/components/modules/ROOT/pages/elasticsearch-rest-component.adoc
+++ b/docs/components/modules/ROOT/pages/elasticsearch-rest-component.adoc
@@ -73,7 +73,7 @@ with the following path and query parameters:
 |===
 
 
-==== Query Parameters (11 parameters):
+==== Query Parameters (13 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -87,7 +87,9 @@ with the following path and query parameters:
 | *indexType* (producer) | The type of the index to act against |  | String
 | *maxRetryTimeout* (producer) | The time in ms before retry | 30000 | int
 | *operation* (producer) | What operation to perform |  | ElasticsearchOperation
+| *scrollKeepAliveMs* (producer) | Time in ms during which elasticsearch will keep search context alive | 60000 | int
 | *socketTimeout* (producer) | The timeout in ms to wait before the socket will timeout. | 30000 | int
+| *useScroll* (producer) | Enable scroll usage | false | boolean
 | *waitForActiveShards* (producer) | Index creation waits for the write consistency number of shards to be available | 1 | int
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
 |===
@@ -260,6 +262,43 @@ Map<String, Object> query = new HashMap<>();
 query.put("query", match);
 SearchHits response = template.requestBody("direct:search", query, SearchHits.class);
 
+----
+
+Search using Elasticsearch scroll api in order to fetch all results.
+
+[source,java]
+----
+from("direct:search")
+  .to("elasticsearch-rest://elasticsearch?operation=Search&indexName=twitter&indexType=tweet&useScroll=true&scrollKeepAliveMs=30000");
+----
+
+[source,xml]
+----
+<route>
+    <from uri="direct:search" />
+    <to uri="elasticsearch-rest://elasticsearch?operation=Search&indexName=twitter&indexType=tweet&useScroll=true&scrollKeepAliveMs=30000"/>
+</route>
+----
+
+[source,java]
+----
+String query = "{\"query\":{\"match\":{\"content\":\"new release of ApacheCamel\"}}}";
+try (ElasticsearchScrollRequestIterator response = template.requestBody("direct:search", query, ElasticsearchScrollRequestIterator.class)) {
+    // do something smart with results
+}
+----
+
+link:split-eip.html[Split EIP] can also be used.
+
+[source,java]
+----
+from("direct:search")
+  .to("elasticsearch-rest://elasticsearch?operation=Search&indexName=twitter&indexType=tweet&useScroll=true&scrollKeepAliveMs=30000")
+  .split()
+  .body()
+  .streaming()
+  .to("mock:output")
+  .end();
 ----
 
 === MultiSearch Example

--- a/docs/components/modules/ROOT/pages/kura.adoc
+++ b/docs/components/modules/ROOT/pages/kura.adoc
@@ -13,8 +13,7 @@ services and finally forward the current temperature value to your data
 center service using Camel EIP and components.
 
 [[Kura-KuraRouteractivator]]
-KuraRouter activator
-^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter activator
 
 Bundles deployed to the Eclipse Kura are usually
 http://eclipse.github.io/kura/doc/hello-example.html#create-java-class[developed
@@ -47,8 +46,7 @@ every class extending `KuraRouter`, there will be a dedicated
 per OSGi bundle.
 
 [[Kura-DeployingKuraRouter]]
-Deploying KuraRouter
-^^^^^^^^^^^^^^^^^^^^
+==== Deploying KuraRouter
 
 Bundle containing your Kura router class should import the following
 packages in the OSGi manifest:
@@ -96,15 +94,13 @@ start <your-bundle-id>
 ----------------------------------------------------------------------------------
 
 [[Kura-KuraRouterutilities]]
-KuraRouter utilities 
-^^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter utilities 
 
  Kura router base class provides many useful utilities. This section
 explores each of them.
 
 [[Kura-SLF4Jlogger]]
-SLF4J logger
-++++++++++++
+===== SLF4J logger
 
 Kura uses SLF4J facade for logging purposes. Protected member `log`
 returns SLF4J logger instance associated with the given Kura router.
@@ -123,8 +119,7 @@ public class MyKuraRouter extends KuraRouter {
 ----------------------------------------------
 
 [[Kura-BundleContext]]
-BundleContext
-+++++++++++++
+===== BundleContext
 
 Protected member `bundleContext` returns bundle context associated with
 the given Kura router.
@@ -144,8 +139,7 @@ public class MyKuraRouter extends KuraRouter {
 ---------------------------------------------------------------------------------------------------------------
 
 [[Kura-CamelContext]]
-CamelContext
-++++++++++++
+===== CamelContext
 
 Protected member `camelContext` is the `CamelContext` associated with
 the given Kura router.
@@ -164,8 +158,7 @@ public class MyKuraRouter extends KuraRouter {
 ----------------------------------------------
 
 [[Kura-ProducerTemplate]]
-ProducerTemplate
-++++++++++++++++
+===== ProducerTemplate
 
 Protected member `producerTemplate` is the `ProducerTemplate` instance
 associated with the given Camel context.
@@ -184,8 +177,7 @@ public class MyKuraRouter extends KuraRouter {
 -----------------------------------------------------------
 
 [[Kura-ConsumerTemplate]]
-ConsumerTemplate
-++++++++++++++++
+===== ConsumerTemplate
 
 Protected member `consumerTemplate` is the `ConsumerTemplate` instance
 associated with the given Camel context.
@@ -204,8 +196,7 @@ public class MyKuraRouter extends KuraRouter {
 --------------------------------------------------------------------------------------------------
 
 [[Kura-OSGiserviceresolver]]
-OSGi service resolver
-+++++++++++++++++++++
+===== OSGi service resolver
 
 OSGi service resolver (`service(Class<T> serviceType)`) can be used to
 easily retrieve service by type from the OSGi bundle context.
@@ -242,8 +233,7 @@ public class MyKuraRouter extends KuraRouter {
 ---------------------------------------------------------------
 
 [[Kura-KuraRouteractivatorcallbacks]]
-KuraRouter activator callbacks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== KuraRouter activator callbacks
 
 Kura router comes with the lifecycle callbacks that can be used to
 customize the way the Camel router works. For example to configure the
@@ -266,8 +256,7 @@ public class MyKuraRouter extends KuraRouter {
 --------------------------------------------------------------------------
 
 [[Kura-LoadingXMLroutesfromConfigurationAdmin]]
-Loading XML routes from ConfigurationAdmin
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Loading XML routes from ConfigurationAdmin
 
 Sometimes it is desired to read the XML definition of the routes from
 the server configuration. This a common scenario for IoT gateways where
@@ -294,8 +283,7 @@ Camel XML route file, for example:
  
 
 [[Kura-DeployingKurarouterasadeclarativeOSGiservice]]
-Deploying Kura router as a declarative OSGi service
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Deploying Kura router as a declarative OSGi service
 
 If you would like to deploy your Kura router as a declarative OSGi
 service, you can use `activate` and `deactivate` methods provided by
@@ -309,8 +297,7 @@ service, you can use `activate` and `deactivate` methods provided by
 ----------------------------------------------------------------------------------------------------------------------------------------------
 
 [[Kura-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/docs/components/modules/ROOT/pages/leveldb.adoc
+++ b/docs/components/modules/ROOT/pages/leveldb.adoc
@@ -13,8 +13,7 @@ Current features it provides:
 * LevelDBAggregationRepository
 
 [[LevelDB-UsingLevelDBAggregationRepository]]
-Using LevelDBAggregationRepository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using LevelDBAggregationRepository
 
 `LevelDBAggregationRepository` is an `AggregationRepository` which on
 the fly persists the aggregated messages. This ensures that you will not
@@ -70,8 +69,7 @@ The `repositoryName` option must be provided. Then either the
 `persistentFileName` or the `levelDBFile` must be provided.
 
 [[LevelDB-Whatispreservedwhenpersisting]]
-What is preserved when persisting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== What is preserved when persisting
 
 `LevelDBAggregationRepository` will only preserve any `Serializable`
 compatible message body data types. Message headers must be primitive /
@@ -80,8 +78,7 @@ and a `WARN` is logged. And it only persists the `Message` body and the
 `Message` headers. The `Exchange` properties are *not* persisted.
 
 [[LevelDB-Recovery]]
-Recovery
-^^^^^^^^
+==== Recovery
 
 The `LevelDBAggregationRepository` will by default recover any failed
 Exchange. It does this by having a background tasks
@@ -123,21 +120,18 @@ https://svn.apache.org/repos/asf/camel/trunk/components/camel-leveldb/src/test/j
 test].
 
 [[LevelDB-UsingLevelDBAggregationRepositoryinJavaDSL]]
-Using LevelDBAggregationRepository in Java DSL
-++++++++++++++++++++++++++++++++++++++++++++++
+===== Using LevelDBAggregationRepository in Java DSL
 
 In this example we want to persist aggregated messages in the
 `target/data/leveldb.dat` file.
 
 [[LevelDB-UsingLevelDBAggregationRepositoryinSpringXML]]
-Using LevelDBAggregationRepository in Spring XML
-++++++++++++++++++++++++++++++++++++++++++++++++
+===== Using LevelDBAggregationRepository in Spring XML
 
 The same example but using Spring XML instead:
 
 [[LevelDB-Dependencies]]
-Dependencies
-^^^^^^^^^^^^
+==== Dependencies
 
 To use LevelDB in your camel routes you need to add
 the a dependency on *camel-leveldb*.
@@ -156,8 +150,7 @@ the download page for the latest versions).
 ----------------------------------------
 
 [[LevelDB-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/docs/components/modules/ROOT/pages/script.adoc
+++ b/docs/components/modules/ROOT/pages/script.adoc
@@ -14,8 +14,7 @@ return value should be used as a changed message body then
 use Message Translator EIP instead.
 
 [[Script-UsingfromJavaDSL]]
-Using from Java DSL
-^^^^^^^^^^^^^^^^^^^
+==== Using from Java DSL
 
 The route below will read the file contents and validate them against a
 regular expression.
@@ -28,8 +27,7 @@ from("file://inbox")
 ---------------------------------------------------
 
 [[Script-UsingfromSpringDSL]]
-Using from Spring DSL
-^^^^^^^^^^^^^^^^^^^^^
+==== Using from Spring DSL
 
 And from XML its easy as well
 
@@ -64,8 +62,7 @@ Mind that you can use CDATA in XML if the groovy scrip uses < > etc
 -------------------------------------------------------------------------------------------------
 
 [[Script-Usingexternalscriptfiles]]
-Using external script files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using external script files
 
 You can refer to external script files instead of inlining the script.
 For example to load a groovy script from the classpath you need to
@@ -90,8 +87,7 @@ of classpath: such as file:/var/myscript.groovy
  
 
 [[Script-UsingThisPattern]]
-Using This Pattern
-++++++++++++++++++
+===== Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
 Getting Started, you may also find the

--- a/docs/components/modules/ROOT/pages/shiro.adoc
+++ b/docs/components/modules/ROOT/pages/shiro.adoc
@@ -37,8 +37,7 @@ for this component:
 ------------------------------------------------------------
 
 [[ShiroSecurity-ShiroSecurityBasics]]
-Shiro Security Basics
-^^^^^^^^^^^^^^^^^^^^^
+==== Shiro Security Basics
 
 To employ Shiro security on a camel route, a ShiroSecurityPolicy object
 must be instantiated with security configuration details (including
@@ -75,8 +74,7 @@ sec-level1 = zone1:readonly:*
 ------------------------------------------------------------------
 
 [[ShiroSecurity-InstantiatingaShiroSecurityPolicyObject]]
-Instantiating a ShiroSecurityPolicy Object
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Instantiating a ShiroSecurityPolicy Object
 
 A ShiroSecurityPolicy object is instantiated as follows
 
@@ -97,8 +95,7 @@ A ShiroSecurityPolicy object is instantiated as follows
 ----------------------------------------------------------------------------------------
 
 [[ShiroSecurity-ShiroSecurityPolicyOptions]]
-ShiroSecurityPolicy Options
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== ShiroSecurityPolicy Options
 
 [width="100%",cols="10%,10%,10%,90%",options="header",]
 |=======================================================================
@@ -147,8 +144,7 @@ require all of the roles to be met.
 |=======================================================================
 
 [[ShiroSecurity-ApplyingShiroAuthenticationonaCamelRoute]]
-Applying Shiro Authentication on a Camel Route
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Applying Shiro Authentication on a Camel Route
 
 The ShiroSecurityPolicy, tests and permits incoming message exchanges
 containing a encrypted SecurityToken in the Message Header to proceed
@@ -183,8 +179,7 @@ the user is a valid user.
 -----------------------------------------------------------------------
 
 [[ShiroSecurity-ApplyingShiroAuthorizationonaCamelRoute]]
-Applying Shiro Authorization on a Camel Route
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Applying Shiro Authorization on a Camel Route
 
 Authorization can be applied on a camel route by associating a
 Permissions List with the ShiroSecurityPolicy. The Permissions List
@@ -219,8 +214,7 @@ permission set, the request is not authorized to continue any further.
 -------------------------------------------------------------------------------------------
 
 [[ShiroSecurity-CreatingaShiroSecurityTokenandinjectingitintoaMessageExchange]]
-Creating a ShiroSecurityToken and injecting it into a Message Exchange
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Creating a ShiroSecurityToken and injecting it into a Message Exchange
 
 A ShiroSecurityToken object may be created and injected into a Message
 Exchange using a Shiro Processor called ShiroSecurityTokenInjector. An
@@ -239,8 +233,7 @@ ShiroSecurityTokenInjector in the client is shown below
 -------------------------------------------------------------------------------------
 
 [[ShiroSecurity-SendingMessagestoroutessecuredbyaShiroSecurityPolicy]]
-Sending Messages to routes secured by a ShiroSecurityPolicy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Sending Messages to routes secured by a ShiroSecurityPolicy
 
 Messages and Message Exchanges sent along the camel route where the
 security policy is applied need to be accompanied by a SecurityToken in
@@ -274,15 +267,13 @@ ProducerTemplate in Camel along with a SecurityToken
 -------------------------------------------------------------------------------------------------
 
 [[ShiroSecurity-SendingMessagestoroutessecuredbyaShiroSecurityPolicymucheasierfromCamel2.12onwards]]
-Sending Messages to routes secured by a ShiroSecurityPolicy (much easier from Camel 2.12 onwards)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Sending Messages to routes secured by a ShiroSecurityPolicy (much easier from Camel 2.12 onwards)
 
 From *Camel 2.12* onwards its even easier as you can provide the subject
 in two different ways.
 
 [[ShiroSecurity-UsingShiroSecurityToken]]
-Using ShiroSecurityToken
-++++++++++++++++++++++++
+===== Using ShiroSecurityToken
 
 You can send a message to a Camel route with a header of key
 `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` of the type

--- a/docs/components/modules/ROOT/pages/spring-cloud.adoc
+++ b/docs/components/modules/ROOT/pages/spring-cloud.adoc
@@ -22,8 +22,7 @@ soon as you add that dependency into your classpath, Spring Boot will
 automatically auto-configure Camel for you.
 
 [[SpringCloud-CamelSpringCloudStarter]]
-Camel Spring Cloud Starter
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Camel Spring Cloud Starter
 
 *Available as of Camel 2.19*
 

--- a/docs/components/modules/ROOT/pages/spring-javaconfig.adoc
+++ b/docs/components/modules/ROOT/pages/spring-javaconfig.adoc
@@ -10,8 +10,7 @@ You can use either the XML or Java config approaches with Camel; its
 your choice really on which you prefer.
 
 [[SpringJavaConfig-UsingSpringJavaConfig]]
-Using Spring Java Config
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using Spring Java Config
 
 To use Spring Java Config in your Camel project the easiest thing to do
 is add the following to your pom.xml
@@ -32,8 +31,7 @@ Note that this library is totally optional; you could just wire Camel
 together yourself with Java Config.
 
 [[SpringJavaConfig-Configuration]]
-Configuration
-^^^^^^^^^^^^^
+==== Configuration
 
 The most common case of using JavaConfig with Camel would be to create
 configuration with defined list of routes to be used by router.
@@ -69,8 +67,7 @@ public class MyRouteConfiguration extends CamelConfiguration {
 --------------------------------------------------------------
 
 [[SpringJavaConfig-Testing]]
-Testing
-^^^^^^^
+==== Testing
 
 Since *Camel 2.11.0* you can use the `CamelSpringJUnit4ClassRunner` with
 `CamelSpringDelegatingTestContextLoader`. This is the recommended way to

--- a/docs/components/modules/ROOT/pages/test-cdi.adoc
+++ b/docs/components/modules/ROOT/pages/test-cdi.adoc
@@ -65,8 +65,7 @@ containers].
 |=======================================================================
 
 [[CDITesting-CamelCDITest]]
-Camel CDI Test
-^^^^^^^^^^^^^^
+==== Camel CDI Test
 
 With this approach, your test classes use the JUnit runner provided in
 Camel CDI test. This runner manages the lifecycle of a standalone CDI
@@ -202,8 +201,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Arquillian]]
-Arquillian
-^^^^^^^^^^
+==== Arquillian
 
 With this approach, you use the JUnit runner or TestNG support provided
 by Arquillian to delegate the bootstrap of the CDI container. You need
@@ -368,8 +366,7 @@ for a complete working example of testing a Camel CDI application using
 the REST DSL and deployed as a WAR in Jetty.
 
 [[CDITesting-PAXExam]]
-PAX Exam
-^^^^^^^^
+==== PAX Exam
 
 If you target OSGi as runtime environment for your Camel CDI
 applications, you can use PAX Exam to automate the deployment of your
@@ -427,8 +424,7 @@ complete working example of testing a Camel CDI application deployed in
 an OSGi container using PAX Exam.
 
 [[CDITesting-TestingPatterns]]
-Testing Patterns
-^^^^^^^^^^^^^^^^
+==== Testing Patterns
 
 You can see the tests in the `camel-example-cdi-test` example for a
 thorough overview of the following testing patterns for Camel CDI
@@ -439,8 +435,7 @@ module, they should equally work with Arquillian and PAX Exam unless
 otherwise stated or illustrated with a specific example.
 
 [[CDITesting-Testroutes]]
-Test routes
-+++++++++++
+===== Test routes
 
 You may want to add some Camel routes to your Camel CDI applications for
 testing purpose. For example to route some exchanges to a `MockEndpoint`
@@ -487,8 +482,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Beanalternatives]]
-Bean alternatives
-+++++++++++++++++
+===== Bean alternatives
 
 You may want to replace a bean that is used in your Camel routes by
 another bean for testing purpose, for example to mock it or change the
@@ -601,8 +595,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-Camelcontextcustomization]]
-Camel context customization
-+++++++++++++++++++++++++++
+===== Camel context customization
 
 You may need to customize your Camel contexts for testing purpose, for
 example disabling JMX management to avoid TCP port allocation conflict.
@@ -632,8 +625,7 @@ class will be used during the test execution instead of the default
 Camel context bean provided by the Camel CDI component.
 
 [[CDITesting-RoutesadvisingwithadviceWith]]
-Routes advising with `adviceWith`
-+++++++++++++++++++++++++++++++++
+===== Routes advising with `adviceWith`
 
 `AdviceWith` is used for testing Camel routes where you
 can _advice_ an existing route before its being tested. It allows to
@@ -667,8 +659,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-JUnitrules]]
-JUnit rules
-+++++++++++
+===== JUnit rules
 
 Camel CDI test starts the CDI container after all the JUnit class rules
 have executed.
@@ -736,8 +727,7 @@ public class CamelCdiTest {
 ----
 
 [[CDITesting-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * CDI component
 * http://arquillian.org[Arquillian Web site]

--- a/docs/components/modules/ROOT/pages/test.adoc
+++ b/docs/components/modules/ROOT/pages/test.adoc
@@ -39,8 +39,7 @@ From Camel 2.9 onwards the <<test-component,Test>> component is provided
 directly in the camel-core.
 
 [[Test-URIformat]]
-URI format
-^^^^^^^^^^
+==== URI format
 
 [source,java]
 --------------------------------
@@ -52,8 +51,7 @@ Component URI that the expected message bodies are
 pulled from before starting the test.
 
 [[Test-URIOptions]]
-URI Options
-^^^^^^^^^^^
+==== URI Options
 
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
@@ -77,8 +75,7 @@ expression.
 |=======================================================================
 
 [[Test-Example]]
-Example
-^^^^^^^
+==== Example
 
 For example, you could write a test case as follows:
 
@@ -96,8 +93,7 @@ To see how you can set other expectations on the test endpoint, see the
 <<mock-component,Mock>> component.
 
 [[Test-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Component

--- a/docs/user-manual/en/faq/how-do-i-configure-endpoints.adoc
+++ b/docs/user-manual/en/faq/how-do-i-configure-endpoints.adoc
@@ -124,8 +124,7 @@ pop3://host:port?password=foo
 ----
 
 [[HowdoIconfigureendpoints-ReferringbeansfromEndpointURIs]]
-Referring beans from Endpoint URIs
-++++++++++++++++++++++++++++++++++
+===== Referring beans from Endpoint URIs
 
 *Available as of Camel 2.0*
 
@@ -145,8 +144,7 @@ Will lookup a bean with the id `mySpecialFileSorter` in the
 Registry.
 
 [[HowdoIconfigureendpoints-Configuringparametervaluesusingrawvalues,egsuchaspasswords]]
-Configuring parameter values using raw values, eg such as passwords
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Configuring parameter values using raw values, eg such as passwords
 
 *Available as of Camel 2.11*
 
@@ -170,8 +168,7 @@ In the above example, we have declare the password value as raw, and the
 actual password would be as typed, eg `se+re?t&23`.
 
 [[HowdoIconfigureendpoints-Usingpropertyplaceholders]]
-Using property placeholders
-+++++++++++++++++++++++++++
+===== Using property placeholders
 
 Camel have extensive support for using property placeholders, which you
 can read more about here. For
@@ -225,8 +222,7 @@ To understand more about property placeholders, read the
 documentation.
 
 [[HowdoIconfigureendpoints-Configuringurisusingendpointwithbeanpropertystyle]]
-Configuring URIs using endpoint with bean property style
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Configuring URIs using endpoint with bean property style
 
 *Available as of Camel 2.15*
 

--- a/docs/user-manual/modules/ROOT/pages/async.adoc
+++ b/docs/user-manual/modules/ROOT/pages/async.adoc
@@ -1,6 +1,5 @@
 [[Async-Async]]
-Async
-~~~~~
+=== Async
 
 *Available as of Camel 2.0*
 
@@ -24,8 +23,7 @@ distill the difference. +
 *threads* DSL and what it can be used for.
 
 [[Async-Background]]
-Background
-~~~~~~~~~~
+=== Background
 
 The new Async API in Camel 2.0 leverages in much
 greater detail the Java Concurrency API and its support for executing
@@ -34,8 +32,7 @@ tasks asynchronous. +
 users with knowledge of the Java Concurrency API.
 
 [[Async-Afewconceptstomaster]]
-A few concepts to master
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== A few concepts to master
 
 When doing messaging there are a few aspects to keep in mind.
 
@@ -66,8 +63,7 @@ For all message exchange they can be executed either:
 * asynchronous
 
 [[Async-SynchronousRequestReply]]
-Synchronous Request Reply
-+++++++++++++++++++++++++
+===== Synchronous Request Reply
 
 A synchronous exchange is defined as the caller sends a message and
 waits until its complete before continuing. This is illustrated in the
@@ -84,8 +80,7 @@ application still waits for the response. +
  3. The response is send back to the client.
 
 [[Async-AsynchronousRequestReply]]
-Asynchronous Request Reply
-++++++++++++++++++++++++++
+===== Asynchronous Request Reply
 
 On the other hand the asynchronous version is where the caller sends a
 message to an Endpoint and then returns immediately
@@ -108,8 +103,7 @@ got as _response_ from step 1. With this handle it retrieves the reply,
 wait if necessary if the reply is not ready.
 
 [[Async-SynchronousRequestOnly]]
-Synchronous Request Only
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Synchronous Request Only
 
 You can also do synchronous Request only with
 Camel. The client sends a message to Camel in which a reply is not
@@ -136,8 +130,7 @@ In case of failure the client can detect this as an exception is thrown.
 (and `exchange.isFailed()` returns `true`).
 
 [[Async-AsynchronousRequestOnly]]
-Asynchronous Request Only
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Asynchronous Request Only
 
 As opposed to the synchronous Request Only the
 Async counter part will *not* wait for the processing
@@ -176,8 +169,7 @@ With these diagrams in mind lets turn out attention to the
 Async API and how to use it with Camel.
 
 [[Async1TheClientAPI]]
-The Async Client API
-~~~~~~~~~~~~~~~~~~~~
+=== The Async Client API
 
 Camel provides the Async Client API in the
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/ProducerTemplate.html[ProducerTemplate]
@@ -214,8 +206,7 @@ response. You can do this by using the `extractFutureBody` method, or
 just use plain Java but invoke `get()` on the `Future` handle.
 
 [[Async-TheClientAPIwithcallbacks]]
-The Async Client API with callbacks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== The Async Client API with callbacks
 
 In addition to the Client API from above Camel provides a variation that
 uses callbacks when the message
@@ -242,8 +233,7 @@ difference is that they invokes the callback as well when the
 Exchange is done being routed.
 
 [[Async-TheFutureAPI]]
-The Future API
-++++++++++++++
+===== The Future API
 
 The `java.util.concurrent.Future` API have among others the following
 methods:
@@ -261,8 +251,7 @@ exception.
 |=======================================================================
 
 [[Async-Example:AsynchronousRequestReply]]
-Example: Asynchronous Request Reply
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Example: Asynchronous Request Reply
 
 Suppose we want to call a <<http-component,HTTP>> service but it is usually
 slow and thus we do not want to block and wait for the response, as we
@@ -331,8 +320,7 @@ All together it should give you the basic idea how to use this
 Async API and what it can do.
 
 [[Async-Example:SynchronousRequestReply]]
-Example: Synchronous Request Reply
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Example: Synchronous Request Reply
 
 This example is just a pure synchronous version of the async based example above.
 
@@ -357,8 +345,7 @@ assertMockEndpointsSatisfied();
 ---------------------------------------------------------------------------
 
 [[Async-UsingtheAPIwithcallbacks]]
-Using the Async API with callbacks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using the Async API with callbacks
 
 Suppose we want to call a <<http-component,HTTP>> service but it is usually
 slow and thus we do not want to block and wait for the response, but
@@ -438,8 +425,7 @@ template.asyncCallbackRequestBody(url, "Willem", callback);
 ---------------------------------------------------------------------------
 
 [[Async-UsingtheAPIwiththeCamelclassicAPI]]
-Using the Async API with the Camel classic API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using the Async API with the Camel classic API
 
 When using the Camel API to create a producer and send an
 Exchange we do it like this:
@@ -476,14 +462,12 @@ Exchange response = future.get();
 ------------------------------------------------------------------------------------------------------------------------------
 
 [[Async2UsingtheThreadsDSL]]
-Using the Threads DSL
-~~~~~~~~~~~~~~~~~~~~~
+=== Using the Threads DSL
 
 In Camel 2.0 the `threads` DSL replaces the old `thread` DSL.
 
 [[Async-Camel2.0to2.3behavior]]
-Camel 2.0 to 2.3 behavior
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Camel 2.0 to 2.3 behavior
 
 The `threads` DSL leverages the JDK concurrency framework for multi
 threading. It can be used to turn a synchronous route into
@@ -495,8 +479,7 @@ will complete as well if no reply was expected such as
 Request Only messaging.
 
 [[Async-Camel2.4onwardsbehavior]]
-Camel 2.4 onwards behavior
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Camel 2.4 onwards behavior
 
 The `threads` DSL leverages the JDK concurrency framework for multi
 threading. It can be used to turn a synchronous route into
@@ -557,8 +540,7 @@ based. The default option is *IfReplyExpected*.
 |=======================================================================
 
 [[Async-Aboutrejectedtasks]]
-About rejected tasks
-++++++++++++++++++++
+===== About rejected tasks
 
 The `threads` DSL uses a thread pool which has a worker queue for tasks.
 When the worker queue gets full, the task is rejected. You can customize
@@ -586,8 +568,7 @@ so we discourage you from using these options in those Camel releases.
 This has been fixed in Camel 2.10 onwards.
 
 [[Async-Example:threadsDSL]]
-Example: threads DSL
-^^^^^^^^^^^^^^^^^^^^
+==== Example: threads DSL
 
 Suppose we receive orders on a JMS queue. Some of the orders expect a
 reply while other do not (either a `JMSReplyTo` exists or not). And lets
@@ -640,8 +621,7 @@ Exchange that does not participate in the same
 transaction.
 
 [[Async-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Asynchronous Processing
 * Request Reply

--- a/docs/user-manual/modules/ROOT/pages/asynchronous-routing-engine.adoc
+++ b/docs/user-manual/modules/ROOT/pages/asynchronous-routing-engine.adoc
@@ -1,6 +1,5 @@
 [[AsynchronousRoutingEngine-AsynchronousRoutingEngine]]
-Asynchronous Routing Engine
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Asynchronous Routing Engine
 
 *Available as of Camel 2.4*
 
@@ -48,8 +47,7 @@ In the future additional Components will be
 supported as well where it's applicable.
 
 [[AsynchronousRoutingEngine-Forcingtousesynchronousprocessing]]
-Forcing to use synchronous processing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Forcing to use synchronous processing
 
 You can configure the endpoints with the option `synchronous=true` to
 force using synchronous processing. For example when sending a web
@@ -62,8 +60,7 @@ to disable it. The JBI and NMR component
 are always asynchronous and doesn't support this option.
 
 [[AsynchronousRoutingEngine-Backgroundinformation]]
-Background information
-~~~~~~~~~~~~~~~~~~~~~~
+=== Background information
 
 See Asynchronous Processing for
 additional information and the concepts behind the asynchronous model.

--- a/docs/user-manual/modules/ROOT/pages/backlog-tracer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-tracer.adoc
@@ -104,8 +104,7 @@ format.
 You would need to enable this using the JMX API.
 
 [[BacklogTracer-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:tracer.html[Tracer]
 * link:tracer-example.html[Tracer Example]

--- a/docs/user-manual/modules/ROOT/pages/backlogdebugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlogdebugger.adoc
@@ -1,6 +1,5 @@
 [[BacklogDebugger-BacklogDebugger]]
-BacklogDebugger
-~~~~~~~~~~~~~~~
+=== BacklogDebugger
 
 *Available as of Camel 2.12*
 
@@ -17,8 +16,7 @@ You can enable or disable the BacklogDebugger dynamically, by calling
 `enableDebugger` or `disableDebugger` methods.
 
 [[BacklogDebugger-Options]]
-Options
-^^^^^^^
+==== Options
 
 [width="100%",cols="10%,20%,70%",options="header",]
 |=======================================================================
@@ -41,8 +39,7 @@ is that the file content has to be read from the file.
 |=======================================================================
 
 [[BacklogDebugger-Operations]]
-Operations
-^^^^^^^^^^
+==== Operations
 
 [width="100%",cols="10%,20%,70%",options="header",]
 |=======================================================================
@@ -92,14 +89,12 @@ Exchange at the node.
 |=======================================================================
 
 [[BacklogDebugger-Enabling]]
-Enabling
-^^^^^^^^
+==== Enabling
 
 You would need to enable this using the JMX API.
 
 [[BacklogDebugger-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * BacklogTracer
 * link:debugger.adoc[Debugger]

--- a/docs/user-manual/modules/ROOT/pages/bam-example.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bam-example.adoc
@@ -1,6 +1,5 @@
 [[BAMExample-BusinessActivityMonitorExample]]
-Business Activity Monitor (BAM) Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Business Activity Monitor (BAM) Example
 
 The BAM (Business Activity Monitor) example shows how to
 monitor your transaction flows using Camel.
@@ -18,8 +17,7 @@ generated within the allowed amount of time and error is generated and
 sent to an Endpoint.
 
 [[BAMExample-Overview]]
-Overview
-^^^^^^^^
+==== Overview
 
 This example lives in the _examples/camel-example-bam_ directory. It
 will poll the following directories
@@ -44,8 +42,7 @@ which defines the JPA `EntityManagerFactory` and tells Camel to look in
 the *org.apache.camel.example.bam* package to find its routes.
 
 [[BAMExample-Codewalkthrough]]
-Code walkthrough
-^^^^^^^^^^^^^^^^
+==== Code walkthrough
 
 So lets start with the activities definition in
 http://svn.apache.org/repos/asf/camel/trunk/examples/camel-example-bam/src/main/java/org/apache/camel/example/bam/MyActivities.java[MyActivities]
@@ -92,8 +89,7 @@ Components such as ActiveMQ,
 <<xmpp-component,XMPP>> etc.
 
 [[BAMExample-Runningtheexample]]
-Running the example
-^^^^^^^^^^^^^^^^^^^
+==== Running the example
 
 To run the example we use the link:camel-maven-plugin.adoc[Camel Maven
 Plugin]. For example from the source or binary distribution the

--- a/docs/user-manual/modules/ROOT/pages/bam.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bam.adoc
@@ -1,6 +1,5 @@
 [[BAM-BusinessActivityMonitoring]]
-Business Activity Monitoring
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Business Activity Monitoring
 
 The *Camel BAM* module provides a Business Activity Monitoring (BAM)
 framework for testing business processes across multiple message
@@ -12,8 +11,7 @@ want to test that, for a given Purchase Order, you receive a matching
 Invoice from system B within a specific time period.
 
 [[BAM-HowCamelBAMWorks]]
-How Camel BAM Works
-^^^^^^^^^^^^^^^^^^^
+==== How Camel BAM Works
 
 Camel BAM uses a link:correlation-identifier.html[Correlation
 Identifier] on an input message to determine the _Process Instance_ to
@@ -47,8 +45,7 @@ activity - such as to set time expectations or perform real time
 reconciliation of values across activities.
 
 [[BAM-SimpleExample]]
-Simple Example
-^^^^^^^^^^^^^^
+==== Simple Example
 
 The following example shows how to perform some time based rules on a
 simple business process of 2 activities - A and B - which correspond
@@ -65,16 +62,14 @@ ProcessBuilder is a RouteBuilder and can be
 added to any CamelContext.
 
 [[BAM-CompleteExample]]
-Complete Example
-^^^^^^^^^^^^^^^^
+==== Complete Example
 
 For a complete example please see the link:bam-example.html[BAM
 Example], which is part of the standard Camel
 Examples
 
 [[BAM-UseCases]]
-Use Cases
-^^^^^^^^^
+==== Use Cases
 
 In the world of finance, a common requirement is tracking trades. Often
 a trader will submit a Front Office Trade which then flows through the

--- a/docs/user-manual/modules/ROOT/pages/batch-consumer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/batch-consumer.adoc
@@ -1,6 +1,5 @@
 [[BatchConsumer-BatchConsumer]]
-Batch Consumer
-~~~~~~~~~~~~~~
+=== Batch Consumer
 
 *Available as of Camel 2.0*
 
@@ -28,8 +27,7 @@ Consumer] by its consumer:
 * <<aws-s3-component,S3>>
 
 [[BatchConsumer-ConsumerOptions]]
-Consumer Options
-^^^^^^^^^^^^^^^^
+==== Consumer Options
 
 The Batch Consumer supports the following options:
 
@@ -44,8 +42,7 @@ starting up the server that there are thousands of files. Set a value of
 |=======================================================================
 
 [[BatchConsumer-ExchangeProperties]]
-Exchange Properties
-^^^^^^^^^^^^^^^^^^^
+==== Exchange Properties
 
 The following properties is set on the Exchange for
 each Exchange polled in the same batch.
@@ -64,8 +61,7 @@ Is only `true` for the last entry.
 |=======================================================================
 
 [[BatchConsumer-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Polling Consumer
 

--- a/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
@@ -1,12 +1,10 @@
 [[BeanIntegration-BeanIntegration]]
-Bean Integration
-~~~~~~~~~~~~~~~~
+=== Bean Integration
 
 Camel supports the integration of beans and POJOs in a number of ways
 
 [[BeanIntegration-Annotations]]
-Annotations
-^^^^^^^^^^^
+==== Annotations
 
 If a bean is defined in Spring XML or scanned using
 the Spring component scanning mechanism and a *<camelContext>* is used
@@ -64,8 +62,7 @@ See the POJO Messaging Example for how
 to use the annotations for routing and messaging.
 
 [[BeanIntegration-BeanComponent]]
-Bean Component
-^^^^^^^^^^^^^^
+==== Bean Component
 
 The <<bean-component,Bean>> component allows one to invoke a particular
 method. Alternately the <<bean-component,Bean>> component supports the
@@ -77,8 +74,7 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/compon
 to some Camel endpoint.
 
 [[BeanIntegration-SpringRemoting]]
-Spring Remoting
-^^^^^^^^^^^^^^^
+==== Spring Remoting
 
 We support a Spring Remoting provider which
 uses Camel as the underlying transport mechanism. The nice thing about

--- a/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
+++ b/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
@@ -1,13 +1,11 @@
 [[chapter-getting-started]]
 [[BookGettingStarted-GettingStartedwithApacheCamel]]
-Getting Started with Apache Camel
----------------------------------
+== Getting Started with Apache Camel
 
 [[BookGettingStarted-eip-book]]
 
 [[BookGettingStarted-TheEnterpriseIntegrationPatternsEIPBook]]
-The _Enterprise Integration Patterns_ (EIP) book
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== The _Enterprise Integration Patterns_ (EIP) book
 
 The purpose of a _patterns_ book is not to advocate new techniques that
 the authors have invented, but rather to document existing best
@@ -32,8 +30,7 @@ name and most are also given a graphical symbol, intended to be used in
 architectural diagrams.
 
 [[BookGettingStarted-TheCamelproject]]
-The Camel project
-~~~~~~~~~~~~~~~~~
+=== The Camel project
 
 Camel (http://camel.apache.org) is an open-source, Java-based project
 that helps the user implement many of the design patterns in the EIP
@@ -42,8 +39,7 @@ book, it would be a good idea for people who work with Camel to have the
 EIP book as a reference.
 
 [[BookGettingStarted-OnlinedocumentationforCamel]]
-Online documentation for Camel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Online documentation for Camel
 
 The documentation is all under the Documentation category on the
 right-side menu of the Camel website (also available in
@@ -55,8 +51,7 @@ http://www.manning.com/ibsen/chapter1sample.pdf[free Chapter One (pdf)],
 which is highly recommended to read to get more familiar with Camel.
 
 [[BookGettingStarted-Ausefultipfornavigatingtheonlinedocumentation]]
-A useful tip for navigating the online documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== A useful tip for navigating the online documentation
 
 The breadcrumbs at the top of the online Camel documentation can help
 you navigate between parent and child subsections. +
@@ -78,8 +73,7 @@ bookmarks to pages that you frequently reference can also save time.
 [[BookGettingStarted-online-javadoc-docs]]
 
 [[BookGettingStarted-OnlineJavadocdocumentation]]
-Online Javadoc documentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Online Javadoc documentation
 
 The Apache Camel website provides
 http://camel.apache.org/maven/current/camel-core/apidocs/index.html[Javadoc
@@ -96,8 +90,7 @@ http://camel.apache.org/maven/current/camel-spring/apidocs/index.html[Spring
 API].
 
 [[BookGettingStarted-ConceptsandterminologyfundamentaltoCamel]]
-Concepts and terminology fundamental to Camel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Concepts and terminology fundamental to Camel
 
 In this section some of the concepts and terminology that are
 fundamental to Camel are explained. This section is not meant as a
@@ -106,8 +99,7 @@ complete Camel tutorial, but as a first step in that direction.
 [[BookGettingStarted-endpoint]]
 
 [[BookGettingStarted-Endpoint]]
-Endpoint
-^^^^^^^^
+==== Endpoint
 
 The term _endpoint_ is often used when talking about inter-process
 communication. For example, in client-server communication, the client
@@ -182,8 +174,7 @@ the http://camel.apache.org/maven/current/camel-ftp/apidocs/[FTP Javadoc
 hierarchy].
 
 [[BookGettingStarted-CamelContext]]
-CamelContext
-^^^^^^^^^^^^
+==== CamelContext
 
 A `CamelContext` object represents the Camel runtime system. You
 typically have one `CamelContext` object in an application. A typical
@@ -218,8 +209,7 @@ test may fail due to messages not having had a chance to be fully
 processed.
 
 [[BookGettingStarted-CamelTemplate]]
-CamelTemplate
-^^^^^^^^^^^^^
+==== CamelTemplate
 
 Camel used to have a class called `CamelClient`, but this was renamed to
 be `CamelTemplate` to be similar to a naming convention used in some
@@ -238,8 +228,7 @@ move along routes – discussed in link:book-getting-started.html[Section
 [[BookGettingStarted-url-uri-urn-iri]]
 
 [[BookGettingStarted-TheMeaningofURL,URI,URNandIRI]]
-The Meaning of URL, URI, URN and IRI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== The Meaning of URL, URI, URN and IRI
 
 Some Camel methods take a parameter that is a _URI_ string. Many people
 know that a URI is "something like a URL" but do not properly understand
@@ -285,8 +274,7 @@ a IRI can contain those same letters and digits, and _also_ European
 accented characters, Greek letters, Chinese ideograms and so on.
 
 [[BookGettingStarted-Components]]
-Components
-^^^^^^^^^^
+==== Components
 
 _Component_ is confusing terminology; _EndpointFactory_ would have been
 more appropriate because a `Component` is a factory for creating
@@ -414,8 +402,7 @@ than (as claimed) a URI.
 [[BookGettingStarted-message-and-exchange]]
 
 [[BookGettingStarted-MessageandExchange]]
-Message and Exchange
-^^^^^^^^^^^^^^^^^^^^
+==== Message and Exchange
 
 The `Message` interface provides an abstraction for a single message,
 such as a request, reply or exception message.
@@ -447,8 +434,7 @@ generic types that are instantiated on (a class that implements)
 the generic signatures of classes and methods.
 
 [[BookGettingStarted-Processor]]
-Processor
-^^^^^^^^^
+==== Processor
 
 The `Processor` interface represents a class that processes a message.
 The signature of this interface is shown below:
@@ -482,8 +468,7 @@ is, condition).
 [[BookGettingStarted-routes]]
 
 [[BookGettingStarted-Routes,RouteBuildersandJavaDSL]]
-Routes, RouteBuilders and Java DSL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Routes, RouteBuilders and Java DSL
 
 A _route_ is the step-by-step movement of a `Message` from an input
 queue, through arbitrary types of decision making (such as filters and
@@ -494,8 +479,7 @@ scope of this document. The other way is through what Camel calls a Java
 _DSL_ (domain-specific language).
 
 [[BookGettingStarted-IntroductiontoJavaDSL]]
-Introduction to Java DSL
-++++++++++++++++++++++++
+===== Introduction to Java DSL
 
 For many people, the term "domain-specific language" implies a compiler
 or interpreter that can process an input file containing keywords and
@@ -545,8 +529,7 @@ a `RouteBuilder` wrapper around it) and add it to the `CamelContext`
 object associated with the `RouteBuilder`.
 
 [[BookGettingStarted-CritiqueofJavaDSL]]
-Critique of Java DSL
-++++++++++++++++++++
+===== Critique of Java DSL
 
 The online Camel documentation compares Java DSL favorably against the
 alternative of configuring routes and endpoints in a XML-based Spring
@@ -568,8 +551,7 @@ BNF would almost certainly be significantly less than the effort
 currently required to study the API of the `RouterBuilder` classes.
 
 [[BookGettingStarted-ContinueLearningaboutCamel]]
-Continue Learning about Camel
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Continue Learning about Camel
 
 Return to the main Getting Started page for
 additional introductory reference information.

--- a/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
@@ -1,6 +1,5 @@
 [[BrowsableEndpoint-BrowsableEndpoint]]
-BrowsableEndpoint
-~~~~~~~~~~~~~~~~~
+=== BrowsableEndpoint
 
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/BrowsableEndpoint.html[BrowsableEndpoint]
 is an extension interface an Endpoint may implement

--- a/docs/user-manual/modules/ROOT/pages/building.adoc
+++ b/docs/user-manual/modules/ROOT/pages/building.adoc
@@ -1,14 +1,12 @@
 [[Building-BuildingCamelfromSource]]
-Building Camel from Source
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Building Camel from Source
 
 Camel uses http://maven.apache.org/[Maven] as its build and management
 tool. If you don't fancy using Maven you can use your IDE directly or
 Download a distribution or JAR.
 
 [[Building-Prequisites]]
-Prequisites
-^^^^^^^^^^^
+==== Prequisites
 
 *Required:*
 
@@ -31,8 +29,7 @@ Prequisites
 PATH to generate the PDF documentation
 
 [[Building-Mavenoptions]]
-Maven options
-^^^^^^^^^^^^^
+==== Maven options
 
 To build camel maven has to be configured to use more memory
 
@@ -54,8 +51,7 @@ set MAVEN_OPTS="-Xms2048m -Xmx3584m"
 -------------------------------------------------------
 
 [[Building-Anormalbuild]]
-A normal build
-^^^^^^^^^^^^^^
+==== A normal build
 
 [source,text]
 -----------------
@@ -63,8 +59,7 @@ mvn clean install
 -----------------
 
 [[Building-Anormalbuildwithoutrunningtests]]
-A quick build without running tests
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== A quick build without running tests
 
 The following skips building the manual, the distro and does not execute
 the unit tests.
@@ -75,8 +70,7 @@ mvn clean install -Pfastinstall
 -------------------------------
 
 [[Building-Anormalbuildwithoutrunningtestsbutcheckstyleverificationenabled]]
-A normal build without running tests but checkstyle verification enabled
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== A normal build without running tests but checkstyle verification enabled
 
 [source,text]
 -------------------------------------------
@@ -84,15 +78,13 @@ mvn clean install -Pfastinstall,sourcecheck
 -------------------------------------------
 
 [[Building-UsinganIDE]]
-Using an IDE
-^^^^^^^^^^^^
+==== Using an IDE
 
 If you prefer to use an IDE then you can auto-generate the IDE's project
 files using maven plugins. e.g.
 
 [[Building-IntelliJ]]
-IntelliJ
-++++++++
+===== IntelliJ
 
 [source,text]
 -------------
@@ -100,8 +92,7 @@ mvn idea:idea
 -------------
 
 [[Building-Eclipse]]
-Eclipse
-+++++++
+===== Eclipse
 
 There are several ways to import the projects into Eclipse.
 
@@ -216,8 +207,7 @@ need to update the projects.
 --------------------------------------------------------------------------
 
 [[Building-Buildingwithcheckstyle]]
-Building with checkstyle
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Building with checkstyle
 
 To enable source style checking with checkstyle, build Camel with the
 -Psourcecheck parameter
@@ -228,8 +218,7 @@ mvn -Psourcecheck clean install
 -------------------------------
 
 [[Building-Buildingsourcejars]]
-Building source jars
-^^^^^^^^^^^^^^^^^^^^
+==== Building source jars
 
 If you want to build jar files with the source code, that for instance
 Eclipse can important so you can debug the Camel code as well. Then you
@@ -241,8 +230,7 @@ mvn clean source:jar install -Pfastinstall
 ------------------------------------------
 
 [[Building-Workingwithkaraffeatures]]
-Working with karaf features
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Working with karaf features
 
 If you change anything in the features.xml from `platform/karaf` you can
 run a validation step to ensure the generated features.xml file is
@@ -255,8 +243,7 @@ mvn clean install -Pvalidate
 ----------------------------
 
 [[Building-ExecutingunittestsusingEkstazi]]
-Executing unit tests using Ekstazi
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Executing unit tests using Ekstazi
 
 Normally, when you execute the unit tests during your development cycle
 for a particular component, you are executing all the tests each time.
@@ -276,8 +263,7 @@ mvn test -Pekstazi
 ------------------
 
 [[Building-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Running Unit Tests
 * Source

--- a/docs/user-manual/modules/ROOT/pages/camel-boot.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-boot.adoc
@@ -1,6 +1,5 @@
 [[CamelBoot-CamelBoot]]
-Camel Boot
-~~~~~~~~~~
+=== Camel Boot
 
 Camel lets you boot up a JVM process and configure Camel nicely using
 whichever dependency injection framework you choose.
@@ -14,22 +13,19 @@ required.
 The following camel boot options are supported:
 
 [[CamelBoot-CDI]]
-CDI
-^^^
+==== CDI
 
 Using the <<cdi-component,camel-cdi module>> you can boot up your Camel
 Java process using the *org.apache.camel.cdi.Main* class
 
 [[CamelBoot-Spring]]
-Spring
-^^^^^^
+==== Spring
 
 Using the <<SpringSupport-SpringSupport,camel-spring module>> you can boot your
 Camel Java process using the *org.apache.camel.spring.Main* class
 
 [[CamelBoot-SpringBoot]]
-Spring Boot
-^^^^^^^^^^^
+==== Spring Boot
 
 You can combine Spring Boot with Camel using
 <<SpringBoot-SpringBoot,Camel's Spring Boot integration>>. In this case

--- a/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
@@ -1,6 +1,5 @@
 [[CamelConfigurationUtilities-JSSEUtility]]
-JSSE Utility
-~~~~~~~~~~~~
+=== JSSE Utility
 
 The JSSE Utility, available as of *2.8*, allows you to easily configure
 aspects of the
@@ -9,8 +8,7 @@ Secure Socket Extension] (JSSE) API in order to greatly simplify the use
 of custom transport layer security (TLS) settings on Camel components.
 
 [[CamelConfigurationUtilities-SupportedComponents]]
-Supported Components
-^^^^^^^^^^^^^^^^^^^^
+==== Supported Components
 
 The following Camel components directly support the use of this
 configuration utility:
@@ -32,8 +30,7 @@ configuration utility:
 * <<http-component,HTTP>>
 
 [[CamelConfigurationUtilities-Configuration]]
-Configuration
-^^^^^^^^^^^^^
+==== Configuration
 
 The key component in configuring TLS through the JSSE API is the
 SSLContext.  The
@@ -67,8 +64,7 @@ namespaces for Spring and Blueprint based configuration, respectively.
 
 
 [[CamelConfigurationUtilities-SSLContextParameters]]
-SSLContextParameters
-++++++++++++++++++++
+===== SSLContextParameters
 
 SSLContextParameters (sslContextParameters) contain the following elements:
 
@@ -168,8 +164,7 @@ override the settings specified at the SSLContextParameters level.
 
 
 [[CamelConfigurationUtilities-KeyManagersParameters]]
-KeyManagersParameters
-+++++++++++++++++++++
+===== KeyManagersParameters
 
 KeyManagersParameters contain the following elements:
 
@@ -201,8 +196,7 @@ store containing a user or server private key.  In some cases, such as
 when using PKCS#11, the key store is omitted entirely.
 
 [[CamelConfigurationUtilities-TrustManagersParameters]]
-TrustManagersParameters
-+++++++++++++++++++++++
+===== TrustManagersParameters
 
 TrustManagersParameters contain the following elements:
 
@@ -231,8 +225,7 @@ store containing trusted CA certificates / public keys.  In some cases,
 such as when using PKCS#11, the key store is omitted entirely.
 
 [[CamelConfigurationUtilities-KeyStoreParameters]]
-KeyStoreParameters
-++++++++++++++++++
+===== KeyStoreParameters
 
 KeyStoreParameters contain the following elements:
 
@@ -277,8 +270,7 @@ configuration.
 
 
 [[CamelConfigurationUtilities-FilterParameters]]
-FilterParameters
-++++++++++++++++
+===== FilterParameters
 
 FilterParameters contain the following elements:
 
@@ -294,8 +286,7 @@ patterns for which matching values should be included.  The list of
 excludes takes precedence over the include patterns.
 
 [[CamelConfigurationUtilities-SecureRandomParameters]]
-SecureRandomParameters
-++++++++++++++++++++++
+===== SecureRandomParameters
 SecureRandomParameters contain the following elements:
 
 * algorithm (attribute)
@@ -313,8 +304,7 @@ used to create the SecureRandom represented by this object's
 configuration.  If omitted, the default look-up behavior is used.
 
 [[CamelConfigurationUtilities-SSLContextServerParameters]]
-SSLContextServerParameters
-++++++++++++++++++++++++++
+===== SSLContextServerParameters
 SSLContextServerParameters contain the following elements:
 
 * clientAuthentication (attribute)
@@ -353,8 +343,7 @@ setting in the SSLContextParameters. This option has no affect on the
 SSLEngine configuration.
 
 [[CamelConfigurationUtilities-SSLContextClientParameters]]
-SSLContextClientParameters
-++++++++++++++++++++++++++
+===== SSLContextClientParameters
 SSLContextClientParameters contains the following elements:
 
 * sniHostNames (elements)
@@ -379,12 +368,10 @@ secureSocketProtocolsFilter::
 See <<CamelConfigurationUtilities-SSLContextServerParameters>>.
 
 [[CamelConfigurationUtilities-Examples]]
-Examples
-^^^^^^^^
+==== Examples
 
 [[CamelConfigurationUtilities-ProgrammaticUsage]]
-Programmatic Usage
-++++++++++++++++++
+===== Programmatic Usage
 
 [[CamelConfigurationUtilities-SettingClientAuthenticationOntheServerSide]]
 Setting Client Authentication On the Server Side
@@ -487,8 +474,7 @@ KeyStore keyStore = ksp.createKeyStore();
 ---------------------------------------------------
 
 [[CamelConfigurationUtilities-XMLConfiguration]]
-XML Configuration
-+++++++++++++++++
+===== XML Configuration
 
 [NOTE]
 ====

--- a/docs/user-manual/modules/ROOT/pages/camel-jar-dependencies.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jar-dependencies.adoc
@@ -1,12 +1,10 @@
 [[CamelJARDependencies-CamelJARDependencies]]
-Camel JAR Dependencies
-~~~~~~~~~~~~~~~~~~~~~~
+=== Camel JAR Dependencies
 
 Camel core itself is lightweight and can run with a few .jars.
 
 [[CamelJARDependencies-camel-coredependenciesforCamel2.0orlower]]
-`camel-core` dependencies for Camel 2.0 or lower
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== `camel-core` dependencies for Camel 2.0 or lower
 
 * `commons-logging-api.jar` - API for commons logging
 * JAXB 2.1.x - XML stuff - Is provided in the JDK core from Java 1.6
@@ -14,8 +12,7 @@ Camel core itself is lightweight and can run with a few .jars.
 core from Java 1.6
 
 [[CamelJARDependencies-camel-coredependenciesforCamel2.1-2.6]]
-`camel-core` dependencies for Camel 2.1 - 2.6
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== `camel-core` dependencies for Camel 2.1 - 2.6
 
 * `commons-logging-api-1.1.jar` - API for commons logging
 * `commons-management-1.0.jar` - API for JMX
@@ -24,21 +21,18 @@ core from Java 1.6
 JDK core from Java 1.6
 
 [[CamelJARDependencies-camel-coredependenciesforCamel2.7-2.8]]
-`camel-core` dependencies for Camel 2.7 - 2.8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== `camel-core` dependencies for Camel 2.7 - 2.8
 
 * `slf4j-api-1.5.11.jar` - API for slf4j logging
 * `commons-management-1.0.jar` - API for JMX
 
 [[CamelJARDependencies-camel-coredependenciesforCamel2.9]]
-`camel-core` dependencies for Camel 2.9
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== `camel-core` dependencies for Camel 2.9
 
 * `slf4j-api-1.6.1.jar` - API for slf4j logging
 
 [[CamelJARDependencies-OptionaldependenciesforJMXforCamel1.x-2.8]]
-Optional dependencies for JMX for Camel 1.x - 2.8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Optional dependencies for JMX for Camel 1.x - 2.8
 
 * `spring-core.jar`, `spring-beans.jar`,
 `spring-context.jar`, `spring-aop.jar` - All 4 jars needed to use JMX
@@ -47,8 +41,7 @@ with Camel (subject to change in the future).
 From *Camel 2.9*: the Spring JARs are no longer required for using JMX.
 
 [[CamelJARDependencies-OtherComponents]]
-Other Components
-~~~~~~~~~~~~~~~~
+=== Other Components
 
 All the other link:component.adoc[Components] have a range of 3rd party
 .jars they depend on. They are listed in the maven pom files which files

--- a/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
@@ -1,6 +1,5 @@
 [[CamelContext-CamelContext]]
-CamelContext
-~~~~~~~~~~~~
+=== CamelContext
 
 The
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext]
@@ -12,8 +11,7 @@ See link:lifecycle.adoc[Lifecycle] to understand the overall lifecycle
 of the CamelContext.
 
 [[CamelContext-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:route-builder.adoc[RouteBuilder]
 * link:routes.adoc[Routes]

--- a/docs/user-manual/modules/ROOT/pages/cep.adoc
+++ b/docs/user-manual/modules/ROOT/pages/cep.adoc
@@ -1,6 +1,5 @@
 [[CEP-CamelCEP]]
-Camel CEP
----------
+== Camel CEP
 
 http://en.wikipedia.org/wiki/Complex_event_processing[Complex Event
 Processing] or
@@ -20,8 +19,7 @@ http://netflix.github.com/RxJava/javadoc/[API] which is a JVM port of
 the https://rx.codeplex.com/[Reactive Extensions]
 
 [[CEP-CEPwithCamelRX]]
-CEP with Camel RX
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== CEP with Camel RX
 
 Camel RX provides various ways to get an
 http://netflix.github.com/RxJava/javadoc/rx/Observable.html[Observable<T>]

--- a/docs/user-manual/modules/ROOT/pages/debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/debugger.adoc
@@ -1,6 +1,5 @@
 [[Debugger-Debugger]]
-Debugger
-~~~~~~~~
+=== Debugger
 
 *Available as of Camel 2.6*
 
@@ -14,15 +13,13 @@ TIP:There is also a BacklogDebugger which allows
 to debug from JMX, and 3rd party tooling.
 
 [[Debugger-AbouttheDebugger]]
-About the Debugger
-^^^^^^^^^^^^^^^^^^
+==== About the Debugger
 
 The Debugger allows tooling or the likes to attach breakpoints which is
 being invoked when Exchanges is being routed.
 
 [[Debugger-Defaultimplementation]]
-Default implementation
-^^^^^^^^^^^^^^^^^^^^^^
+==== Default implementation
 
 Camel provides a default implementation
 `org.apache.camel.impl.DefaultDebugger` which you can set on the
@@ -36,8 +33,7 @@ breakpoints. And to suspend/resume all breakpoints etc. +
 the condition matches.
 
 [[Debugger-EasilydebuggingCamelroutesfromcamel-test]]
-Easily debugging Camel routes from `camel-test`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Easily debugging Camel routes from `camel-test`
 
 If you are developing unit tests using the `camel-test` component, then
 the Debugger comes out of the box. +
@@ -45,8 +41,7 @@ the Debugger comes out of the box. +
 debugger, by overriding `isUseDebugger()` method and return `true`.
 
 [[Debugger-Example]]
-Example
-+++++++
+===== Example
 
 In this unit test
 
@@ -115,8 +110,7 @@ endpoint.
 image:debugger.data/debug.png[image]
 
 [[Debugger-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Tracer
 * link:backlogdebugger.adoc[BacklogDebugger]

--- a/docs/user-manual/modules/ROOT/pages/delay-interceptor.adoc
+++ b/docs/user-manual/modules/ROOT/pages/delay-interceptor.adoc
@@ -1,6 +1,5 @@
 [[DelayInterceptor-DelayInterceptor]]
-Delay Interceptor
-~~~~~~~~~~~~~~~~~
+=== Delay Interceptor
 
 *Available in Camel 1.5*
 
@@ -16,8 +15,7 @@ The delay interceptor can be configured as follows:
 * adding the delay interceptor to the CamelContext in Java code.
 
 [[DelayInterceptor-ConfiguringusingSpring]]
-Configuring using Spring
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Configuring using Spring
 
 Just set the delay attribute of the camelContext tag as shown below:
 
@@ -32,8 +30,7 @@ Just set the delay attribute of the camelContext tag as shown below:
 --------------------------------------------------------------------------------------------------
 
 [[DelayInterceptor-ConfiguringusingJava]]
-Configuring using Java
-^^^^^^^^^^^^^^^^^^^^^^
+==== Configuring using Java
 
 You can add the delayer interceptor in the RouteBulder as shown below:
 
@@ -55,8 +52,7 @@ getContext().setDelayer(200);
 -----------------------------
 
 [[DelayInterceptor-Granularity]]
-Granularity
-^^^^^^^^^^^
+==== Granularity
 
 In *Camel 2.0* you can configure it on both camel context and per route
 as you like. Per route will override the camel context setting. +
@@ -79,8 +75,7 @@ with 200 millis.
 ------------------------
 
 [[DelayInterceptor-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Tracer
 * link:debugger.adoc[Debugger]

--- a/docs/user-manual/modules/ROOT/pages/dependency-injection.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dependency-injection.adoc
@@ -1,6 +1,5 @@
 [[DependencyInjection-DependencyInjection]]
-Dependency Injection
-~~~~~~~~~~~~~~~~~~~~
+=== Dependency Injection
 
 _Dependency Injection_ or _Inversion of Control_ is a pattern where
 dependencies of an object are injected into the object without the

--- a/docs/user-manual/modules/ROOT/pages/dozer-type-conversion.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dozer-type-conversion.adoc
@@ -1,6 +1,5 @@
 [[DozerTypeConversion-DozerTypeConversion]]
-Dozer Type Conversion
-----------------------
+== Dozer Type Conversion
 
 https://github.com/DozerMapper/dozer/blob/master/docs/asciidoc/about/about.adoc[Dozer] is a fast
 and flexible framework for mapping back and forth between Java Beans.
@@ -101,8 +100,7 @@ inconsistencies between the beans i.e. the address properties, knowing
 that Dozer will automatically match and convert the others.
 
 [[DozerTypeConversion-ConfiguringDozer]]
-Configuring Dozer
-~~~~~~~~~~~~~~~~~
+=== Configuring Dozer
 
 Dozer's configuration is extremely flexible and many mapping scenarios
 are covered https://github.com/DozerMapper/dozer/blob/master/docs/asciidoc/documentation/mappings.adoc[here].
@@ -131,8 +129,7 @@ For our simple example, the configuration looks like the following.
 ---------------------------------------------------------------------------------------------------------
 
 [[DozerTypeConversion-SupportforDozerinCamel]]
-Support for Dozer in Camel
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Support for Dozer in Camel
 
 Camel provides a simple mechanism to integrate Dozer Mappers with it's
 own powerful http://camel.apache.org/type-converter.html[Type

--- a/docs/user-manual/modules/ROOT/pages/dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dsl.adoc
@@ -1,6 +1,5 @@
 [[DSL-DSL]]
-DSL
-~~~
+=== DSL
 
 Camel uses a Java _Domain Specific Language_ or DSL for creating
 link:enterprise-integration-patterns.adoc[Enterprise Integration
@@ -32,8 +31,7 @@ rulebase
 routes using the routing DSL
 
 [[DSL-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 For more examples of the DSL in action see
 

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -1,6 +1,5 @@
 [[Endpoint-Endpoints]]
-Endpoints
-~~~~~~~~~
+=== Endpoints
 
 Camel supports the Message Endpoint pattern
 using the
@@ -27,8 +26,7 @@ consuming message exchanges from the endpoint via a
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/PollingConsumer.html[PollingConsumer]
 
 [[Endpoint-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Configuring Camel
 * Message Endpoint pattern

--- a/docs/user-manual/modules/ROOT/pages/enterprise-integration-patterns.adoc
+++ b/docs/user-manual/modules/ROOT/pages/enterprise-integration-patterns.adoc
@@ -1,6 +1,5 @@
 [[EnterpriseIntegrationPatterns-EnterpriseIntegrationPatterns]]
-Enterprise Integration Patterns
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Enterprise Integration Patterns
 
 Camel supports most of the
 http://www.eaipatterns.com/toc.html[Enterprise Integration Patterns]
@@ -26,8 +25,7 @@ http://www.eaipatterns.com/download/EIP_Visio_stencil.zip[Microsoft
 Visio], or http://www.graffletopia.com/stencils/137[Omnigraffle].
 
 [[EnterpriseIntegrationPatterns-MessagingSystems]]
-Messaging Systems
-^^^^^^^^^^^^^^^^^
+==== Messaging Systems
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -59,8 +57,7 @@ connect to a messaging channel to send and receive messages?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessagingChannels]]
-Messaging Channels
-^^^^^^^^^^^^^^^^^^
+==== Messaging Channels
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -90,8 +87,7 @@ affecting the others?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessageConstruction]]
-Message Construction
-^^^^^^^^^^^^^^^^^^^^
+==== Message Construction
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -114,8 +110,7 @@ to send the reply?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessageRouting]]
-Message Routing
-^^^^^^^^^^^^^^^
+==== Message Routing
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -204,8 +199,7 @@ of endpoints at the same time?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessageTransformation]]
-Message Transformation
-^^^^^^^^^^^^^^^^^^^^^^
+==== Message Transformation
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -237,8 +231,7 @@ semantically equivalent, but arrive in a different format?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessagingEndpoints]]
-Messaging Endpoints
-^^^^^^^^^^^^^^^^^^^
+==== Messaging Endpoints
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
@@ -290,8 +283,7 @@ and via non-messaging techniques?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-SystemManagement]]
-System Management
-^^^^^^^^^^^^^^^^^
+==== System Management
 
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================

--- a/docs/user-manual/modules/ROOT/pages/error-handler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/error-handler.adoc
@@ -1,6 +1,5 @@
 [[ErrorHandler-ErrorHandler]]
-Error Handler
-~~~~~~~~~~~~~
+=== Error Handler
 
 Camel supports pluggable
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/ErrorHandler.html[ErrorHandler]
@@ -30,8 +29,7 @@ more power.
 The current implementations Camel provides out of the box are:
 
 [[ErrorHandler-Nontransacted]]
-Non transacted
-~~~~~~~~~~~~~~
+=== Non transacted
 
 * DefaultErrorHandler is the default
 error handler in Camel. This error handler does not support a dead
@@ -44,8 +42,7 @@ sending it to a dead letter endpoint
 * NoErrorHandler for no error handling
 
 [[ErrorHandler-Transacted]]
-Transacted
-~~~~~~~~~~
+=== Transacted
 
 * TransactionErrorHandler is the
 default error handler in Camel for transacted routes. See the
@@ -57,12 +54,10 @@ examples. Error handling rules are inherited on each routing rule within
 a single RouteBuilder
 
 [[ErrorHandler-ShortSummaryoftheprovidedErrorHandlers]]
-Short Summary of the provided Error Handlers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Short Summary of the provided Error Handlers
 
 [[ErrorHandler-DefaultErrorHandlerhttps://cwiki.apache.org/confluence/pages/viewpage.action?pageId=113880]]
-DefaultErrorHandler
-++++++++++++++++++++++++++++++++++++++++++++++++++
+===== DefaultErrorHandler
 
 The DefaultErrorHandler is the default
 error handler in Camel. Unlike link:dead-letter-channel.html[Dead Letter
@@ -70,8 +65,7 @@ Channel] it does not have any dead letter queue, and do *not* handle
 exceptions by default.
 
 [[ErrorHandler-DeadLetterChannelhttps://cwiki.apache.org/confluence/pages/viewpage.action?pageId=49482]]
-Dead Letter Channel
-++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Dead Letter Channel
 
 The Dead Letter Channel will redeliver at
 most 6 times using 1 second delay, and if the exchange failed it will be
@@ -104,8 +98,7 @@ or also from *Camel 2.3.0 onwards*
 --------------------------------------------------------------------------------------------------
 
 [[ErrorHandler-LoggingErrorHandler]]
-Logging Error Handler
-+++++++++++++++++++++
+===== Logging Error Handler
 
 The logging error handler will log (by default at ERROR level) whenever
 an uncaught exception is thrown. The logging category, logger and level
@@ -153,8 +146,7 @@ from("seda:a").errorHandler(loggingErrorHandler("mylogger.name").level(LoggingLe
 Loggers may also be defined for specific routes.
 
 [[ErrorHandler-NoErrorHandler]]
-No Error Handler
-++++++++++++++++
+===== No Error Handler
 
 The no error handler is to be used for disabling error handling.
 
@@ -186,8 +178,7 @@ or also from *Camel 2.3.0 onwards*
 ---------------------------------------------------------------
 
 [[ErrorHandler]]
-TransactionErrorHandler
-+++++++++++++++++++++++
+===== TransactionErrorHandler
 
 The TransactionErrorHandler is the
 default error handler in Camel for transacted routes.
@@ -203,8 +194,7 @@ overrules the default error handler. This is convention over
 configuration.
 
 [[ErrorHandler-Featuressupportbyvariouss]]
-Features support by various Error Handlers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Features support by various Error Handlers
 
 Here is a breakdown of which features is supported by the
 Error Handler(s):
@@ -272,8 +262,7 @@ See Exception Clause documentation for
 documentation of some of the features above.
 
 [[ErrorHandler-Scopes]]
-Scopes
-^^^^^^
+==== Scopes
 
 The error handler is scoped as either
 
@@ -318,8 +307,7 @@ RouteBuilder builder = new RouteBuilder() {
 ---------------------------------------------------------------
 
 [[ErrorHandler-Springbasedconfiguration]]
-Spring based configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Spring based configuration
 
 *Java DSL vs. Spring DSL*
 The error handler is configured a bit differently in Java DSL and Spring
@@ -341,8 +329,7 @@ handler then its use everywhere. But you can override this in a route
 and use another error handler.
 
 [[ErrorHandler-Springbasedconfigurationsample]]
-Spring based configuration sample
-+++++++++++++++++++++++++++++++++
+===== Spring based configuration sample
 
 In this sample we configure a link:dead-letter-channel.html[Dead Letter
 Channel] on the route that should redeliver at most 3 times and use a
@@ -360,8 +347,7 @@ From Camel 2.3.0, camel provides a customer bean configuration for the
 Error Handler, you can find the examples here.
 
 [[ErrorHandler-Usingthetransactionalerrorhandler]]
-Using the transactional error handler
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using the transactional error handler
 
 The transactional error handler is based on spring transaction. This
 requires the usage of the camel-spring component. +
@@ -370,8 +356,7 @@ samples for how to use and transactional behavior and configuration with
 this error handler.
 
 [[ErrorHandler-Seealso]]
-See also
-^^^^^^^^
+==== See also
 
 * Error handling in Camel for
 introduction and background material on error handling in Camel

--- a/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
@@ -684,8 +684,7 @@ errorHandler(defaultErrorHandler()
 ----
 
 [[ExceptionClause-UsingonRedeliveryinSpringDSL.1]]
-Using `onRedelivery` in Spring DSL
-++++++++++++++++++++++++++++++++++
+===== Using `onRedelivery` in Spring DSL
 
 In Spring DSL you need to use the *`onExceptionOccurredRef`* attribute
 to refer to a spring bean id that is your custom processor:

--- a/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
@@ -1,6 +1,5 @@
 [[ExchangePattern-ExchangePattern]]
-Exchange Pattern
-~~~~~~~~~~~~~~~~
+=== Exchange Pattern
 
 There are many different _Message Exchange Patterns_ you can use in
 messaging. This concept is also demonstrated in WSDL and JBI's MEPs.

--- a/docs/user-manual/modules/ROOT/pages/exchange.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exchange.adoc
@@ -1,6 +1,5 @@
 [[Exchange-MessageExchange]]
-Message Exchange
-~~~~~~~~~~~~~~~~
+=== Message Exchange
 
 To support various message exchange patterns
 like one way Event Message and
@@ -13,8 +12,7 @@ Request Reply where there is an inbound and
 outbound Message.
 
 [[Exchange-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Event Message
 * Request Reply

--- a/docs/user-manual/modules/ROOT/pages/expression.adoc
+++ b/docs/user-manual/modules/ROOT/pages/expression.adoc
@@ -1,6 +1,5 @@
 [[Expression-Expressions]]
-Expressions
-~~~~~~~~~~~
+=== Expressions
 
 Expressions and Predicates can then be used to
 create the various link:enterprise-integration-patterns.adoc[Enterprise
@@ -12,8 +11,7 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Expres
 strategies using a variety of different Languages.
 
 [[Expression-API]]
-API
-^^^
+==== API
 
 If you are outside of the DSL and want to create your own
 expressions you can either implement the
@@ -23,8 +21,7 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/builde
 class].
 
 [[Expression-Expression]]
-Expression
-++++++++++
+===== Expression
 
 The API for a Camel Expression is defined in the
 `org.apache.camel.Expression` interface as shown:
@@ -45,8 +42,7 @@ public interface Expression {
 -------------------------------------------------------------------------------
 
 [[Expression-Predicate]]
-Predicate
-+++++++++
+===== Predicate
 
 The API for a Camel Predicate is defined in the
 `org.apache.camel.Predicate` interface as shown:
@@ -68,8 +64,7 @@ public interface Predicate {
 -------------------------------------------------------------------------------
 
 [[Expression-ExpressionLanguages]]
-Expression Languages
-^^^^^^^^^^^^^^^^^^^^
+==== Expression Languages
 
 The following languages are supported out of the box
 
@@ -105,8 +100,7 @@ link:annotation-based-expression-language.html[Annotation Based
 Expression Language].
 
 [[Expression-UsingExpressionsinyourIDE]]
-Using Expressions in your IDE
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using Expressions in your IDE
 
 To use different expression and predicates in your IDE you need to
 perform a static import of the builder class for the language(s) you
@@ -129,8 +123,7 @@ and <<ruby-language,Ruby>> |http://camel.apache.org/maven/current/camel-script/a
 |=======================================================================
 
 [[Expression-SeeAlso]]
-See Also
-++++++++
+===== See Also
 
 * Predicate
 

--- a/docs/user-manual/modules/ROOT/pages/getting-started.adoc
+++ b/docs/user-manual/modules/ROOT/pages/getting-started.adoc
@@ -1,6 +1,5 @@
 [[GettingStarted-GettingStarted]]
-Getting Started
-~~~~~~~~~~~~~~~
+=== Getting Started
 
 First you need to Download the Camel distribution;
 or you could grab the Source and try
@@ -18,8 +17,7 @@ Spring based link:xml-configuration.adoc[Xml
 Configuration]
 
 [[GettingStarted-WorkingwithCamelContextsandRouteBuilders]]
-Working with CamelContexts and RouteBuilders
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Working with CamelContexts and RouteBuilders
 
 To get started with Camel:
 
@@ -41,15 +39,13 @@ through another example] +
  And after the walks head over to the tutorials.
 
 [[GettingStarted-WorkingwithSpring]]
-Working with Spring
-^^^^^^^^^^^^^^^^^^^
+==== Working with Spring
 
 If you use Spring as a Dependency Injection container then please refer
 to the Camel Spring documentation.
 
 [[GettingStarted-OtherResources]]
-Other Resources
-^^^^^^^^^^^^^^^
+==== Other Resources
 
 We strongly suggest that you brew a cup of coffee or tea and take the 30
 minutes to read one or more of the following resources:

--- a/docs/user-manual/modules/ROOT/pages/groovy-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/groovy-dsl.adoc
@@ -1,6 +1,5 @@
 [[GroovyDSL-AbouttheGroovyDSL]]
-About the Groovy DSL
-^^^^^^^^^^^^^^^^^^^^
+==== About the Groovy DSL
 
 The Groovy DSL implementation is built on top of the existing Java-based
 DSL, but it additionally allows to use Groovy language
@@ -15,8 +14,7 @@ allows to embed small scripts into Java routes. The Groovy DSL requires
 Groovy 2.0 or newer and is available as of *Camel 2.11*.
 
 [[GroovyDSL-Introduction]]
-Introduction
-^^^^^^^^^^^^
+==== Introduction
 
 Because Groovy is syntactically very similar to Java, you can write your
 Groovy routes just like Java routes. The same Java DSL classes are being
@@ -67,8 +65,7 @@ The corresponding route in Java would look something like this:
 -----------------------------------------------------------------------------------------
 
 [[GroovyDSL-DevelopingwiththeGroovyDSL]]
-Developing with the Groovy DSL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Developing with the Groovy DSL
 
 To be able to use the Groovy DSL in your camel routes you need to add
 the a dependency on *camel-groovy* which implements the Groovy DSL.
@@ -132,8 +129,7 @@ when `mvn eclipse:eclipse` is executed:
 ----------------------------------------------------------------------------------------
 
 [[GroovyDSL-UsingClosuresinyourroutes]]
-Using Closures in your routes
-+++++++++++++++++++++++++++++
+===== Using Closures in your routes
 
 Groovy closures can be used to write concise implementations of Camel
 processors, expressions, predicates, and aggregation strategies. It is
@@ -251,8 +247,7 @@ Similarly, `expression(Closure)` returns a Camel expression,
 returns an AggregationStrategy.
 
 [[GroovyDSL-UsingGroovyXMLprocessing]]
-Using Groovy XML processing
-+++++++++++++++++++++++++++
+===== Using Groovy XML processing
 
 Groovy provides special http://groovy-lang.org/processing-xml.html[XML
 processing support] through its `XmlParser`, `XmlNodePrinter` and
@@ -299,8 +294,7 @@ Currently, marshalling is only supported for `groovy.util.Node` objects.
 ------------------------------------------------------
 
 [[GroovyDSL-UsingGroovyGStrings]]
-Using Groovy GStrings
-+++++++++++++++++++++
+===== Using Groovy GStrings
 
 Groovy
 http://docs.groovy-lang.org/latest/html/documentation/index.html#all-strings[GStrings]
@@ -317,8 +311,7 @@ TypeConverter to automatically turn them into
 the required type.
 
 [[GroovyDSL-CustomDSLextensions]]
-Custom DSL extensions
-+++++++++++++++++++++
+===== Custom DSL extensions
 
 You can easily define your custom extensions - be it as a Java DSL
 extension for your Groovy routes or for any other class unrelated to
@@ -402,7 +395,6 @@ Using the plain Java DSL, the route would look something like this:
 -----------------------------------
 
 [[GroovyDSL-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:dsl.adoc[DSL]

--- a/docs/user-manual/modules/ROOT/pages/http-session.adoc
+++ b/docs/user-manual/modules/ROOT/pages/http-session.adoc
@@ -1,6 +1,5 @@
 [[HTTPSession-HTTPSession]]
-HTTP-Session Handling
-~~~~~~~~~~~~~~~~~~~~~
+=== HTTP-Session Handling
 
 Several Camel components can use HTTP as the underlying transport protocol.
 In general HTTP calls are stateless in nature, however some servers allow
@@ -9,8 +8,7 @@ session (e.g. via a session cookie called "JSESSIONID" with servers implementing
 the JEE Servlet specification).
 
 [[HTTPSession-SessionScope]]
-Session Scope
-^^^^^^^^^^^^^
+==== Session Scope
 
 If a Camel route intends to implement some kind of HTTP session handling
 the scope of this session should be considered.
@@ -19,16 +17,14 @@ Independently of the session scope the implementation must honor the domain of
 the handled cookies.
 
 [[HTTPSession-ContextScope]]
-Route/Context Scope
-+++++++++++++++++++
+===== Route/Context Scope
 
 It might be desirable to have a single session for a route or a 
 CamelContext. This essentially means that all calls to
 a server issued from a route or CamelContext share a single HTTP session.
 
 [[HTTPSession-EndpointScope]]
-Endpoint Scope
-++++++++++++++
+===== Endpoint Scope
 
 It is also possible to have a session on an
 Endpoint entity. This would mean that all invocations of
@@ -39,8 +35,7 @@ Some components like camel-http, and camel-http4 support endpoint scoped session
 even prior to version 2.19.
 
 [[HTTPSession-ExchangeScope]]
-Exchange Scope
-++++++++++++++
+===== Exchange Scope
 
 The third option to define a session scope is on 
 Exchange level. This is particularly useful for scenarios
@@ -54,8 +49,7 @@ is defined on exchange scope, each invocation of the route will get a separate s
 and the server can maintain a separate state for the different parallel invocations.
 
 [[HTTPSession-Usage]]
-Usage
-^^^^^
+==== Usage
 
 If you are a Camel user, you see that several Camel components support the cookieHandler
 parameter on endpoint level. All you need to do is to instantiate a cookie handler 
@@ -77,8 +71,7 @@ this means that each Exchange will get its own browser instance (so sessions are
 As the ExchangeCookieHandler does not store any state it is generally not useful to have
 multiple ExchangeCookieHandler instances (as they would access the same data, anyway).
 
-Example
-+++++++
+===== Example
 
 The following three routes will each do two invocations of an echo REST service. In the first
 route (without a cookie handler) each invocation will get a new session. For the second route
@@ -129,8 +122,7 @@ will copy the reference to this cookie store (so there is effectively a shared c
 As a workaround, you can call a cookieHandler.getCookieStore() e.g. by setting this to some dummy header.
 
 [[HTTPSession-ComponentDevelopers]]
-Component Developers
-^^^^^^^^^^^^^^^^^^^^
+==== Component Developers
 
 If you want to develop a HTTP based component that is supposed to participate in a session
 you have to add the following parts to your code:

--- a/docs/user-manual/modules/ROOT/pages/injector.adoc
+++ b/docs/user-manual/modules/ROOT/pages/injector.adoc
@@ -1,6 +1,5 @@
 [[Injector-Injector]]
-Injector
-~~~~~~~~
+=== Injector
 
 The
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/Injector.html[Injector]

--- a/docs/user-manual/modules/ROOT/pages/intercept.adoc
+++ b/docs/user-manual/modules/ROOT/pages/intercept.adoc
@@ -1,6 +1,5 @@
 [[Intercept-Intercept]]
-Intercept
-~~~~~~~~~
+=== Intercept
 
 The intercept feature in Camel supports intercepting
 Exchanges while they are _on route_.  +
@@ -44,8 +43,7 @@ regular Java code in a POJO or
 Processor.
 
 [[Intercept-Intercept.1]]
-Intercept
-^^^^^^^^^
+==== Intercept
 
 `Intercept` is like a regular interceptor that is applied on each
 processing step the Exchange undergo while its being
@@ -80,8 +78,7 @@ And in the route below we want to stop in certain conditions, when the
 message contains the word 'Hello':
 
 [[Intercept-UsingfromSpringDSL]]
-Using from Spring DSL
-+++++++++++++++++++++
+===== Using from Spring DSL
 
 The same hello world sample in Spring DSL would be:
 
@@ -105,8 +102,7 @@ And the sample for using the *when* predicate would be:
 And the sample for using the *when* and *stop* would be:
 
 [[Intercept-InterceptFrom]]
-InterceptFrom
-^^^^^^^^^^^^^
+==== InterceptFrom
 
 `InterceptFrom` is for intercepting any incoming
 Exchange, in any route (it intercepts all the `from`
@@ -134,8 +130,7 @@ And if want to only apply a specific endpoint, as the *seda:bar*
 endpoint in the sample below, we can do it like this:
 
 [[Intercept-UsingfromSpringDSL.1]]
-Using from Spring DSL
-+++++++++++++++++++++
+===== Using from Spring DSL
 
 Intercept is of course also available using Spring DSL as shown in the
 sample below:
@@ -145,8 +140,7 @@ intercept from certain endpoints and route then elsewhere and `stop` to
 not continue routing in the original intended route path.
 
 [[Intercept-InterceptSendToEndpoint]]
-InterceptSendToEndpoint
-^^^^^^^^^^^^^^^^^^^^^^^
+==== InterceptSendToEndpoint
 
 *Available as of Camel 2.0*
 
@@ -186,8 +180,7 @@ does not control skipping behaviour
 is matched, leading to more natural logic altogether.
 
 [[Intercept-UsingfromSpringDSL.2]]
-Using from Spring DSL
-+++++++++++++++++++++
+===== Using from Spring DSL
 
 Intercept endpoint is of course also available using Spring DSL.
 
@@ -201,8 +194,7 @@ And the 3rd with the `skip`, notice skip is set with the
 tag:
 
 [[Intercept-AdvancedusageofIntercpt]]
-Advanced usage of Intercpt
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Advanced usage of Intercpt
 
 The `interceptFrom` and `interceptSendToEndpoint` supports endpoint URI
 matching by the following rules in the given order:
@@ -218,8 +210,7 @@ match by wildcard. Then you know the real endpoint that was intercepted
 and can react accordingly.
 
 [[Intercept-Matchbywildcard]]
-Match by wildcard
-+++++++++++++++++
+===== Match by wildcard
 
 Match by wildcard allows you to match a range of endpoint or all of a
 given type. For instance use `uri="file:*"` will match all
@@ -242,8 +233,7 @@ intercept("file://order/inbox/*").to("log:newfileorders");
 To intercept any files received from the `order/inbox` folder.
 
 [[Intercept-Matchbyregularexpression]]
-Match by regular expression
-+++++++++++++++++++++++++++
+===== Match by regular expression
 
 Match by regular expression is just like match by wildcard but using
 regex instead. So if we want to intercept incoming messages from gold
@@ -266,8 +256,7 @@ construct a `Consumer` using the Camel API and consumes an
 Endpoint then the `interceptFrom` is not triggered.
 
 [[Intercept-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:architecture.adoc[Architecture]
 

--- a/docs/user-manual/modules/ROOT/pages/inversion-of-control-with-smart-defaults.adoc
+++ b/docs/user-manual/modules/ROOT/pages/inversion-of-control-with-smart-defaults.adoc
@@ -1,6 +1,5 @@
 [[InversionOfControlWithSmartDefaults-InversionOfControlWithSmartDefaults]]
-Inversion Of Control With Smart Defaults
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Inversion Of Control With Smart Defaults
 
 Inversion of Control is a powerful way of wiring together your beans so
 that the beans themselves can stay simple & be injected with their

--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -1,6 +1,5 @@
 [[JavaDSL-JavaDSL]]
-Java DSL
-~~~~~~~~
+=== Java DSL
 
 Apache Camel offers a Java based DSL using the fluent builder style. The
 Java DSL is available by extending the
@@ -64,8 +63,7 @@ or not.
 -------------------------------------------------------
 
 [[JavaDSL-Routes]]
-Routes
-~~~~~~
+=== Routes
 
 Camel supports the definition of routing rules using a Java
 DSL (domain specific language) which avoids the need for
@@ -88,8 +86,7 @@ As you can see from the above Camel uses URIs to wire
 endpoints together.
 
 [[JavaDSL-URIStringformatting]]
-URI String formatting
-^^^^^^^^^^^^^^^^^^^^^
+==== URI String formatting
 
 *Available as of Camel 2.0*
 
@@ -107,8 +104,7 @@ fromF("file://%s?include=%s", path, pattern).toF("mock:%s", result);
 -------------------------------------------------------
 
 [[JavaDSL-Filters]]
-Filters
-^^^^^^^
+==== Filters
 
 You can combine simple routes with filters which can be arbitrary
 Predicate implementations.
@@ -127,8 +123,7 @@ RouteBuilder builder = new RouteBuilder() {
 -------------------------------------------------------
 
 [[JavaDSL-Choices]]
-Choices
-^^^^^^^
+==== Choices
 
 With a choice you provide a list of predicates and outcomes along with
 an optional default otherwise clause which is invoked if none of the
@@ -153,8 +148,7 @@ RouteBuilder builder = new RouteBuilder() {
 -------------------------------------------------------
 
 [[JavaDSL-Usingacustomprocessor]]
-Using a custom processor
-++++++++++++++++++++++++
+===== Using a custom processor
 
 Here is an example of using a custom Processor
 
@@ -192,8 +186,7 @@ RouteBuilder builder = new RouteBuilder() {
 -------------------------------------------------------
 
 [[JavaDSL-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:dsl.adoc[DSL]
 

--- a/docs/user-manual/modules/ROOT/pages/json.adoc
+++ b/docs/user-manual/modules/ROOT/pages/json.adoc
@@ -1,6 +1,5 @@
 [[JSON-JSON]]
-JSON
-~~~~
+=== JSON
 
 JSON is a Data Format to marshal and unmarshal
 Java objects to and from http://www.json.org/[JSON].
@@ -26,8 +25,7 @@ conversions via the <<xmljson-dataformat,camel-xmljson>> data format, which
 is documented separately.
 
 [[JSON-UsingJSONdataformatwiththeXStreamlibrary]]
-Using JSON data format with the XStream library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using JSON data format with the XStream library
 
 [source,java]
 ------------------------------------------------------------
@@ -38,8 +36,7 @@ from("activemq:My.Queue").
 ------------------------------------------------------------
 
 [[JSON-UsingJSONdataformatwiththeJacksonlibrary]]
-Using JSON data format with the Jackson library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using JSON data format with the Jackson library
 
 [source,java]
 ------------------------------------------------------------
@@ -50,8 +47,7 @@ from("activemq:My.Queue").
 ------------------------------------------------------------
 
 [[JSON-UsingJSONdataformatwiththeGSONlibrary]]
-Using JSON data format with the GSON library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using JSON data format with the GSON library
 
 [source,java]
 ------------------------------------------------------------
@@ -62,8 +58,7 @@ from("activemq:My.Queue").
 ------------------------------------------------------------
 
 [[JSON-UsingJSONdataformatwiththeJohnzonlibrary]]
-Using JSON data format with the Johnzon library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using JSON data format with the Johnzon library
 
 [source,java]
 ------------------------------------------------------------
@@ -74,8 +69,7 @@ from("activemq:My.Queue").
 ------------------------------------------------------------
 
 [[JSON-UsingJSONinSpringDSL]]
-Using JSON in Spring DSL
-++++++++++++++++++++++++
+===== Using JSON in Spring DSL
 
 When using Data Format in Spring DSL you need to
 declare the data formats first. This is done in the *DataFormats* XML
@@ -102,8 +96,7 @@ And then you can refer to this id in the route:
 -------------------------------------
 
 [[JSON-ExcludingPOJOfieldsfrommarshalling]]
-Excluding POJO fields from marshalling
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Excluding POJO fields from marshalling
 
 *As of Camel 2.10* +
  When marshalling a POJO to JSON you might want to exclude certain
@@ -133,8 +126,7 @@ The line above will exclude fields annotated with `@ExcludeAge` when
 marshalling to JSON.
 
 [[JSON-Configuringfieldnamingpolicy]]
-Configuring field naming policy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Configuring field naming policy
 
 *Available as of Camel 2.11*
 
@@ -235,8 +227,7 @@ And use it in Camel routes by referring to its bean id as shown:
 ---------------------------------------------------------------
 
 [[JSON-IncludeExcludefieldsusingthejsonViewattributewithJacksonDataFormat]]
-Include/Exclude fields using the `jsonView` attribute with  `JacksonDataFormat`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Include/Exclude fields using the `jsonView` attribute with  `JacksonDataFormat`
 
 *Available as of Camel 2.12*
 
@@ -269,8 +260,7 @@ And the same in XML DSL:
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 [[JSON-SettingserializationincludeoptionforJacksonmarshal]]
-Setting serialization include option for Jackson marshal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Setting serialization include option for Jackson marshal
 
 *Available as of Camel 2.13.3/2.14*
 
@@ -306,8 +296,7 @@ Or from XML DSL you configure this as
 ------------------------------------------------------------
 
 [[JSON-UnmarshallingfromjsontoPOJOwithdynamicclassname]]
-Unmarshalling from json to POJO with dynamic class name
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Unmarshalling from json to POJO with dynamic class name
 
 *Available as of Camel 2.14*
 
@@ -338,8 +327,7 @@ Or from XML DSL you configure this as
 -------------------------------------------------------------
 
 [[JSON-UnmarshallingfromjsontoListMaporListpojo]]
-Unmarshalling from json to List<Map> or List<pojo>
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Unmarshalling from json to List<Map> or List<pojo>
 
 *Available as of Camel 2.14*
 
@@ -378,8 +366,7 @@ And you can specify the pojo type also
 -------------------------------------------------------------------------------------------
 
 [[JSON-UsingcustomJacksonObjectMapper]]
-Using custom Jackson ObjectMapper
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using custom Jackson ObjectMapper
 
 *Available as of Camel 2.17*
 
@@ -397,8 +384,7 @@ Where myMapper is the id of the custom instance that Camel will lookup
 in the Registry
 
 [[JSON-UsingcustomJacksonmodules]]
-Using custom Jackson modules
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using custom Jackson modules
 
 *Available as of Camel 2.15*
 
@@ -433,8 +419,7 @@ to the module as shown below:
 moduleRefs="myJacksonModule,myOtherModule"
 
 [[JSON-EnablingordisablefeaturesusingJackson]]
-Enabling or disable features using Jackson
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Enabling or disable features using Jackson
 
 *Available as of Camel 2.15*
 
@@ -470,8 +455,7 @@ df.disableFeature(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
 ----------------------------------------------------------------------
 
 [[JSON-ConvertingMapstoPOJOusingJackson]]
-Converting Maps to POJO using Jackson
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Converting Maps to POJO using Jackson
 
 Available since *Camel 2.16*. Jackson `ObjectMapper` can be used to
 convert maps to POJO objects. Jackson component comes with the data
@@ -493,8 +477,7 @@ registry, it will used by the converter to perform the conversion.
 Otherwise the default mapper will be used.  
 
 [[JSON-FormattedJSONmarshalling-pretty-printing]]
-Formatted JSON marshalling (pretty-printing)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Formatted JSON marshalling (pretty-printing)
 
 *Available as of Camel 2.16*
 
@@ -529,8 +512,7 @@ combination with other settings for `JsonLibrary`, `unmarshalType`,
 [[JSON]]
 
 [[JSON-IntegratingJacksonwithCamelsTypeConverters]]
-Integrating Jackson with Camel's TypeConverters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Integrating Jackson with Camel's TypeConverters
 
 [[JSON.1]]
 
@@ -556,8 +538,7 @@ can annotate POJO class with JAXB annotations that Jackson can
 leverage. 
 
 [[JSON-DependenciesforXStream]]
-Dependencies for XStream
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Dependencies for XStream
 
 To use JSON in your camel routes you need to add the a dependency on
 *camel-xstream* which implements this data format.
@@ -576,8 +557,7 @@ the download page for the latest versions).
 ----------------------------------------
 
 [[JSON-DependenciesforJackson]]
-Dependencies for Jackson
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Dependencies for Jackson
 
 To use JSON in your camel routes you need to add the a dependency on
 *camel-jackson* which implements this data format.
@@ -596,8 +576,7 @@ the download page for the latest versions).
 ----------------------------------------
 
 [[JSON-DependenciesforGSON]]
-Dependencies for GSON
-^^^^^^^^^^^^^^^^^^^^^
+==== Dependencies for GSON
 
 To use JSON in your camel routes you need to add the a dependency on
 *camel-gson* which implements this data format.
@@ -616,8 +595,7 @@ the download page for the latest versions).
 -------------------------------------
 
 [[JSON-DependenciesforJohnzon]]
-Dependencies for Johnzon
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Dependencies for Johnzon
 
 To use JSON in your camel routes you need to add the a dependency on
 *camel-johnzon* which implements this data format.

--- a/docs/user-manual/modules/ROOT/pages/karaf.adoc
+++ b/docs/user-manual/modules/ROOT/pages/karaf.adoc
@@ -1,8 +1,7 @@
 :experimental:
 
 [[Karaf-KarafSupport]]
-Karaf Support
-~~~~~~~~~~~~~
+=== Karaf Support
 
 Apache Camel is designed to work nicely into
 http://karaf.apache.org[Apache Karaf] OSGi container.
@@ -39,8 +38,7 @@ Here are the versions that are compatible:
 |============================
 
 [[Karaf-PreparingKarafforCamel]]
-Preparing Karaf for Camel
-~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Preparing Karaf for Camel
 
 Camel uses several bundles to provide low level package, such as
 `javax.annotation` or `javax.xml.bind`.
@@ -65,8 +63,7 @@ copying the `etc/jre.properties.cxf` and override the existing
 
 
 [[Karaf-InstallCamelinKaraf]]
-Install Camel in Karaf
-~~~~~~~~~~~~~~~~~~~~~~
+=== Install Camel in Karaf
 
 Assuming that you have a running Karaf instance, you can register the
 Camel features descriptor:
@@ -133,15 +130,13 @@ karaf@root> features:install camel-stream
 ----
 
 [[Karaf-Karafcommands]]
-Karaf commands
-~~~~~~~~~~~~~~
+=== Karaf commands
 
 When you install the camel feature, new Karaf commands become available
 automatically.
 
 [[Karaf-KarafcommandsinCamel2.8.x]]
-Karaf commands in Camel 2.8.x
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Karaf commands in Camel 2.8.x
 
 [width="100%",cols="1s,4",options="header",]
 |=======================================================================
@@ -169,8 +164,7 @@ context
 |=======================================================================
 
 [[Karaf-KarafcommandsinCamel2.9onwards]]
-Karaf commands in Camel 2.9 onwards
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Karaf commands in Camel 2.9 onwards
 
 [width="100%",cols="1s,4",options="header",]
 |=======================================================================
@@ -207,8 +201,7 @@ onwards you can use `*` as wildcard to match multiple routes.
 |=======================================================================
 
 [[Karaf-KarafcommandsinCamel2.10onwards]]
-Karaf commands in Camel 2.10 onwards
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Karaf commands in Camel 2.10 onwards
 
 [width="100%",cols="1s,4",options="header",]
 |=======================================================================
@@ -218,8 +211,7 @@ available in the current Karaf instance
 |=======================================================================
 
 [[Karaf-KarafcommandsinCamel2.11onwards]]
-Karaf commands in Camel 2.11 onwards
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Karaf commands in Camel 2.11 onwards
 
 [width="100%",cols="1s,4",options="header",]
 |=======================================================================
@@ -231,8 +223,7 @@ route(s)
 |=======================================================================
 
 [[Karaf-KarafcommandsinCamel2.12.4onwards]]
-Karaf commands in Camel 2.12.4 onwards
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Karaf commands in Camel 2.12.4 onwards
 
 [width="100%",cols="1s,4",options="header",]
 |=========================================================
@@ -242,8 +233,7 @@ Karaf commands in Camel 2.12.4 onwards
 |=========================================================
 
 [[Karaf-camel:context-list]]
-`camel:context-list`
-^^^^^^^^^^^^^^^^^^^^
+==== `camel:context-list`
 
 The `camel:context-list` command displays the list of Camel contexts
 available in the current Karaf instance:
@@ -260,8 +250,7 @@ status (started/stopped), the uptime (since when the context has been
 started).
 
 [[Karaf-camel:route-list]]
-`camel:route-list`
-^^^^^^^^^^^^^^^^^^
+==== `camel:route-list`
 
 The `camel:route-list` command displays the list of Camel routes
 available in the current Karaf instance:
@@ -283,8 +272,7 @@ karaf@root> camel:route-list 66-camel-3
 TIP: use the kbd:[TAB] key to completion on the Camel context ID.
 
 [[Karaf-camel:info-context]]
-`camel:info-context`
-^^^^^^^^^^^^^^^^^^^^
+==== `camel:info-context`
 
 The `camel:context-info` command displays detail information about a
 given Camel context:
@@ -331,8 +319,7 @@ endpoints defined.
 TIP: use kbd:[TAB] key for completion on the Camel context name.
 
 [[Karaf-camel:context-start]]
-`camel:context-start`
-^^^^^^^^^^^^^^^^^^^^^
+==== `camel:context-start`
 
 The `camel:context-start` command starts a given Camel context:
 
@@ -344,8 +331,7 @@ karaf@root> camel:context-start 66-camel-3
 TIP: use kbd:[TAB] key for completion on the Camel context name.
 
 [[Karaf-camel:context-stop]]
-`camel:context-stop`
-^^^^^^^^^^^^^^^^^^^^
+==== `camel:context-stop`
 
 The `camel:context-stop` command stops a given Camel context. After
 stopping the context it becomes unavailable and cannot be started again.
@@ -358,8 +344,7 @@ karaf@root> karaf@root> camel:context-stop 66-camel-3
 TIP: use kbd:[TAB] key for completion on the Camel context name.
 
 [[Karaf-camel:route-info]]
-`camel:route-info`
-^^^^^^^^^^^^^^^^^^
+==== `camel:route-info`
 
 The `camel:route-info` command provides detail information about a
 Camel route:
@@ -401,8 +386,7 @@ used to define the route).
 TIP: use kbd:[TAB] key for completion on the route name.
 
 [[Karaf-camel:route-show]]
-`camel:route-show`
-^^^^^^^^^^^^^^^^^^
+==== `camel:route-show`
 
 The `camel:route-show` command renders the route in XML. It's
 independent from the DSL used to define the route:
@@ -420,8 +404,7 @@ karaf@root> camel:route-show route1
 TIP: use kbd:[TAB] key for completion on the route name.
 
 [[Karaf-camel:route-start]]
-`camel:route-start`
-^^^^^^^^^^^^^^^^^^^
+==== `camel:route-start`
 
 The `camel:route-start` command starts a Camel route:
 
@@ -433,8 +416,7 @@ karaf@root> camel:route-start route1
 TIP: use kbd:[TAB] key for completion on the route name.
 
 [[Karaf-camel:route-stop]]
-`camel:route-stop`
-^^^^^^^^^^^^^^^^^^
+==== `camel:route-stop`
 
 The `camel:route-stop` command stops a Camel route:
 
@@ -444,12 +426,10 @@ karaf@root> camel:route-stop route1
 ----
 
 [[Karaf-Camel2.9ornewer]]
-Camel 2.9 or newer
-++++++++++++++++++
+===== Camel 2.9 or newer
 
 [[Karaf-camel:route-suspend]]
-`camel:route-suspend`
-^^^^^^^^^^^^^^^^^^^^^
+==== `camel:route-suspend`
 
 The `camel:route-suspend` command suspends a Camel route:
 
@@ -461,8 +441,7 @@ karaf@root> camel:route-suspend route1
 TIP: use kbd:[TAB] key for completion on the route name.
 
 [[Karaf-camel:route-resume]]
-`camel:route-resume`
-^^^^^^^^^^^^^^^^^^^^
+==== `camel:route-resume`
 
 The `camel:route-resume` command resume a Camel route:
 
@@ -474,12 +453,10 @@ karaf@root> camel:route-resume route1
 TIP: use kbd:[TAB] key for completion on the route name.
 
 [[Karaf-Camel2.10ornewer]]
-Camel 2.10 or newer
-+++++++++++++++++++
+===== Camel 2.10 or newer
 
 [[Karaf-camel:endpoint-list]]
-`camel:endpoint-list`
-^^^^^^^^^^^^^^^^^^^^^
+==== `camel:endpoint-list`
 
 The `camel:endpoint-list` command displays the list of the endpoints
 available in all camel contexts of the current Karaf instance:
@@ -496,12 +473,10 @@ It displays the context name/ID (used in others commands), the URI of
 the endpoint and the current status (started/stopped).
 
 [[Karaf-Camel2.12.4ornewer]]
-Camel 2.12.4 or newer
-++++++++++++++++++++++
+===== Camel 2.12.4 or newer
 
 [[Karaf-camel:context-suspend]]
-`camel:context-suspend`
-^^^^^^^^^^^^^^^^^^^^^^^
+==== `camel:context-suspend`
 
 The `camel:context-suspend` command suspends a given Camel context.
 It then may be resumed again.
@@ -514,8 +489,7 @@ karaf@root> karaf@root> camel:context-suspend 66-camel-3
 TIP: use kbd:[TAB] key for completion on the Camel context name.
 
 [[Karaf-camel:context-resume]]
-`camel:context-resume`
-^^^^^^^^^^^^^^^^^^^^^^
+==== `camel:context-resume`
 
 The `camel:context-resume` command resumes a given Camel context.
 After that it returns to the _started_ state.

--- a/docs/user-manual/modules/ROOT/pages/lifecycle.adoc
+++ b/docs/user-manual/modules/ROOT/pages/lifecycle.adoc
@@ -1,6 +1,5 @@
 [[Lifecycle-CamelLifecycle]]
-Camel Lifecycle
-~~~~~~~~~~~~~~~
+=== Camel Lifecycle
 
 Camel uses a simple _lifecycle_ interface called
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Service.html[Service]
@@ -19,8 +18,7 @@ If you are working with Spring you may wish to read the
 Camel Spring documentation.
 
 [[Lifecycle-CamelContextLifecycle]]
-CamelContext Lifecycle
-^^^^^^^^^^^^^^^^^^^^^^
+==== CamelContext Lifecycle
 
 The `CamelContext` provides methods to control its lifecycle:
 
@@ -56,8 +54,7 @@ Endpoints and therefore you can still use them after
 resuming.
 
 [[Lifecycle-Servicelifecycle]]
-Service lifecycle
-^^^^^^^^^^^^^^^^^
+==== Service lifecycle
 
 A service (`org.apache.camel.Service`) in Camel adheres to the following
 lifecycle states as illustrated in the diagram below:
@@ -75,8 +72,7 @@ track of state. You implement your custom logic in the `doStart`,
 `doStop`, `doSuspend`, `doResume` methods.
 
 [[Lifecycle-Routeslifecycle]]
-Routes lifecycle
-^^^^^^^^^^^^^^^^
+==== Routes lifecycle
 
 Routes in Camel have the following operations to control its lifecycle
 
@@ -107,8 +103,7 @@ If a route consumer does not support suspension, it will fallback and
 stop the route instead.
 
 [[Lifecycle-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * link:camelcontext.adoc[CamelContext]
 * link:architecture.adoc[Architecture]

--- a/docs/user-manual/modules/ROOT/pages/oncompletion.adoc
+++ b/docs/user-manual/modules/ROOT/pages/oncompletion.adoc
@@ -1,6 +1,5 @@
 [[OnCompletion-OnCompletion]]
-OnCompletion
-~~~~~~~~~~~~
+=== OnCompletion
 
 Camel has this concept of a Unit of Work that encompass the
 Exchange. The unit of work among others supports
@@ -67,8 +66,7 @@ they need, eg the File component does that for work
 that moves/deletes the original file etc.
 
 [[OnCompletion-onCompletionwithroutescope]]
-onCompletion with route scope
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== onCompletion with route scope
 
 The *onCompletion* DSL allows you to add custom routes/processors when
 the original Exchange is complete. Camel spin off a
@@ -125,8 +123,7 @@ property `Exchange.ON_COMPLETION` with a boolean value of `true` when it
 spin offs the *onCompletion* Exchange.
 
 [[OnCompletion-UsingonCompletionfromSpringDSL]]
-Using onCompletion from Spring DSL
-++++++++++++++++++++++++++++++++++
+===== Using onCompletion from Spring DSL
 
 The onCompletion is defined like this with Spring DSL:
 
@@ -165,8 +162,7 @@ attribute on the <onCompletion> tag so the failure example would be:
 -----------------------------------------------------------
 
 [[OnCompletion-onCompletionwithglobalscope]]
-onCompletion with global scope
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== onCompletion with global scope
 
 This works just like the route scope except from the fact that they are
 defined globally. An example below:
@@ -182,8 +178,7 @@ from("direct:start")
 -----------------------------------------------------------
 
 [[OnCompletion-UsingonCompletionfromSpringDSL.1]]
-Using onCompletion from Spring DSL
-++++++++++++++++++++++++++++++++++
+===== Using onCompletion from Spring DSL
 
 This works just like the route scope except from the fact that they are
 defined globally. An example below:
@@ -211,8 +206,7 @@ scoped and thus its only the route scoped that are used. The globally
 scoped ones are never used.
 
 [[OnCompletion-UsingonCompletionwithonWhenpredicate]]
-Using onCompletion with onWhen predicate
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using onCompletion with onWhen predicate
 
 As other DSL in Camel you can attach a Predicate to
 the *onCompletion* so it only triggers in certain conditions, when the
@@ -235,8 +229,7 @@ from("direct:start")
 -----------------------------------------------------------
 
 [[OnCompletion-UsingonCompletionwithorwithoutthreadpool]]
-Using onCompletion with or without thread pool
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using onCompletion with or without thread pool
 
 *Available as of Camel 2.14*
 
@@ -280,8 +273,7 @@ to be used, using the executorServiceRef option
  
 
 [[OnCompletion-UsingonCompletiontorunbeforerouteconsumersendsbackresponsetocallee]]
-Using onCompletion to run before route consumer sends back response to callee
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using onCompletion to run before route consumer sends back response to callee
 
 *Available as of Camel 2.14*
 
@@ -325,8 +317,7 @@ And in XML DSL you set the mode attribute to BeforeConsumer:
  
 
 [[OnCompletion-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * Unit of Work
 

--- a/docs/user-manual/modules/ROOT/pages/registry.adoc
+++ b/docs/user-manual/modules/ROOT/pages/registry.adoc
@@ -1,6 +1,5 @@
 [[Registry-Registry]]
-Registry
-~~~~~~~~
+=== Registry
 
 Camel supports a pluggable
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/Registry.html[Registry]

--- a/docs/user-manual/modules/ROOT/pages/routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routes.adoc
@@ -1,6 +1,5 @@
 [[Routes-Routes]]
-Routes
-~~~~~~
+=== Routes
 
 Camel supports the definition of routing rules using a Java DSL (domain specific language) which avoids the need for cumbersome XML using a RouteBuilder.
 
@@ -19,8 +18,7 @@ RouteBuilder builder = new RouteBuilder() {
 As you can see from the above Camel uses URIs to wire endpoints together.
 
 [[Routes-URI-String-Formatting]]
-URI String formatting
-^^^^^^^^^^^^^^^^^^^^^^
+==== URI String formatting
 Available as of Camel 2.0
 
 If you have endpoint URIs that accept options and you want to be able to substitute the value, e.g. build the URI by concat the strings together, then you can use the java.lang.String.format method. But in Camel 2.0 we have added two convenient methods in the Java DSL so you can do fromF and toF that uses String formatting to build the URI.
@@ -33,8 +31,7 @@ fromF("file://%s?include=%s", path, pattern).toF("mock:%s", result);
 --------------------------------------------------------------------
 
 [[Routes-Filters]]
-Filters
-^^^^^^^
+==== Filters
 You can combine simple routes with filters which can be arbitrary Predicate implementations.
 
 [source,java]
@@ -51,8 +48,7 @@ RouteBuilder builder = new RouteBuilder() {
 -------------------------------------------------------------
 
 [[Routes-Choices]]
-Choices
-^^^^^^^
+==== Choices
 With a choice you provide a list of predicates and outcomes along with an optional default otherwise clause which is invoked if none of the conditions are met.
 
 [source,java]
@@ -74,8 +70,7 @@ RouteBuilder builder = new RouteBuilder() {
 -------------------------------------------------------------
 
 [[Routes-Using-a-custom-processor]]
-Using a custom processor
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using a custom processor
 
 Here is an example of using a custom Processor
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/scala-dsl-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/scala-dsl-eip.adoc
@@ -1,5 +1,4 @@
-Scala DSL - EIP
-===============
+= Scala DSL - EIP
 
 [TIP]
 ====
@@ -33,12 +32,10 @@ test source code] for the Scala Component to find more examples.
 ** 4.1 link:#ScalaDSL-EIP-Contentenricher[Content enricher]
 
 [[ScalaDSL-EIP-Messagingsystems]]
-Messaging systems
------------------
+== Messaging systems
 
 [[ScalaDSL-EIP-Pipelinepipeline]]
-Pipeline
-~~~~~~~~
+=== Pipeline
 
 There is a simple syntax available for specifying pipeline, by simple
 putting `to` or `→` between the different steps in the pipeline.
@@ -66,8 +63,7 @@ where every step in the pipeline starts with either `to` or `→`.
 ----------------------------------------------------------
 
 [[ScalaDSL-EIP-Filterfilter]]
-Filter
-~~~~~~
+=== Filter
 
 For a message filter, use the `when()` method with a parameter of type
 The `Exchange ⇒ Boolean`. In the example below, we use a Scala
@@ -97,12 +93,10 @@ the more elaborate syntax.
 ----------------------------------------------------------
 
 [[ScalaDSL-EIP-Messagingchannels]]
-Messaging channels
-^^^^^^^^^^^^^^^^^^
+==== Messaging channels
 
 [[ScalaDSL-EIP-Deadletterchannel]]
-Dead letter channel
-+++++++++++++++++++
+===== Dead letter channel
 
 The http://www.eaipatterns.com/DeadLetterChannel.html[dead letter
 channel] can be created with the syntax similar to the one used in
@@ -130,12 +124,10 @@ http://camel.apache.org/error-handler.html#ErrorHandler-LoggingErrorHandler[Logg
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Messagerouting]]
-Message routing
-^^^^^^^^^^^^^^^
+==== Message routing
 
 [[ScalaDSL-EIP-Aggregator]]
-Aggregator
-++++++++++
+===== Aggregator
 
 The aggregator EIP aggregates messages based on some message correlation
 criteria. In the Scala DSL, the `aggregate` method takes a function
@@ -144,8 +136,7 @@ the sample below, message are being aggregated if the first 7 letters in
 the message body are the same.
 
 [[ScalaDSL-EIP-Contentbasedrouter]]
-Content based router
-++++++++++++++++++++
+===== Content based router
 
 Similar to the Filter, the content based router
 uses `when` methods with `Exchange ⇒ Boolean` function literals and an
@@ -170,8 +161,7 @@ language of the message body.
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Delayer]]
-Delayer
-+++++++
+===== Delayer
 
 Unlike a throttler, which only slows down messages if the rate exceeds a
 threshold, a delayer delays every messages with a fixed amount of time.
@@ -197,8 +187,7 @@ without doing anything to `mock:b`
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Loadbalancer]]
-Load balancer
-+++++++++++++
+===== Load balancer
 
 To distribute the message handling load over multiple endpoints, we add
 a `loadbalance` to our route definition. You can optionally specify a
@@ -216,8 +205,7 @@ load balancer strategy, like `roundrobin`
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Multicast]]
-Multicast
-+++++++++
+===== Multicast
 
 Multicast allows you to send a message to multiple endpoints at the same
 time. In a simple route, you can specify multiple targets in the `to` or
@@ -230,8 +218,7 @@ time. In a simple route, you can specify multiple targets in the `to` or
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Recipientlist]]
-Recipient list
-++++++++++++++
+===== Recipient list
 
 You can handle a static recipient list with a multicast or
 pipeline, but this EIP is usually applied when
@@ -273,8 +260,7 @@ the target.
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Resequencer]]
-Resequencer
-+++++++++++
+===== Resequencer
 
 Use the `resequence` method to add a resequencer to the RouteBuilder.
 The method takes a function (`Exchange ⇒ Unit`) that determines the
@@ -312,8 +298,7 @@ will be send to `mock:e` whenever a batch of 5 messages is available.
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Splitter]]
-Splitter
-++++++++
+===== Splitter
 
 To handle large message in smaller chunks, you can write a Scala
 `Exchange ⇒ Any*` method and add it to your route with the `splitter`
@@ -341,8 +326,7 @@ other languages like XPath can
 be within the Scala DSL.
 
 [[ScalaDSL-EIP-Throttler]]
-Throttler
-+++++++++
+===== Throttler
 
 The throttler allows you to slow down messages before sending them
 along. The `throttle` methods allows you to specify the maximum
@@ -369,12 +353,10 @@ seconds will arrive at the `mock:c` endpoint.
 ----------------------------------------------------------------------------------------------------------------
 
 [[ScalaDSL-EIP-Messagetransformation]]
-Message transformation
-^^^^^^^^^^^^^^^^^^^^^^
+==== Message transformation
 
 [[ScalaDSL-EIP-Contentenricher]]
-Content enricher
-++++++++++++++++
+===== Content enricher
 
 Using a processor function (`Exchange → Unit`), you can alter/enrich the
 message content. This example uses a simple function literal to append

--- a/docs/user-manual/modules/ROOT/pages/scala-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/scala-dsl.adoc
@@ -1,6 +1,5 @@
 [[ScalaDSL-AbouttheScalaDSL]]
-About the Scala DSL
-^^^^^^^^^^^^^^^^^^^
+==== About the Scala DSL
 
 http://www.scala-lang.org/[Scala] is a general purpose programming
 language designed to express common programming patterns in a concise,
@@ -10,8 +9,7 @@ Java-based DSL, but it adds Scala syntax sugar to make
 building routes even more convenient.
 
 [[ScalaDSL-Documentation]]
-Documentation
-^^^^^^^^^^^^^
+==== Documentation
 
 * Scala DSL - Getting Started gives
 you basic information on how to use the Scala DSL.
@@ -23,8 +21,7 @@ languages] explains the usage of traits to add support for other
 languages (e.g. XPath)
 
 [[ScalaDSL-References]]
-References
-^^^^^^^^^^
+==== References
 
 * At http://www.eu.apachecon.com[ApacheCon Europe 2008] there was a Fast
 Feather talk that introduced some of the basic Scala language concepts
@@ -38,8 +35,7 @@ within the Scala DSL, as well as how to use
 Camel's test kit to test the example.
 
 [[ScalaDSL-Dependencies]]
-Dependencies
-^^^^^^^^^^^^
+==== Dependencies
 
 To use the Scala DSL in your camel routes you need to add the a
 dependency on *camel-scala* which implements the Scala DSL.

--- a/docs/user-manual/modules/ROOT/pages/scripting-languages.adoc
+++ b/docs/user-manual/modules/ROOT/pages/scripting-languages.adoc
@@ -1,6 +1,5 @@
 [[ScriptingLanguages-ScriptingLanguages]]
-Scripting Languages
-~~~~~~~~~~~~~~~~~~~
+=== Scripting Languages
 
 Camel supports a number of scripting languages which can be used to
 create an Expression or
@@ -43,8 +42,7 @@ However any http://jcp.org/en/jsr/detail?id=223[JSR 223] scripting
 language can be used using the generic DSL methods.
 
 [[ScriptingLanguages-ScriptContext]]
-ScriptContext
-^^^^^^^^^^^^^
+==== ScriptContext
 
 The JSR-223 scripting languages ScriptContext is pre configured with the
 following attributes all set at `ENGINE_SCOPE`:
@@ -73,8 +71,7 @@ See Scripting Languages for the list of
 languages with explicit DSL support.
 
 [[ScriptingLanguages-AdditionalargumentstoScriptingEngine]]
-Additional arguments to ScriptingEngine
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Additional arguments to ScriptingEngine
 
 *Available as of Camel 2.8*
 
@@ -83,8 +80,7 @@ header on the Camel message with the key `CamelScriptArguments`.
 See this example:
 
 [[ScriptingLanguages-Usingpropertiesfunction]]
-Using properties function
-^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using properties function
 
 *Available as of Camel 2.9*
 
@@ -107,8 +103,7 @@ same example is simpler:
 -------------------------------------------------------------------------------
 
 [[ScriptingLanguages-Loadingscriptfromexternalresource]]
-Loading script from external resource
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Loading script from external resource
 
 *Available as of Camel 2.11*
 
@@ -123,8 +118,7 @@ eg to refer to a file on the classpath you can do:
 -------------------------------------------------------------------
 
 [[ScriptingLanguages-Howtogettheresultfrommultiplestatementsscript]]
-How to get the result from multiple statements script
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== How to get the result from multiple statements script
 
 *Available as of Camel 2.14*
 
@@ -145,8 +139,7 @@ result = body * 2 + 1
  
 
 [[ScriptingLanguages-Dependencies]]
-Dependencies
-^^^^^^^^^^^^
+==== Dependencies
 
 To use scripting languages in your camel routes you need to add the a
 dependency on *camel-script* which integrates the JSR-223 scripting
@@ -166,8 +159,7 @@ the download page for the latest versions).
 ---------------------------------------
 
 [[ScriptingLanguages-SeeAlso]]
-See Also
-~~~~~~~~
+=== See Also
 
 * Languages
 * link:dsl.adoc[DSL]

--- a/docs/user-manual/modules/ROOT/pages/spring-testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/spring-testing.adoc
@@ -1,6 +1,5 @@
 [[SpringTesting-SpringTesting]]
-Spring Testing
-~~~~~~~~~~~~~~
+=== Spring Testing
 
 Testing is a crucial part of any development or
 integration work. The Spring Framework offers a number of features that
@@ -55,8 +54,7 @@ as *@Autowired*, *@DirtiesContext*, and *@ContextConfiguration*. |* JUnit 3.x 
 |=======================================================================
 
 [[SpringTesting-CamelSpringTestSupport]]
-CamelSpringTestSupport
-^^^^^^^^^^^^^^^^^^^^^^
+==== CamelSpringTestSupport
 
 org.apache.camel.test.CamelSpringTestSupport,
 org.apache.camel.test.junit4.CamelSpringTestSupport, and
@@ -81,8 +79,7 @@ aware counterparts from Camel Test are available
 in your test.
 
 [[SpringTesting-PlainSpringTest]]
-Plain Spring Test
-^^^^^^^^^^^^^^^^^
+==== Plain Spring Test
 
 In this approach, your test classes directly inherit from the Spring
 Test abstract test classes or use the JUnit 4.x test runner provided in
@@ -91,8 +88,7 @@ class and the full suite of Spring Test annotations but does not support
 the features provided by the CamelSpringTestSupport classes.
 
 [[SpringTesting-PlainSpringTestusingJUnit3.xwithXMLConfigExample]]
-Plain Spring Test using JUnit 3.x with XML Config Example
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Plain Spring Test using JUnit 3.x with XML Config Example
 
 Here is a simple unit test using JUnit 3.x support from Spring Test
 using http://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/java/org/apache/camel/spring/patterns/FilterTest.java[XML
@@ -124,8 +120,7 @@ src/test/resources/org/apache/camel/spring/patterns/FilterTest-context.xml
 --------------------------------------------------------------------------
 
 [[SpringTesting-PlainSpringTestusingJUnit4.xwithJavaConfigExample]]
-Plain Spring Test using JUnit 4.x with Java Config Example
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Plain Spring Test using JUnit 4.x with Java Config Example
 
 You can completely avoid using an XML configuration file by using
 Spring Java Config.  Here is a unit test
@@ -142,8 +137,7 @@ http://jira.springframework.org/browse/SJC-238[SJC-238] to address this
 and make Spring Test work more cleanly with Spring JavaConfig.
 
 [[SpringTesting-PlainSpringTestusingJUnit4.0.xRunnerwithXMLConfig]]
-Plain Spring Test using JUnit 4.0.x Runner with XML Config
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Plain Spring Test using JUnit 4.0.x Runner with XML Config
 
 You can avoid extending Spring classes by using the
 SpringJUnit4ClassRunner provided by Spring Test.  This custom JUnit
@@ -179,8 +173,7 @@ public class MyCamelTest {
 ------------------------------------------------------
 
 [[SpringTesting-PlainSpringTestusingJUnit4.1.xRunnerwithXMLConfig]]
-Plain Spring Test using JUnit 4.1.x Runner with XML Config
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Plain Spring Test using JUnit 4.1.x Runner with XML Config
 
 You can avoid extending Spring classes by using the
 SpringJUnit4ClassRunner provided by Spring Test.  This custom JUnit
@@ -217,8 +210,7 @@ public class MyCamelTest {
 ------------------------------------------------------
 
 [[SpringTesting-CamelEnhancedSpringTest]]
-Camel Enhanced Spring Test
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Camel Enhanced Spring Test
 
 Using org.apache.camel.test.junit4.CamelSpringJUnit4ClassRunner runner
 with the *@RunWith* annotation or extending
@@ -327,8 +319,7 @@ public class CamelSpringJUnit4ClassRunnerPlainTest {
 ----------------------------------------------------------------------------------------------------
 
 [[SpringTesting-AddingmoreMockexpectations]]
-Adding more Mock expectations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Adding more Mock expectations
 
 If you wish to programmatically add any new assertions to your test you
 can easily do so with the following. Notice how we use @EndpointInject
@@ -356,8 +347,7 @@ public class MyCamelTest extends AbstractJUnit38SpringContextTests {
 --------------------------------------------------------------------
 
 [[SpringTesting-Furtherprocessingthereceivedmessages]]
-Further processing the received messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Further processing the received messages
 
 Sometimes once a <<mock-component,Mock>> endpoint has received some
 messages you want to then process them further to add further assertions
@@ -392,8 +382,7 @@ public class MyCamelTest extends AbstractJUnit38SpringContextTests {
 --------------------------------------------------------------------
 
 [[SpringTesting-Sendingandreceivingmessages]]
-Sending and receiving messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Sending and receiving messages
 
 It might be that the
 link:enterprise-integration-patterns.adoc[Enterprise Integration
@@ -431,8 +420,7 @@ public class Foo {
 --------------------------------------------------
 
 [[SpringTesting-SeeAlso]]
-See Also
-^^^^^^^^
+==== See Also
 
 * A
 https://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/java/org/apache/camel/spring/mock/InterceptSendToMockEndpointStrategyTest.java[real

--- a/docs/user-manual/modules/ROOT/pages/spring.adoc
+++ b/docs/user-manual/modules/ROOT/pages/spring.adoc
@@ -15,8 +15,7 @@ Apache Camel is designed to work nicely with the Spring Framework in a number of
 * From Camel 2.17.1: Camel supports Spring Cache based Idempotent repository
 
 
-Using Spring to configure the CamelContext
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Using Spring to configure the CamelContext
 
 You can configure a CamelContext inside any spring.xml using the CamelContextFactoryBean. This will automatically start the CamelContext along with any referenced Routes along any referenced Component and Endpoint instances.
 
@@ -26,8 +25,7 @@ You can configure a CamelContext inside any spring.xml using the CamelContextFac
 ** Using Spring XML
 
 [[Spring-AddingCamelSchema]]
-Adding Camel Schema
-~~~~~~~~~~~~~~~~~~~
+=== Adding Camel Schema
 For Camel 1.x you need to use the following namespace:
 ....
 http://activemq.apache.org/camel/schema/spring
@@ -55,8 +53,7 @@ So the XML file looks like this:
     ">
 --------------------------------------------------------------------------------------------------------------
 
-Using `camel:` Namespace
-++++++++++++++++++++++++
+===== Using `camel:` Namespace
 Or you can refer to the camel XSD in the XML declaration:
 ....
 xmlns:camel="http://camel.apache.org/schema/spring"
@@ -86,12 +83,10 @@ http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/came
   </camel:camelContext>
 --------------------------------------------------------------------------------------------------------------
 
-Advanced Configuration Using Spring
-+++++++++++++++++++++++++++++++++++
+===== Advanced Configuration Using Spring
 See more details at Advanced configuration of CamelContext using Spring
 
-Using Java Code
-~~~~~~~~~~~~~~~
+=== Using Java Code
 You can use Java Code to define your link:route-builder.adoc[RouteBuilder] implementations. These can be defined as beans in spring and then referenced in your camel context e.g.
 [source,xml]
 --------------------------------------------------------------------------------------------------------------
@@ -101,8 +96,7 @@ You can use Java Code to define your link:route-builder.adoc[RouteBuilder] imple
 <bean id="myBuilder" class="org.apache.camel.spring.example.test1.MyRouteBuilder"/>
 --------------------------------------------------------------------------------------------------------------
 
-Using <package>
-~~~~~~~~~~~~~~~
+=== Using <package>
 Camel also provides a powerful feature that allows for the automatic discovery and initialization of routes in given packages. This is configured by adding tags to the camel context in your spring context definition, specifying the packages to be recursively searched for RouteBuilder implementations. To use this feature in 1.X, requires a <package></package> tag specifying a comma separated list of packages that should be searched e.g.
 
 [source,xml]
@@ -117,8 +111,7 @@ Will ignore already instantiated classes
 
 The *`<package>`* and *`<packageScan>`* will skip any classes which has already been created by Spring etc. So if you define a route builder as a spring bean tag then that class will be skipped. You can include those beans using *`<routeBuilder ref="theBeanId"/>`* or the *`<contextScan>`* feature.
 
-Using `<packageScan>`
-+++++++++++++++++++++
+===== Using `<packageScan>`
 
 In Camel 2.0 this has been extended to allow selective inclusion and exclusion of discovered route classes using Ant like path matching. In spring this is specified by adding a *`<packageScan/>`* tag. The tag must contain one or more *`package`* elements (similar to *`1.x`*), and optionally one or more *`includes`* or *`excludes`* elements specifying patterns to be applied to the fully qualified names of the discovered classes. e.g.,
 
@@ -153,8 +146,7 @@ For example:
 *`org.simple.IncludedRoute`*, *`org.simple.Excluded`* but _not_ match
 *`org.simple.PrecludedRoute`*.
 
-Using `contextScan`
-+++++++++++++++++++
+===== Using `contextScan`
 
 *Available as of Camel 2.4*
 
@@ -188,8 +180,7 @@ You can also use the ANT style for inclusion and exclusion, as mentioned above i
 
 how do i import routes from other xml files
 
-Test Time Exclusion.
-++++++++++++++++++++
+===== Test Time Exclusion.
 At test time it is often desirable to be able to selectively exclude matching routes from being initialized that are not applicable or useful to the test scenario. For instance you might a spring context file *`routes-context.xml`* and three Route builders **`RouteA`, **`RouteB` and *`RouteC`* in the *`org.example.routes`* package. The *`packageScan`* definition would discover all three of these routes and initialize them.
 
 Say *`RouteC`* is not applicable to our test scenario and generates a lot of noise during test. It would be nice to be able to exclude this route from this specific test. The *`SpringTestSupport`* class has been modified to allow this. It provides two methods (*`excludedRoute`* and *`excludedRoutes`*) that may be overridden to exclude a single class or an array of classes.
@@ -226,8 +217,7 @@ protected Class[] excludeRoutes() {
 --------------------------------------------------------------------------------------------------------------
 
 
-Using Spring XML
-~~~~~~~~~~~~~~~~
+=== Using Spring XML
 You can use Spring 2.0 XML configuration to specify your XML Configuration for link:routes.adoc[Routes] such as in the following http://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/resources/org/apache/camel/spring/routingUsingCamelContextFactory.xml[example].
 [source,xml]
 --------------------------------------------------------------------------------------------------------------
@@ -261,8 +251,7 @@ Which allows you to configure a component using some name (*`activemq`* in the a
 
 For more detail see Configuring Endpoints and Components.
 
-Spring Cache Idempotent Repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Spring Cache Idempotent Repository
 
 Available as of *Camel 2.17.1*
 
@@ -288,13 +277,11 @@ Available as of *Camel 2.17.1*
 CamelContextAware
 If you want to be injected with the link:camelcontext.adoc[CamelContext] in your POJO just implement the http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContextAware.html[CamelContextAware interface]; then when Spring creates your POJO the CamelContext will be injected into your POJO. Also see the Bean Integration for further injections.
 
-Integration Testing
-~~~~~~~~~~~~~~~~~~~
+=== Integration Testing
 
 To avoid a hung route when testing using Spring Transactions see the note about Spring Integration Testing under Transactional Client.
 
-See also
-~~~~~~~~
+=== See also
 
 * Spring JMS Tutorial
 * Creating a new Spring based Camel Route

--- a/docs/user-manual/modules/ROOT/pages/team.adoc
+++ b/docs/user-manual/modules/ROOT/pages/team.adoc
@@ -62,8 +62,7 @@ sort it in alphabetical order.
 |=================================================
 
 [[Team-Contributors]]
-Contributors
-^^^^^^^^^^^^
+==== Contributors
 
 [NOTE]
 ====

--- a/docs/user-manual/modules/ROOT/pages/testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/testing.adoc
@@ -9,8 +9,7 @@ ifndef::env-github[]
 endif::[]
 
 [[Testing-Testing]]
-Testing
-~~~~~~~
+=== Testing
 
 Testing is a crucial activity in any piece of software development or
 integration. Typically Camel Riders use various different
@@ -28,8 +27,7 @@ However the Camel project has tried to make the testing of Camel as easy
 and powerful as possible so we have introduced the following features.
 
 [[Testing-Testingmechanisms]]
-Testing mechanisms
-^^^^^^^^^^^^^^^^^^
+==== Testing mechanisms
 
 The following mechanisms are supported
 
@@ -87,8 +85,7 @@ they all reuse the link:bean-integration.adoc[Camel binding and
 injection annotations].
 
 [[Testing-CamelTestExample]]
-Camel Test Example
-++++++++++++++++++
+===== Camel Test Example
 
 Here is the Camel Test
 link:../../../components/camel-test/src/test/java/org/apache/camel/test/patterns/FilterTest.java[example]:
@@ -103,8 +100,7 @@ has no CDI, Spring or Guice dependency injection configuration but instead
 overrides the `createRouteBuilder()` method.
 
 [[Testing-CdiTestExample]]
-CDI Test Example
-++++++++++++++++
+===== CDI Test Example
 
 Here is the CDI Testing
 link:../../../components/camel-test-cdi/src/test/java/org/apache/camel/test/cdi/FilterTest.java[example]:
@@ -118,8 +114,7 @@ You can find more testing patterns illustrated in the `camel-example-cdi-test` e
 and the test classes that come with it.
 
 [[Testing-SpringTestwithXMLConfigExample]]
-Spring Test with XML Config Example
-+++++++++++++++++++++++++++++++++++
+===== Spring Test with XML Config Example
 
 Here is the Spring Testing
 link:../../../components/camel-spring/src/test/java/org/apache/camel/spring/patterns/FilterTest.java[example
@@ -147,8 +142,7 @@ include::../../../components/camel-spring/src/test/resources/org/apache/camel/sp
 ----
 
 [[Testing-SpringTestwithJavaConfigExample]]
-Spring Test with Java Config Example
-++++++++++++++++++++++++++++++++++++
+===== Spring Test with Java Config Example
 
 Here is the Spring Testing
 link:../../../components/camel-spring-javaconfig/src/test/java/org/apache/camel/spring/javaconfig/patterns/FilterTest.java[example
@@ -188,8 +182,7 @@ include::../../../components/camel-spring-javaconfig/src/test/java/org/apache/ca
 ----
 
 [[Testing-SpringTestwithXMLConfigandDeclarativeConfigurationExample]]
-Spring Test with XML Config and Declarative Configuration Example
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+===== Spring Test with XML Config and Declarative Configuration Example
 
 Here is a Camel test support enhanced link:spring-testing.adoc[Spring
 Testing] link:../../../components/camel-test-spring/src/test/java/org/apache/camel/test/spring/CamelSpringRunnerPlainTest.java[example
@@ -207,8 +200,7 @@ the test class.  See Spring Testing for a list
 of annotations you can use in your tests.
 
 [[Testing-BlueprintTest]]
-Blueprint Test
-++++++++++++++
+===== Blueprint Test
 
 Here is the Blueprint Testing
 link:../../../components/camel-test-blueprint/src/test/java/org/apache/camel/test/blueprint/DebugBlueprintTest.java[example
@@ -230,8 +222,7 @@ include::../../../components/camel-test-blueprint/src/test/resources/org/apache/
 ----
 
 [[Testing-Testingendpoints]]
-Testing endpoints
-^^^^^^^^^^^^^^^^^
+==== Testing endpoints
 
 Camel provides a number of endpoints which can make testing easier.
 
@@ -256,8 +247,7 @@ expectations to be added to different endpoints; you can then run your
 tests and assert that your expectations are met at the end.
 
 [[Testing-Stubbingoutphysicaltransporttechnologies]]
-Stubbing out physical transport technologies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Stubbing out physical transport technologies
 
 If you wish to test out a route but want to avoid actually using a real
 physical transport (for example to unit test a transformation route
@@ -281,8 +271,7 @@ validate the endpoint URI, which makes stubbing much easier.
 |=======================================================================
 
 [[Testing-Testingexistingroutes]]
-Testing existing routes
-^^^^^^^^^^^^^^^^^^^^^^^
+==== Testing existing routes
 
 Camel provides some features to aid during testing of existing routes
 where you cannot or will not use <<mock-component,Mock>> etc. For example

--- a/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
+++ b/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
@@ -95,8 +95,7 @@ using a finally, then the `end()` should be at the end of the `doCatch`
 to indicate the end there.
 
 [[TryCatchFinally-Usingtry..catch..finallyinSpringDSL]]
-Using try .. catch .. finally in Spring DSL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using try .. catch .. finally in Spring DSL
 
 We show the three sample samples using Spring DSL instead.
 


### PR DESCRIPTION
Accordng to issue [12708](https://issues.apache.org/jira/browse/CAMEL-12708), created by @tadayosi.

Changes where made, using [AsciiDoc plugin](https://plugins.jetbrains.com/plugin/7391-asciidoc). By the way, plugin marked old-style headers as warnings.

Few bugs were found and fixed: there were with extra "^", "~", "+".
Issue can be closed.