### PR TITLE
Add checkstyle "separated" property

### DIFF
--- a/buildingtools/camel-checkstyle.xml
+++ b/buildingtools/camel-checkstyle.xml
@@ -112,6 +112,7 @@ lengths, if/try depths, etc...
         <module name="ImportOrder">
             <property name="groups" value="java,javax,org.w3c,org.xml,junit"/>
             <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
         </module>
         <!--
         <module name="ImportControl">


### PR DESCRIPTION
By default property "separated" is false.
As I see (latests code style fix commits), import groups have to be separated.
Without that property I get errors like "Extra separation in import group..." when using IntelliJ IDEA Checkstyle plugin.
Looks like maven checkstyle plugin ignores that property.
