### PR TITLE
CAMEL-13186: camel-salesforce-maven-plugin additional customizations missing

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.camel.component.salesforce.api.dto.AbstractSObjectBase;
@@ -75,8 +76,8 @@ public class GenerateMojo extends AbstractSalesforceMojo {
             return stack.peek();
         }
 
-        public String enumTypeName(final String name) {
-            return (name.endsWith("__c") ? name.substring(0, name.length() - 3) : name) + "Enum";
+        public String enumTypeName(final String sObjectName, final String name) {
+            return sObjectName + "_" + (name.endsWith("__c") ? name.substring(0, name.length() - 3) : name) + "Enum";
         }
 
         public List<SObjectField> externalIdsOf(final String name) {
@@ -109,20 +110,34 @@ public class GenerateMojo extends AbstractSalesforceMojo {
             // check if this is a picklist
             if (isPicklist(field)) {
                 if (Boolean.TRUE.equals(useStringsForPicklists)) {
+                    if (picklistsEnumToSObject.containsKey(description.getName())
+                        && picklistsEnumToSObject.get(description.getName()).contains(field.getName())) {
+                        return enumTypeName(description.getName(), field.getName());
+                    }
+                    return String.class.getName();
+                } else if (picklistsStringToSObject.containsKey(description.getName())
+                    && picklistsStringToSObject.get(description.getName()).contains(field.getName())) {
                     return String.class.getName();
                 }
 
                 // use a pick list enum, which will be created after generating
                 // the SObject class
-                return description.getName() + "_" + enumTypeName(field.getName());
+                return enumTypeName(description.getName(), field.getName());
             } else if (isMultiSelectPicklist(field)) {
                 if (Boolean.TRUE.equals(useStringsForPicklists)) {
+                    if (picklistsEnumToSObject.containsKey(description.getName())
+                        && picklistsEnumToSObject.get(description.getName()).contains(field.getName())) {
+                        return enumTypeName(description.getName(), field.getName()) + "[]";
+                    }
+                    return String.class.getName() + "[]";
+                } else if (picklistsStringToSObject.containsKey(description.getName())
+                    && picklistsStringToSObject.get(description.getName()).contains(field.getName())) {
                     return String.class.getName() + "[]";
                 }
 
                 // use a pick list enum array, enum will be created after
                 // generating the SObject class
-                return description.getName() + "_" + enumTypeName(field.getName()) + "[]";
+                return enumTypeName(description.getName(), field.getName()) + "[]";
             } else {
                 // map field to Java type
                 final String soapType = field.getSoapType();
@@ -280,17 +295,19 @@ public class GenerateMojo extends AbstractSalesforceMojo {
 
     private static final List<String> BLACKLISTED_PROPERTIES = Arrays.asList("PicklistValues", "ChildRelationships");
 
-    private static final String JAVA_EXT = ".java";
+    private static final Pattern FIELD_DEFINITION_PATTERN = Pattern.compile("\\w+\\.{1}\\w+");
 
+    private static final String JAVA_EXT = ".java";
     // used for velocity logging, to avoid creating velocity.log
     private static final Logger LOG = Logger.getLogger(GenerateMojo.class.getName());
-    private static final String MULTIPICKLIST = "multipicklist";
 
+    private static final String MULTIPICKLIST = "multipicklist";
     private static final String PACKAGE_NAME_PATTERN = "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
     private static final String PICKLIST = "picklist";
     private static final String SOBJECT_LOOKUP_VM = "/sobject-lookup.vm";
     private static final String SOBJECT_PICKLIST_VM = "/sobject-picklist.vm";
     private static final String SOBJECT_POJO_OPTIONAL_VM = "/sobject-pojo-optional.vm";
+
     private static final String SOBJECT_POJO_VM = "/sobject-pojo.vm";
 
     private static final String SOBJECT_QUERY_RECORDS_OPTIONAL_VM = "/sobject-query-records-optional.vm";
@@ -327,6 +344,27 @@ public class GenerateMojo extends AbstractSalesforceMojo {
     String packageName;
 
     /**
+     * Names of specific picklist/multipicklist fields, which should be
+     * converted to Enum (default case) if property
+     * {@link this#useStringsForPicklists} is set to true. Format:
+     * SObjectApiName.FieldApiName (e.g. Account.DataSource)
+     */
+    @Parameter
+    String[] picklistToEnums;
+
+    /**
+     * Names of specific picklist/multipicklist fields, which should be
+     * converted to String if property {@link this#useStringsForPicklists} is
+     * set to false. Format: SObjectApiName.FieldApiName (e.g.
+     * Account.DataSource)
+     */
+    @Parameter
+    String[] picklistToStrings;
+
+    @Parameter(property = "camelSalesforce.useStringsForPicklists", defaultValue = "false")
+    Boolean useStringsForPicklists;
+
+    /**
      * Exclude Salesforce SObjects that match pattern.
      */
     @Parameter(property = "camelSalesforce.excludePattern")
@@ -344,16 +382,29 @@ public class GenerateMojo extends AbstractSalesforceMojo {
     @Parameter
     private String[] includes;
 
+    private final Map<String, Set<String>> picklistsEnumToSObject = new HashMap<>();
+
+    private final Map<String, Set<String>> picklistsStringToSObject = new HashMap<>();
+
     private final Map<String, String> types = new HashMap<>(DEFAULT_TYPES);
 
     @Parameter(property = "camelSalesforce.useOptionals", defaultValue = "false")
     private boolean useOptionals;
 
-    @Parameter(property = "camelSalesforce.useStringsForPicklists", defaultValue = "false")
-    private Boolean useStringsForPicklists;
+    void parsePicklistToEnums() {
+        parsePicklistOverrideArgs(picklistToEnums, picklistsEnumToSObject);
+    }
+
+    void parsePicklistToStrings() {
+        parsePicklistOverrideArgs(picklistToStrings, picklistsStringToSObject);
+    }
 
     void processDescription(final File pkgDir, final SObjectDescription description, final GeneratorUtility utility)
         throws IOException {
+        useStringsForPicklists = useStringsForPicklists == null ? Boolean.FALSE : useStringsForPicklists;
+
+        parsePicklistToEnums();
+        parsePicklistToStrings();
 
         // generate a source file for SObject
         final VelocityContext context = new VelocityContext();
@@ -420,7 +471,7 @@ public class GenerateMojo extends AbstractSalesforceMojo {
         // write required Enumerations for any picklists
         for (final SObjectField field : description.getFields()) {
             if (utility.isPicklist(field) || utility.isMultiSelectPicklist(field)) {
-                final String enumName = description.getName() + "_" + utility.enumTypeName(field.getName());
+                final String enumName = utility.enumTypeName(description.getName(), field.getName());
                 final String enumFileName = enumName + JAVA_EXT;
                 final File enumFile = new File(pkgDir, enumFileName);
 
@@ -570,4 +621,21 @@ public class GenerateMojo extends AbstractSalesforceMojo {
 
         return Collections.unmodifiableMap(lookupMap);
     }
+
+    private static void parsePicklistOverrideArgs(final String[] picklists,
+        final Map<String, Set<String>> picklistsToSObject) {
+        if (picklists != null && picklists.length > 0) {
+            String[] strings;
+            for (final String picklist : picklists) {
+                if (!FIELD_DEFINITION_PATTERN.matcher(picklist).matches()) {
+                    throw new IllegalArgumentException(
+                        "Invalid format provided for picklistFieldToEnum value - allowed format SObjectName.FieldName");
+                }
+                strings = picklist.split("\\.");
+                picklistsToSObject.putIfAbsent(strings[0], new HashSet<>());
+                picklistsToSObject.get(strings[0]).add(strings[1]);
+            }
+        }
+    }
+
 }

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/GenerateMojoTest.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/GenerateMojoTest.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven;
+
+import java.util.ArrayList;
+
+import org.apache.camel.component.salesforce.api.dto.SObjectDescription;
+import org.apache.camel.component.salesforce.api.dto.SObjectField;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class GenerateMojoTest {
+
+    private static final String ACCOUNT = "Account";
+    private static final String CONTACT = "Contact";
+    private static final String MULTIPICKLIST = "multipicklist";
+    private static final String PICKLIST = "picklist";
+
+    private static final String PROPER_DEFAULT_MULTIPICKLIST_TYPE_ENDING = "Enum[]";
+    private static final String PROPER_DEFAULT_PICKLIST_TYPE_ENDING = "Enum";
+    private static final String PROPER_MULTIPICKLIST_TO_STRING_TYPE = String.class.getName() + "[]";
+    private static final String PROPER_PICKLIST_TO_STRING_TYPE = String.class.getName();
+
+    @Test
+    public void shouldParsePicklistsToObjects() {
+        // given
+        final int properCountExceptions = 0;
+        final GenerateMojo mojo = new GenerateMojo();
+        mojo.picklistToStrings = createValidPicklistToStrings();
+        mojo.picklistToEnums = createValidPicklistToEnums();
+
+        // when
+        int resultCountExceptions = 0;
+        try {
+            mojo.parsePicklistToEnums();
+        } catch (final IllegalArgumentException e) {
+            resultCountExceptions++;
+        }
+
+        try {
+            mojo.parsePicklistToStrings();
+        } catch (final IllegalArgumentException e) {
+            resultCountExceptions++;
+        }
+
+        // then
+        assertEquals(properCountExceptions, resultCountExceptions);
+    }
+
+    @Test
+    public void shouldParsePicklistsToObjectsFail() {
+        // given
+        final int properCountExceptions = 2;
+        final String[] invalidPicklistToStrings = new String[] {"Account,DataSource"};
+        final String[] invalidPicklistToEnums = new String[] {"Con-tact.Contact_Source_Information__c"};
+        final GenerateMojo mojo = new GenerateMojo();
+        mojo.picklistToStrings = invalidPicklistToStrings;
+        mojo.picklistToEnums = invalidPicklistToEnums;
+
+        // when
+        int resultCountExceptions = 0;
+        try {
+            mojo.parsePicklistToEnums();
+        } catch (final IllegalArgumentException e) {
+            resultCountExceptions++;
+        }
+
+        try {
+            mojo.parsePicklistToStrings();
+        } catch (final IllegalArgumentException e) {
+            resultCountExceptions++;
+        }
+
+        // then
+        assertEquals(properCountExceptions, resultCountExceptions);
+    }
+
+    @Test
+    public void shouldReturnStringOrEnumTypesDefaultEnumMode() {
+        // given
+        final String sObjectName = ACCOUNT;
+        final GenerateMojo mojo = new GenerateMojo();
+        mojo.picklistToStrings = new String[] {sObjectName + ".StandardPicklist",
+            sObjectName + ".Stringified_Custom_Picklist_Type__c"};
+        mojo.parsePicklistToStrings();
+        assertTrue(mojo.picklistToStrings != null && mojo.picklistToStrings.length > 1);
+
+        final SObjectDescription accountDescription = new SObjectDescription();
+        accountDescription.setName(ACCOUNT);
+        accountDescription.setFields(new ArrayList<>());
+
+        final SObjectField defaultPicklist = createField("Default_Picklist__c", PICKLIST);
+        final SObjectField defaultMultipicklist = createField("Default_Multipicklist__c", MULTIPICKLIST);
+        final SObjectField picklistToString = createField(
+            mojo.picklistToStrings[0].substring(mojo.picklistToStrings[0].indexOf('.') + 1), PICKLIST);
+        final SObjectField multipicklistToString = createField(
+            mojo.picklistToStrings[1].substring(mojo.picklistToStrings[1].indexOf('.') + 1), MULTIPICKLIST);
+        accountDescription.getFields().add(defaultPicklist);
+        accountDescription.getFields().add(defaultMultipicklist);
+        accountDescription.getFields().add(picklistToString);
+        accountDescription.getFields().add(multipicklistToString);
+
+        mojo.useStringsForPicklists = false;
+        final GenerateMojo.GeneratorUtility utility = mojo.new GeneratorUtility();
+
+        // when
+        final String resultDefaultPicklistType = utility.getFieldType(accountDescription, defaultPicklist);
+        final String resultDefaultMultipicklistType = utility.getFieldType(accountDescription, defaultMultipicklist);
+        final String resultPicklistToStringType = utility.getFieldType(accountDescription, picklistToString);
+        final String resultMultipicklistToStringType = utility.getFieldType(accountDescription, multipicklistToString);
+
+        // then
+        assertThat(resultDefaultPicklistType, endsWith(PROPER_DEFAULT_PICKLIST_TYPE_ENDING));
+        assertThat(resultDefaultMultipicklistType, endsWith(PROPER_DEFAULT_MULTIPICKLIST_TYPE_ENDING));
+        assertThat(resultPicklistToStringType, equalTo(PROPER_PICKLIST_TO_STRING_TYPE));
+        assertThat(resultMultipicklistToStringType, equalTo(PROPER_MULTIPICKLIST_TO_STRING_TYPE));
+    }
+
+    @Test
+    public void shouldReturnStringOrEnumTypesStringMode() {
+        // given
+        final String sObjectName = CONTACT;
+        final GenerateMojo mojo = new GenerateMojo();
+        mojo.picklistToEnums = new String[] {sObjectName + ".Enum_Contact_Source_Information__c",
+            sObjectName + ".Enum_Contract_Type__c"};
+        mojo.parsePicklistToEnums();
+
+        final SObjectDescription contactDescription = new SObjectDescription();
+        contactDescription.setName(sObjectName);
+        contactDescription.setFields(new ArrayList<>());
+
+        final SObjectField stringPicklist = createField("Nonspecific_Picklist__c", PICKLIST);
+        final SObjectField stringMultipicklist = createField("Nonspecific_Multipicklist__c", MULTIPICKLIST);
+        final SObjectField picklistToEnum = createField(
+            mojo.picklistToEnums[0].substring(mojo.picklistToEnums[0].indexOf('.') + 1), PICKLIST);
+        final SObjectField multipicklistToEnum = createField(
+            mojo.picklistToEnums[1].substring(mojo.picklistToEnums[1].indexOf('.') + 1), MULTIPICKLIST);
+        contactDescription.getFields().add(stringPicklist);
+        contactDescription.getFields().add(stringMultipicklist);
+        contactDescription.getFields().add(picklistToEnum);
+        contactDescription.getFields().add(multipicklistToEnum);
+
+        mojo.useStringsForPicklists = true;
+        final GenerateMojo.GeneratorUtility utility = mojo.new GeneratorUtility();
+
+        // when
+        final String resultStringPicklistType = utility.getFieldType(contactDescription, stringPicklist);
+        final String resultStringMultipicklistType = utility.getFieldType(contactDescription, stringMultipicklist);
+        final String resultPicklistToEnumType = utility.getFieldType(contactDescription, picklistToEnum);
+        final String resultMultipicklistToEnumType = utility.getFieldType(contactDescription, multipicklistToEnum);
+
+        // then
+        assertThat(resultPicklistToEnumType, endsWith(PROPER_DEFAULT_PICKLIST_TYPE_ENDING));
+        assertThat(resultMultipicklistToEnumType, endsWith(PROPER_DEFAULT_MULTIPICKLIST_TYPE_ENDING));
+        assertThat(resultStringPicklistType, equalTo(PROPER_PICKLIST_TO_STRING_TYPE));
+        assertThat(resultStringMultipicklistType, equalTo(PROPER_MULTIPICKLIST_TO_STRING_TYPE));
+    }
+
+    private static SObjectField createField(final String name, final String type) {
+        final SObjectField field = new SObjectField();
+        field.setName(name);
+        field.setType(type);
+        return field;
+    }
+
+    private static String[] createValidPicklistToEnums() {
+        return new String[] {CONTACT + ".Contact_Source_Information__c", CONTACT + ".Contract_Type__c",
+            CONTACT + ".Custom_Picklist_Type__c"};
+    }
+
+    private static String[] createValidPicklistToStrings() {
+        return new String[] {ACCOUNT + ".DataSource", ACCOUNT + ".Custom_Picklist_Type__c",
+            ACCOUNT + ".Other_Custom_Picklist_Type__c"};
+    }
+}


### PR DESCRIPTION
Picklist/Multipicklists can be now exclusively enforced to be of type String/enum.

This cleans up #2779 and it is based on #2785 to have fewer merge conflicts.

@przemeklenik can you please take a look and see if I missed anything, this should incorporate your changes and in addition some clean up work I wanted to do.