### PR TITLE
CAMEL-13428: camel-undertow - Response with large data gets truncated on cloud

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -121,7 +121,7 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_LENGTH, 0);
             // do not include content-type as that would indicate to the caller that we can only do text/plain
             httpExchange.getResponseHeaders().put(Headers.ALLOW, allowedMethods);
-            httpExchange.getResponseSender().close();
+            httpExchange.endExchange();
             return;
         }
 
@@ -156,7 +156,6 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             ByteBuffer bodyAsByteBuffer = tc.convertTo(ByteBuffer.class, body);
             httpExchange.getResponseSender().send(bodyAsByteBuffer);
         }
-        httpExchange.getResponseSender().close();
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-13428

Explicit sender close is not needed as the `sender()` without callback automatically closes it for you:
http://undertow.io/undertow-docs/undertow-docs-1.4.0/#undertow-handler-authors-guide