### PR TITLE
CAMEL-13386: Maven Flatten plugin refinements

### DIFF
--- a/apache-camel/src/main/descriptors/src.xml
+++ b/apache-camel/src/main/descriptors/src.xml
@@ -54,6 +54,7 @@
         <exclude>**/cobertura.ser</exclude>
 
         <exclude>**/node_modules/**</exclude>
+        <exclude>**/.flattened-pom.xml</exclude>
       </excludes>
     </fileSet>
 

--- a/apache-camel/src/main/descriptors/unix-bin.xml
+++ b/apache-camel/src/main/descriptors/unix-bin.xml
@@ -49,6 +49,7 @@
         <exclude>**/target/*</exclude>
         <exclude>**/*.ser</exclude>
         <exclude>**/*.log</exclude>
+        <exclude>**/.flattened-pom.xml</exclude>
       </excludes>
       <lineEnding>unix</lineEnding>
     </fileSet>

--- a/apache-camel/src/main/descriptors/windows-bin.xml
+++ b/apache-camel/src/main/descriptors/windows-bin.xml
@@ -49,6 +49,7 @@
         <exclude>**/target/*</exclude>
         <exclude>**/*.ser</exclude>
         <exclude>**/*.log</exclude>
+        <exclude>**/.flattened-pom.xml</exclude>
       </excludes>
       <lineEnding>dos</lineEnding>
     </fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,15 @@
 
     <build>
         <defaultGoal>install</defaultGoal>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -326,6 +335,28 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
                     <version>1.1.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-cli</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                            <configuration>
+                                <updatePomFile>true</updatePomFile>
+                                <pomElements>
+                                    <build>keep</build>
+                                    <dependencyManagement>keep</dependencyManagement>
+                                    <description>keep</description>
+                                    <name>keep</name>
+                                    <parent>expand</parent>
+                                    <pluginManagement>keep</pluginManagement>
+                                    <profiles>remove</profiles>
+                                    <properties>keep</properties>
+                                </pomElements>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
 
             </plugins>
@@ -620,32 +651,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>flatten-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-cli</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>flatten</goal>
-                                </goals>
-                                <configuration>
-                                    <updatePomFile>true</updatePomFile>
-                                    <pomElements>
-                                        <build>keep</build>
-                                        <dependencyManagement>keep</dependencyManagement>
-                                        <description>keep</description>
-                                        <name>keep</name>
-                                        <parent>expand</parent>
-                                        <pluginManagement>keep</pluginManagement>
-                                        <profiles>remove</profiles>
-                                        <properties>expand</properties>
-                                    </pomElements>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -727,32 +732,6 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>flatten-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-cli</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>flatten</goal>
-                                </goals>
-                                <configuration>
-                                    <updatePomFile>true</updatePomFile>
-                                    <pomElements>
-                                        <build>keep</build>
-                                        <dependencyManagement>keep</dependencyManagement>
-                                        <description>keep</description>
-                                        <name>keep</name>
-                                        <parent>expand</parent>
-                                        <pluginManagement>keep</pluginManagement>
-                                        <profiles>remove</profiles>
-                                        <properties>expand</properties>
-                                    </pomElements>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This makes sure that Maven Flatten plugin is run in all profiles not just for `release` and changes the `properties` element processing to `keep` in contrast to the previous setting (`expand`) it should not replace property placeholders with expanded properties that might contain values specific to the machine the build is running.

Also makes sure that the distribution archives do not hold the `.flattened-pom.xml` file.