### PR TITLE
[CAMEL-13499] Use Random.nextDouble instead of Math.random for better…

### DIFF
--- a/examples/camel-example-cdi-metrics/src/main/java/org/apache/camel/example/cdi/metrics/UnreliableService.java
+++ b/examples/camel-example-cdi-metrics/src/main/java/org/apache/camel/example/cdi/metrics/UnreliableService.java
@@ -21,13 +21,15 @@ import javax.enterprise.context.ApplicationScoped;
 import com.codahale.metrics.annotation.Metered;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
+import java.util.Random;
 
 @ApplicationScoped
 public class UnreliableService {
 
     @Metered
     public void attempt(Exchange exchange) {
-        if (Math.random() < 0.5) {
+	Random rand = new Random();
+        if (rand.nextDouble() < 0.5) {
             throw new RuntimeExchangeException("Random failure", exchange);
         }
     }

--- a/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/CreditAgencyProcessor.java
+++ b/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/CreditAgencyProcessor.java
@@ -18,14 +18,16 @@ package org.apache.camel.loanbroker;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import java.util.Random;
 
 //START SNIPPET: creditAgency
 public class CreditAgencyProcessor implements Processor {
 
     public void process(Exchange exchange) throws Exception {
         String ssn = exchange.getIn().getHeader(Constants.PROPERTY_SSN, String.class);
-        int score = (int) (Math.random() * 600 + 300);
-        int hlength = (int) (Math.random() * 19 + 1);
+        Random rand = new Random();
+	int score = (int) (rand.nextDouble() * 600 + 300);
+        int hlength = (int) (rand.nextDouble() * 19 + 1);
 
         exchange.getOut().setHeader(Constants.PROPERTY_SCORE, score);
         exchange.getOut().setHeader(Constants.PROPERTY_HISTORYLENGTH, hlength);

--- a/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/bank/BankProcessor.java
+++ b/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/bank/BankProcessor.java
@@ -20,6 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.loanbroker.Constants;
 
+import java.util.Random;
 //START SNIPPET: bank
 public class BankProcessor implements Processor {
     private final String bankName;
@@ -33,7 +34,8 @@ public class BankProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         String ssn = exchange.getIn().getHeader(Constants.PROPERTY_SSN, String.class);
         Integer historyLength = exchange.getIn().getHeader(Constants.PROPERTY_HISTORYLENGTH, Integer.class);
-        double rate = primeRate + (double) (historyLength / 12) / 10 + (Math.random() * 10) / 10;
+        Random rand = new Random();
+	double rate = primeRate + (double) (historyLength / 12) / 10 + (rand.nextDouble()  * 10) / 10;
 
         // set reply details as headers
         exchange.getOut().setHeader(Constants.PROPERTY_BANK, bankName);


### PR DESCRIPTION
… performance

[CAMEL-13499](https://issues.apache.org/jira/browse/CAMEL-13499) There is a slight performance cost associated with Math.random that does not exist in Random.nextDouble. Switching to Random.nextDouble offers the same functionality as Math.random, removes the performance overhead, and allows for more control over the randomness if such a thing is needed in the future.