### PR TITLE
CAMEL-13316: Olingo components handle value/property results

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Consumer.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Consumer.java
@@ -142,7 +142,9 @@ public class Olingo2Consumer extends AbstractApiConsumer<Olingo2ApiName, Olingo2
             for (ODataEntry entry : odataFeed.getEntries()) {
                 splitResult.add(entry);
             }
-        } else if (result instanceof ODataEntry) {
+        } else if (result instanceof List) {
+            return result;
+        } else {
             splitResult.add(result);
         }
 

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.olingo4.api.Olingo4ResponseHandler;
 import org.apache.camel.component.olingo4.internal.Olingo4ApiName;
 import org.apache.camel.support.component.AbstractApiConsumer;
 import org.apache.camel.support.component.ApiConsumerHelper;
+import org.apache.olingo.client.api.domain.ClientCollectionValue;
 import org.apache.olingo.client.api.domain.ClientEntity;
 import org.apache.olingo.client.api.domain.ClientEntitySet;
 import org.apache.olingo.client.api.domain.ClientValue;
@@ -155,7 +156,13 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
                 }
                 splitResult.add(entity);
             }
-        } else if (result instanceof ClientEntity) {
+        } else if (result instanceof ClientValue && ((ClientValue) result).isCollection()) {
+            ClientValue value = (ClientValue) result;
+            ClientCollectionValue<ClientValue> collection = value.asCollection();
+            collection.forEach(v -> {
+                splitResult.add(v);
+            });
+        } else {
             splitResult.add(result);
         }
 

--- a/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/Olingo4ComponentTest.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/Olingo4ComponentTest.java
@@ -35,6 +35,7 @@ import org.apache.olingo.client.api.domain.ClientEntitySet;
 import org.apache.olingo.client.api.domain.ClientPrimitiveValue;
 import org.apache.olingo.client.api.domain.ClientProperty;
 import org.apache.olingo.client.api.domain.ClientServiceDocument;
+import org.apache.olingo.client.api.domain.ClientValue;
 import org.apache.olingo.commons.api.Constants;
 import org.apache.olingo.commons.api.edm.Edm;
 import org.apache.olingo.commons.api.ex.ODataError;
@@ -456,6 +457,30 @@ public class Olingo4ComponentTest extends AbstractOlingo4TestSupport {
             }
         }
     }
+    /**
+     * Read value of the People object and split the results
+     * into individual messages
+     */
+    @Test
+    public void testConsumerReadClientValuesSplitResults() throws Exception {
+        final Map<String, Object> headers = new HashMap<>();
+        String endpoint = "olingo4://read/People('russellwhyte')/FavoriteFeature?consumer.splitResult=true";
+
+        MockEndpoint mockEndpoint = getMockEndpoint("mock:consumer-splitresult-value");
+        mockEndpoint.expectedMinimumMessageCount(1);
+
+        final ClientValue resultValue = requestBodyAndHeaders(endpoint, null, headers);
+        assertIsInstanceOf(ClientValue.class, resultValue);
+
+        mockEndpoint.assertIsSatisfied();
+        //
+        // 1 individual message in the exchange
+        //
+        Object body = mockEndpoint.getExchanges().get(0).getIn().getBody();
+        assertIsInstanceOf(ClientPrimitiveValue.class, body);
+        ClientPrimitiveValue value = (ClientPrimitiveValue) body;
+        assertEquals("Feature1", value.toString());
+    }
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
@@ -508,9 +533,15 @@ public class Olingo4ComponentTest extends AbstractOlingo4TestSupport {
                 //
                 // Consumer endpoint
                 //
-                from("olingo4://read/People?filterAlreadySeen=true&consumer.delay=2&consumer.sendEmptyMessageWhenIdle=true&consumer.splitResult=false").to("mock:consumer-alreadyseen");
+                from("olingo4://read/People?filterAlreadySeen=true&consumer.delay=2&consumer.sendEmptyMessageWhenIdle=true&consumer.splitResult=false")
+                    .to("mock:consumer-alreadyseen");
 
-                from("olingo4://read/People?consumer.splitResult=true").to("mock:consumer-splitresult");
+                from("olingo4://read/People?consumer.splitResult=true")
+                    .to("mock:consumer-splitresult");
+
+                from("olingo4://read/People('russellwhyte')/FavoriteFeature?consumer.splitResult=true")
+                    .to("mock:consumer-splitresult-value");
+
             }
         };
     }


### PR DESCRIPTION
* When split, both olingo components handle results which are values or
  properties rather than entities.

* Provides tests confirming the fix.