### PR TITLE
Update the version of guava used by Camel swagger (CAMEL-13083)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -660,7 +660,7 @@
     <stompjms-version>1.19</stompjms-version>
     <swagger-java-version>1.5.21</swagger-java-version>
     <swagger-java-parser-version>1.0.37</swagger-java-parser-version>
-    <swagger-java-guava-version>20.0</swagger-java-guava-version>
+    <swagger-java-guava-version>27.0.1-jre</swagger-java-guava-version>
     <swagger-ui-version>2.2.10</swagger-ui-version>
     <stax-api-version>1.0.1</stax-api-version>
     <stax2-api-bundle-version>3.1.4</stax2-api-bundle-version>


### PR DESCRIPTION
To fix this vulnerability: https://github.com/google/guava/wiki/CVE-2018-10237