### PR TITLE
CAMEL-13150: Add command "exchangeProperty" for dateExpression in ExpressionBuilder

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
+++ b/camel-core/src/main/java/org/apache/camel/builder/ExpressionBuilder.java
@@ -1946,7 +1946,7 @@ public final class ExpressionBuilder {
                     if (date == null) {
                         throw new IllegalArgumentException("Cannot find java.util.Date object at command: " + command);
                     }
-                } else if (command.startsWith("property.")) {
+                } else if (command.startsWith("property.") || command.startsWith("exchangeProperty.")) {
                     String key = command.substring(command.lastIndexOf('.') + 1);
                     date = exchange.getProperty(key, Date.class);
                     if (date == null) {

--- a/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
+++ b/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
@@ -570,6 +570,10 @@ public class SimpleTest extends LanguageTestSupport {
         assertExpression("date:property.birthday:yyyyMMdd", "19760622");
         assertExpression("date:property.birthday+24h:yyyyMMdd", "19760623");
 
+        assertExpression("date:exchangeProperty.birthday", propertyCalendar.getTime());
+        assertExpression("date:exchangeProperty.birthday:yyyyMMdd", "19760622");
+        assertExpression("date:exchangeProperty.birthday+24h:yyyyMMdd", "19760623");
+
         try {
             assertExpression("date:yyyyMMdd", "19740420");
             fail("Should thrown an exception");


### PR DESCRIPTION
Command **_property_** is deprecated since v2.15