### PR TITLE
CAMEL-13331: Deploy flat Maven POMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ log-camel-lsp.out
 *.code-workspace
 components/camel-cxf/activemq-data
 *.swp
+.flattened-pom.xml

--- a/bom/camel-bom/pom.xml
+++ b/bom/camel-bom/pom.xml
@@ -3054,6 +3054,16 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>bom</flattenMode>
+          <pomElements>
+            <repositories>remove</repositories>
+          </pomElements>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/components/camel-ipfs/pom.xml
+++ b/components/camel-ipfs/pom.xml
@@ -77,4 +77,19 @@
             </releases>
         </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <pomElements combine.children="append">
+                        <repositories>keep</repositories>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/components/camel-nagios/pom.xml
+++ b/components/camel-nagios/pom.xml
@@ -96,4 +96,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <pomElements combine.children="append">
+                        <repositories>keep</repositories>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/components/camel-paho/pom.xml
+++ b/components/camel-paho/pom.xml
@@ -91,4 +91,18 @@
         </repository>
     </repositories>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <pomElements combine.children="append">
+                        <repositories>keep</repositories>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/components/camel-restlet/pom.xml
+++ b/components/camel-restlet/pom.xml
@@ -159,4 +159,18 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <pomElements combine.children="append">
+                        <repositories>keep</repositories>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/examples/camel-example-restlet-jdbc/pom.xml
+++ b/examples/camel-example-restlet-jdbc/pom.xml
@@ -130,6 +130,15 @@
                     </connectors>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <pomElements combine.children="append">
+                        <repositories>keep</repositories>
+                    </pomElements>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,13 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.1.0</version>
+                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>
@@ -609,6 +616,32 @@
                                 </goals>
                                 <configuration>
                                     <additionalOptions>${javadoc.opts}</additionalOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-cli</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                                <configuration>
+                                    <updatePomFile>true</updatePomFile>
+                                    <pomElements>
+                                        <build>keep</build>
+                                        <dependencyManagement>keep</dependencyManagement>
+                                        <description>keep</description>
+                                        <name>keep</name>
+                                        <parent>expand</parent>
+                                        <pluginManagement>keep</pluginManagement>
+                                        <profiles>remove</profiles>
+                                        <properties>expand</properties>
+                                    </pomElements>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Uses `flatten-maven-plugin` to flatten the deployed the POMs. Any POM that includes a `<repository>` has additional configuration to keep it.

To test run `./mvnw -Pdeploy flatten:flatten` and compare `pom.xml`s with `.flattened-pom.xml`s or `./mvnw -Pdeploy install` and take a look in the `$HOME/.m2/repository`.