### PR TITLE
[CAMEL-13468]Exception tag is missing when Camel Java DSL is converte…

### DIFF
--- a/core/camel-core/src/main/java/org/apache/camel/model/OnExceptionDefinition.java
+++ b/core/camel-core/src/main/java/org/apache/camel/model/OnExceptionDefinition.java
@@ -178,6 +178,7 @@ public class OnExceptionDefinition extends ProcessorDefinition<OnExceptionDefini
     @Override
     public OnExceptionDefinition onException(Class<? extends Throwable> exceptionType) {
         getExceptionClasses().add(exceptionType);
+        getExceptions().add(exceptionType.getName());
         return this;
     }
 

--- a/core/camel-core/src/main/java/org/apache/camel/model/RoutesDefinition.java
+++ b/core/camel-core/src/main/java/org/apache/camel/model/RoutesDefinition.java
@@ -249,6 +249,7 @@ public class RoutesDefinition extends OptionalIdentifiedDefinition<RoutesDefinit
     public OnExceptionDefinition onException(Class<? extends Throwable> exception) {
         OnExceptionDefinition answer = new OnExceptionDefinition(exception);
         answer.setRouteScoped(false);
+        answer.getExceptions().add(exception.getName());
         getOnExceptions().add(answer);
         return answer;
     }

--- a/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedRouteDumpRouteAsXmlTest.java
+++ b/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedRouteDumpRouteAsXmlTest.java
@@ -58,6 +58,7 @@ public class ManagedRouteDumpRouteAsXmlTest extends ManagementTestSupport {
         assertTrue(xml.contains("myRoute"));
         assertTrue(xml.contains("ref:bar"));
         assertTrue(xml.contains("{{result}}"));
+        assertTrue(xml.contains("java.lang.Exception"));
     }
 
     @Test
@@ -89,6 +90,7 @@ public class ManagedRouteDumpRouteAsXmlTest extends ManagementTestSupport {
         assertTrue(xml.contains("myRoute"));
         assertTrue(xml.contains("ref:bar"));
         assertTrue(xml.contains("mock:result"));
+        assertTrue(xml.contains("java.lang.Exception"));
     }
 
     @Test
@@ -120,6 +122,7 @@ public class ManagedRouteDumpRouteAsXmlTest extends ManagementTestSupport {
         assertTrue(xml.contains("myRoute"));
         assertTrue(xml.contains("mock://bar"));
         assertTrue(xml.contains("mock:result"));
+        assertTrue(xml.contains("java.lang.Exception"));
     }
 
     static ObjectName getRouteObjectName(MBeanServer mbeanServer) throws Exception {
@@ -141,6 +144,7 @@ public class ManagedRouteDumpRouteAsXmlTest extends ManagementTestSupport {
                 Endpoint bar = context.getEndpoint("mock:bar");
                 bindToRegistry("bar", bar);
 
+                onException(Exception.class).log("${exception.stacktrace}").logStackTrace(true).handled(true);
 
                 from("direct:start").routeId("myRoute")
                     .log("Got ${body}")


### PR DESCRIPTION
…d into XML using dumpRouteAsXml() operation

JIRA:- https://issues.apache.org/jira/browse/CAMEL-13468