### PR TITLE
replaced (deprecated) property with exchangeProperty

### DIFF
--- a/examples/camel-example-billboard-aggr/src/test/java/org/apache/camel/example/billboard/SongRecord.java
+++ b/examples/camel-example-billboard-aggr/src/test/java/org/apache/camel/example/billboard/SongRecord.java
@@ -100,4 +100,16 @@ public class SongRecord {
         this.source = source;
     }
     
+    @Override
+    public String toString() {
+        return "{" +
+            " rank='" + getRank() + "'" +
+            ", song='" + getSong() + "'" +
+            ", artist='" + getArtist() + "'" +
+            ", year='" + getYear() + "'" +
+            ", lyrics='" + getLyrics() + "'" +
+            ", source='" + getSource() + "'" +
+            "}";
+    }
+    
 }


### PR DESCRIPTION
With this small changes this example works also with Camel 3.
Added toString method for malformed record tracing logic.