### PR TITLE
CAMEL-13355: copy method updated to include maxConcurrentConsumers

### DIFF
--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpConfiguration.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpConfiguration.java
@@ -154,6 +154,7 @@ public class MllpConfiguration implements Cloneable {
             target.stringPayload = source.stringPayload;
             target.validatePayload = source.validatePayload;
             target.charsetName = source.charsetName;
+            target.maxConcurrentConsumers = source.maxConcurrentConsumers;
         }
     }
 

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpEndpointTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpEndpointTest.java
@@ -16,33 +16,38 @@
  */
 package org.apache.camel.component.mllp;
 
-import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the MllpEndpoint class.
+ *
+ * @author vishal423
  */
 public class MllpEndpointTest {
-    static final String MSH_SEGMENT = "MSH|^~\\&|0|90100053675|JCAPS|CC|20131125122938|RISMD|ORM|28785|D|2.3";
 
-    // @formatter:off
-    static final String REMAINING_SEGMENTS =
-        "PID|1||4507626^^^MRN^MRN||RAD VALIDATE^ROBERT||19650916|M||U|1818 UNIVERSITY AVE^^MADISON^WI^53703^USA^^^||(608)251-9999|||M|||579-85-3510||| " + '\r'
-            + "PV1||OUTPATIENT|NMPCT^^^WWNMD^^^^^^^DEPID||||011463^ZARAGOZA^EDWARD^J.^^^^^EPIC^^^^PROVID|011463^ZARAGOZA^EDWARD^J.^^^^^EPIC^^^^PROVID"
-            +     "|||||||||||90100053686|SELF||||||||||||||||||||||||201311251218|||||||V" + '\r'
-            + "ORC|RE|9007395^EPC|9007395^EPC||Final||^^^201311251221^201311251222^R||201311251229|RISMD^RADIOLOGY^RADIOLOGIST^^|||SMO PET^^^7044^^^^^SMO PET CT||||||||||||||||I" + '\r'
-            + "OBR|1|9007395^EPC|9007395^EPC|IMG7118^PET CT LIMITED CHEST W CONTRAST^IMGPROC^^PET CT CHEST||20131125|||||Ancillary Pe|||||||NMPCT|MP2 NM INJ01^MP2 NM INJECTION ROOM 01^PROVID"
-            +     "|||201311251229||NM|Final||^^^201311251221^201311251222^R||||^test|E200003^RADIOLOGY^RESIDENT^^^^^^EPIC^^^^PROVID"
-            +     "|812644^RADIOLOGY^GENERIC^ATTENDING 1^^^^^EPIC^^^^PROVID~000043^RADIOLOGY^RADIOLOGISTTWO^^^^^^EPIC^^^^PROVID|U0058489^SWAIN^CYNTHIA^LEE^||201311251245" + '\r'
-            + "OBX|1|ST|&GDT|1|[11/25/2013 12:28:14 PM - PHYS, FIFTYFOUR]50||||||Final||||" + '\r' + '\n';
-    // @formatter:on
+    /**
+     * Assert that the default maxConcurrentConsumers property is correctly set on the endpoint instance.
+     */
+    @Test
+    public void testCreateEndpointWithDefaultConfigurations() {
+        MllpEndpoint mllpEndpoint = new MllpEndpoint("mllp://dummy", new MllpComponent(), new MllpConfiguration());
 
-    static final String TEST_MESSAGE = MSH_SEGMENT + '\r' + REMAINING_SEGMENTS;
-
-    MllpEndpoint instance;
-
-    @Before
-    public void setUp() throws Exception {
-        instance = new MllpEndpoint("mllp://dummy", new MllpComponent(), new MllpConfiguration());
+        assertEquals(5, mllpEndpoint.getConfiguration().getMaxConcurrentConsumers());
     }
 
+    /**
+     * Assert that the maxConcurrentConsumers property overridden in the MllpConfiguration
+     * object is correctly set on the endpoint instance.
+     */
+    @Test
+    public void testCreateEndpointWithCustomMaxConcurrentConsumers() {
+        final int maxConcurrentConsumers = 10;
+        MllpConfiguration mllpConfiguration = new MllpConfiguration();
+        mllpConfiguration.setMaxConcurrentConsumers(maxConcurrentConsumers);
+        MllpEndpoint mllpEndpoint = new MllpEndpoint("mllp://dummy", new MllpComponent(), mllpConfiguration);
+
+        assertEquals(maxConcurrentConsumers, mllpEndpoint.getConfiguration().getMaxConcurrentConsumers());
+    }
 }

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpEndpointTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpEndpointTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the MllpEndpoint class.
- *
- * @author vishal423
  */
 public class MllpEndpointTest {
 


### PR DESCRIPTION
- Closes CAMEL-13355
- This change would allow maxConcurrentConsumers property set at component level to be used during endpoint instance creation.
- Refactored unit tests to remove code not in use and added unit tests related to this change.