### PR TITLE
[fix] Close the FileInputStream on StaxProcessor

### DIFF
--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -40,8 +40,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>
+        </dependency>		
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>5.1.0</version>
         </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
The stax processor doesn't close the stream opened on reader.parse(is).
See the https://issues.apache.org/jira/browse/CAMEL-13373