### PR TITLE
[CAMEL-13341] camel-linkedin: If accessToken is set, other credential…

### DIFF
--- a/components/camel-linkedin/camel-linkedin-api/src/main/java/org/apache/camel/component/linkedin/api/LinkedInOAuthRequestFilter.java
+++ b/components/camel-linkedin/camel-linkedin-api/src/main/java/org/apache/camel/component/linkedin/api/LinkedInOAuthRequestFilter.java
@@ -89,8 +89,11 @@ public final class LinkedInOAuthRequestFilter implements ClientRequestFilter {
                                       boolean lazyAuth, String[] enabledProtocols) {
 
         this.oAuthParams = oAuthParams;
-        this.oAuthToken = null;
-
+        if (oAuthParams.getSecureStorage() != null) {
+            this.oAuthToken = oAuthParams.getSecureStorage().getOAuthToken();
+        } else {
+            this.oAuthToken = null;
+        }
 
         if (httpParams != null && httpParams.get(ConnRoutePNames.DEFAULT_PROXY) != null) {
             final HttpHost proxyHost = (HttpHost)httpParams.get(ConnRoutePNames.DEFAULT_PROXY);
@@ -361,11 +364,6 @@ public final class LinkedInOAuthRequestFilter implements ClientRequestFilter {
                     return;
                 }
                 LOG.info("OAuth secure storage returned a null or expired token, creating a new token...");
-
-                // throw an exception if a user password is not set for authorization
-                if (oAuthParams.getUserPassword() == null || oAuthParams.getUserPassword().isEmpty()) {
-                    throw new IllegalArgumentException("Missing password for LinkedIn authorization");
-                }
             }
 
             // need new OAuth token, authorize user, LinkedIn does not support OAuth2 grant_type=refresh_token

--- a/components/camel-linkedin/camel-linkedin-api/src/test/java/org/apache/camel/component/linkedin/api/AbstractResourceIntegrationTest.java
+++ b/components/camel-linkedin/camel-linkedin-api/src/test/java/org/apache/camel/component/linkedin/api/AbstractResourceIntegrationTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractResourceIntegrationTest extends Assert {
         // check if accessToken is set
         if (accessToken != null) {
             token = new OAuthToken(null, accessToken,
-                    (expiryTime != null) ? Long.parseLong(expiryTime) : DEFAULT_EXPIRY);
+                    (expiryTime != null && !"".equals(expiryTime.trim())) ? Long.parseLong(expiryTime) : DEFAULT_EXPIRY);
         }
 
         final OAuthSecureStorage secureStorage = new OAuthSecureStorage() {

--- a/components/camel-linkedin/camel-linkedin-component/src/main/java/org/apache/camel/component/linkedin/LinkedInConfiguration.java
+++ b/components/camel-linkedin/camel-linkedin-component/src/main/java/org/apache/camel/component/linkedin/LinkedInConfiguration.java
@@ -152,8 +152,8 @@ public class LinkedInConfiguration {
     }
 
     /**
-     * A number of milliseconds since the UNIX Epoch. The default is 60 days. 
-     * A LinkedIn access token expires when this amount of time elapses after the token is in use. 
+     * A number of milliseconds since the UNIX Epoch. The default is 60 days.
+     * A LinkedIn access token expires when this amount of time elapses after the token is in use.
      */
     public void setExpiryTime(Long expiryTime) {
         this.expiryTime = expiryTime;
@@ -247,7 +247,8 @@ public class LinkedInConfiguration {
                 && (redirectUri == null ? other.redirectUri == null : redirectUri.equals(other.redirectUri))
                 && Arrays.equals(scopes, other.scopes)
                 && (httpParams == null ? other.httpParams == null : httpParams.equals(other.httpParams))
-                && (lazyAuth == other.lazyAuth);
+                && (lazyAuth == other.lazyAuth)
+                && (accessToken == null ? other.accessToken == null : accessToken.equals(other.accessToken));
         }
         return false;
     }
@@ -256,16 +257,35 @@ public class LinkedInConfiguration {
     public int hashCode() {
         return new HashCodeBuilder().append(userName).append(userPassword).append(secureStorage)
             .append(clientId).append(clientSecret)
-            .append(redirectUri).append(scopes).append(httpParams).append(lazyAuth).toHashCode();
+            .append(redirectUri).append(scopes).append(httpParams).append(lazyAuth).append(accessToken).toHashCode();
     }
 
     public void validate() throws IllegalArgumentException {
-        StringHelper.notEmpty(userName, "userName");
-        if (ObjectHelper.isEmpty(userPassword) && secureStorage == null) {
-            throw new IllegalArgumentException("Property userPassword or secureStorage is required");
+            //if access token is null, authentication credentials have to be validated
+        if(ObjectHelper.isEmpty(accessToken)) {
+            StringHelper.notEmpty(userName, "userName");
+            if (ObjectHelper.isEmpty(userPassword) && secureStorage == null) {
+                throw new IllegalArgumentException("Property userPassword or secureStorage is required");
+            }
+            StringHelper.notEmpty(clientId, "clientId");
+            StringHelper.notEmpty(clientSecret, "clientSecret");
+        } else {
+            //if accessToken is net, other parameters hav to be empty
+            if (!ObjectHelper.isEmpty(userName)) {
+                throw new IllegalArgumentException("Property accessToken can not be defined if property userName is set");
+            }
+            if (!ObjectHelper.isEmpty(userPassword)) {
+                throw new IllegalArgumentException("Property accessToken can not be defined if property userPassword is set");
+            }
+            if (!ObjectHelper.isEmpty(clientId)) {
+                throw new IllegalArgumentException("Property accessToken can not be defined if property clientId is set");
+            }
+            if (!ObjectHelper.isEmpty(clientSecret)) {
+                throw new IllegalArgumentException("Property accessToken can not be defined if property clientSecret is set");
+            }
         }
-        StringHelper.notEmpty(clientId, "clientId");
-        StringHelper.notEmpty(clientSecret, "clientSecret");
+
+        //redirectUri has to be valid for both cases
         StringHelper.notEmpty(redirectUri, "redirectUri");
     }
 }


### PR DESCRIPTION
…s should be unnecessary

Issue https://issues.apache.org/jira/browse/CAMEL-13341

Added better validation and handling of accessToken. Now it is possible to use only accessToken to configure linkedin component and no username, password, client id or secret is needed anymore.
On the other hand is not possible to define both accessToken and username, password,  ...