### PR TITLE
CAMEL-12834: Fix failing CDI tests

### DIFF
--- a/components/camel-cdi/pom.xml
+++ b/components/camel-cdi/pom.xml
@@ -258,10 +258,6 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/*Cdi20Test.java</exclude>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UnsatisfiedContextForEndpointInjectTest.java</exclude>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UriWithWrongContextTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -306,14 +302,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UnsatisfiedContextForEndpointInjectTest.java</exclude>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UriWithWrongContextTest.java</exclude>
-                            </excludes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -531,12 +519,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <reuseForks>true</reuseForks>
-                            <excludes>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UnsatisfiedContextForEndpointInjectTest.java</exclude>
-                                <!-- Reactivate when CAMEL-12834 is fixed -->
-                                <exclude>**/UriWithWrongContextTest.java</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/ExpectedDeploymentException.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/ExpectedDeploymentException.java
@@ -55,7 +55,9 @@ public final class ExpectedDeploymentException implements TestRule {
                             // OpenWebBeans logs the deployment exception details
                             // TODO: OpenWebBeans only log the root cause of exception thrown in producer methods
                             //assertThat(log.getMessages(), containsInRelativeOrder(pecs(messages)))
-                            assertThat(log.getMessages(), anyOf(hasItems(messages)));
+
+                            List<String> causeExceptionsMessages = getCauseExceptionsMessages(exception);
+                            assertThat(causeExceptionsMessages, anyOf(hasItems(messages)));
                         } catch (AssertionError error) {
                             // Weld stores the deployment exception details in the exception message
                             assertThat(exception.getMessage(), allOf(pecs(messages)));
@@ -63,6 +65,17 @@ public final class ExpectedDeploymentException implements TestRule {
                     }
                 }
             });
+    }
+
+    private List<String> getCauseExceptionsMessages(Throwable exception) {
+        List<String> exceptionsMessages = new ArrayList<>();
+        Throwable cause = exception;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+            exceptionsMessages.add(cause.getMessage());
+        }
+        exceptionsMessages.addAll(log.getMessages());
+        return exceptionsMessages;
     }
 
     public static ExpectedDeploymentException none() {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UriWithWrongContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UriWithWrongContextTest.java
@@ -45,12 +45,12 @@ public class UriWithWrongContextTest {
     @ClassRule
     public static TestRule exception = ExpectedDeploymentException.none()
         .expect(RuntimeException.class)
-//        .expectMessage(containsString("Error adding routes of type [" + UriWithWrongContextRoute.class.getName() + "] to Camel context [first]"))
-//        .expectMessage(containsString("Error injecting endpoint annotated with @org.apache.camel.cdi.Uri"))
-        .expectMessage(allOf(
-                containsString("WELD-001408 Unsatisfied dependencies for type [Endpoint] with qualifiers ["),
-                containsString("] at injection point [[field] @"),
-                containsString(" org.apache.camel.cdi.test.UriWithWrongContextRoute.inbound]")));
+        .expectMessage(
+            // WELD-1.0, WELD-1.2, WELD-2.0 have different exception messages
+            // Check only error code and injection point
+            allOf(
+                containsString("WELD-001408"),
+                containsString("org.apache.camel.cdi.test.UriWithWrongContextRoute.inbound")));
 
     @Deployment
     public static Archive<?> deployment() {
@@ -72,7 +72,8 @@ public class UriWithWrongContextTest {
 class UriWithWrongContextRoute extends RouteBuilder {
 
     @Inject
-    @Uri(value = "direct:inbound") @ContextName("second")
+    @Uri(value = "direct:inbound")
+    @ContextName("second")
     Endpoint inbound;
 
     @Override


### PR DESCRIPTION
Test were failed because they run with different maven profiles: weld-1.0, weld-1.2, weld-2.0.
Different versions of WELD have different exception messages.

Failing tests:
1. UriWithWrongContextTest - removed unnesesary checks, checking only error code and injection point
1. UnsatisfiedContextForEndpointInjectTest - fixed by adding cause exception message at ExpectedDeploymentException