### PR TITLE
CAMEL-13191: Fix Regex Pattern to hide passwords in URI 

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -44,7 +44,7 @@ public final class URISupport {
     // Match the user password in the URI as second capture group
     // (applies to URI with authority component and userinfo token in the form
     // "user:password").
-    private static final Pattern USERINFO_PASSWORD = Pattern.compile("(.*://.*:)(.*)(@)");
+    private static final Pattern USERINFO_PASSWORD = Pattern.compile("(.*://.*?:)(.*)(@)");
 
     // Match the user password in the URI path as second capture group
     // (applies to URI path with authority component and userinfo token in the

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -49,7 +49,7 @@ public final class URISupport {
     // Match the user password in the URI path as second capture group
     // (applies to URI path with authority component and userinfo token in the
     // form "user:password").
-    private static final Pattern PATH_USERINFO_PASSWORD = Pattern.compile("(.*:)(.*)(@)");
+    private static final Pattern PATH_USERINFO_PASSWORD = Pattern.compile("(.*?:)(.*)(@)");
 
     private static final String CHARSET = "UTF-8";
 

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -247,9 +247,24 @@ public class URISupportTest {
     }
 
     @Test
+    public void testSanitizeUriWithUserInfoAndCollonPassword() {
+        String uri = "sftp://USERNAME:HARRISON:COLLON@sftp.server.test";
+        String expected = "sftp://USERNAME:xxxxxx@sftp.server.test";
+        assertEquals(expected, URISupport.sanitizeUri(uri));
+    }
+
+    @Test
     public void testSanitizePathWithUserInfo() {
         String path = "GEORGE:HARRISON@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
         String expected = "GEORGE:xxxxxx@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
+        assertEquals(expected, URISupport.sanitizePath(path));
+    }
+
+    @Test
+    public void testSanitizePathWithUserInfoAndCollonPassword() {
+        String path = "USERNAME:HARRISON:COLLON@sftp.server.test";
+        String expected = "USERNAME:xxxxxx@sftp.server.test";
+        System.out.println(URISupport.sanitizePath(path));
         assertEquals(expected, URISupport.sanitizePath(path));
     }
 

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -264,7 +264,6 @@ public class URISupportTest {
     public void testSanitizePathWithUserInfoAndColonPassword() {
         String path = "USERNAME:HARRISON:COLON@sftp.server.test";
         String expected = "USERNAME:xxxxxx@sftp.server.test";
-        System.out.println(URISupport.sanitizePath(path));
         assertEquals(expected, URISupport.sanitizePath(path));
     }
 

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -247,8 +247,8 @@ public class URISupportTest {
     }
 
     @Test
-    public void testSanitizeUriWithUserInfoAndCollonPassword() {
-        String uri = "sftp://USERNAME:HARRISON:COLLON@sftp.server.test";
+    public void testSanitizeUriWithUserInfoAndColonPassword() {
+        String uri = "sftp://USERNAME:HARRISON:COLON@sftp.server.test";
         String expected = "sftp://USERNAME:xxxxxx@sftp.server.test";
         assertEquals(expected, URISupport.sanitizeUri(uri));
     }
@@ -261,8 +261,8 @@ public class URISupportTest {
     }
 
     @Test
-    public void testSanitizePathWithUserInfoAndCollonPassword() {
-        String path = "USERNAME:HARRISON:COLLON@sftp.server.test";
+    public void testSanitizePathWithUserInfoAndColonPassword() {
+        String path = "USERNAME:HARRISON:COLON@sftp.server.test";
         String expected = "USERNAME:xxxxxx@sftp.server.test";
         System.out.println(URISupport.sanitizePath(path));
         assertEquals(expected, URISupport.sanitizePath(path));


### PR DESCRIPTION
Created Ticket https://issues.apache.org/jira/browse/CAMEL-13191
For this issue I have created this minor patch. 

The pattern stops colon search after the first colon, so the sanitizeUri method will hide the complete password part. 