### PR TITLE
CAMEL-13150: Add command "exchangeProperty" for dateExpression in ExpressionBuilder

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
@@ -1946,7 +1946,7 @@ public final class ExpressionBuilder {
                     if (date == null) {
                         throw new IllegalArgumentException("Cannot find java.util.Date object at command: " + command);
                     }
-                } else if (command.startsWith("property.")) {
+                } else if (command.startsWith("property.") || command.startsWith("exchangeProperty.")) {
                     String key = command.substring(command.lastIndexOf('.') + 1);
                     date = exchange.getProperty(key, Date.class);
                     if (date == null) {


### PR DESCRIPTION
Command "property" is deprecated since 2.15
