### PR TITLE
CAMEL-13521: Add reverse proxy option in camel-netty4-http

### DIFF
--- a/components/camel-netty4-http/pom.xml
+++ b/components/camel-netty4-http/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- for testing rest-dsl -->
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
+++ b/components/camel-netty4-http/src/main/docs/netty4-http-component.adoc
@@ -131,7 +131,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *protocol* | *Required* The protocol to use which is either http or https |  | String
+| *protocol* | *Required* The protocol to use which is either http, https or proxy - a consumer only option. |  | String
 | *host* | *Required* The local hostname such as localhost, or 0.0.0.0 when being a consumer. The remote HTTP server hostname when using producer. |  | String
 | *port* | The host port number |  | int
 | *path* | Resource path |  | String
@@ -391,7 +391,7 @@ ProducerTemplate as shown below:
 
 And we get back "Bye World" as the output.
 
-=== How do I let Netty match wildcards
+==== How do I let Netty match wildcards
 
 By default Netty4 HTTP will only match on exact uri's. But you can
 instruct Netty to match prefixes. For example
@@ -422,7 +422,7 @@ To match *any* endpoint you can do:
 from("netty4-http:http://0.0.0.0:8123?matchOnUriPrefix=true").to("mock:foo");
 -----------------------------------------------------------------------------
 
-=== Using multiple routes with same port
+==== Using multiple routes with same port
 
 In the same CamelContext you can have multiple
 routes from Netty4 HTTP that shares the same port (eg a
@@ -516,6 +516,37 @@ And in the routes you refer to this option as shown below
 
 See the Netty HTTP Server Example
 for more details and example how to do that.
+
+==== Implementing a reverse proxy
+
+Netty HTTP component can act as a reverse proxy, in that case
+`Exchange.HTTP_SCHEME`, `Exchange.HTTP_HOST` and
+`Exchange.HTTP_PORT` headers are populated from the absolute
+URL received on the request line of the HTTP request.
+
+Here's an example of a HTTP proxy that simply transforms the response
+from the origin server to uppercase.
+
+[source,java]
+------------------------------------------------------------------------------------------
+from("netty-http:proxy://0.0.0.0:8080")
+    .toD("netty-http:"
+        + "${headers." + Exchange.HTTP_SCHEME + "}://"
+        + "${headers." + Exchange.HTTP_HOST + "}:"
+        + "${headers." + Exchange.HTTP_PORT + "}")
+    .process(this::processResponse);
+
+void processResponse(final Exchange exchange) {
+    final NettyHttpMessage message = exchange.getIn(NettyHttpMessage.class);
+    final FullHttpResponse response = message.getHttpResponse();
+
+    final ByteBuf buf = response.content();
+    final String string = buf.toString(StandardCharsets.UTF_8);
+
+    buf.resetWriterIndex();
+    ByteBufUtil.writeUtf8(buf, string.toUpperCase(Locale.US));
+}
+------------------------------------------------------------------------------------------
 
 === Using HTTP Basic Authentication
 

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConfiguration.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConfiguration.java
@@ -97,7 +97,7 @@ public class NettyHttpConfiguration extends NettyConfiguration {
     }
 
     /**
-     * The protocol to use which is either http or https
+     * The protocol to use which is either http, https or proxy - a consumer only option.
      */
     public void setProtocol(String protocol) {
         this.protocol = protocol;
@@ -317,5 +317,9 @@ public class NettyHttpConfiguration extends NettyConfiguration {
 
     public boolean isUseRelativePath() {
         return this.useRelativePath;
+    }
+
+    public boolean isHttpProxy() {
+        return "proxy".equals(super.protocol);
     }
 }

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerChannelHandler.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerChannelHandler.java
@@ -35,10 +35,12 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
+import org.apache.camel.Message;
 import org.apache.camel.component.netty4.NettyConverter;
 import org.apache.camel.component.netty4.NettyHelper;
 import org.apache.camel.component.netty4.handlers.ServerChannelHandler;
 import org.apache.camel.component.netty4.http.HttpPrincipal;
+import org.apache.camel.component.netty4.http.NettyHttpConfiguration;
 import org.apache.camel.component.netty4.http.NettyHttpConsumer;
 import org.apache.camel.component.netty4.http.NettyHttpSecurityConfiguration;
 import org.apache.camel.component.netty4.http.SecurityAuthenticator;
@@ -264,7 +266,9 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
 
     @Override
     protected void beforeProcess(Exchange exchange, final ChannelHandlerContext ctx, final Object message) {
-        if (consumer.getConfiguration().isBridgeEndpoint()) {
+        final NettyHttpConfiguration configuration = consumer.getConfiguration();
+
+        if (configuration.isBridgeEndpoint()) {
             exchange.setProperty(Exchange.SKIP_GZIP_ENCODING, Boolean.TRUE);
             exchange.setProperty(Exchange.SKIP_WWW_FORM_URLENCODED, Boolean.TRUE);
         }
@@ -274,6 +278,11 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
         if (!keepAlive) {
             // Just make sure we close the connection this time.
             exchange.setProperty(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.CLOSE.toString());
+        }
+
+        final Message in = exchange.getIn();
+        if (configuration.isHttpProxy()) {
+            in.removeHeader("Proxy-Connection");
         }
     }
 

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerMultiplexChannelHandler.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerMultiplexChannelHandler.java
@@ -36,6 +36,7 @@ import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.netty4.http.HttpServerConsumerChannelFactory;
+import org.apache.camel.component.netty4.http.NettyHttpConfiguration;
 import org.apache.camel.component.netty4.http.NettyHttpConsumer;
 import org.apache.camel.http.common.CamelServlet;
 import org.apache.camel.support.RestConsumerContextPathMatcher;
@@ -193,6 +194,16 @@ public class HttpServerMultiplexChannelHandler extends SimpleChannelInboundHandl
     private HttpServerChannelHandler getHandler(HttpRequest request, String method) {
         HttpServerChannelHandler answer = null;
 
+        // quick path to find if there are handlers with HTTP proxy consumers
+        for (final HttpServerChannelHandler handler : consumers) {
+            NettyHttpConsumer consumer = handler.getConsumer();
+
+            final NettyHttpConfiguration configuration = consumer.getConfiguration();
+            if (configuration.isHttpProxy()) {
+                return handler;
+            }
+        }
+
         // need to strip out host and port etc, as we only need the context-path for matching
         if (method == null) {
             return null;
@@ -222,6 +233,7 @@ public class HttpServerMultiplexChannelHandler extends SimpleChannelInboundHandl
         if (answer == null) {
             for (final HttpServerChannelHandler handler : consumers) {
                 NettyHttpConsumer consumer = handler.getConsumer();
+
                 String consumerPath = consumer.getConfiguration().getPath();
                 boolean matchOnUriPrefix = consumer.getEndpoint().getConfiguration().isMatchOnUriPrefix();
                 // Just make sure the we get the right consumer path first

--- a/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/ProxyProtocolTest.java
+++ b/components/camel-netty4-http/src/test/java/org/apache/camel/component/netty4/http/ProxyProtocolTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyProtocolTest {
+
+    private final DefaultCamelContext context = new DefaultCamelContext();
+
+    private final int port = AvailablePortFinder.getNextAvailable();
+
+    public ProxyProtocolTest() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                final int originPort = AvailablePortFinder.getNextAvailable();
+
+                // proxy from http://localhost:port to
+                // http://localhost:originPort/path
+                from("netty-http:proxy://localhost:" + port)
+                    .to("netty-http:http://localhost:" + originPort);
+
+                // origin service that serves `"origin server"` on
+                // http://localhost:originPort/path
+                from("netty-http:http://localhost:" + originPort + "/path").setBody()
+                    .constant("origin server");
+            }
+        });
+        context.start();
+    }
+
+    @Test
+    public void shouldProvideProxyProtocolSupport() {
+        final NettyHttpEndpoint endpoint = context.getEndpoint("netty-http:proxy://localhost", NettyHttpEndpoint.class);
+
+        assertThat(endpoint.getConfiguration().isHttpProxy()).isTrue();
+    }
+
+    @Test
+    public void shouldServeAsHttpProxy() throws Exception {
+        final Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", port));
+
+        // request for http://test/path will be proxied by http://localhost:port
+        // and diverted to http://localhost:originPort/path
+        final HttpURLConnection connection = (HttpURLConnection) new URL("http://test/path").openConnection(proxy);
+
+        try (InputStream stream = connection.getInputStream()) {
+            assertThat(IOUtils.readLines(stream, StandardCharsets.UTF_8)).containsOnly("origin server");
+        }
+    }
+
+    @After
+    public void shutdownCamel() throws Exception {
+        context.stop();
+    }
+}

--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -141,7 +141,10 @@ public interface Exchange {
     String FILTER_NON_XML_CHARS = "CamelFilterNonXmlChars";
 
     String GROUPED_EXCHANGE = "CamelGroupedExchange";
-    
+
+    String HTTP_SCHEME             = "CamelHttpScheme";
+    String HTTP_HOST               = "CamelHttpHost";
+    String HTTP_PORT               = "CamelHttpPort";
     String HTTP_BASE_URI           = "CamelHttpBaseUri";
     String HTTP_CHARACTER_ENCODING = "CamelHttpCharacterEncoding";
     String HTTP_METHOD             = "CamelHttpMethod";

--- a/platforms/spring-boot/components-starter/camel-netty4-http-starter/src/main/java/org/apache/camel/component/netty4/http/springboot/NettyHttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-netty4-http-starter/src/main/java/org/apache/camel/component/netty4/http/springboot/NettyHttpComponentConfiguration.java
@@ -165,7 +165,8 @@ public class NettyHttpComponentConfiguration
     public static class NettyHttpConfigurationNestedConfiguration {
         public static final Class CAMEL_NESTED_CLASS = org.apache.camel.component.netty4.http.NettyHttpConfiguration.class;
         /**
-         * The protocol to use which is either http or https
+         * The protocol to use which is either http, https or proxy - a consumer
+         * only option.
          */
         private String protocol;
         /**


### PR DESCRIPTION
This adds support for reverse proxy functionality in `camel-netty4-http` component.

While testing this I can see that the latency on the 99 percentile is ~50msec on my machine, would love to know if that can be optimized even further. Transfer rate is definitely something that could be looked at.

In my tests I used a route like:

```java
from("netty-http:proxy://0.0.0.0:8080")
    .toD("netty-http:"
        + "${headers." + Exchange.HTTP_SCHEME + "}://"
        + "${headers." + Exchange.HTTP_HOST + "}:"
        + "${headers." + Exchange.HTTP_PORT + "}")
```

I did notice some string/lambda allocations in the Pipeline that we might want to take a look at also.

After some warmup here's a test I run with 1000 requests with concurrency of 100:
```shell
$ ab -c 100 -n 1000 -k -X localhost:8080 http://localhost:8000/hello
This is ApacheBench, Version 2.3 <$Revision: 1843412 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost [through localhost:8080] (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        nginx/1.15.12
Server Hostname:        localhost
Server Port:            8000

Document Path:          /hello
Document Length:        13 bytes

Concurrency Level:      100
Time taken for tests:   0.534 seconds
Complete requests:      1000
Failed requests:        0
Keep-Alive requests:    995
Total transferred:      263975 bytes
HTML transferred:       13000 bytes
Requests per second:    1872.85 [#/sec] (mean)
Time per request:       53.395 [ms] (mean)
Time per request:       0.534 [ms] (mean, across all concurrent requests)
Transfer rate:          482.80 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   3.1      0      15
Processing:     1   50  26.0     46     145
Waiting:        1   50  26.1     45     145
Total:          1   51  26.2     47     149

Percentage of the requests served within a certain time (ms)
  50%     47
  66%     59
  75%     66
  80%     71
  90%     86
  95%    100
  98%    114
  99%    123
 100%    149 (longest request)
```

Versus going directly to the origin:
```shell
$ ab -c 100 -n 1000 -k http://localhost:8000/hello
This is ApacheBench, Version 2.3 <$Revision: 1843412 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        nginx/1.15.12
Server Hostname:        localhost
Server Port:            8000

Document Path:          /hello
Document Length:        13 bytes

Concurrency Level:      100
Time taken for tests:   0.082 seconds
Complete requests:      1000
Failed requests:        0
Keep-Alive requests:    1000
Total transferred:      264000 bytes
HTML transferred:       13000 bytes
Requests per second:    12125.62 [#/sec] (mean)
Time per request:       8.247 [ms] (mean)
Time per request:       0.082 [ms] (mean, across all concurrent requests)
Transfer rate:          3126.14 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   2.5      0      12
Processing:     1    6  14.3      2      67
Waiting:        1    6  14.2      2      67
Total:          1    7  16.0      2      76

Percentage of the requests served within a certain time (ms)
  50%      2
  66%      2
  75%      3
  80%      3
  90%     13
  95%     64
  98%     70
  99%     71
 100%     76 (longest request)

```

Submitted for review.