### PR TITLE
CAMEL-13077: Fix polling return for empty OData ClientEntitySets

### DIFF
--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.olingo4.api.Olingo4ResponseHandler;
 import org.apache.camel.component.olingo4.internal.Olingo4ApiName;
 import org.apache.camel.support.component.AbstractApiConsumer;
 import org.apache.camel.support.component.ApiConsumerHelper;
+import org.apache.olingo.client.api.domain.ClientEntitySet;
 
 /**
  * The Olingo4 consumer.
@@ -82,7 +83,15 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
                 throw error[0];
             }
 
-            return ApiConsumerHelper.getResultsProcessed(this, result[0], isSplitResult());
+            //
+            // Allow consumer idle properties to properly handle an empty polling response
+            //
+            if (result[0] instanceof ClientEntitySet && (((ClientEntitySet) result[0]).getEntities().isEmpty())) {
+                return 0;
+            } else {
+                int processed = ApiConsumerHelper.getResultsProcessed(this, result[0], isSplitResult());
+                return processed;
+            }
 
         } catch (Throwable t) {
             throw RuntimeCamelException.wrapRuntimeCamelException(t);


### PR DESCRIPTION
* ApiConsumerHelper does not recognise ClientEntitySets and thus defaults
  to return a constant 1. This means that the scheduling polling is never
  concluded to be idle and the backoffXXX consumer properties do not work.

* If the ClientEntitySet is empty then return 0 to allow for backoffXXX
  properties to correctly handle the scheduling of the polling.