### PR TITLE
CAMEL-13185: Add splitResults implementations to Olingo Components

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Consumer.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Consumer.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.component.olingo2;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.apache.camel.Exchange;
@@ -26,6 +28,7 @@ import org.apache.camel.component.olingo2.api.Olingo2ResponseHandler;
 import org.apache.camel.component.olingo2.internal.Olingo2ApiName;
 import org.apache.camel.support.component.AbstractApiConsumer;
 import org.apache.camel.support.component.ApiConsumerHelper;
+import org.apache.olingo.odata2.api.ep.entry.ODataEntry;
 import org.apache.olingo.odata2.api.ep.feed.ODataFeed;
 
 /**
@@ -128,5 +131,21 @@ public class Olingo2Consumer extends AbstractApiConsumer<Olingo2ApiName, Olingo2
         }
 
         resultIndex.index(result);
+    }
+
+    @Override
+    public Object splitResult(Object result) {
+        List<Object> splitResult = new ArrayList<>();
+
+        if (result instanceof ODataFeed) {
+            ODataFeed odataFeed = (ODataFeed) result;
+            for (ODataEntry entry : odataFeed.getEntries()) {
+                splitResult.add(entry);
+            }
+        } else if (result instanceof ODataEntry) {
+            splitResult.add(result);
+        }
+
+        return splitResult;
     }
 }

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.component.olingo4;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.apache.camel.Exchange;
@@ -26,7 +28,11 @@ import org.apache.camel.component.olingo4.api.Olingo4ResponseHandler;
 import org.apache.camel.component.olingo4.internal.Olingo4ApiName;
 import org.apache.camel.support.component.AbstractApiConsumer;
 import org.apache.camel.support.component.ApiConsumerHelper;
+import org.apache.olingo.client.api.domain.ClientEntity;
 import org.apache.olingo.client.api.domain.ClientEntitySet;
+import org.apache.olingo.client.api.domain.ClientValue;
+import org.apache.olingo.client.core.domain.ClientPrimitiveValueImpl;
+import org.apache.olingo.client.core.domain.ClientPropertyImpl;
 
 /**
  * The Olingo4 consumer.
@@ -129,5 +135,30 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
         }
 
         resultIndex.index(result);
+    }
+
+    @Override
+    public Object splitResult(Object result) {
+        List<Object> splitResult = new ArrayList<>();
+
+        if (result instanceof ClientEntitySet) {
+            ClientEntitySet entitySet = (ClientEntitySet) result;
+            for (ClientEntity entity : entitySet.getEntities()) {
+                //
+                // If $count has been set to true then this value is left behind
+                // on the ClientEntitySet. Therefore, append it to each result.
+                //
+                if (entitySet.getCount() != null) {
+                    ClientValue value = new ClientPrimitiveValueImpl.BuilderImpl()
+                                                            .buildInt32(entitySet.getCount());
+                    entity.getProperties().add(new ClientPropertyImpl("ResultCount", value));
+                }
+                splitResult.add(entity);
+            }
+        } else if (result instanceof ClientEntity) {
+            splitResult.add(result);
+        }
+
+        return splitResult;
     }
 }


### PR DESCRIPTION
* Adds splitResults methods to both Olingo 2 & 4 Consumers