### PR TITLE
Add specificAvroReader consumer property.

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -79,6 +79,7 @@ with the following path and query parameters:
 |===
 | Name | Description | Default | Type
 | *brokers* (common) | URL of the Kafka brokers to use. The format is host1:port1,host2:port2, and the list can be a subset of brokers or a VIP pointing to a subset of brokers. This option is known as bootstrap.servers in the Kafka documentation. |  | String
+| *schema.registry.url* (common) | URL of the Confluent schema registry servers to use. The format is host1:port1,host2:port2. This is known as schema.registry.url in the Confluent documentation. | | String
 | *clientId* (common) | The client id is a user-specified string sent in each request to help trace calls. It should logically identify the application making the request. |  | String
 | *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy
 | *reconnectBackoffMaxMs* (common) | The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect. If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum. After calculating the backoff increase, 20% random jitter is added to avoid connection storms. | 1000 | Integer

--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -111,6 +111,7 @@ with the following path and query parameters:
 | *sessionTimeoutMs* (consumer) | The timeout used to detect failures when using Kafka's group management facilities. | 10000 | Integer
 | *topicIsPattern* (consumer) | Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern. | false | boolean
 | *valueDeserializer* (consumer) | Deserializer class for value that implements the Deserializer interface. | org.apache.kafka.common.serialization.StringDeserializer | String
+| *specificAvroReader* (consumer) | This enables the use of a specific Avro reader for use with the Confluent schema registry and the io.confluent.kafka.serializers.KafkaAvroDeserializer. The default value is false. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | *bridgeEndpoint* (producer) | If the option is true, then KafkaProducer will ignore the KafkaConstants.TOPIC header setting of the inbound message. | false | boolean

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -58,6 +58,8 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
     @UriParam(label = "common")
     private String brokers;
     @UriParam(label = "common")
+    private String schemaRegistryURL;
+    @UriParam(label = "common")
     private String clientId;
     @UriParam(label = "common", description = "To use a custom HeaderFilterStrategy to filter header to and from Camel message.")
     private HeaderFilterStrategy headerFilterStrategy = new KafkaHeaderFilterStrategy();
@@ -357,6 +359,7 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
         addPropertyIfNotNull(props, ProducerConfig.RETRY_BACKOFF_MS_CONFIG, getRetryBackoffMs());
         addPropertyIfNotNull(props, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, isEnableIdempotence());
         addPropertyIfNotNull(props, ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, getReconnectBackoffMaxMs());
+        addPropertyIfNotNull(props, "schema.registry.url", getSchemaRegistryURL());
 
         // SSL
         applySslConfiguration(props, getSslContextParameters());
@@ -417,6 +420,7 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
         addPropertyIfNotNull(props, ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, getReconnectBackoffMs());
         addPropertyIfNotNull(props, ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, getRetryBackoffMs());
         addPropertyIfNotNull(props, ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, getReconnectBackoffMaxMs());
+        addPropertyIfNotNull(props, "schema.registry.url", getSchemaRegistryURL());
 
         // SSL
         applySslConfiguration(props, getSslContextParameters());
@@ -774,6 +778,20 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
     public void setBrokers(String brokers) {
         this.brokers = brokers;
     }
+
+    public String getSchemaRegistryURL() {
+		return schemaRegistryURL;
+	}
+
+    /**
+     * URL of the Kafka schema registry to use.
+     * The format is host1:port1,host2:port2.
+     * <p/>
+     * This option is known as <tt>schema.registry.url</tt> in the Kafka documentation.
+     */
+	public void setSchemaRegistryURL(String schemaRegistryURL) {
+		this.schemaRegistryURL = schemaRegistryURL;
+	}
 
     public String getCompressionCodec() {
         return compressionCodec;

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -138,6 +138,8 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
     private boolean breakOnFirstError;
     @UriParam(label = "consumer")
     private StateRepository<String, String> offsetRepository;
+    @UriParam(label = "consumer", defaultValue = "false")
+    private boolean specificAvroReader = false;
 
     //Producer Camel specific configuration properties
     @UriParam(label = "producer")
@@ -421,6 +423,7 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
         addPropertyIfNotNull(props, ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, getRetryBackoffMs());
         addPropertyIfNotNull(props, ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, getReconnectBackoffMaxMs());
         addPropertyIfNotNull(props, "schema.registry.url", getSchemaRegistryURL());
+        addPropertyIfNotNull(props, "specific.avro.reader", isSpecificAvroReader());
 
         // SSL
         applySslConfiguration(props, getSslContextParameters());
@@ -763,6 +766,17 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
      */
     public void setBreakOnFirstError(boolean breakOnFirstError) {
         this.breakOnFirstError = breakOnFirstError;
+    }
+    
+    public boolean isSpecificAvroReader() {
+    	return specificAvroReader;
+    }
+    
+    /**
+     * This enables the use of a specific Avro reader for use with the Confluent schema registry and the io.confluent.kafka.serializers.KafkaAvroDeserializer. The default value is false.
+     */
+    public void setSpecificAvroReader(boolean specificAvroReader) {
+    	this.specificAvroReader = specificAvroReader;
     }
 
     public String getBrokers() {


### PR DESCRIPTION
This is an additional property that is specific to the Confluent version of Kafka that supports the use of Avro with the schema registry. I overlooked this property in my prior changes as I was focused on the getting the component working with the schema registry and not specifically with the Avro serializer and deserializer. This oversight was pointed out to me by bozic. 