### PR TITLE
CAMEL-13414 use System.currentTimeMillis()

### DIFF
--- a/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerEventsConsumer.java
+++ b/components/camel-docker/src/main/java/org/apache/camel/component/docker/consumer/DockerEventsConsumer.java
@@ -54,7 +54,7 @@ public class DockerEventsConsumer extends DefaultConsumer {
      * Determine the point in time to begin streaming events
      */
     private long processInitialEvent() {
-        long currentTime = new Date().getTime();
+        long currentTime = System.currentTimeMillis();
         Long initialRange = DockerHelper.getProperty(DockerConstants.DOCKER_INITIAL_RANGE, endpoint.getConfiguration(), null, Long.class);
         if (initialRange != null) {
             currentTime = currentTime - initialRange;

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/SftpChangedExclusiveReadLockStrategy.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/strategy/SftpChangedExclusiveReadLockStrategy.java
@@ -54,7 +54,7 @@ public class SftpChangedExclusiveReadLockStrategy implements GenericFileExclusiv
         long lastModified = Long.MIN_VALUE;
         long length = Long.MIN_VALUE;
         StopWatch watch = new StopWatch();
-        long startTime = new Date().getTime();
+        long startTime = System.currentTimeMillis();
 
         while (!exclusive) {
             // timeout check

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/NowSearchTerm.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/NowSearchTerm.java
@@ -51,7 +51,7 @@ public class NowSearchTerm extends ComparisonTerm {
     }
 
     private Date getDate() {
-        long now = new Date().getTime();
+        long now = System.currentTimeMillis();
         return new Date(now + offset);
     }
 


### PR DESCRIPTION
new Date() is just a thin wrapper around System.currentTimeMillis(). Using System.currentTimeMillis() can help avoid to create a new Date object and the system can speed up