### PR TITLE
CAMEL-13321 - camel-twitter-direct-message doesn't use default delay of 30s

### DIFF
--- a/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/AbstractTwitterEndpoint.java
+++ b/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/AbstractTwitterEndpoint.java
@@ -38,6 +38,7 @@ public abstract class AbstractTwitterEndpoint extends DefaultPollingEndpoint imp
 
     public AbstractTwitterEndpoint(String uri, AbstractTwitterComponent component, TwitterConfiguration properties) {
         super(uri, component);
+        setDelay(DEFAULT_CONSUMER_DELAY);
         this.properties = properties;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-13321