### PR TITLE
Camel 2.23.x : CAMEL-13125

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -295,15 +295,6 @@ public class MongoDbEndpoint extends DefaultEndpoint {
         super.doStart();
     }
 
-    @Override
-    protected void doStop() throws Exception {
-        super.doStop();
-        if (mongoConnection != null) {
-            LOG.debug("Closing connection");
-            mongoConnection.close();
-        }
-    }
-
     public Exchange createMongoDbExchange(DBObject dbObj) {
         Exchange exchange = super.createExchange();
         Message message = exchange.getIn();


### PR DESCRIPTION
CAMEL-13125 : Endpoint shutdown closes mongo connection, killing the connection for everyone.