### PR TITLE
CAMEL-13191: Fix Regex Pattern to hide passwords in URI

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/URISupport.java
+++ b/camel-core/src/main/java/org/apache/camel/util/URISupport.java
@@ -46,11 +46,11 @@ public final class URISupport {
     
     // Match the user password in the URI as second capture group
     // (applies to URI with authority component and userinfo token in the form "user:password").
-    private static final Pattern USERINFO_PASSWORD = Pattern.compile("(.*://.*:)(.*)(@)");
+    private static final Pattern USERINFO_PASSWORD = Pattern.compile("(.*://.*?:)(.*)(@)");
     
     // Match the user password in the URI path as second capture group
     // (applies to URI path with authority component and userinfo token in the form "user:password").
-    private static final Pattern PATH_USERINFO_PASSWORD = Pattern.compile("(.*:)(.*)(@)");
+    private static final Pattern PATH_USERINFO_PASSWORD = Pattern.compile("(.*?:)(.*)(@)");
     
     private static final String CHARSET = "UTF-8";
 

--- a/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -219,10 +219,24 @@ public class URISupportTest extends ContextTestSupport {
         String expected = "jt400://GEORGE:xxxxxx@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.DTAQ";
         assertEquals(expected, URISupport.sanitizeUri(uri));
     }
+    
+    @Test
+    public void testSanitizeUriWithUserInfoAndColonPassword() {
+        String uri = "sftp://USERNAME:HARRISON:COLON@sftp.server.test";
+        String expected = "sftp://USERNAME:xxxxxx@sftp.server.test";
+        assertEquals(expected, URISupport.sanitizeUri(uri));
+    }
 
     public void testSanitizePathWithUserInfo() {
         String path = "GEORGE:HARRISON@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
         String expected = "GEORGE:xxxxxx@LIVERPOOL/QSYS.LIB/BEATLES.LIB/PENNYLANE.PGM";
+        assertEquals(expected, URISupport.sanitizePath(path));
+    }
+    
+    @Test
+    public void testSanitizePathWithUserInfoAndColonPassword() {
+        String path = "USERNAME:HARRISON:COLON@sftp.server.test";
+        String expected = "USERNAME:xxxxxx@sftp.server.test";
         assertEquals(expected, URISupport.sanitizePath(path));
     }
 

--- a/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -220,7 +220,6 @@ public class URISupportTest extends ContextTestSupport {
         assertEquals(expected, URISupport.sanitizeUri(uri));
     }
     
-    @Test
     public void testSanitizeUriWithUserInfoAndColonPassword() {
         String uri = "sftp://USERNAME:HARRISON:COLON@sftp.server.test";
         String expected = "sftp://USERNAME:xxxxxx@sftp.server.test";
@@ -233,7 +232,6 @@ public class URISupportTest extends ContextTestSupport {
         assertEquals(expected, URISupport.sanitizePath(path));
     }
     
-    @Test
     public void testSanitizePathWithUserInfoAndColonPassword() {
         String path = "USERNAME:HARRISON:COLON@sftp.server.test";
         String expected = "USERNAME:xxxxxx@sftp.server.test";


### PR DESCRIPTION
Backport from 3.x to 2.22.x
