### PR TITLE
CAMEL-13300: camel-box - Authentication fails without clues when 2-step verification is enabled

### DIFF
--- a/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/internal/BoxConnectionHelper.java
+++ b/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/internal/BoxConnectionHelper.java
@@ -122,7 +122,7 @@ public final class BoxConnectionHelper {
             passwordField.val(configuration.getUserPassword());
 
             //submit loginPage
-            final Map<String, String> cookies = new HashMap();
+            final Map<String, String> cookies = new HashMap<>();
             cookies.putAll(loginPageResponse.cookies());
 
             Connection.Response response = addProxy(loginForm.submit(), proxy)
@@ -173,7 +173,7 @@ public final class BoxConnectionHelper {
 
         } catch (BoxAPIException e) {
             throw new RuntimeCamelException(
-                    String.format("Box API connection failed: API returned the error code %d\n\n%s",
+                    String.format("Box API connection failed: API returned the error code %d%n%n%s",
                             e.getResponseCode(), e.getResponse()),
                     e);
         } catch (Exception e) {
@@ -184,16 +184,26 @@ public final class BoxConnectionHelper {
     /**
      * Validation of page:
      * - detects CAPTCHA test
+     * - detects 2-step verification
      * - detects invalid credentials error
      * - detects wrong clientId error
      */
     private static void validatePage(Document page) {
+        // CAPTCHA
         Elements captchaDivs = page.select("div[class*=g-recaptcha]");
         if (!captchaDivs.isEmpty()) {
             throw new IllegalArgumentException(
                     "Authentication requires CAPTCHA test. First you need to authenticate the account manually via web to unlock CAPTCHA.");
         }
 
+        // 2-step verification
+        Elements twoStepDivs = page.select("div[data-module=two-factor-enroll-form]");
+        if (!twoStepDivs.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "2-step verification is enabled on the Box account. Turn it off for camel-box to proceed the standard authentication.");
+        }
+
+        // login failures
         Elements errorDivs = page.select("div[class*=error_message]");
         String errorMessage = null;
         if (!errorDivs.isEmpty()) {
@@ -245,7 +255,7 @@ public final class BoxConnectionHelper {
                     configuration.getClientId(), configuration.getClientSecret(), encryptionPref, accessTokenCache);
         } catch (BoxAPIException e) {
             throw new RuntimeCamelException(
-                    String.format("Box API connection failed: API returned the error code %d\n\n%s",
+                    String.format("Box API connection failed: API returned the error code %d%n%n%s",
                             e.getResponseCode(), e.getResponse()),
                     e);
         }
@@ -276,7 +286,7 @@ public final class BoxConnectionHelper {
                     configuration.getClientId(), configuration.getClientSecret(), encryptionPref, accessTokenCache);
         } catch (BoxAPIException e) {
             throw new RuntimeCamelException(
-                    String.format("Box API connection failed: API returned the error code %d\n\n%s",
+                    String.format("Box API connection failed: API returned the error code %d%n%n%s",
                             e.getResponseCode(), e.getResponse()),
                     e);
         }

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/internal/BoxConnectionHelperIntegrationTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/internal/BoxConnectionHelperIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.box.internal;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import com.box.sdk.BoxAPIConnection;
+import com.box.sdk.BoxUser;
+import org.apache.camel.component.box.BoxConfiguration;
+import org.apache.camel.support.IntrospectionSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test class for {@link BoxConnectionHelper}.
+ */
+public class BoxConnectionHelperIntegrationTest {
+
+    private static final String TEST_OPTIONS_PROPERTIES = "/test-options.properties";
+
+    private BoxConfiguration configuration = new BoxConfiguration();
+
+    @Before
+    public void loadConfiguration() throws Exception {
+        Properties properties = new Properties();
+        try {
+            properties.load(getClass().getResourceAsStream(TEST_OPTIONS_PROPERTIES));
+        } catch (Exception e) {
+            throw new IOException(String.format("%s could not be loaded: %s", TEST_OPTIONS_PROPERTIES, e.getMessage()),
+                    e);
+        }
+
+        Map<String, Object> options = properties.entrySet().stream().collect(
+                Collectors.<Map.Entry, String, Object>toMap(e -> (String) e.getKey(), Map.Entry::getValue));
+
+        IntrospectionSupport.setProperties(configuration, options);
+    }
+
+    @Test
+    public void testCreateConnection() {
+        BoxAPIConnection connection = BoxConnectionHelper.createConnection(configuration);
+        BoxUser user = BoxUser.getCurrentUser(connection);
+        assertNotNull(user);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-13300