### PR TITLE
Refactor SJMS tests to use external AMQ

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsDestinationCreationStrategyTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsDestinationCreationStrategyTest.java
@@ -40,6 +40,7 @@ public class SjmsDestinationCreationStrategyTest extends JmsTestSupport {
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = new DefaultCamelContext();
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(brokerUri);
+        setupFactoryExternal(connectionFactory);
         SjmsComponent component = new SjmsComponent();
         component.setConnectionFactory(connectionFactory);
         component.setDestinationCreationStrategy(new TestDestinationCreationStrategyTest());

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/QueueProducerQoSTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/QueueProducerQoSTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.sjms.support.JmsTestSupport;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class QueueProducerQoSTest extends JmsTestSupport {
@@ -40,6 +42,7 @@ public class QueueProducerQoSTest extends JmsTestSupport {
 
     @Test
     public void testInOutQueueProducerTTL() throws Exception {
+        Assume.assumeFalse(externalAmq);
         mockExpiredAdvisory.expectedMessageCount(1);
 
         String endpoint = String.format("sjms:queue:%s?ttl=1000&exchangePattern=InOut&responseTimeOut=500", TEST_INOUT_DESTINATION_NAME);
@@ -62,6 +65,7 @@ public class QueueProducerQoSTest extends JmsTestSupport {
 
     @Test
     public void testInOnlyQueueProducerTTL() throws Exception {
+        Assume.assumeFalse(externalAmq);
         mockExpiredAdvisory.expectedMessageCount(1);
 
         String endpoint = String.format("sjms:queue:%s?ttl=1000", TEST_INONLY_DESTINATION_NAME);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/JmsTestSupport.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/support/JmsTestSupport.java
@@ -36,6 +36,9 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
 
 /**
  * A support class that builds up and tears down an ActiveMQ instance to be used
@@ -50,8 +53,10 @@ public class JmsTestSupport extends CamelTestSupport {
     private Connection connection;
     private Session session;
     private DestinationCreationStrategy destinationCreationStrategy = new DefaultDestinationCreationStrategy();
+    protected boolean externalAmq = false;
+    protected Properties properties;
 
-    /** 
+    /**
      * Set up the Broker
      *
      * @see org.apache.camel.test.junit4.CamelTestSupport#doPreSetup()
@@ -61,12 +66,29 @@ public class JmsTestSupport extends CamelTestSupport {
     @Override
     protected void doPreSetup() throws Exception {
         deleteDirectory("target/activemq-data");
-        broker = new BrokerService();
-        int port = AvailablePortFinder.getNextAvailable(33333);
-        brokerUri = "tcp://localhost:" + port;
-        broker.getManagementContext().setConnectorPort(AvailablePortFinder.getNextAvailable(port + 1));
-        configureBroker(broker);
-        startBroker();
+        properties = new Properties();
+        final URL url = getClass().getResource("/test-options.properties");
+        int port;
+        String host;
+        try (InputStream inStream = url.openStream()) {
+            properties.load(inStream);
+            if (Boolean.valueOf(properties.getProperty("amq.external"))) {
+                log.info("Using external AMQ");
+                port = Integer.parseInt(properties.getProperty("amq.port"));
+                host = properties.getProperty("amq.host");
+                externalAmq = true;
+            } else {
+                port = AvailablePortFinder.getNextAvailable(33333);
+                host = "localhost";
+            }
+        }
+        brokerUri = String.format("tcp://%s:%s", host, port);
+        if (!externalAmq) {
+            broker = new BrokerService();
+            broker.getManagementContext().setConnectorPort(AvailablePortFinder.getNextAvailable(port + 1));
+            configureBroker(broker);
+            startBroker();
+        }
     }
 
     protected void configureBroker(BrokerService broker) throws Exception {
@@ -74,6 +96,13 @@ public class JmsTestSupport extends CamelTestSupport {
         broker.setPersistent(false);
         broker.deleteAllMessages();
         broker.addConnector(brokerUri);
+    }
+
+    protected void setupFactoryExternal(ActiveMQConnectionFactory factory) {
+        if (externalAmq) {
+            factory.setUserName(properties.getProperty("amq.username"));
+            factory.setPassword(properties.getProperty("amq.password"));
+        }
     }
 
     private void startBroker() throws Exception {
@@ -85,7 +114,7 @@ public class JmsTestSupport extends CamelTestSupport {
     public void tearDown() throws Exception {
         super.tearDown();
         DefaultCamelContext dcc = (DefaultCamelContext)context;
-        while (!dcc.isStopped()) {
+        while (broker != null && !dcc.isStopped()) {
             log.info("Waiting on the Camel Context to stop");
         }
         log.info("Closing JMS Session");
@@ -114,6 +143,7 @@ public class JmsTestSupport extends CamelTestSupport {
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(brokerUri);
+        setupFactoryExternal(connectionFactory);
         connection = connectionFactory.createConnection();
         connection.start();
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/components/camel-sjms/src/test/resources/test-options.properties
+++ b/components/camel-sjms/src/test/resources/test-options.properties
@@ -1,0 +1,6 @@
+amq.external=false
+# If testing with external AMQ, uncomment and fill properties
+#amq.port=61617
+#amq.host=localhost
+#amq.username=admin
+#amq.password=admin


### PR DESCRIPTION
Enables to use external AMQ instead of embedded broker for tests. By default it will still run with embedded broker.