### PR TITLE
CAMEL-13249: invoke `applyFilterToCamelHeaders` instead of `applyFilterToExternalHeaders`

### DIFF
--- a/components/camel-http-common/pom.xml
+++ b/components/camel-http-common/pom.xml
@@ -78,6 +78,12 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpRestHeaderFilterStrategy.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpRestHeaderFilterStrategy.java
@@ -31,7 +31,7 @@ public class HttpRestHeaderFilterStrategy extends HttpHeaderFilterStrategy {
 
     @Override
     public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
-        boolean answer = super.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+        boolean answer = super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
         // using rest producer then headers are mapping to uri and query parameters using {key} syntax
         // if there is a match to an existing Camel Message header, then we should filter (=true) this
         // header as its already been mapped by the RestProducer from camel-core, and we do not want

--- a/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpHeaderFilterStrategyTest.java
+++ b/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpHeaderFilterStrategyTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.http4;
+package org.apache.camel.http.common;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.http.common.HttpHeaderFilterStrategy;

--- a/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpRestHeaderFilterStrategyTest.java
+++ b/components/camel-http-common/src/test/java/org/apache/camel/http/common/HttpRestHeaderFilterStrategyTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.http.common;
+
+import org.apache.camel.Exchange;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpRestHeaderFilterStrategyTest {
+
+    private static final Exchange NOT_USED = null;
+
+    @Test
+    public void shouldDecideOnApplingHeaderFilterToTemplateTokens() {
+        final HttpRestHeaderFilterStrategy strategy = new HttpRestHeaderFilterStrategy("{uriToken1}{uriToken2}",
+            "q1=%7BqueryToken1%7D%26q2=%7BqueryToken2%7D%26");
+
+        assertThat(strategy.applyFilterToCamelHeaders("uriToken1", "value", NOT_USED)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders("uriToken2", "value", NOT_USED)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders("queryToken1", "value", NOT_USED)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders("queryToken2", "value", NOT_USED)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders("unknown", "value", NOT_USED)).isFalse();
+    }
+}

--- a/components/camel-http4/pom.xml
+++ b/components/camel-http4/pom.xml
@@ -104,5 +104,11 @@
       <version>${jetty-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HeaderFilteringTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HeaderFilteringTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http4;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.apache.camel.Producer;
+import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.spi.RestConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class HeaderFilteringTest {
+
+    private static final String BODY = "{\"example\":\"json\"}";
+
+    private int port;
+
+    private HttpServer server;
+
+    @Test
+    public void shouldFilterIncomingHttpHeadersInProducer() throws Exception {
+        final HttpComponent http = new HttpComponent();
+
+        final DefaultCamelContext context = new DefaultCamelContext();
+        final Producer producer = http.createProducer(context, "http://localhost:" + port, "GET", "/test", null, null,
+            "application/json", "application/json", new RestConfiguration(), Collections.emptyMap());
+
+        final DefaultExchange exchange = new DefaultExchange(context);
+        final DefaultMessage in = new DefaultMessage(context);
+        in.setHeader("Host", "www.not-localhost.io");
+        in.setBody(BODY);
+        exchange.setIn(in);
+
+        try {
+            producer.process(exchange);
+        } catch (final HttpOperationFailedException e) {
+            fail(e.getMessage() + "\n%s", e.getResponseBody());
+        }
+    }
+
+    @Before
+    public void startHttpServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/test", this::handleTest);
+        server.start();
+
+        port = server.getAddress().getPort();
+    }
+
+    @After
+    public void stopHttpServer() {
+        server.stop(0);
+    }
+
+    void handleTest(final HttpExchange exchange) throws IOException {
+        try (final OutputStream responseBody = exchange.getResponseBody()) {
+            try {
+                assertThat(exchange.getRequestBody())
+                    .hasSameContentAs(new ByteArrayInputStream(BODY.getBytes(StandardCharsets.UTF_8)));
+                assertThat(exchange.getRequestHeaders()).containsEntry("Host",
+                    Collections.singletonList("localhost:" + port));
+
+                exchange.sendResponseHeaders(200, 0);
+            } catch (final AssertionError error) {
+                final StringWriter out = new StringWriter();
+                error.printStackTrace(new PrintWriter(out));
+
+                final String failure = out.toString();
+                final byte[] failureBytes = failure.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(500, failureBytes.length);
+                responseBody.write(failureBytes);
+            }
+        }
+    }
+}

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpRestHeaderFilterStrategy.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpRestHeaderFilterStrategy.java
@@ -35,7 +35,7 @@ public class NettyHttpRestHeaderFilterStrategy extends NettyHttpHeaderFilterStra
 
     @Override
     public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
-        boolean answer = super.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+        boolean answer = super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
         // using rest producer then headers are mapping to uri and query parameters using {key} syntax
         // if there is a match to an existing Camel Message header, then we should filter (=true) this
         // header as its already been mapped by the RestProducer from camel-core, and we do not want


### PR DESCRIPTION
This changes the invocation in `HttpRestHeaderFilterStrategy::applyFilterToCamelHeaders` to delegate to `super::applyFilterToCamelHeaders` instead of `super::applyFilterToExternalHeaders`.

Also adds integration test demonstrating the issue and refactors `HttpRestHeaderFilterStrategyTest` from `components/camel-http4` to `/components/camel-http-common` as it doesn't depend on `http4` component and tests a class in `camel-http-common`.

@davsclaus @oscerd can you take a look, this seems right to me, but the use of `applyFilterToExternalHeaders` vs `applyFilterToCamelHeaders` seems intentional so I could be missing something.

If this change gets approved I'll backport it to `2.23.x` and forward port it to `master`.