### PR TITLE
CAMEL-12323 - camel-spark-rest - Avoid singleton spark instance

### DIFF
--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/CamelSpark.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/CamelSpark.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.sparkrest;
 
 import spark.Route;
-import spark.Spark;
+import spark.Service;
 
 public final class CamelSpark {
 
@@ -25,106 +25,78 @@ public final class CamelSpark {
     }
 
     /**
-     * Stops the Spark Server
-     */
-    public static void stop() {
-        Spark.stop();
-    }
-
-    /**
-     * Configures the port number to use
-     */
-    public static void port(int port) {
-        Spark.port(port);
-    }
-
-    /**
-     * Configures the IP address to use
-     */
-    public static void ipAddress(String ip) {
-        Spark.ipAddress(ip);
-    }
-
-    /**
      * Configures the thread pool
      */
-    public static void threadPool(int minThreads, int maxThreads, int timeOutMillis) {
+    public static void threadPool(Service sparkInstance, int minThreads, int maxThreads, int timeOutMillis) {
         int min = minThreads > 0 ? minThreads : -1;
         int max = maxThreads > 0 ? maxThreads : -1;
         int idle = timeOutMillis > 0 ? timeOutMillis : -1;
-
-        Spark.threadPool(max, min, idle);
-    }
-
-    /**
-     * Configures connection to be secure
-     */
-    public static void security(String keystoreFile, String keystorePassword, String truststoreFile, String truststorePassword) {
-        Spark.secure(keystoreFile, keystorePassword, truststoreFile, truststorePassword);
+        sparkInstance.threadPool(max, min, idle);
     }
 
     /**
      * Adds a Spark REST verb that routes to the given spark route
      *
+     * @param sparkInstance the SPARK instance
      * @param verb   the HTTP verb
      * @param path   the context path
      * @param accept the accept header
      * @param route  the spark route (we call a Camel route from here)
      */
-    public static void spark(String verb, String path, String accept, Route route) {
+    public static void spark(Service sparkInstance, String verb, String path, String accept, Route route) {
         if ("get".equals(verb)) {
             if (accept != null) {
-                Spark.get(path, accept, route);
+                sparkInstance.get(path, accept, route);
             } else {
-                Spark.get(path, route);
+                sparkInstance.get(path, route);
             }
         } else if ("post".equals(verb)) {
             if (accept != null) {
-                Spark.post(path, accept, route);
+                sparkInstance.post(path, accept, route);
             } else {
-                Spark.post(path, route);
+                sparkInstance.post(path, route);
             }
         } else if ("put".equals(verb)) {
             if (accept != null) {
-                Spark.put(path, accept, route);
+                sparkInstance.put(path, accept, route);
             } else {
-                Spark.put(path, route);
+                sparkInstance.put(path, route);
             }
         } else if ("patch".equals(verb)) {
             if (accept != null) {
-                Spark.patch(path, accept, route);
+                sparkInstance.patch(path, accept, route);
             } else {
-                Spark.patch(path, route);
+                sparkInstance.patch(path, route);
             }
         } else if ("delete".equals(verb)) {
             if (accept != null) {
-                Spark.delete(path, accept, route);
+                sparkInstance.delete(path, accept, route);
             } else {
-                Spark.delete(path, route);
+                sparkInstance.delete(path, route);
             }
         } else if ("head".equals(verb)) {
             if (accept != null) {
-                Spark.head(path, accept, route);
+                sparkInstance.head(path, accept, route);
             } else {
-                Spark.head(path, route);
+                sparkInstance.head(path, route);
             }
         } else if ("trace".equals(verb)) {
             if (accept != null) {
-                Spark.trace(path, accept, route);
+                sparkInstance.trace(path, accept, route);
             } else {
-                Spark.trace(path, route);
+                sparkInstance.trace(path, route);
             }
         } else if ("connect".equals(verb)) {
             if (accept != null) {
-                Spark.connect(path, accept, route);
+                sparkInstance.connect(path, accept, route);
             } else {
-                Spark.connect(path, route);
+                sparkInstance.connect(path, route);
             }
         } else if ("options".equals(verb)) {
             if (accept != null) {
-                Spark.options(path, accept, route);
+                sparkInstance.options(path, accept, route);
             } else {
-                Spark.options(path, route);
+                sparkInstance.options(path, route);
             }
         }
     }

--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkComponent.java
@@ -36,11 +36,17 @@ import org.apache.camel.util.HostUtils;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
+import spark.Service;
 
 @Component("spark-rest")
 public class SparkComponent extends DefaultComponent implements RestConsumerFactory, RestApiConsumerFactory {
 
     private static final Pattern PATTERN = Pattern.compile("\\{(.*?)\\}");
+    
+    /**
+     * SPARK instance for the component
+     */
+    private Service sparkInstance;
 
     @Metadata(defaultValue = "4567")
     private int port = 4567;
@@ -67,6 +73,10 @@ public class SparkComponent extends DefaultComponent implements RestConsumerFact
     private SparkConfiguration sparkConfiguration = new SparkConfiguration();
     @Metadata(label = "advanced")
     private SparkBinding sparkBinding = new DefaultSparkBinding();
+
+    public Service getSparkInstance() {
+      return sparkInstance;
+    }
 
     public int getPort() {
         return port;
@@ -218,20 +228,21 @@ public class SparkComponent extends DefaultComponent implements RestConsumerFact
     protected void doStart() throws Exception {
         super.doStart();
 
+        sparkInstance = Service.ignite();
         if (getPort() != 4567) {
-            CamelSpark.port(getPort());
+            sparkInstance.port(getPort());
         } else {
             // if no explicit port configured, then use port from rest configuration
             RestConfiguration config = getCamelContext().getRestConfiguration("spark-rest", true);
             int port = config.getPort();
             if (port > 0) {
-                CamelSpark.port(port);
+                sparkInstance.port(port);
             }
         }
 
         String host = getIpAddress();
         if (host != null) {
-            CamelSpark.ipAddress(host);
+            sparkInstance.ipAddress(host);
         } else {
             // if no explicit port configured, then use port from rest configuration
             RestConfiguration config = getCamelContext().getRestConfiguration("spark-rest", true);
@@ -245,12 +256,14 @@ public class SparkComponent extends DefaultComponent implements RestConsumerFact
                     host = HostUtils.getLocalIp();
                 }
             }
-            CamelSpark.ipAddress(host);
+            sparkInstance.ipAddress(host);
         }
 
         if (keystoreFile != null || truststoreFile != null) {
-            CamelSpark.security(keystoreFile, keystorePassword, truststoreFile, truststorePassword);
+            sparkInstance.secure(keystoreFile, keystorePassword, truststoreFile, truststorePassword);
         }
+        
+        CamelSpark.threadPool(sparkInstance, minThreads, maxThreads, timeOutMillis);
 
         // configure component options
         RestConfiguration config = getCamelContext().getRestConfiguration("spark-rest", true);
@@ -263,7 +276,7 @@ public class SparkComponent extends DefaultComponent implements RestConsumerFact
     @Override
     protected void doShutdown() throws Exception {
         super.doShutdown();
-        CamelSpark.stop();
+        sparkInstance.stop();
     }
 
     @Override

--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkConsumer.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkConsumer.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.sparkrest;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.support.DefaultConsumer;
+import spark.Service;
 
 public class SparkConsumer extends DefaultConsumer {
 
@@ -46,7 +47,7 @@ public class SparkConsumer extends DefaultConsumer {
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-
+        Service sparkInstance = getEndpoint().getComponent().getSparkInstance();
         String verb = getEndpoint().getVerb();
         String path = getEndpoint().getPath();
         String accept = getEndpoint().getAccept();
@@ -57,15 +58,15 @@ public class SparkConsumer extends DefaultConsumer {
         } else {
             log.debug("Spark-rest: {}({})", verb, path);
         }
-        CamelSpark.spark(verb, path, accept, route);
+        CamelSpark.spark(sparkInstance, verb, path, accept, route);
 
         // special if cors is enabled in rest-dsl then we need a spark-route to trigger cors support
         if (enableCors && !"options".equals(verb)) {
-            CamelSpark.spark("options", path, accept, route);
+            CamelSpark.spark(sparkInstance, "options", path, accept, route);
         }
 
         if (matchOnUriPrefix) {
-            CamelSpark.spark(verb, path + "/*", accept, route);
+            CamelSpark.spark(sparkInstance, verb, path + "/*", accept, route);
         }
     }
 

--- a/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkEndpoint.java
+++ b/components/camel-spark-rest/src/main/java/org/apache/camel/component/sparkrest/SparkEndpoint.java
@@ -132,4 +132,9 @@ public class SparkEndpoint extends DefaultEndpoint {
         HttpMethod method = getCamelContext().getTypeConverter().mandatoryConvertTo(HttpMethod.class, verb);
         verb = method.name();
     }
+
+    @Override
+    public SparkComponent getComponent() {
+      return (SparkComponent) super.getComponent();
+    }
 }


### PR DESCRIPTION
This PR aims to solve [CAMEL-12323](https://issues.apache.org/jira/browse/CAMEL-12323) :

- An instance of Spark is created using Service.ignite() in the component.
- The classes SparkEndpoint and SparkConsumer use that instance instead of the Spark singleton.