### PR TITLE
[CAMEL-13465] Camel-box, BoxGroupMembership.Info getGroupMembershipIn…

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxGroupsManager.java
@@ -251,7 +251,7 @@ public class BoxGroupsManager {
         try {
             LOG.debug("Deleting groupMembership(id={})", groupMembershipId);
             if (groupMembershipId == null) {
-                throw new IllegalArgumentException("Parameter 'groupMemebershipId' can not be null");
+                throw new IllegalArgumentException("Parameter 'groupMembershipId' can not be null");
             }
 
             BoxGroupMembership groupMembership = new BoxGroupMembership(boxConnection, groupMembershipId);
@@ -266,18 +266,18 @@ public class BoxGroupsManager {
     /**
      * Get group membership information.
      * 
-     * @param groupMemebershipId
+     * @param groupMembershipId
      *            - the id of group membership.
      * @return The group information.
      */
-    public BoxGroupMembership.Info getGroupMembershipInfo(String groupMemebershipId) {
+    public BoxGroupMembership.Info getGroupMembershipInfo(String groupMembershipId) {
         try {
-            LOG.debug("Getting info for groupMemebership(id={})", groupMemebershipId);
-            if (groupMemebershipId == null) {
-                throw new IllegalArgumentException("Parameter 'groupMemebershipId' can not be null");
+            LOG.debug("Getting info for groupMemebership(id={})", groupMembershipId);
+            if (groupMembershipId == null) {
+                throw new IllegalArgumentException("Parameter 'groupMembershipId' can not be null");
             }
 
-            BoxGroupMembership group = new BoxGroupMembership(boxConnection, groupMemebershipId);
+            BoxGroupMembership group = new BoxGroupMembership(boxConnection, groupMembershipId);
 
             return group.getInfo();
         } catch (BoxAPIException e) {

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -560,9 +560,9 @@ box:groups/endpoint?[options]
 
 |getGroupMemberships |memberships |groupId |java.uti.Collection
 
-|getGroupMembershipInfo |membershipInfo |groupMemebershipId |com.box.sdk.BoxGroup.Info
+|getGroupMembershipInfo |membershipInfo |groupMembershipId |com.box.sdk.BoxGroup.Info
 
-|updateGroupMembershipInfo |updateMembershipInfo |groupMemebershipId, info |com.box.sdk.BoxGroupMembership
+|updateGroupMembershipInfo |updateMembershipInfo |groupMembershipId, info |com.box.sdk.BoxGroupMembership
 |===
 
 URI Options for _groups_

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxGroupsManagerIntegrationTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxGroupsManagerIntegrationTest.java
@@ -154,7 +154,7 @@ public class BoxGroupsManagerIntegrationTest extends AbstractBoxTestSupport {
     public void testGetGroupMembershipInfo() throws Exception {
         BoxGroupMembership.Info info = testGroup.addMembership(testUser, BoxGroupMembership.Role.MEMBER);
 
-        // using String message body for single parameter "groupMemebershipId"
+        // using String message body for single parameter "groupMembershipId"
         final com.box.sdk.BoxGroupMembership.Info result = requestBody("direct://GETGROUPMEMBERSHIPINFO", info.getID());
 
         assertNotNull("getGroupMembershipInfo result", result);
@@ -213,7 +213,7 @@ public class BoxGroupsManagerIntegrationTest extends AbstractBoxTestSupport {
 
                 // test route for getGroupMembershipInfo
                 from("direct://GETGROUPMEMBERSHIPINFO")
-                    .to("box://" + PATH_PREFIX + "/getGroupMembershipInfo?inBody=groupMemebershipId");
+                    .to("box://" + PATH_PREFIX + "/getGroupMembershipInfo?inBody=groupMembershipId");
 
                 // test route for getGroupMemberships
                 from("direct://GETGROUPMEMBERSHIPS")


### PR DESCRIPTION
…fo(String groupMemebershipId) typo in argument name

Issue: https://issues.apache.org/jira/browse/CAMEL-13465

Typo in API was forcing users to use wrong name of argument in their code.