### PR TITLE
CAMEL-13513 CXFRS header "CamelDestinationOverrideUrl" ignored after changing it twice

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsBlueprintEndpoint.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsBlueprintEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+import org.springframework.util.ReflectionUtils;
 
 public class CxfRsBlueprintEndpoint extends CxfRsEndpoint {
     private AbstractJAXRSFactoryBean bean;
@@ -77,9 +78,17 @@ public class CxfRsBlueprintEndpoint extends CxfRsEndpoint {
     @Override
     protected JAXRSClientFactoryBean newJAXRSClientFactoryBean() {
         checkBeanType(bean, JAXRSClientFactoryBean.class);
-        // TODO Need to find a way to setup the JAXRSClientFactory Bean, as the JAXRSClientFactoryBean properties could be changed by the configurer
-        return (RsClientBlueprintBean)bean;
+        return (RsClientBlueprintBean)newInstanceWithCommonProperties();
     }
-    
+
+    private RsClientBlueprintBean newInstanceWithCommonProperties() {
+        RsClientBlueprintBean cfb = new RsClientBlueprintBean();
+
+        if (bean instanceof RsClientBlueprintBean) {
+            ReflectionUtils.shallowCopyFieldState(bean, cfb);
+        }
+
+        return cfb;
+    }
 
 }

--- a/tests/camel-blueprint-cxf-test/src/test/java/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeansTest.java
+++ b/tests/camel-blueprint-cxf-test/src/test/java/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeansTest.java
@@ -16,13 +16,27 @@
  */
 package org.apache.camel.test.cxf.blueprint;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.ProcessingException;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.apache.camel.component.cxf.jaxrs.CxfRsEndpoint;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class CxfRsEndpointBeansTest extends CamelBlueprintTestSupport {
+
+    @Produce(uri = "direct:startURLOverride")
+    private ProducerTemplate pT;
 
     @Override
     protected String getBlueprintDescriptor() {
@@ -43,7 +57,40 @@ public class CxfRsEndpointBeansTest extends CamelBlueprintTestSupport {
         JAXRSClientFactoryBean client = serviceEndpoint.createJAXRSClientFactoryBean();
         assertEquals("These cxfrs endpoints don't share the same bus", server.getBus().getId(), client.getBus().getId());
     }
-    
 
+    @Test
+    public void testDestinationOverrideURLHandling() {
+
+        try {
+            context.getRouteController().startRoute("url-override-route");
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        List<String> expected = Arrays.asList(
+                                              "foo1",
+                                              "foo2",
+                                              "foo1",
+                                              "foo2",
+                                              "foo1");
+
+        expected.forEach(host -> pT.send(exchange -> {
+            Message in = exchange.getIn();
+            in.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, false);
+            in.setHeader(CxfConstants.OPERATION_NAME, "getCustomer");
+            in.setBody("Scott");
+            in.setHeader(Exchange.ACCEPT_CONTENT_TYPE, "application/json");
+            in.setHeader(Exchange.DESTINATION_OVERRIDE_URL, "http://" + host);
+            in.setHeader(Exchange.HTTP_METHOD, "GET");
+        }));
+
+        MockEndpoint mockEndpoint = getMockEndpoint("mock:resultURLOverride");
+        Assert.assertArrayEquals(expected.toArray(),
+                                 mockEndpoint.getExchanges().stream()
+                                     .map(exchange -> exchange.getProperty(Exchange.EXCEPTION_CAUGHT, ProcessingException.class).getCause().toString())
+                                     .map(exceptionMessage -> exceptionMessage.split("\\: ")[1])
+                                     .collect(Collectors.toList()).toArray());
+
+    }
 
 }

--- a/tests/camel-blueprint-cxf-test/src/test/java/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeansTest.java
+++ b/tests/camel-blueprint-cxf-test/src/test/java/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeansTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 public class CxfRsEndpointBeansTest extends CamelBlueprintTestSupport {
 
-    @Produce(uri = "direct:startURLOverride")
+    @Produce("direct:startURLOverride")
     private ProducerTemplate pT;
 
     @Override

--- a/tests/camel-blueprint-cxf-test/src/test/resources/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeans.xml
+++ b/tests/camel-blueprint-cxf-test/src/test/resources/org/apache/camel/test/cxf/blueprint/CxfRsEndpointBeans.xml
@@ -45,6 +45,13 @@
 		</cxf:providers>
     </cxf:rsClient>
 
+	<cxf:rsClient id="restClient" address="http://foo"
+		serviceClass="org.apache.camel.component.cxf.jaxrs.testbean.CustomerServiceResource"
+		loggingFeatureEnabled="true">
+		<cxf:providers>
+			<ref component-id="jsonProvider" />
+		</cxf:providers>
+	</cxf:rsClient>
 
 	<bean id="jsonProvider" class="org.apache.cxf.jaxrs.provider.json.JSONProvider" />
 
@@ -53,6 +60,18 @@
 		<camel:route>
 			<camel:from uri="direct:start" />
 			<camel:to uri="mock:result" />
+		</camel:route>
+
+
+		<camel:route autostart="false" id="url-override-route">
+
+			<camel:onException>
+				<camel:exception>javax.ws.rs.ProcessingException</camel:exception>
+				<camel:to uri="mock:resultURLOverride" />
+			</camel:onException>
+
+			<camel:from uri="direct:startURLOverride" />
+			<camel:to uri="cxfrs:bean:restClient" />
 		</camel:route>
 
 	</camel:camelContext>


### PR DESCRIPTION
This issue has been fixed for the CXFRS Spring Endpoint with the CAMEL-12541 but not for the CXFRS Blueprint endpoint.
Integration tests has been disabled on master but the test works on 2.x branches.