### PR TITLE
CAMEL-13319 - TwitterConverter calls deprecated getSenderScreenName, throws UnsupportedOperationException

### DIFF
--- a/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/util/TwitterConverter.java
+++ b/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/util/TwitterConverter.java
@@ -46,7 +46,7 @@ public final class TwitterConverter {
     @Converter
     public static String toString(DirectMessage dm) throws ParseException {
         return new StringBuilder()
-            .append(dm.getCreatedAt()).append(" (").append(dm.getSenderScreenName()).append(") ")
+            .append(dm.getCreatedAt()).append(" (").append(dm.getSenderId()).append(") ")
             .append(dm.getText())
             .toString();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-13319