### PR TITLE
CAMEL-13234: Use weld3 instead of weld2 at CDI example projects

### DIFF
--- a/components/camel-test-cdi/pom.xml
+++ b/components/camel-test-cdi/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
-            <version>${weld2-version}</version>
+            <version>${weld3-version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/examples/camel-example-cdi-aws-s3/pom.xml
+++ b/examples/camel-example-cdi-aws-s3/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -95,8 +95,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-cassandraql/pom.xml
+++ b/examples/camel-example-cdi-cassandraql/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -108,8 +108,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-kubernetes/pom.xml
+++ b/examples/camel-example-cdi-kubernetes/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -91,8 +91,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-metrics/pom.xml
+++ b/examples/camel-example-cdi-metrics/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -130,8 +130,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-properties/pom.xml
+++ b/examples/camel-example-cdi-properties/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -127,8 +127,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-rest-servlet/pom.xml
+++ b/examples/camel-example-cdi-rest-servlet/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -135,8 +135,8 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.servlet</groupId>
-            <artifactId>weld-servlet</artifactId>
-            <version>${weld2-version}</version>
+            <artifactId>weld-servlet-shaded</artifactId>
+            <version>${weld3-version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/examples/camel-example-cdi-test/pom.xml
+++ b/examples/camel-example-cdi-test/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -112,8 +112,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi-xml/pom.xml
+++ b/examples/camel-example-cdi-xml/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -124,8 +124,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-cdi/pom.xml
+++ b/examples/camel-example-cdi/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -76,8 +76,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>

--- a/examples/camel-example-fhir/pom.xml
+++ b/examples/camel-example-fhir/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -101,8 +101,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/camel-example-opentracing/client/pom.xml
+++ b/examples/camel-example-opentracing/client/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -95,8 +95,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>

--- a/examples/camel-example-swagger-cdi/pom.xml
+++ b/examples/camel-example-swagger-cdi/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>1.2</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -87,8 +87,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>

--- a/examples/camel-example-transformer-cdi/pom.xml
+++ b/examples/camel-example-transformer-cdi/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -88,8 +88,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>

--- a/examples/camel-example-widget-gadget-cdi/pom.xml
+++ b/examples/camel-example-widget-gadget-cdi/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -105,8 +105,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>

--- a/examples/camel-example-zipkin/client/pom.xml
+++ b/examples/camel-example-zipkin/client/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.2-version}</version>
+            <version>${cdi-api-2.0-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -90,8 +90,8 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jboss.weld.se</groupId>
-                        <artifactId>weld-se</artifactId>
-                        <version>${weld2-version}</version>
+                        <artifactId>weld-se-shaded</artifactId>
+                        <version>${weld3-version}</version>
                     </dependency>
                     <!-- logging -->
                     <dependency>


### PR DESCRIPTION
1. Double checked all modified examples to work with weld3.
1. There are more things that use weld2: camel-archetype-cdi, etc.