### PR TITLE
[CAMEL-13304] Camel Bindy Tab delimited - Handling Blank Values

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -200,7 +200,16 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
         return line -> {
             try {
                 // Trim the line coming in to remove any trailing whitespace
-                String trimmedLine = line.trim();
+                String trimmedLine;
+
+                // if separator is a tab, don't trim any leading whitespaces (could be empty values separated by tabs)
+                if (separator.equals("\t")) {
+                    // trim only trailing whitespaces
+                    trimmedLine = line.replaceAll("\\s+$", "");
+                } else {
+                    trimmedLine = line.trim();
+                }
+
                 // Increment counter
                 count.incrementAndGet();
                 Map<String, Object> model;


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-13304

When using tab as a separator in CSV (i.e. TSV format), trimming any leading whitespaces might lead to breaking empty field values.

Trailing whitespaces shouldn't be a problem, since all unset fields will have their default values. Also, empty lines are discarded by line = line.replaceAll("\s+$", ""); as they were before.