### PR TITLE
FUSEDOC-2912 Add info about accessToken parameter.

### DIFF
--- a/components/camel-linkedin/camel-linkedin-component/src/main/docs/linkedin-component.adoc
+++ b/components/camel-linkedin/camel-linkedin-component/src/main/docs/linkedin-component.adoc
@@ -95,10 +95,30 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *accessToken* (common) | LinkedIn access token to avoid username and password login. |  | String
+| *accessToken* (common) | LinkedIn access token to avoid username and password login procedure. 
+
+
+LinkedIn responds to login forms by using a CAPTCHA. This makes it impossible 
+for a standalone, headless process to log in to LinkedIn by specifying a username and password. 
+To work around this, obtain a LinkedIn access token and provide the token as
+the setting of the *accessToken* parameter.
+
+Obtaining a LinkedIn access token is a multi-step procedure. You must configure your 
+LinkedIn application, obtain a LinkedIn authorization code, and exchange that 
+code for the LinkedIn access token. For details, see 
+link:https://developer.linkedin.com/docs/oauth2[Authenticating with OAuth for LinkedIn developers].
+
+The default behavior is that the access token expires after 60 days. To change this, specify a value
+for the *expiryTime* paramter. If the access token expires, the LinkedIn component tries to log in to 
+LinkedIn by providing a username and password, which results in a CAPTCHA so the login fails. 
+The LinkedIn component cannot refresh the access token. You must manually obtain a new access token 
+each time an access token expires. When you update the access token you must restart the application 
+so that it uses the new token. 
+
+|  | String
 | *clientId* (common) | LinkedIn application client ID |  | String
 | *clientSecret* (common) | LinkedIn application client secret |  | String
-| *expiryTime* (common) | LinkedIn access token expiry time in milliseconds since Unix Epoch, default is 60 days in the future. |  | Long
+| *expiryTime* (common) | LinkedIn access token expiry time in milliseconds since the UNIX Epoch. The default is 60 days. |  | Long
 | *httpParams* (common) | Custom HTTP params, for example proxy host and port, use constants from AllClientPNames |  | Map
 | *inBody* (common) | Sets the name of a parameter to be passed in the exchange In Body |  | String
 | *lazyAuth* (common) | Flag to enable/disable lazy OAuth, default is true. when enabled, OAuth token retrieval or generation is not done until the first REST call | true | boolean


### PR DESCRIPTION
This update adds information about using a LinkedIn access token to work around the username/password login procedure for LinkedIn, which returns a CAPTCHA. Dhiraj Bokde provided the information in response to 
https://issues.jboss.org/browse/ENTESB-8088. 
This doc update is required to resolve 
https://issues.jboss.org/browse/FUSEDOC-2912 

