### PR TITLE
fixed issue with useStringsForPicklists property in JUnit tests; back…

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/FieldTypeOverride.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/FieldTypeOverride.java
@@ -1,0 +1,106 @@
+package org.apache.camel.maven;
+
+import java.util.Collections;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Allows redefinition for Picklist/Multipicklist/Date fields to other than standard java types.
+ */
+public final class FieldTypeOverride {
+
+
+    private String objectName;
+    private String fieldName;
+    private String javaOverrideTypeName;
+
+    public FieldTypeOverride() {
+    }
+
+    public FieldTypeOverride(String objectName, String fieldName, String javaOverrideTypeName) {
+        this.objectName = Objects.requireNonNull(objectName);
+        this.fieldName = Objects.requireNonNull(fieldName);
+        this.javaOverrideTypeName = Objects.requireNonNull(javaOverrideTypeName);
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public void setObjectName(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getJavaOverrideTypeName() {
+        return javaOverrideTypeName;
+    }
+
+    public void setJavaOverrideTypeName(String javaOverrideTypeName) {
+        this.javaOverrideTypeName = javaOverrideTypeName;
+    }
+
+    static final class Definition {
+
+        private final String correspondingSalesforceFieldType;
+        private final String correspondingSalesforceFieldSoapType;
+        private final Set<String> javaTypeNames;
+
+        Definition(String correspondingSalesforceFieldType, String correspondingSalesforceFieldSoapType, String javaTypeName) {
+            this.correspondingSalesforceFieldType = Objects.requireNonNull(correspondingSalesforceFieldType);
+            this.correspondingSalesforceFieldSoapType = Objects.requireNonNull(correspondingSalesforceFieldSoapType);
+            this.javaTypeNames = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(javaTypeName)));
+        }
+
+        Definition(String correspondingSalesforceFieldType, String correspondingSalesforceFieldSoapType, String... javaTypeNames) {
+            Objects.requireNonNull(javaTypeNames);
+            this.correspondingSalesforceFieldType = Objects.requireNonNull(correspondingSalesforceFieldType);
+            this.correspondingSalesforceFieldSoapType = Objects.requireNonNull(correspondingSalesforceFieldSoapType);
+            this.javaTypeNames = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(javaTypeNames)));
+        }
+
+        String getCorrespondingSalesforceFieldType() {
+            return correspondingSalesforceFieldType;
+        }
+
+        String getCorrespondingSalesforceFieldSoapType() {
+            return correspondingSalesforceFieldSoapType;
+        }
+
+        Set<String> getJavaTypeNames() {
+            return javaTypeNames;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Definition that = (Definition) o;
+            return Objects.equals(correspondingSalesforceFieldType, that.correspondingSalesforceFieldType) &&
+                    Objects.equals(correspondingSalesforceFieldSoapType, that.correspondingSalesforceFieldSoapType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(correspondingSalesforceFieldType, correspondingSalesforceFieldSoapType);
+        }
+
+        @Override
+        public String toString() {
+            return "Definition{" +
+                    "correspondingSalesforceFieldType='" + correspondingSalesforceFieldType + '\'' +
+                    ", correspondingSalesforceFieldSoapType='" + correspondingSalesforceFieldSoapType + '\'' +
+                    '}';
+        }
+    }
+}

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo-optional.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo-optional.vm
@@ -61,6 +61,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public class ${desc.Name}Optional extends AbstractSObjectBase {
 
 #foreach ( $field in $desc.Fields )
+$utility.overrideFieldType($desc, $field)
 #set ( $fieldType = $utility.getFieldType($desc, $field) )
 #if ( $utility.notBaseField($field.Name) )
 #set ( $fieldName = $field.Name )

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo.vm
@@ -75,6 +75,7 @@ public class $desc.Name extends AbstractDescribedSObjectBase {
     private static final SObjectDescription DESCRIPTION = createSObjectDescription();
 
 #foreach ( $field in $desc.Fields )
+$utility.overrideFieldType($desc, $field)
 #set ( $fieldType = $utility.getFieldType($desc, $field) )
 #if ( ($utility.notBaseField($field.Name)) && ($fieldType) )
 #set ( $fieldName = $field.Name )

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoIntegrationTest.java
@@ -16,24 +16,24 @@
  */
 package org.apache.camel.maven;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.tools.JavaFileObject;
-
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compilation.Status;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
-
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.camel.maven.AbstractSalesforceMojoIntegrationTest.setup;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +78,12 @@ public class CamelSalesforceMojoIntegrationTest {
         mojo.packageName = "test.dto";
 
         // set code generation properties
-        mojo.includePattern = "(.*__c)|(PushTopic)|(Document)|(Account)";
+        mojo.includePattern = "(.*__c)|(PushTopic)|(Document)|(Account)|(Case)";
+        List<FieldTypeOverride> picklistOrDateRedefinitionList = new LinkedList<>();
+        picklistOrDateRedefinitionList.add(new FieldTypeOverride("Account", "AccountSource", String.class.getName()));
+        picklistOrDateRedefinitionList.add(new FieldTypeOverride("Case", "ClosedDate", OffsetTime.class.getName()));
+
+        mojo.fieldTypeOverrides = picklistOrDateRedefinitionList;
 
         return mojo;
     }

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoOverrideFieldsTest.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoOverrideFieldsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CamelSalesforceMojoOverrideFieldsTest {
+
+    @Test
+    public void shouldDisallowFieldsOverrides() {
+        // given
+        int properCountExceptions = 9;
+        final List<ImmutablePair<String, FieldTypeOverride>> invalidOverrides = new LinkedList<>();
+        invalidOverrides.add(ImmutablePair.of("datetime", new FieldTypeOverride("Account", "AccountSource", "String[]")));
+        invalidOverrides.add(ImmutablePair.of("time", new FieldTypeOverride("Account", "AccountSource", "String[]")));
+        invalidOverrides.add(ImmutablePair.of("date", new FieldTypeOverride("Account", "AccountSource", "String[]")));
+        invalidOverrides.add(ImmutablePair.of("g", new FieldTypeOverride("Account", "AccountSource", "String[]")));
+        invalidOverrides.add(ImmutablePair.of("float", new FieldTypeOverride("Account", "AccountSource", "String")));
+        invalidOverrides.add(ImmutablePair.of("decimal", new FieldTypeOverride("Account", "AccountSource", String.class.getName())));
+        invalidOverrides.add(ImmutablePair.of("picklist", new FieldTypeOverride("Account", "AccountSource", String.class.getName() + "[]")));
+        invalidOverrides.add(ImmutablePair.of("picklist", new FieldTypeOverride("Account", "AccountSource", ZonedDateTime.class.getName())));
+        invalidOverrides.add(ImmutablePair.of("multipicklist", new FieldTypeOverride("Account", "AccountSource", OffsetTime.class.getName())));
+
+        // when
+        int countExceptionsThrown = 0;
+        for (ImmutablePair<String, FieldTypeOverride> invalidOverride : invalidOverrides) {
+            try {
+                GenerateMojo.isOverrideAllowed(invalidOverride.getLeft(), invalidOverride.getRight());
+            } catch (IllegalArgumentException e) {
+                countExceptionsThrown++;
+            }
+        }
+
+        // then
+        Assert.assertEquals(properCountExceptions, countExceptionsThrown);
+    }
+
+    @Test(expected = Test.None.class)
+    public void shouldAllowFieldsOverrides() {
+    // given
+        final List<ImmutablePair<String, FieldTypeOverride>> validOverrides = new LinkedList<>();
+        validOverrides.add(ImmutablePair.of("datetime", new FieldTypeOverride("Account", "AccountSource", OffsetTime.class.getName())));
+        validOverrides.add(ImmutablePair.of("datetime", new FieldTypeOverride("Account", "AccountSource", LocalDate.class.getName())));
+        validOverrides.add(ImmutablePair.of("time", new FieldTypeOverride("Account", "AccountSource", LocalDate.class.getName())));
+        validOverrides.add(ImmutablePair.of("time", new FieldTypeOverride("Account", "AccountSource", ZonedDateTime.class.getName())));
+        validOverrides.add(ImmutablePair.of("date", new FieldTypeOverride("Account", "AccountSource", OffsetTime.class.getName())));
+        validOverrides.add(ImmutablePair.of("date", new FieldTypeOverride("Account", "AccountSource", ZonedDateTime.class.getName())));
+        validOverrides.add(ImmutablePair.of("g", new FieldTypeOverride("Account", "AccountSource", LocalDate.class.getName())));
+        validOverrides.add(ImmutablePair.of("picklist", new FieldTypeOverride("Account", "AccountSource", String.class.getName())));
+        validOverrides.add(ImmutablePair.of("multipicklist", new FieldTypeOverride("Account", "AccountSource", String.class.getName())));
+        validOverrides.add(ImmutablePair.of("multipicklist", new FieldTypeOverride("Account", "AccountSource", String.class.getName() + "[]")));
+
+    // when then
+        for (ImmutablePair<String, FieldTypeOverride> validOverride : validOverrides) {
+            GenerateMojo.isOverrideAllowed(validOverride.getLeft(), validOverride.getRight());
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
fixed issue with useStringsForPicklists property in JUnit tests; backported Date/Time solutions from later releases; added possibility to override types for picklist/multipiklists and date fields to specific other types.
To use new feature, simply append in pom.xml following section within "configuration" node (example):

<fieldTypeOverrides>
                <fieldTypeOverride>
                  <objectName>Account</objectName>
                  <fieldName>AccountSource</fieldName>
                  <javaOverrideTypeName>String</javaOverrideTypeName>
                </fieldTypeOverride>
                <fieldTypeOverride>
                  <objectName>Case</objectName>
                  <fieldName>ClosedDate</fieldName>
                  <javaOverrideTypeName>java.time.OffsetTime</javaOverrideTypeName>
                </fieldTypeOverride>
</fieldTypeOverrides>