### PR TITLE
[CAMEL-13305] camel-sql cannot resolve nested simple expression

### DIFF
--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/DefaultSqlPrepareStatementStrategyTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/DefaultSqlPrepareStatementStrategyTest.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.sql.stored;
+
+import java.sql.SQLException;
+import org.apache.camel.component.sql.DefaultSqlPrepareStatementStrategy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultSqlPrepareStatementStrategyTest {
+
+    @Test
+    public void testReplaceNestedExpressions() throws SQLException {
+        DefaultSqlPrepareStatementStrategy strategy = new DefaultSqlPrepareStatementStrategy();
+        String sql = "INSERT INTO example VALUES (:?${array[${index}]})";
+
+        String expected = "INSERT INTO example VALUES (?)";
+        String query = strategy.prepareQuery(sql, true, null);
+        assertEquals(expected, query);
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-13305

When using nested expressions in SQL routes, such as
.to("sql:INSERT INTO example VALUES (:?${array[${index}]})");
both REPLACE_PATTERN and NAME_PATTERN are unable to match the whole expression correctly. We have to find correct enclosing bracket and create a substring in such cases.