### PR TITLE
support for AWS S3 delimiter config

### DIFF
--- a/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
+++ b/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
@@ -38,6 +38,8 @@ public class S3Configuration implements Cloneable {
     private String fileName;
     @UriParam(label = "consumer")
     private String prefix;
+    @UriParam(label = "consumer")
+    private String delimiter;
     @UriParam
     private String region;
     @UriParam(label = "consumer", defaultValue = "true")
@@ -150,7 +152,20 @@ public class S3Configuration implements Cloneable {
     }
 
     /**
-     * The prefix which is used in the
+     * The delimiter which is used in the
+     * com.amazonaws.services.s3.model.ListObjectsRequest to only consume
+     * objects we are interested in.
+     */
+    public void setDelimiter(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public String getDelimiter() {
+        return delimiter;
+    }
+
+    /**
+     * The delimiter which is used in the
      * com.amazonaws.services.s3.model.ListObjectsRequest to only consume
      * objects we are interested in.
      */

--- a/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Consumer.java
+++ b/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Consumer.java
@@ -75,6 +75,8 @@ public class S3Consumer extends ScheduledBatchPollingConsumer {
             ListObjectsRequest listObjectsRequest = new ListObjectsRequest();
             listObjectsRequest.setBucketName(bucketName);
             listObjectsRequest.setPrefix(getConfiguration().getPrefix());
+            listObjectsRequest.setDelimiter(getConfiguration().getDelimiter());
+
             if (maxMessagesPerPoll > 0) {
                 listObjectsRequest.setMaxKeys(maxMessagesPerPoll);
             }

--- a/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/S3ConsumerDelimiterTest.java
+++ b/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/S3ConsumerDelimiterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.s3;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.util.StringInputStream;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+/**
+ * Test to verify that the polling consumer delivers an empty Exchange when the
+ * sendEmptyMessageWhenIdle property is set and a polling event yields no
+ * results.
+ */
+public class S3ConsumerDelimiterTest extends CamelTestSupport {
+
+    @BindToRegistry("amazonS3Client")
+    DummyAmazonS3Client clientMock = new DummyAmazonS3Client();
+
+    @Test
+    public void testConsumePrefixedMessages() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        assertMockEndpointsSatisfied();
+        assertEquals("Camel rocks!", mock.getExchanges().get(0).getIn().getBody(String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("aws-s3://mycamelbucket?amazonS3Client=#amazonS3Client&delay=50" + "&maxMessagesPerPoll=5&delimiter=_").to("mock:result");
+            }
+        };
+    }
+
+    class DummyAmazonS3Client extends AmazonS3Client {
+
+        private AtomicInteger requestCount = new AtomicInteger(0);
+
+        DummyAmazonS3Client() {
+            super(new BasicAWSCredentials("myAccessKey", "mySecretKey"));
+        }
+
+        @Override
+        public ObjectListing listObjects(ListObjectsRequest request) throws AmazonClientException, AmazonServiceException {
+            int currentRequestCount = requestCount.incrementAndGet();
+
+            assertEquals("mycamelbucket", request.getBucketName());
+            if (currentRequestCount == 2) {
+                assertEquals("_", request.getDelimiter());
+            }
+
+            ObjectListing response = new ObjectListing();
+            response.setBucketName(request.getBucketName());
+            response.setDelimiter(request.getDelimiter());
+
+            S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
+            s3ObjectSummary.setBucketName(request.getBucketName());
+            s3ObjectSummary.setKey("key");
+            response.getObjectSummaries().add(s3ObjectSummary);
+
+            return response;
+        }
+
+        @Override
+        public S3Object getObject(String bucketName, String key) throws AmazonClientException, AmazonServiceException {
+            assertEquals("mycamelbucket", bucketName);
+            assertEquals("key", key);
+
+            S3Object s3Object = new S3Object();
+            s3Object.setBucketName(bucketName);
+            s3Object.setKey(key);
+            try {
+                s3Object.setObjectContent(new StringInputStream("Camel rocks!"));
+            } catch (UnsupportedEncodingException e) {
+                // noop
+            }
+
+            return s3Object;
+        }
+
+        @Override
+        public void deleteObject(String bucketName, String key) throws AmazonClientException, AmazonServiceException {
+            // noop
+        }
+    }
+}


### PR DESCRIPTION
Hi guys, 

setting just a prefix is not enough, also delimiter must be set if one want to use s3 filtering feature. See  

https://github.com/aws/aws-sdk-java/blob/1f42e8bdc5e671621342fc8ebc7a3d6a6811395c/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3.java#L409

Hope the code change is fine with you :) 