### PR TITLE
Improve camel-example-cdi-cassandraql readme

### DIFF
--- a/examples/camel-example-cdi-cassandraql/README.md
+++ b/examples/camel-example-cdi-cassandraql/README.md
@@ -8,12 +8,15 @@ The example get the list of pods from a Kubernetes cluster and print name and st
 
 The `camel-cdi`, `camel-core` and `camel-cassandraql` components are used in this example.
 The example assumes you have a running Cassandra Cluster in your environment. We will use Docker to spin up this cluster.
-As first step we will need to run a single node cluster:
 
+By default cluster requires significant amount of RAM memory (approx. 12GB).
+You can limit memory of docker container specifying parameter: `--env MAX_HEAP_SIZE`
+
+As first step we will need to run a single node cluster:
 ```
-$ docker run --name master_node -dt oscerd/cassandra
-$ docker run --name node1 -d -e SEED="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' master_node)" oscerd/cassandra
-$ docker run --name node2 -d -e SEED="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' master_node)" oscerd/cassandra
+$ docker run --name master_node --env MAX_HEAP_SIZE='800M' -dt oscerd/cassandra
+$ docker run --name node1 --env MAX_HEAP_SIZE='800M' -d -e SEED="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' master_node)" oscerd/cassandra
+$ docker run --name node2 --env MAX_HEAP_SIZE='800M' -d -e SEED="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' master_node)" oscerd/cassandra
 ```
 
 We now have three nodes in our cluster.


### PR DESCRIPTION
Working on CAMEL-13234 I had to run `camel-example-cdi-cassandraql` example, so run into problem with memory limits.
Added information about limiting memory to Cassandra docker container.