### PR TITLE
Use unchecked exceptions in service API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -186,9 +186,6 @@ The functionality to change the simple language tokens for start/end functions h
 
 The following API changes may affect your existing Camel applications, which needs to be migrated.
 
-TODO: Should this be a table?
-TODO: Add the other moved classes/packages etc
-
 #### CamelContext
 
 The methods on `CamelContext` that are related to catalog has been moved into a new `CatalogCamelContext` interface, which you can access by adapting:
@@ -197,6 +194,11 @@ The methods on `CamelContext` that are related to catalog has been moved into a 
 
 The `loadRouteDefinitions` and `loadRestDefinitions` on `ModelCamelContext` has been changed to `addRouteDefinitions` and `addRestDefinitions` to be aligned with the other methods. You can find loader methods on the `ModelHelper` utility class.
 
+#### Checked vs unchecked exceptions
+
+Most of the Camel exception classes has been migrated to be unchecked (eg extends `RuntimeException`). 
+
+Also the lifecycle of the `start`, `stop` and `suspend`, `resume` methods on `Service` and `SuspendableService` has been changed to not throw checked exceptions.
 
 #### Generic Information
 

--- a/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/CamelMessageConsumer.java
+++ b/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/CamelMessageConsumer.java
@@ -63,8 +63,6 @@ public class CamelMessageConsumer implements MessageConsumer {
                 if (pollingConsumer != null) {
                     pollingConsumer.stop();
                 }
-            } catch (JMSException e) {
-                throw e;
             } catch (Exception e) {
                 throw JMSExceptionSupport.create(e);
             }

--- a/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/CamelMessageProducer.java
+++ b/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/CamelMessageProducer.java
@@ -69,8 +69,6 @@ public class CamelMessageProducer extends ActiveMQMessageProducerSupport {
             closed = true;
             try {
                 producer.stop();
-            } catch (JMSException e) {
-                throw e;
             } catch (Exception e) {
                 throw JMSExceptionSupport.create(e);
             }

--- a/components/camel-ahc-ws/src/main/java/org/apache/camel/component/ahc/ws/WsConsumer.java
+++ b/components/camel-ahc-ws/src/main/java/org/apache/camel/component/ahc/ws/WsConsumer.java
@@ -31,15 +31,15 @@ public class WsConsumer extends DefaultConsumer {
     }
 
     @Override
-    public void start() throws Exception {
-        super.start();
+    public void doStart() throws Exception {
+        super.doStart();
         getEndpoint().connect(this);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         getEndpoint().disconnect(this);
-        super.stop();
+        super.doStop();
     }
 
     @Override

--- a/components/camel-atmosphere-websocket/src/main/java/org/apache/camel/component/atmosphere/websocket/MemoryWebSocketStore.java
+++ b/components/camel-atmosphere-websocket/src/main/java/org/apache/camel/component/atmosphere/websocket/MemoryWebSocketStore.java
@@ -42,14 +42,14 @@ public class MemoryWebSocketStore implements WebSocketStore {
      * @see org.apache.camel.Service#start()
      */
     @Override
-    public void start() throws Exception {
+    public void start() {
     }
 
     /* (non-Javadoc)
      * @see org.apache.camel.Service#stop()
      */
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         values.clear();
         keys.clear();
     }

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/AmbiguousMethodCallException.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/AmbiguousMethodCallException.java
@@ -18,15 +18,14 @@ package org.apache.camel.component.bean;
 
 import java.util.Collection;
 
-import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
+import org.apache.camel.RuntimeExchangeException;
 
 /**
  * An exception thrown if an attempted method invocation resulted in an ambiguous method
  * such that multiple methods match the inbound message exchange
  */
-public class AmbiguousMethodCallException extends CamelExchangeException {
-    private static final long serialVersionUID = -8867010485101806951L;
+public class AmbiguousMethodCallException extends RuntimeExchangeException {
 
     private final Collection<MethodInfo> methods;
 

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodNotFoundException.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodNotFoundException.java
@@ -16,12 +16,11 @@
  */
 package org.apache.camel.component.bean;
 
-import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
+import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.util.ObjectHelper;
 
-public class MethodNotFoundException extends CamelExchangeException {
-    private static final long serialVersionUID = -7411465307141051012L;
+public class MethodNotFoundException extends RuntimeExchangeException {
 
     private final Object bean;
     private final String methodName;

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/ParameterBindingException.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/ParameterBindingException.java
@@ -23,7 +23,6 @@ import org.apache.camel.util.ObjectHelper;
 
 public class ParameterBindingException extends RuntimeCamelException {
 
-    private static final long serialVersionUID = 1L;
     private final Method method;
     private final int index;
     private final Class<?> parameterType;

--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintCamelContext.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintCamelContext.java
@@ -105,7 +105,7 @@ public class BlueprintCamelContext extends DefaultCamelContext implements Servic
         this.bundleStateService = bundleStateService;
     }
    
-    public void doInit() {
+    public void doInit() throws Exception {
         log.trace("init {}", this);
         // add service listener so we can be notified when blueprint container is done
         // and we would be ready to start CamelContext
@@ -234,7 +234,7 @@ public class BlueprintCamelContext extends DefaultCamelContext implements Servic
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         final ClassLoader original = Thread.currentThread().getContextClassLoader();
         try {
             // let's set a more suitable TCCL while starting the context

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventComponentTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventComponentTest.java
@@ -78,11 +78,11 @@ public class EventComponentTest {
     static class NotStartedCamelContext extends DefaultCamelContext {
 
         @Override
-        public void start() throws Exception {
+        public void start() {
             start(false);
         }
 
-        void start(boolean start) throws Exception {
+        void start(boolean start) {
             if (start) {
                 super.start();
             }

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextBeanTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextBeanTest.java
@@ -80,7 +80,7 @@ class UnstoppedCamelContext extends DefaultCamelContext {
     static boolean isStopCalled;
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         super.stop();
         isStopCalled = true;
     }

--- a/components/camel-cometd/src/main/java/org/apache/camel/component/cometd/CometdConsumer.java
+++ b/components/camel-cometd/src/main/java/org/apache/camel/component/cometd/CometdConsumer.java
@@ -42,8 +42,8 @@ public class CometdConsumer extends DefaultConsumer implements CometdProducerCon
     }
 
     @Override
-    public void start() throws Exception {
-        super.start();
+    public void doStart() throws Exception {
+        super.doStart();
         // must connect first
         endpoint.connect(this);
         // should probably look into synchronization for this.
@@ -53,9 +53,9 @@ public class CometdConsumer extends DefaultConsumer implements CometdProducerCon
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         endpoint.disconnect(this);
-        super.stop();
+        super.doStop();
     }
 
     public void setBayeux(BayeuxServerImpl bayeux) {

--- a/components/camel-cometd/src/main/java/org/apache/camel/component/cometd/CometdProducer.java
+++ b/components/camel-cometd/src/main/java/org/apache/camel/component/cometd/CometdProducer.java
@@ -43,10 +43,9 @@ public class CometdProducer extends DefaultProducer implements CometdProducerCon
     }
 
     @Override
-    public void start() throws Exception {
-        super.start();
+    public void doStart() throws Exception {
+        super.doStart();
         // must connect first
-
         endpoint.connect(this);
         // should probably look into synchronization for this.
         if (service == null) {
@@ -55,7 +54,7 @@ public class CometdProducer extends DefaultProducer implements CometdProducerCon
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         super.stop();
         endpoint.disconnect(this);
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfMultipleConsumersSupportTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfMultipleConsumersSupportTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.cxf;
 
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
@@ -49,7 +48,7 @@ public class CxfMultipleConsumersSupportTest extends CamelTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToStartRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().endsWith(
                 "Multiple consumers for the same endpoint is not allowed: cxf://http://localhost:" + port1 
                 + "/CxfMultipleConsumersSupportTest/test?serviceClass=org.apache.camel.component.cxf.HelloService"));

--- a/components/camel-ehcache/src/main/java/org/apache/camel/component/ehcache/EhcacheManager.java
+++ b/components/camel-ehcache/src/main/java/org/apache/camel/component/ehcache/EhcacheManager.java
@@ -52,12 +52,12 @@ public class EhcacheManager implements Service {
     }
 
     @Override
-    public synchronized void start() throws Exception {
+    public synchronized void start() {
         refCount.retain();
     }
 
     @Override
-    public synchronized void stop() throws Exception {
+    public synchronized void stop() {
         refCount.release();
         userCaches.values().forEach(UserManagedCache::close);
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpConsumerIdempotentRefTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpConsumerIdempotentRefTest.java
@@ -103,10 +103,10 @@ public class FtpConsumerIdempotentRefTest extends FtpServerTestSupport {
             return;  
         }
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
         }
     }
 }

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyLanguage.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyLanguage.java
@@ -40,11 +40,11 @@ public class GroovyLanguage extends LanguageSupport {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
             InvokerHelper.removeClass(script);
         }
 

--- a/components/camel-guava-eventbus/src/test/java/org/apache/camel/component/guava/eventbus/GuavaEventBusConsumerConfigurationTest.java
+++ b/components/camel-guava-eventbus/src/test/java/org/apache/camel/component/guava/eventbus/GuavaEventBusConsumerConfigurationTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.guava.eventbus;
 
 import com.google.common.eventbus.EventBus;
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.SimpleRegistry;
@@ -49,7 +48,7 @@ public class GuavaEventBusConsumerConfigurationTest extends CamelTestSupport {
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalStateException ise = assertIsInstanceOf(IllegalStateException.class, e.getCause());
             assertEquals("You cannot set both 'eventClass' and 'listenerInterface' parameters.", ise.getMessage());
         }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastErrorMessagesTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastErrorMessagesTest.java
@@ -33,7 +33,7 @@ public class HazelcastErrorMessagesTest extends HazelcastCamelTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("You cannot send messages to this endpoint: hazelcast-atomicvalue://foo"));
+            assertTrue(e.getCause().getMessage().contains("You cannot send messages to this endpoint: hazelcast-atomicvalue://foo"));
         }
     }
 
@@ -50,7 +50,7 @@ public class HazelcastErrorMessagesTest extends HazelcastCamelTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("You cannot send messages to this endpoint: hazelcast-instance://foo"));
+            assertTrue(e.getCause().getMessage().contains("You cannot send messages to this endpoint: hazelcast-instance://foo"));
         }
     }
 

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpsTwoDifferentSslContextParametersGetTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpsTwoDifferentSslContextParametersGetTest.java
@@ -87,7 +87,7 @@ public class HttpsTwoDifferentSslContextParametersGetTest extends BaseHttpsTest 
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = (IllegalArgumentException) e.getCause().getCause();
             assertNotNull(iae);
             assertTrue(iae.getMessage().startsWith("Only same instance of SSLContextParameters is supported."));

--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -37,7 +37,6 @@
     </properties>
 
     <dependencies>
-        <!-- TODO: requires camel-core -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>

--- a/components/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/InfinispanManager.java
+++ b/components/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/InfinispanManager.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.Service;
+import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ObjectHelper;
 import org.infinispan.cache.impl.DecoratedCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -33,7 +33,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class InfinispanManager implements Service {
+public class InfinispanManager extends ServiceSupport {
     private static final transient Logger LOGGER = LoggerFactory.getLogger(InfinispanManager.class);
 
     private final InfinispanConfiguration configuration;
@@ -57,7 +57,7 @@ public class InfinispanManager implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void doStart() throws Exception {
         cacheContainer = configuration.getCacheContainer();
 
         if (cacheContainer == null) {
@@ -129,7 +129,7 @@ public class InfinispanManager implements Service {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void doStop() throws Exception {
         if (isManagedCacheContainer) {
             cacheContainer.stop();
         }

--- a/components/camel-infinispan/src/test/resources/log4j.xml
+++ b/components/camel-infinispan/src/test/resources/log4j.xml
@@ -82,7 +82,7 @@
 
     <root>
         <priority value="INFO" />
-        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
     </root>
 
 </log4j:configuration>

--- a/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationSpringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationSpringTest.java
@@ -29,11 +29,11 @@ public class CamelJaxbNoNamespaceSchemaLocationSpringTest extends CamelJaxbNoNam
         setUseRouteBuilder(false);
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationTest.xml");
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbSpringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbSpringTest.java
@@ -29,11 +29,11 @@ public class CamelJaxbSpringTest extends CamelJaxbTest {
         setUseRouteBuilder(false);
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/jaxb/CamelJaxbTest.xml");
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsEndpoint.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsEndpoint.java
@@ -485,7 +485,7 @@ public class JmsEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         int running = runningMessageListeners.get();
         if (running <= 0) {
             super.stop();
@@ -495,7 +495,7 @@ public class JmsEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         int running = runningMessageListeners.get();
         if (running <= 0) {
             super.shutdown();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTestConnectionOnStartupTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTestConnectionOnStartupTest.java
@@ -20,9 +20,7 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateConsumerException;
 import org.apache.camel.FailedToCreateProducerException;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
@@ -43,7 +41,7 @@ public class JmsTestConnectionOnStartupTest extends CamelTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToCreateConsumerException e) {
+        } catch (Exception e) {
             assertEquals("Failed to create Consumer for endpoint: activemq://queue:foo?testConnectionOnStartup=true. "
                 + "Reason: Cannot get JMS Connection on startup for destination foo", e.getMessage());
         }
@@ -61,8 +59,8 @@ public class JmsTestConnectionOnStartupTest extends CamelTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToCreateRouteException ex) {
-            FailedToCreateProducerException e = (FailedToCreateProducerException) ex.getCause();
+        } catch (Exception ex) {
+            FailedToCreateProducerException e = assertIsInstanceOf(FailedToCreateProducerException.class, ex.getCause());
             assertTrue(e.getMessage().startsWith("Failed to create Producer for endpoint: activemq://queue:foo?testConnectionOnStartup=true."));
             assertTrue(e.getMessage().contains("java.net.ConnectException"));
         }

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueService.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueService.java
@@ -20,6 +20,7 @@ import com.ibm.as400.access.AS400;
 import com.ibm.as400.access.BaseDataQueue;
 import com.ibm.as400.access.DataQueue;
 import com.ibm.as400.access.KeyedDataQueue;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.Service;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -58,7 +59,7 @@ class Jt400DataQueueService implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         if (queue == null) {
             AS400 system = endpoint.getSystem();
             if (endpoint.isKeyed()) {
@@ -69,12 +70,16 @@ class Jt400DataQueueService implements Service {
         }
         if (!queue.getSystem().isConnected(AS400.DATAQUEUE)) {
             LOG.info("Connecting to {}", endpoint);
-            queue.getSystem().connectService(AS400.DATAQUEUE);
+            try {
+                queue.getSystem().connectService(AS400.DATAQUEUE);
+            } catch (Exception e) {
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+            }
         }
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (queue != null) {
             LOG.info("Releasing connection to {}", endpoint);
             AS400 system = queue.getSystem();

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerRebalancePartitionRevokeTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerRebalancePartitionRevokeTest.java
@@ -99,11 +99,11 @@ public class KafkaConsumerRebalancePartitionRevokeTest extends BaseEmbeddedKafka
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
         }
 
         @Override

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerRebalanceTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerRebalanceTest.java
@@ -80,11 +80,11 @@ public class KafkaConsumerRebalanceTest extends BaseEmbeddedKafkaTest {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
         }
 
         @Override

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/cluster/lock/KubernetesLeadershipController.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/cluster/lock/KubernetesLeadershipController.java
@@ -75,7 +75,7 @@ public class KubernetesLeadershipController implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         if (serializedExecutor == null) {
             LOG.debug("{} Starting leadership controller...", logPrefix());
             serializedExecutor = camelContext.getExecutorServiceManager().newSingleThreadScheduledExecutor(this, "CamelKubernetesLeadershipController");
@@ -87,7 +87,7 @@ public class KubernetesLeadershipController implements Service {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         LOG.debug("{} Stopping leadership controller...", logPrefix());
         if (serializedExecutor != null) {
             serializedExecutor.shutdownNow();

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/cluster/lock/TimedLeaderNotifier.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/cluster/lock/TimedLeaderNotifier.java
@@ -92,20 +92,24 @@ public class TimedLeaderNotifier implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         if (this.executor == null) {
             this.executor = camelContext.getExecutorServiceManager().newSingleThreadScheduledExecutor(this, "CamelKubernetesLeaderNotifier");
         }
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (this.executor != null) {
             ScheduledExecutorService executor = this.executor;
             this.executor = null;
 
             executor.shutdownNow();
-            executor.awaitTermination(1, TimeUnit.SECONDS);
+            try {
+                executor.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+            }
         }
     }
 

--- a/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneIndexProducer.java
+++ b/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneIndexProducer.java
@@ -30,11 +30,8 @@ public class LuceneIndexProducer extends DefaultProducer {
         this.indexer = indexer;
     }
     
-    public void start() throws Exception {
-        super.doStart();
-    }
-
-    public void stop() throws Exception {
+    @Override
+    public void doStop() throws Exception {
         this.indexer.getNiofsDirectory().close();
         super.doStop();
     }

--- a/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneQueryProducer.java
+++ b/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneQueryProducer.java
@@ -39,12 +39,14 @@ public class LuceneQueryProducer extends DefaultProducer {
         maxNumberOfHits = config.getMaxHits();
     }
     
-    public void start() throws Exception {
+    @Override
+    public void doStart() throws Exception {
         searcher = new LuceneSearcher();
         super.doStart();
     }
 
-    public void stop() throws Exception {
+    @Override
+    public void doStop() throws Exception {
         searcher.close();
         super.doStop();
     }

--- a/components/camel-mina2/src/test/java/org/apache/camel/component/mina2/Mina2EncodingTest.java
+++ b/components/camel-mina2/src/test/java/org/apache/camel/component/mina2/Mina2EncodingTest.java
@@ -193,7 +193,7 @@ public class Mina2EncodingTest extends BaseMina2Test {
                 }
             });
             fail("Should have thrown a ResolveEndpointFailedException due invalid encoding parameter");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("The encoding: XXX is not supported", iae.getMessage());
         }

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerBootstrapFactory.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerBootstrapFactory.java
@@ -88,7 +88,7 @@ public class HttpServerBootstrapFactory extends SingleTCPNettyServerBootstrapFac
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // only stop if no more active consumers
         int consumers = channelFactory.consumers();
         if (consumers == 0) {

--- a/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/QuartzPropertiesTest.java
+++ b/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/QuartzPropertiesTest.java
@@ -60,7 +60,7 @@ public class QuartzPropertiesTest extends BaseQuartzTest {
             quartz.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertEquals("Error loading Quartz properties file: doesnotexist.properties", e.getMessage());
+            assertEquals("Error loading Quartz properties file: doesnotexist.properties", e.getCause().getMessage());
         }
     }
 

--- a/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/QuartzPropertiesTest.java
+++ b/components/camel-quartz2/src/test/java/org/apache/camel/component/quartz2/QuartzPropertiesTest.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 package org.apache.camel.component.quartz2;
+
 import java.io.InputStream;
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Test;
-import org.quartz.SchedulerException;
-
 
 public class QuartzPropertiesTest extends BaseQuartzTest {
 
@@ -60,7 +59,7 @@ public class QuartzPropertiesTest extends BaseQuartzTest {
         try {
             quartz.start();
             fail("Should have thrown exception");
-        } catch (SchedulerException e) {
+        } catch (Exception e) {
             assertEquals("Error loading Quartz properties file: doesnotexist.properties", e.getMessage());
         }
     }

--- a/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/BasicPublisherTest.java
+++ b/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/BasicPublisherTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import org.apache.camel.Exchange;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreams;
 import org.apache.camel.test.junit4.CamelTestSupport;
@@ -104,7 +104,7 @@ public class BasicPublisherTest extends CamelTestSupport {
         disp3.dispose();
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void testOnlyOneCamelProducerPerPublisher() throws Exception {
 
         new RouteBuilder() {

--- a/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/support/ReactiveStreamsTestService.java
+++ b/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/support/ReactiveStreamsTestService.java
@@ -38,12 +38,12 @@ public class ReactiveStreamsTestService implements CamelReactiveStreamsService {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
 
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
 
     }
 

--- a/components/camel-reactor/src/test/java/org/apache/camel/component/reactor/engine/ReactorStreamsServiceTest.java
+++ b/components/camel-reactor/src/test/java/org/apache/camel/component/reactor/engine/ReactorStreamsServiceTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -394,7 +394,7 @@ public class ReactorStreamsServiceTest extends ReactorStreamsServiceTestSupport 
     // misc
     // ************************************************
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void testOnlyOneCamelProducerPerPublisher() throws Exception {
         context.addRoutes(new RouteBuilder() {
             @Override

--- a/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletCustomDataFormatInvalidTest.java
+++ b/components/camel-restlet/src/test/java/org/apache/camel/component/restlet/RestRestletCustomDataFormatInvalidTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.restlet;
 
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.apache.camel.impl.JndiRegistry;
@@ -58,7 +57,7 @@ public class RestRestletCustomDataFormatInvalidTest extends RestletTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause().getMessage().contains("JsonDataFormat name: bla must not be an existing bean instance from the registry"));
         }
     }

--- a/components/camel-rxjava2/src/test/java/org/apache/camel/component/rxjava2/engine/RxJavaStreamsServiceTest.java
+++ b/components/camel-rxjava2/src/test/java/org/apache/camel/component/rxjava2/engine/RxJavaStreamsServiceTest.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import org.apache.camel.Exchange;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -386,7 +386,7 @@ public class RxJavaStreamsServiceTest extends RxJavaStreamsServiceTestSupport {
     // misc
     // ************************************************
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void testOnlyOneCamelProducerPerPublisher() throws Exception {
         context.addRoutes(new RouteBuilder() {
             @Override

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -385,11 +385,8 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
                 subscriptionHelper = null;
             }
             if (session != null && session.getAccessToken() != null) {
-                try {
-                    // logout of Salesforce
-                    ServiceHelper.stopService(session);
-                } catch (SalesforceException ignored) {
-                }
+                // logout of Salesforce
+                ServiceHelper.stopService(session);
             }
         } finally {
             if (httpClient != null) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/SalesforceSession.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.Service;
 import org.apache.camel.component.salesforce.AuthenticationType;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
@@ -355,15 +356,23 @@ public class SalesforceSession implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // auto-login at start if needed
-        login(accessToken);
+        try {
+            login(accessToken);
+        } catch (SalesforceException e) {
+            throw RuntimeCamelException.wrapRuntimeCamelException(e);
+        }
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // logout
-        logout();
+        try {
+            logout();
+        } catch (SalesforceException e) {
+            throw RuntimeCamelException.wrapRuntimeCamelException(e);
+        }
     }
 
     public long getTimeout() {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
@@ -100,12 +100,16 @@ public abstract class AbstractClientBase implements SalesforceSession.Salesforce
         this.terminationTimeout = terminationTimeout;
     }
 
-    public void start() throws Exception {
+    public void start() {
         // local cache
         accessToken = session.getAccessToken();
         if (accessToken == null) {
             // lazy login here!
-            accessToken = session.login(accessToken);
+            try {
+                accessToken = session.login(accessToken);
+            } catch (SalesforceException e) {
+                throw new RuntimeException(e);
+            }
         }
         instanceUrl = session.getInstanceUrl();
 
@@ -116,7 +120,7 @@ public abstract class AbstractClientBase implements SalesforceSession.Salesforce
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (inflightRequests != null) {
             inflightRequests.arrive();
             if (!inflightRequests.isTerminated()) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AbstractRestProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AbstractRestProcessor.java
@@ -94,12 +94,12 @@ public abstract class AbstractRestProcessor extends AbstractSalesforceProcessor 
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(restClient);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         ServiceHelper.stopService(restClient);
     }
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AnalyticsApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AnalyticsApiProcessor.java
@@ -222,12 +222,12 @@ public class AnalyticsApiProcessor extends AbstractSalesforceProcessor {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(analyticsClient);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // stop the client
         ServiceHelper.stopService(analyticsClient);
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/BulkApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/BulkApiProcessor.java
@@ -434,12 +434,12 @@ public class BulkApiProcessor extends AbstractSalesforceProcessor {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(bulkClient);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // stop the client
         ServiceHelper.stopService(bulkClient);
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/CompositeApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/CompositeApiProcessor.java
@@ -95,12 +95,12 @@ public final class CompositeApiProcessor extends AbstractSalesforceProcessor {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(compositeClient);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         ServiceHelper.stopService(compositeClient);
     }
 

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xslt/SaxonInvalidXsltFileTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xslt/SaxonInvalidXsltFileTest.java
@@ -37,7 +37,7 @@ public class SaxonInvalidXsltFileTest extends TestSupport {
             fail("Should have thrown an exception due XSL compilation error");
         } catch (Exception e) {
             // expected
-            assertIsInstanceOf(TransformerException.class, e.getCause());
+            assertIsInstanceOf(TransformerException.class, e.getCause().getCause());
         }
     }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -492,7 +492,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (getConsumers().isEmpty()) {
             super.stop();
         } else {
@@ -501,7 +501,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         if (isShutdown()) {
             log.trace("Service already shut down");
             return;

--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/HttpClientRouteTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/HttpClientRouteTest.java
@@ -122,7 +122,7 @@ public class HttpClientRouteTest extends ServletCamelRouterTestSupport {
                 }
             });
             fail("Excepts exception here");
-        } catch (FailedToCreateRouteException ex) {
+        } catch (Exception ex) {
             assertTrue("Get a wrong exception.", ex.getCause() instanceof FailedToCreateProducerException);
             assertTrue("Get a wrong cause of exception.", ex.getCause().getCause() instanceof UnsupportedOperationException);
         }

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpointTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/batch/SjmsBatchEndpointTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.sjms.batch;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.camel.CamelContext;
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.AggregationStrategies;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.sjms.SjmsComponent;
@@ -87,7 +88,7 @@ public class SjmsBatchEndpointTest extends CamelTestSupport {
         context.start();
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void testConsumerNegativePollDuration() throws Exception {
         context.addRoutes(new RouteBuilder() {
             @Override
@@ -99,7 +100,7 @@ public class SjmsBatchEndpointTest extends CamelTestSupport {
         context.start();
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void testConsumerNegativeConsumerCount() throws Exception {
         context.addRoutes(new RouteBuilder() {
             @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/NoConnectionFactoryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/NoConnectionFactoryTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.component.sjms.producer;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.FailedToCreateProducerException;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.Assert;
@@ -69,7 +69,7 @@ public class NoConnectionFactoryTest {
         try {
             context.start();
         } catch (Throwable t) {
-            Assert.assertEquals(FailedToCreateRouteException.class, t.getClass());
+            Assert.assertEquals(FailedToStartRouteException.class, t.getClass());
             Assert.assertEquals(FailedToCreateProducerException.class, t.getCause().getClass());
             Assert.assertEquals(IllegalArgumentException.class, t.getCause().getCause().getClass());
             LOG.info("Expected exception was thrown", t);
@@ -85,7 +85,7 @@ public class NoConnectionFactoryTest {
         try {
             context.start();
         } catch (Throwable t) {
-            Assert.assertEquals(FailedToCreateRouteException.class, t.getClass());
+            Assert.assertEquals(FailedToStartRouteException.class, t.getClass());
             Assert.assertEquals(FailedToCreateProducerException.class, t.getCause().getClass());
             Assert.assertEquals(IllegalArgumentException.class, t.getCause().getCause().getClass());
             LOG.info("Expected exception was thrown", t);

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedProducerInOutErrorTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/tx/TransactedProducerInOutErrorTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.component.sjms.tx;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.FailedToCreateProducerException;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.sjms.CamelJmsTestHelper;
 import org.apache.camel.component.sjms.SjmsComponent;
@@ -35,7 +35,7 @@ public class TransactedProducerInOutErrorTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(TransactedProducerInOutErrorTest.class);
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void test() throws Exception {
         CamelContext context = new DefaultCamelContext();
         context.addRoutes(createRouteBuilder());
@@ -44,7 +44,7 @@ public class TransactedProducerInOutErrorTest {
         try {
             context.start();
         } catch (Throwable t) {
-            Assert.assertEquals(FailedToCreateRouteException.class, t.getClass());
+            Assert.assertEquals(FailedToStartRouteException.class, t.getClass());
             Assert.assertEquals(FailedToCreateProducerException.class, t.getCause().getClass());
             Assert.assertEquals(IllegalArgumentException.class, t.getCause().getCause().getClass());
             LOG.info("Exception was thrown as expected", t);

--- a/components/camel-spring-batch/src/test/java/org/apache/camel/component/spring/batch/SpringBatchEndpointTest.java
+++ b/components/camel-spring-batch/src/test/java/org/apache/camel/component/spring/batch/SpringBatchEndpointTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -193,7 +193,7 @@ public class SpringBatchEndpointTest extends CamelTestSupport {
         mockEndpoint.expectedBodiesReceived(jobExecution);
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void shouldThrowExceptionIfUsedAsConsumer() throws Exception {
         // When
         context().addRoutes(new RouteBuilder() {
@@ -303,7 +303,7 @@ public class SpringBatchEndpointTest extends CamelTestSupport {
         assertSame(alternativeJobLauncher, batchEndpointJobLauncher);
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void shouldFailWhenThereIsNoJobLauncher() throws Exception {
         // Given
         SimpleRegistry registry = new SimpleRegistry();
@@ -320,7 +320,7 @@ public class SpringBatchEndpointTest extends CamelTestSupport {
         camelContext.start();
     }
 
-    @Test(expected = FailedToCreateRouteException.class)
+    @Test(expected = FailedToStartRouteException.class)
     public void shouldFailWhenThereIsMoreThanOneJobLauncher() throws Exception {
         // Given
         SimpleRegistry registry = new SimpleRegistry();

--- a/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SupervisingRouteControllerRestartTest.java
+++ b/components/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SupervisingRouteControllerRestartTest.java
@@ -84,7 +84,7 @@ public class SupervisingRouteControllerRestartTest {
         try {
             controller.startRoute("dummy");
         } catch (Exception e) {
-            Assert.assertEquals("Forced error on restart", e.getMessage());
+            Assert.assertEquals("Forced error on restart", e.getCause().getMessage());
         }
 
         Assert.assertTrue(controller.getBackOffContext("dummy").isPresent());

--- a/components/camel-spring/src/main/java/org/apache/camel/language/spel/SpelLanguage.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/language/spel/SpelLanguage.java
@@ -47,7 +47,7 @@ public class SpelLanguage extends LanguageSupport implements Service {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         ObjectHelper.notNull(getCamelContext(), "CamelContext", this);
 
         if (getCamelContext() instanceof SpringCamelContext) {
@@ -59,7 +59,7 @@ public class SpelLanguage extends LanguageSupport implements Service {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // noop
     }
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/CircularComponentCreationTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/CircularComponentCreationTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.camel.spring;
 
-
 import org.apache.camel.FailedToCreateRouteException;
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.util.IOHelper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,8 +30,8 @@ public class CircularComponentCreationTest {
             doTest("org/apache/camel/spring/CircularComponentCreationSimpleTest.xml");
 
             Assert.fail("Exception should have been thrown");
-        } catch (RuntimeCamelException e) {
-            Assert.assertTrue(e.getCause() instanceof FailedToCreateRouteException);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof FailedToCreateRouteException);
         }
     }
 

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/ErrorHandlerCamelContextRefNotFoundTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/ErrorHandlerCamelContextRefNotFoundTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.config;
+
 import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.NoSuchBeanException;
 import org.apache.camel.RuntimeCamelException;
@@ -32,8 +33,8 @@ public class ErrorHandlerCamelContextRefNotFoundTest extends SpringTestSupport {
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             NoSuchBeanException nsbe = assertIsInstanceOf(NoSuchBeanException.class, cause.getCause());
             assertEquals("No bean could be found in the registry for: foo of type: org.apache.camel.builder.ErrorHandlerBuilder", nsbe.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/ErrorHandlerRouteContextRefNotFoundTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/ErrorHandlerRouteContextRefNotFoundTest.java
@@ -32,8 +32,8 @@ public class ErrorHandlerRouteContextRefNotFoundTest extends SpringTestSupport {
         try {
             super.setUp();
             fail("Should have thrown exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             NoSuchBeanException nsbe = assertIsInstanceOf(NoSuchBeanException.class, cause.getCause());
             assertEquals("No bean could be found in the registry for: bar of type: org.apache.camel.builder.ErrorHandlerBuilder", nsbe.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/issues/SpringMainStartFailedIssueTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/issues/SpringMainStartFailedIssueTest.java
@@ -32,8 +32,8 @@ public class SpringMainStartFailedIssueTest extends TestSupport {
         try {
             main.run(args);
             fail("Should have thrown an exception");
-        } catch (RuntimeCamelException e) {
-            assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            assertIsInstanceOf(FailedToCreateRouteException.class, e);
         }
 
         assertNull("Spring application context should NOT be created", main.getApplicationContext());

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.java
@@ -35,8 +35,8 @@ public class SpringCamelContextStartingFailedEventTest extends SpringTestSupport
         try {
             new ClassPathXmlApplicationContext("org/apache/camel/spring/management/SpringCamelContextStartingFailedEventTest.xml");
             fail("Should thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertIsInstanceOf(ResolveEndpointFailedException.class, ftcre.getCause());
             // expected
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/JavaDslTransactedNoTXManagerTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/JavaDslTransactedNoTXManagerTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.spring.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.NoSuchBeanException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -40,7 +39,7 @@ public class JavaDslTransactedNoTXManagerTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause());
             assertEquals("No bean could be found in the registry of type: PlatformTransactionManager", cause.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidDeadLetterUriTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidDeadLetterUriTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.processor;
+
 import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.NoSuchEndpointException;
 import org.apache.camel.RuntimeCamelException;
@@ -37,8 +38,8 @@ public class SpringDeadLetterChannelInvalidDeadLetterUriTest extends SpringTestS
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             NoSuchEndpointException cause = assertIsInstanceOf(NoSuchEndpointException.class, ftcre.getCause());
             assertEquals("No endpoint could be found for: xxx, please check your classpath contains the needed Camel component jar.", cause.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidOptionDeadLetterUriTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDeadLetterChannelInvalidOptionDeadLetterUriTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.processor;
+
 import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.RuntimeCamelException;
@@ -37,8 +38,8 @@ public class SpringDeadLetterChannelInvalidOptionDeadLetterUriTest extends Sprin
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, ftcre.getCause());
             assertTrue(cause.getMessage().endsWith("Unknown parameters=[{foo=bar}]"));
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDoubleLoadBalancerMisconfigurationTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringDoubleLoadBalancerMisconfigurationTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.processor;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.FailedToCreateRouteException;
@@ -32,8 +33,8 @@ public class SpringDoubleLoadBalancerMisconfigurationTest extends ContextTestSup
         try {
             super.setUp();
             fail("Should have thrown exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException fe = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException fe = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             IllegalArgumentException ie = assertIsInstanceOf(IllegalArgumentException.class, fe.getCause());
             assertTrue(ie.getMessage().startsWith("Loadbalancer already configured to: RandomLoadBalancer. Cannot set it to: LoadBalanceType[RoundRobinLoadBalancer"));
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringFilterNoChildTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringFilterNoChildTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.processor;
+
 import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spring.SpringTestSupport;
@@ -30,8 +31,8 @@ public class SpringFilterNoChildTest extends SpringTestSupport {
         try {
             new ClassPathXmlApplicationContext("org/apache/camel/spring/processor/filterNoChild.xml");
             fail("Should thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException cause = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Definition has no children on Filter[xpath{$foo = 'bar'} -> []]", iae.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringRouteWithConstantFieldFromExchangeFailTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringRouteWithConstantFieldFromExchangeFailTest.java
@@ -15,30 +15,16 @@
  * limitations under the License.
  */
 package org.apache.camel.spring.processor;
+
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.processor.RouteWithConstantFieldFromExchangeFailTest;
-import org.junit.Before;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
 public class SpringRouteWithConstantFieldFromExchangeFailTest extends RouteWithConstantFieldFromExchangeFailTest {
 
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        try {
-            super.setUp();
-            fail("Should have thrown an exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException re = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, re.getCause());
-            assertEquals("Constant field with name: XXX not found on Exchange.class", iae.getMessage());
-        }
-    }
-
     protected CamelContext createCamelContext() throws Exception {
         return createSpringCamelContext(this, "org/apache/camel/spring/processor/RouteWithConstantFieldFromExchangeFailTest.xml");
     }
+
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTestHelper.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTestHelper.java
@@ -33,11 +33,11 @@ public final class SpringTestHelper {
 
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(classpathUri);
         test.setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
@@ -31,8 +31,8 @@ public class SpringTryCatchMisconfiguredTest extends ContextTestSupport {
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftce = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftce = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftce.getCause());
             assertEquals("This doCatch should have a doTry as its parent on DoCatch[ [class java.io.IOException] -> [To[mock:fail]]]", iae.getMessage());
         }
@@ -40,8 +40,8 @@ public class SpringTryCatchMisconfiguredTest extends ContextTestSupport {
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMisconfiguredFinallyTest.xml");
             fail("Should have thrown exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftcre.getCause());
             assertEquals("This doFinally should have a doTry as its parent on DoFinally[[To[mock:finally]]]", iae.getMessage());
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.java
@@ -30,8 +30,8 @@ public class SpringTryCatchMustHaveExceptionConfiguredTest extends ContextTestSu
         try {
             createSpringCamelContext(this, "org/apache/camel/spring/processor/SpringTryCatchMustHaveExceptionConfiguredTest.xml");
             fail("Should have thrown exception");
-        } catch (RuntimeCamelException e) {
-            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException ftcre = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftcre.getCause());
             assertEquals("At least one Exception must be configured to catch", iae.getMessage());
         }

--- a/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/MultiRestConsumer.java
+++ b/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/MultiRestConsumer.java
@@ -71,14 +71,14 @@ public class MultiRestConsumer implements Consumer {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         for (Consumer consumer : this.delegateConsumers) {
             consumer.start();
         }
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         for (Consumer consumer : this.delegateConsumers) {
             consumer.stop();
         }

--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/MemoryWebsocketStore.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/MemoryWebsocketStore.java
@@ -49,12 +49,12 @@ public class MemoryWebsocketStore extends ConcurrentHashMap<String, DefaultWebso
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         clear();
     }
     

--- a/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalDomainObjectJSONTest.java
+++ b/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalDomainObjectJSONTest.java
@@ -29,12 +29,12 @@ public class SpringMarshalDomainObjectJSONTest extends MarshalDomainObjectJSONTe
 
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/dataformat/xstream/SpringMarshalDomainObjectJSONTest.xml");
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
 
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalListTest.java
+++ b/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalListTest.java
@@ -29,12 +29,12 @@ public class SpringMarshalListTest extends MarshalListTest {
 
         final AbstractXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("org/apache/camel/dataformat/xstream/SpringMarshalListTest.xml");
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
 
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalOmitFieldsTest.java
+++ b/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringMarshalOmitFieldsTest.java
@@ -31,11 +31,11 @@ public class SpringMarshalOmitFieldsTest extends XStreamDataFormatOmitFieldsTest
             "org/apache/camel/dataformat/xstream/SpringMarshalOmitFieldsTest.xml");
 
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringXStreamConfigurationTest.java
+++ b/components/camel-xstream/src/test/java/org/apache/camel/dataformat/xstream/SpringXStreamConfigurationTest.java
@@ -31,11 +31,11 @@ public class SpringXStreamConfigurationTest extends XStreamConfigurationTest {
             "org/apache/camel/dataformat/xstream/SpringXStreamConfigurationTest.xml");
 
         setCamelContextService(new Service() {
-            public void start() throws Exception {
+            public void start() {
                 applicationContext.start();
             }
 
-            public void stop() throws Exception {
+            public void stop() {
                 applicationContext.stop();
             }
         });

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -463,7 +463,7 @@ Number of Components: 295 in 232 JAR artifacts (0 deprecated)
 | link:camel-jing/src/main/docs/jing-component.adoc[Jing] (camel-jing) +
 `jing:resourceUri` | 1.1 | Validates the payload of a message using RelaxNG Syntax using Jing library.
 
-| link:@@@ARTIFACTID@@@/src/main/docs/jms-component.adoc[JMS] (@@@ARTIFACTID@@@) +
+| link:camel-jms/src/main/docs/jms-component.adoc[JMS] (camel-jms) +
 `jms:destinationType:destinationName` | 1.0 | The jms component allows messages to be sent to (or consumed from) a JMS Queue or Topic.
 
 | link:camel-jmx/src/main/docs/jmx-component.adoc[JMX] (camel-jmx) +

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -463,7 +463,7 @@ Number of Components: 295 in 232 JAR artifacts (0 deprecated)
 | link:camel-jing/src/main/docs/jing-component.adoc[Jing] (camel-jing) +
 `jing:resourceUri` | 1.1 | Validates the payload of a message using RelaxNG Syntax using Jing library.
 
-| link:camel-jms/src/main/docs/jms-component.adoc[JMS] (camel-jms) +
+| link:@@@ARTIFACTID@@@/src/main/docs/jms-component.adoc[JMS] (@@@ARTIFACTID@@@) +
 `jms:destinationType:destinationName` | 1.0 | The jms component allows messages to be sent to (or consumed from) a JMS Queue or Topic.
 
 | link:camel-jmx/src/main/docs/jmx-component.adoc[JMX] (camel-jmx) +

--- a/core/camel-api/src/main/java/org/apache/camel/AlreadyStoppedException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/AlreadyStoppedException.java
@@ -19,8 +19,7 @@ package org.apache.camel;
 /**
  * Exception thrown in situations when a {@link Service} has already been stopped.
  */
-public class AlreadyStoppedException extends CamelException {
-    private static final long serialVersionUID = -8721487434390572639L;
+public class AlreadyStoppedException extends RuntimeCamelException {
 
     public AlreadyStoppedException() {
         super("Already stopped");

--- a/core/camel-api/src/main/java/org/apache/camel/CamelAuthorizationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelAuthorizationException.java
@@ -22,7 +22,7 @@ package org.apache.camel;
  * Camel should not process the message as a result.
  */
 public class CamelAuthorizationException extends CamelExchangeException {
-    private static final long serialVersionUID = 1L;
+
     private final String policyId;
     
     public CamelAuthorizationException(String message, Exchange exchange) {

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -138,18 +138,18 @@ public interface CamelContext extends StatefulService, RuntimeConfiguration {
      * <p/>
      * See more details at the class-level javadoc of this class.
      *
-     * @throws Exception is thrown if starting failed
+     * @throws RuntimeCamelException is thrown if starting failed
      */
-    void start() throws Exception;
+    void start();
 
     /**
      * Stop and shutdown the {@link CamelContext} (will stop all routes/components/endpoints etc and clear internal state/cache).
      * <p/>
      * See more details at the class-level javadoc of this class.
      *
-     * @throws Exception is thrown if stopping failed
+     * @throws RuntimeCamelException is thrown if stopping failed
      */
-    void stop() throws Exception;
+    void stop();
 
     /**
      * Gets the name (id) of the this CamelContext.

--- a/core/camel-api/src/main/java/org/apache/camel/CamelException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Base class for all Camel checked exceptions typically thrown by a {@link Processor}
  */
 public class CamelException extends Exception {
-    private static final long serialVersionUID = -8721487434390572630L;
 
     public CamelException() {
     }

--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel;
 
-
 /**
  * An exception caused by a specific message {@link Exchange}
  */

--- a/core/camel-api/src/main/java/org/apache/camel/CamelExecutionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExecutionException.java
@@ -23,7 +23,6 @@ package org.apache.camel;
  * to send messages to Camel.
  */
 public class CamelExecutionException extends RuntimeExchangeException {
-    private static final long serialVersionUID = -5821095325248904305L;
 
     public CamelExecutionException(String message, Exchange exchange) {
         super(message, exchange);

--- a/core/camel-api/src/main/java/org/apache/camel/CamelUnitOfWorkException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelUnitOfWorkException.java
@@ -26,8 +26,8 @@ import java.util.List;
  * from the {@link #getCauses()} method.
  */
 public class CamelUnitOfWorkException extends CamelExchangeException {
-    private static final long serialVersionUID = 1L;
-    private final List<Exception> causes;
+
+    private transient final List<Exception> causes;
 
     public CamelUnitOfWorkException(Exchange exchange, List<Exception> causes) {
         // just provide the first exception as cause, as it will be logged in the stacktraces

--- a/core/camel-api/src/main/java/org/apache/camel/ExchangeTimedOutException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangeTimedOutException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * An exception thrown if an InOut exchange times out receiving the OUT message
  */
 public class ExchangeTimedOutException extends CamelExchangeException {
-    private static final long serialVersionUID = -7899162905421788853L;
 
     private final long timeout;
 

--- a/core/camel-api/src/main/java/org/apache/camel/ExpectedBodyTypeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpectedBodyTypeException.java
@@ -20,7 +20,7 @@ package org.apache.camel;
  * Thrown if the body could not be converted to the required type
  */
 public class ExpectedBodyTypeException extends RuntimeCamelException {
-    private static final long serialVersionUID = -7121445152234363768L;
+
     private final transient Exchange exchange;
     private final transient Class<?> expectedBodyType;
 

--- a/core/camel-api/src/main/java/org/apache/camel/ExpressionEvaluationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpressionEvaluationException.java
@@ -21,8 +21,6 @@ package org.apache.camel;
  */
 public class ExpressionEvaluationException extends RuntimeCamelException {
 
-    private static final long serialVersionUID = 2939802714638174540L;
-    
     private final transient Expression expression;
     private final transient Exchange exchange;
 

--- a/core/camel-api/src/main/java/org/apache/camel/ExpressionIllegalSyntaxException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpressionIllegalSyntaxException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * An exception thrown if the expression contains illegal syntax.
  */
 public class ExpressionIllegalSyntaxException extends RuntimeCamelException {
-    private static final long serialVersionUID = 6545652894842621836L;
 
     private final String expression;
 

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateConsumerException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateConsumerException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Thrown if Camel failed to create a consumer for a given endpoint.
  */
 public class FailedToCreateConsumerException extends RuntimeCamelException {
-    private static final long serialVersionUID = 1916718168052020246L;
 
     private final String uri;
 

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateProducerException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateProducerException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Thrown if Camel failed to create a producer for a given endpoint.
  */
 public class FailedToCreateProducerException extends RuntimeCamelException {
-    private static final long serialVersionUID = 1341435621084082033L;
 
     private final String uri;
 

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
@@ -21,8 +21,8 @@ import org.apache.camel.util.URISupport;
 /**
  * Exception when failing to create a {@link org.apache.camel.Route}.
  */
-public class FailedToCreateRouteException extends CamelException {
-    private static final long serialVersionUID = 1L;
+public class FailedToCreateRouteException extends RuntimeCamelException {
+
     private final String routeId;
 
     public FailedToCreateRouteException(String routeId, String route, Throwable cause) {

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
@@ -19,8 +19,7 @@ package org.apache.camel;
 /**
  * Exception when failing to start a {@link Route}.
  */
-public class FailedToStartRouteException extends CamelException {
-    private static final long serialVersionUID = -6118520819865759888L;
+public class FailedToStartRouteException extends RuntimeCamelException {
 
     public FailedToStartRouteException(String routeId, String message) {
         super("Failed to start route " + routeId + " because of " + message);

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
@@ -21,16 +21,24 @@ package org.apache.camel;
  */
 public class FailedToStartRouteException extends RuntimeCamelException {
 
+    private String routeId;
+
     public FailedToStartRouteException(String routeId, String message) {
         super("Failed to start route " + routeId + " because of " + message);
+        this.routeId = routeId;
     }
 
     public FailedToStartRouteException(String routeId, String message, Throwable cause) {
         super("Failed to start route " + routeId + " because of " + message, cause);
+        this.routeId = routeId;
     }
 
     public FailedToStartRouteException(Throwable cause) {
         super(cause);
+    }
+
+    public String getRouteId() {
+        return routeId;
     }
 }
 

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
@@ -26,6 +26,10 @@ public class FailedToStartRouteException extends CamelException {
         super("Failed to start route " + routeId + " because of " + message);
     }
 
+    public FailedToStartRouteException(String routeId, String message, Throwable cause) {
+        super("Failed to start route " + routeId + " because of " + message, cause);
+    }
+
     public FailedToStartRouteException(Throwable cause) {
         super(cause);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
@@ -21,7 +21,6 @@ package org.apache.camel;
  */
 public class InvalidPayloadException extends CamelExchangeException {
 
-    private static final long serialVersionUID = -1689157578733908632L;
     private final transient Class<?> type;
 
     public InvalidPayloadException(Exchange exchange, Class<?> type) {

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
@@ -21,7 +21,6 @@ package org.apache.camel;
  */
 public class InvalidPayloadRuntimeException extends RuntimeExchangeException {
 
-    private static final long serialVersionUID = -155083097523464793L;
     private final transient Class<?> type;
 
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type) {

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPropertyException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPropertyException.java
@@ -20,7 +20,7 @@ package org.apache.camel;
  * An exception caused when an invalid property name is used on an object
  */
 public class InvalidPropertyException extends RuntimeCamelException {
-    private static final long serialVersionUID = 3450859794325167954L;
+
     private final transient Object owner;
     private final String propertyName;
 

--- a/core/camel-api/src/main/java/org/apache/camel/LoadPropertiesException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/LoadPropertiesException.java
@@ -22,7 +22,7 @@ import java.net.URL;
  * Represents a failure to open a Properties file at a given URL
  */
 public class LoadPropertiesException extends CamelException {
-    private static final long serialVersionUID = 3684303677685065529L;
+
     private final URL url;
 
     public LoadPropertiesException(URL url, Exception cause) {

--- a/core/camel-api/src/main/java/org/apache/camel/NoFactoryAvailableException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoFactoryAvailableException.java
@@ -22,12 +22,11 @@ import java.io.IOException;
  * Thrown if no factory resource is available for the given URI
  */
 public class NoFactoryAvailableException extends IOException {
-    private static final long serialVersionUID = -425141860196708627L;
 
     private final String uri;
 
     public NoFactoryAvailableException(String uri) {
-        super("Could not find factory class for resource: " + uri);
+        super("Cannot find factory class for resource: " + uri);
         this.uri = uri;
     }
 

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanException.java
@@ -20,7 +20,7 @@ package org.apache.camel;
  * A runtime exception if a given bean could not be found in the {@link org.apache.camel.spi.Registry}
  */
 public class NoSuchBeanException extends RuntimeCamelException {
-    private static final long serialVersionUID = -8721487431101572630L;
+
     private final String name;
 
     public NoSuchBeanException(String name) {

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
@@ -18,11 +18,10 @@ package org.apache.camel;
 
 /**
  * A runtime exception thrown if a routing processor such as a
- * {@link org.apache.camel.processor.RecipientList RecipientList} is unable to resolve an
- * {@link Endpoint} from a URI.
+ * recipient list is unable to resolve an {@link Endpoint} from a URI.
  */
 public class NoSuchEndpointException extends RuntimeCamelException {
-    private static final long serialVersionUID = -8721487431101572630L;
+
     private final String uri;
 
     public NoSuchEndpointException(String uri) {

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderException.java
@@ -23,7 +23,7 @@ package org.apache.camel;
  * @see org.apache.camel.support.ExchangeHelper#getMandatoryHeader(Exchange, String, Class)
  */
 public class NoSuchHeaderException extends CamelExchangeException {
-    private static final long serialVersionUID = -8721487431101572630L;
+
     private final String headerName;
     private final transient Class<?> type;
 

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchLanguageException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchLanguageException.java
@@ -23,7 +23,7 @@ package org.apache.camel;
  * @see org.apache.camel.CamelContext#resolveLanguage(String)
  */
 public class NoSuchLanguageException extends RuntimeCamelException {
-    private static final long serialVersionUID = -8721487431101572630L;
+
     private final String language;
 
     public NoSuchLanguageException(String language) {

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchPropertyException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchPropertyException.java
@@ -24,7 +24,7 @@ package org.apache.camel;
  * 
  */
 public class NoSuchPropertyException extends CamelExchangeException {
-    private static final long serialVersionUID = -8721487431101572630L;
+
     private final String propertyName;
     private final transient Class<?> type;
 

--- a/core/camel-api/src/main/java/org/apache/camel/NoTypeConversionAvailableException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoTypeConversionAvailableException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * An exception thrown if a value could not be converted to the required type
  */
 public class NoTypeConversionAvailableException extends CamelException {
-    private static final long serialVersionUID = -8721487434390572636L;
 
     private final transient Object value;
     private final transient Class<?> type;

--- a/core/camel-api/src/main/java/org/apache/camel/ProxyInstantiationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ProxyInstantiationException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Exception indicating a failure while trying to create a proxy of a given type and on a given endpoint
  */
 public class ProxyInstantiationException extends RuntimeCamelException {
-    private static final long serialVersionUID = -2050115486047385506L;
 
     private final Class<?> type;
     private final Endpoint endpoint;

--- a/core/camel-api/src/main/java/org/apache/camel/ResolveEndpointFailedException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ResolveEndpointFailedException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * A runtime exception thrown if an {@link Endpoint} cannot be resolved via URI
  */
 public class ResolveEndpointFailedException extends RuntimeCamelException {
-    private static final long serialVersionUID = -9121465713858552263L;
 
     private final String uri;
 

--- a/core/camel-api/src/main/java/org/apache/camel/RollbackExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RollbackExchangeException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Exception used for forcing an Exchange to be rolled back.
  */
 public class RollbackExchangeException extends CamelExchangeException {
-    private static final long serialVersionUID = -7837446508365767066L;
 
     public RollbackExchangeException(Exchange exchange) {
         this("Intended rollback", exchange);

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeCamelException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeCamelException.java
@@ -52,4 +52,20 @@ public class RuntimeCamelException extends RuntimeException {
             return new RuntimeCamelException(e);
         }
     }
+
+    /**
+     * Wraps the caused exception in a {@link RuntimeCamelException} if its not
+     * already a runtime exception.
+     *
+     * @param e the caused exception
+     * @return the wrapper exception
+     */
+    public static RuntimeException wrapRuntimeException(Throwable e) {
+        if (e instanceof RuntimeException) {
+            // don't double wrap
+            return (RuntimeException) e;
+        } else {
+            return new RuntimeCamelException(e);
+        }
+    }
 }

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeExchangeException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * A runtime exception caused by a specific message {@link Exchange}
  */
 public class RuntimeExchangeException extends RuntimeCamelException {
-    private static final long serialVersionUID = -8721487431101572630L;
     private final transient Exchange exchange;
 
     public RuntimeExchangeException(String message, Exchange exchange) {

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeExpressionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeExpressionException.java
@@ -21,8 +21,6 @@ package org.apache.camel;
  */
 public class RuntimeExpressionException extends RuntimeCamelException {
 
-    private static final long serialVersionUID = -8417806626073055262L;
-
     public RuntimeExpressionException(String message) {
         super(message);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeTransformException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeTransformException.java
@@ -21,8 +21,6 @@ package org.apache.camel;
  */
 public class RuntimeTransformException extends RuntimeCamelException {
 
-    private static final long serialVersionUID = -8417806626073055262L;
-
     public RuntimeTransformException(String message) {
         super(message);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/Service.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Service.java
@@ -17,12 +17,14 @@
 package org.apache.camel;
 
 /**
- * Represents the core lifecycle API for POJOs which can be started and stopped
+ * Represents the core lifecycle API for services which can be initialized, started and stopped
  */
 public interface Service {
 
     /**
      * Initialize the service
+     *
+     * @throws RuntimeException is thrown if initialization failed
      */
     default void init() {
     }

--- a/core/camel-api/src/main/java/org/apache/camel/Service.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Service.java
@@ -24,22 +24,22 @@ public interface Service {
     /**
      * Initialize the service
      *
-     * @throws RuntimeException is thrown if initialization failed
+     * @throws RuntimeCamelException is thrown if initialization failed
      */
     default void init() {
     }
 
     /**
      * Starts the service
-     * 
-     * @throws Exception is thrown if starting failed
+     *
+     * @throws RuntimeCamelException is thrown if starting failed
      */
-    void start() throws Exception;
+    void start();
 
     /**
      * Stops the service
-     * 
-     * @throws Exception is thrown if stopping failed
+     *
+     * @throws RuntimeCamelException is thrown if stopping failed
      */
-    void stop() throws Exception;
+    void stop();
 }

--- a/core/camel-api/src/main/java/org/apache/camel/ShutdownableService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ShutdownableService.java
@@ -29,8 +29,8 @@ public interface ShutdownableService extends Service {
     /**
      * Shutdown the service, which means it cannot be started again.
      *
-     * @throws Exception thrown if shutting down failed
+     * @throws RuntimeCamelException is thrown if shutdown failed
      */
-    void shutdown() throws Exception;
+    void shutdown();
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/SuspendableService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/SuspendableService.java
@@ -35,16 +35,16 @@ public interface SuspendableService extends Service {
     /**
      * Suspends the service.
      *
-     * @throws Exception is thrown if suspending failed
+     * @throws RuntimeCamelException is thrown if suspending failed
      */
-    void suspend() throws Exception;
+    void suspend();
 
     /**
      * Resumes the service.
      *
-     * @throws Exception is thrown if resuming failed
+     * @throws RuntimeCamelException is thrown if resuming failed
      */
-    void resume() throws Exception;
+    void resume();
 
     /**
      * Tests whether the service is suspended or not.

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
@@ -20,7 +20,6 @@ package org.apache.camel;
  * Exception when failing during type conversion.
  */
 public class TypeConversionException extends RuntimeCamelException {
-    private static final long serialVersionUID = -6118520819865759886L;
 
     private final transient Object value;
     private final transient Class<?> type;

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverterLoaderException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverterLoaderException.java
@@ -19,8 +19,7 @@ package org.apache.camel;
 /**
  * Exception when failing to load type converters.
  */
-public class TypeConverterLoaderException extends CamelException {
-    private static final long serialVersionUID = -6118520819865759887L;
+public class TypeConverterLoaderException extends RuntimeCamelException {
 
     public TypeConverterLoaderException(String message) {
         super("Failed to load type converters because of: " + message);

--- a/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
@@ -23,7 +23,6 @@ package org.apache.camel;
  * of the particular validation technology used.
  */
 public class ValidationException extends CamelExchangeException {
-    private static final long serialVersionUID = -7485357452450907415L;
 
     public ValidationException(Exchange exchange, String message) {
         super(message, exchange);

--- a/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
@@ -25,7 +25,7 @@ package org.apache.camel;
  * @see org.apache.camel.spi.LifecycleStrategy
  */
 public class VetoCamelContextStartException extends Exception {
-    private static final long serialVersionUID = 8046489554418284257L;
+
     private final CamelContext context;
     private final boolean rethrowException;
 

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceHelper.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceHelper.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.camel.Channel;
 import org.apache.camel.Navigate;
 import org.apache.camel.Processor;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.Service;
 import org.apache.camel.ShutdownableService;
 import org.apache.camel.StatefulService;
@@ -50,7 +51,7 @@ public final class ServiceHelper {
      * <p/>
      * Calling this method has no effect if {@code value} is {@code null}.
      */
-    public static void startService(Object value) throws Exception {
+    public static void startService(Object value) {
         if (value instanceof Service) {
             ((Service) value).start();
         } else if (value instanceof Iterable) {
@@ -66,7 +67,7 @@ public final class ServiceHelper {
      * 
      * @see #startService(Object)
      */
-    public static void startService(Object... services) throws Exception {
+    public static void startService(Object... services) {
         if (services != null) {
             for (Object o : services) {
                 startService(o);
@@ -83,7 +84,7 @@ public final class ServiceHelper {
      * 
      * @see #stopService(Collection)
      */
-    public static void stopService(Object... services) throws Exception {
+    public static void stopService(Object... services) {
         if (services != null) {
             for (Object o : services) {
                 stopService(o);
@@ -99,7 +100,7 @@ public final class ServiceHelper {
      * @see Service#stop()
      * @see #stopService(Collection)
      */
-    public static void stopService(Object value) throws Exception {
+    public static void stopService(Object value) {
         if (value instanceof Service) {
             ((Service) value).stop();
         } else if (value instanceof Iterable) {
@@ -118,15 +119,15 @@ public final class ServiceHelper {
      * 
      * @see #stopService(Object)
      */
-    public static void stopService(Collection<?> services) throws Exception {
+    public static void stopService(Collection<?> services) {
         if (services == null) {
             return;
         }
-        Exception firstException = null;
+        RuntimeException firstException = null;
         for (Object value : services) {
             try {
                 stopService(value);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Caught exception stopping service: {}", value, e);
                 }
@@ -149,7 +150,7 @@ public final class ServiceHelper {
      * 
      * @see #stopAndShutdownServices(Collection)
      */
-    public static void stopAndShutdownServices(Object... services) throws Exception {
+    public static void stopAndShutdownServices(Object... services) {
         if (services == null) {
             return;
         }
@@ -165,7 +166,7 @@ public final class ServiceHelper {
      * @see #stopService(Object)
      * @see ShutdownableService#shutdown()
      */
-    public static void stopAndShutdownService(Object value) throws Exception {
+    public static void stopAndShutdownService(Object value) {
         stopService(value);
 
         // then try to shutdown
@@ -186,11 +187,11 @@ public final class ServiceHelper {
      * @see #stopService(Object)
      * @see ShutdownableService#shutdown()
      */
-    public static void stopAndShutdownServices(Collection<?> services) throws Exception {
+    public static void stopAndShutdownServices(Collection<?> services) {
         if (services == null) {
             return;
         }
-        Exception firstException = null;
+        RuntimeException firstException = null;
 
         for (Object value : services) {
 
@@ -204,7 +205,7 @@ public final class ServiceHelper {
                     LOG.trace("Shutting down service: {}", service);
                     service.shutdown();
                 }
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Caught exception shutting down service: {}", value, e);
                 }
@@ -227,17 +228,17 @@ public final class ServiceHelper {
      * 
      * @see #resumeService(Object)
      */
-    public static void resumeServices(Collection<?> services) throws Exception {
+    public static void resumeServices(Collection<?> services) {
         if (services == null) {
             return;
         }
-        Exception firstException = null;
+        RuntimeException firstException = null;
         for (Object value : services) {
             if (value instanceof Service) {
                 Service service = (Service)value;
                 try {
                     resumeService(service);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Caught exception resuming service: {}", service, e);
                     }
@@ -273,7 +274,7 @@ public final class ServiceHelper {
      * @throws Exception is thrown if error occurred
      * @see #startService(Object)
      */
-    public static boolean resumeService(Object service) throws Exception {
+    public static boolean resumeService(Object service) {
         if (service instanceof Suspendable && service instanceof SuspendableService) {
             SuspendableService ss = (SuspendableService) service;
             if (ss.isSuspended()) {
@@ -298,17 +299,17 @@ public final class ServiceHelper {
      * 
      * @see #suspendService(Object)
      */
-    public static void suspendServices(Collection<?> services) throws Exception {
+    public static void suspendServices(Collection<?> services) {
         if (services == null) {
             return;
         }
-        Exception firstException = null;
+        RuntimeException firstException = null;
         for (Object value : services) {
             if (value instanceof Service) {
                 Service service = (Service)value;
                 try {
                     suspendService(service);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Caught exception suspending service: {}", service, e);
                     }
@@ -344,7 +345,7 @@ public final class ServiceHelper {
      * @throws Exception is thrown if error occurred
      * @see #stopService(Object)
      */
-    public static boolean suspendService(Object service) throws Exception {
+    public static boolean suspendService(Object service) {
         if (service instanceof Suspendable && service instanceof SuspendableService) {
             SuspendableService ss = (SuspendableService) service;
             if (!ss.isSuspended()) {

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.support.service;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.StatefulService;
 import org.slf4j.Logger;
@@ -59,7 +60,7 @@ public abstract class ServiceSupport implements StatefulService {
                     try {
                         doInit();
                     } catch (Exception e) {
-                        throw new RuntimeException("Error initializing service", e);
+                        throw RuntimeCamelException.wrapRuntimeCamelException(e);
                     }
                     status = INITIALIZED;
                 }
@@ -73,7 +74,7 @@ public abstract class ServiceSupport implements StatefulService {
      * <b>NOT</b> be overriden as they are used internally to keep track of the state of this service and properly
      * invoke the operation in a safe manner.
      */
-    public void start() throws Exception {
+    public void start() {
         synchronized (lock) {
             if (status == STARTED) {
                 log.trace("Service: {} already started", this);
@@ -99,7 +100,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while starting service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
@@ -110,7 +111,7 @@ public abstract class ServiceSupport implements StatefulService {
      * <b>NOT</b> be overridden as they are used internally to keep track of the state of this service and properly
      * invoke the operation in a safe manner.
      */
-    public void stop() throws Exception {
+    public void stop() {
         synchronized (lock) {
             if (status == STOPPED || status == SHUTTINGDOWN || status == SHUTDOWN) {
                 log.trace("Service: {} already stopped", this);
@@ -129,7 +130,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while stopping service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
@@ -141,7 +142,7 @@ public abstract class ServiceSupport implements StatefulService {
      * invoke the operation in a safe manner.
      */
     @Override
-    public void suspend() throws Exception {
+    public void suspend() {
         synchronized (lock) {
             if (status == SUSPENDED) {
                 log.trace("Service: {} already suspended", this);
@@ -160,7 +161,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while suspending service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
@@ -172,7 +173,7 @@ public abstract class ServiceSupport implements StatefulService {
      * invoke the operation in a safe manner.
      */
     @Override
-    public void resume() throws Exception {
+    public void resume() {
         synchronized (lock) {
             if (status != SUSPENDED) {
                 log.trace("Service is not suspended: {}", this);
@@ -187,7 +188,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while resuming service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
@@ -199,7 +200,7 @@ public abstract class ServiceSupport implements StatefulService {
      * invoke the operation in a safe manner.
      */
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         synchronized (lock) {
             if (status == SHUTDOWN) {
                 log.trace("Service: {} already shut down", this);
@@ -219,7 +220,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error shutting down service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
@@ -60,7 +60,7 @@ public abstract class ServiceSupport implements StatefulService {
                     try {
                         doInit();
                     } catch (Exception e) {
-                        throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                        throw RuntimeCamelException.wrapRuntimeException(e);
                     }
                     status = INITIALIZED;
                 }
@@ -100,7 +100,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while starting service: " + this, e);
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                throw RuntimeCamelException.wrapRuntimeException(e);
             }
         }
     }
@@ -130,7 +130,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while stopping service: " + this, e);
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                throw RuntimeCamelException.wrapRuntimeException(e);
             }
         }
     }
@@ -161,7 +161,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while suspending service: " + this, e);
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                throw RuntimeCamelException.wrapRuntimeException(e);
             }
         }
     }
@@ -188,7 +188,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while resuming service: " + this, e);
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                throw RuntimeCamelException.wrapRuntimeException(e);
             }
         }
     }
@@ -220,7 +220,7 @@ public abstract class ServiceSupport implements StatefulService {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error shutting down service: " + this, e);
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                throw RuntimeCamelException.wrapRuntimeException(e);
             }
         }
     }

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/ServiceSupport.java
@@ -56,7 +56,11 @@ public abstract class ServiceSupport implements StatefulService {
             synchronized (lock) {
                 if (status == NEW) {
                     log.trace("Initializing service: {}", this);
-                    doInit();
+                    try {
+                        doInit();
+                    } catch (Exception e) {
+                        throw new RuntimeException("Error initializing service", e);
+                    }
                     status = INITIALIZED;
                 }
             }
@@ -79,7 +83,13 @@ public abstract class ServiceSupport implements StatefulService {
                 log.trace("Service: {} already starting", this);
                 return;
             }
-            init();
+            try {
+                init();
+            } catch (Exception e) {
+                status = FAILED;
+                log.trace("Error while initializing service: " + this, e);
+                throw e;
+            }
             try {
                 status = STARTING;
                 log.trace("Starting service: {}", this);
@@ -304,7 +314,7 @@ public abstract class ServiceSupport implements StatefulService {
      * Initialize the service.
      * This method will only be called once before starting.
      */
-    protected void doInit() {
+    protected void doInit() throws Exception {
     }
 
     /**

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.apache.camel.AsyncProcessor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.Component;
@@ -307,7 +306,11 @@ public abstract class AbstractCamelContext extends ServiceSupport implements Cam
         this.startupListeners.add(deferStartupListener);
 
         if (init) {
-            init();
+            try {
+                init();
+            } catch (Exception e) {
+                throw new RuntimeException("Error initializing CamelContext", e);
+            }
         }
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -2171,7 +2171,7 @@ public abstract class AbstractCamelContext extends ServiceSupport implements Cam
                 try {
                     doStartOrResumeRoutes(routeServices, true, true, false, true);
                 } catch (Exception e) {
-                    throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                    throw RuntimeCamelException.wrapRuntimeException(e);
                 }
             }
 
@@ -2195,7 +2195,7 @@ public abstract class AbstractCamelContext extends ServiceSupport implements Cam
                         return;
                     }
                 } else {
-                    throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                    throw RuntimeCamelException.wrapRuntimeException(e);
                 }
             }
 
@@ -2229,7 +2229,7 @@ public abstract class AbstractCamelContext extends ServiceSupport implements Cam
                     try {
                         ((ExtendedStartupListener)startup).onCamelContextFullyStarted(this, isStarted());
                     } catch (Exception e) {
-                        throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                        throw RuntimeCamelException.wrapRuntimeException(e);
                     }
                 }
             }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractDynamicRegistry.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractDynamicRegistry.java
@@ -52,7 +52,7 @@ public class AbstractDynamicRegistry<K, V> extends AbstractMap<K, V>  implements
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         if (dynamicMap instanceof LRUCache) {
             ((LRUCache) dynamicMap).resetStatistics();
         }
@@ -186,7 +186,7 @@ public class AbstractDynamicRegistry<K, V> extends AbstractMap<K, V>  implements
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         ServiceHelper.stopService(staticMap.values(), dynamicMap.values());
         purge();
     }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/BaseRouteService.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/BaseRouteService.java
@@ -205,7 +205,7 @@ public abstract class BaseRouteService extends ChildServiceSupport {
         try {
             warmUp();
         } catch (FailedToStartRouteException e) {
-            throw RuntimeCamelException.wrapRuntimeCamelException(e);
+            throw RuntimeCamelException.wrapRuntimeException(e);
         }
 
         try (MDCHelper mdcHelper = new MDCHelper(route.getId())) {

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultClaimCheckRepository.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultClaimCheckRepository.java
@@ -73,12 +73,12 @@ public class DefaultClaimCheckRepository implements ClaimCheckRepository {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // noop
     }
 }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultInterceptSendToEndpoint.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultInterceptSendToEndpoint.java
@@ -124,16 +124,16 @@ public class DefaultInterceptSendToEndpoint implements InterceptSendToEndpoint, 
         return delegate.isSingleton();
     }
 
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(detour, delegate);
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         ServiceHelper.stopService(delegate, detour);
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         ServiceHelper.stopAndShutdownServices(delegate, detour);
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultRoute.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultRoute.java
@@ -123,7 +123,7 @@ public abstract class DefaultRoute extends ServiceSupport implements Route {
      * Do not invoke this method directly, use {@link org.apache.camel.spi.RouteController#startRoute(String)} to start a route.
      */
     @Override
-    public void start() throws Exception {
+    public void start() {
         super.start();
     }
 
@@ -131,7 +131,7 @@ public abstract class DefaultRoute extends ServiceSupport implements Route {
      * Do not invoke this method directly, use {@link org.apache.camel.spi.RouteController#stopRoute(String)} to stop a route.
      */
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         super.stop();
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
@@ -155,11 +155,11 @@ public class DefaultUnitOfWork implements UnitOfWork, Service {
         return answer;
     }
 
-    public void start() throws Exception {
+    public void start() {
         id = null;
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         // need to clean up when we are stopping to not leak memory
         if (synchronizations != null) {
             synchronizations.clear();

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/InterceptSendToEndpointProcessor.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/InterceptSendToEndpointProcessor.java
@@ -120,13 +120,13 @@ public class InterceptSendToEndpointProcessor extends DefaultAsyncProducer {
         return producer.isSingleton();
     }
 
-    public void start() throws Exception {
+    public void start() {
         ServiceHelper.startService(endpoint.getDetour());
         // here we also need to start the producer
         ServiceHelper.startService(producer);
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         // do not stop detour as it should only be stopped when the interceptor stops
         // we should stop the producer here
         ServiceHelper.stopService(producer);

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/LimitedPollingConsumerPollStrategy.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/LimitedPollingConsumerPollStrategy.java
@@ -110,11 +110,11 @@ public class LimitedPollingConsumerPollStrategy extends DefaultPollingConsumerPo
         return false;
     }
 
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         state.clear();
     }
 }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
@@ -78,7 +78,7 @@ public class MDCUnitOfWork extends DefaultUnitOfWork {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         super.stop();
         // and remove when stopping
         clear();

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
@@ -29,12 +29,12 @@ import org.apache.camel.support.LRUCacheFactory;
 class ProvisionalEndpointRegistry extends HashMap<EndpointKey, Endpoint> implements EndpointRegistry<EndpointKey> {
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // noop
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/processor/UnitOfWorkProducer.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/UnitOfWorkProducer.java
@@ -55,11 +55,15 @@ public final class UnitOfWorkProducer extends DefaultAsyncProducer {
         return processor.process(exchange, callback);
     }
 
-    public void start() throws Exception {
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
         ServiceHelper.startService(processor);
     }
 
-    public void stop() throws Exception {
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
         ServiceHelper.stopService(processor);
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/DefaultDebugger.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/DefaultDebugger.java
@@ -330,11 +330,6 @@ public class DefaultDebugger extends ServiceSupport implements Debugger, CamelCo
     }
 
     @Override
-    public void start() throws Exception {
-        super.start();
-    }
-
-    @Override
     protected void doStart() throws Exception {
         ObjectHelper.notNull(camelContext, "CamelContext", this);
 

--- a/core/camel-base/src/main/java/org/apache/camel/runtimecatalog/impl/DefaultRuntimeCamelCatalog.java
+++ b/core/camel-base/src/main/java/org/apache/camel/runtimecatalog/impl/DefaultRuntimeCamelCatalog.java
@@ -52,12 +52,12 @@ public class DefaultRuntimeCamelCatalog extends AbstractCamelCatalog implements 
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         cache.clear();
     }
 

--- a/core/camel-caffeine-lrucache/src/test/java/org/apache/camel/component/caffeine/lrucache/CaffeineLRUCacheTest.java
+++ b/core/camel-caffeine-lrucache/src/test/java/org/apache/camel/component/caffeine/lrucache/CaffeineLRUCacheTest.java
@@ -154,10 +154,10 @@ public class CaffeineLRUCacheTest {
 
         private Boolean stopped;
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             stopped = true;
         }
 

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiBeanRepository.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/core/osgi/OsgiBeanRepository.java
@@ -135,12 +135,12 @@ public class OsgiBeanRepository extends LifecycleStrategySupport implements Bean
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // Unget the OSGi service as OSGi uses reference counting
         // and we should do this as one of the last actions when stopping Camel
         this.serviceReferenceUsageMap.forEach(this::drainServiceUsage);

--- a/core/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/test/MockTypeConverterRegistry.java
+++ b/core/camel-core-osgi/src/test/java/org/apache/camel/core/osgi/test/MockTypeConverterRegistry.java
@@ -112,11 +112,11 @@ public class MockTypeConverterRegistry implements TypeConverterRegistry {
         return null;
     }
 
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         // noop
     }
 }

--- a/core/camel-core/src/main/java/org/apache/camel/language/simple/SimpleLanguage.java
+++ b/core/camel-core/src/main/java/org/apache/camel/language/simple/SimpleLanguage.java
@@ -118,8 +118,7 @@ public class SimpleLanguage extends LanguageSupport implements StaticService {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public void start() throws Exception {
+    public void init() {
         // setup cache which requires CamelContext to be set first
         if (cacheExpression == null && cachePredicate == null && getCamelContext() != null) {
             int maxSize = CamelContextHelper.getMaximumSimpleCacheSize(getCamelContext());
@@ -131,6 +130,11 @@ public class SimpleLanguage extends LanguageSupport implements StaticService {
                 LOG.debug("Simple language disabled predicate/expression cache");
             }
         }
+    }
+
+    @Override
+    public void start() throws Exception {
+        // noop
     }
 
     @Override

--- a/core/camel-core/src/main/java/org/apache/camel/language/simple/SimpleLanguage.java
+++ b/core/camel-core/src/main/java/org/apache/camel/language/simple/SimpleLanguage.java
@@ -133,12 +133,12 @@ public class SimpleLanguage extends LanguageSupport implements StaticService {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (cachePredicate instanceof LRUCache) {
             if (LOG.isDebugEnabled()) {
                 LRUCache cache = (LRUCache) cachePredicate;

--- a/core/camel-core/src/test/java/org/apache/camel/SuspendableServiceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/SuspendableServiceTest.java
@@ -25,10 +25,10 @@ public class SuspendableServiceTest extends Assert {
 
         private boolean suspended;
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
         }
 
         public void suspend() {

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInvokeStaticTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInvokeStaticTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.bean;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -54,7 +53,7 @@ public class BeanInvokeStaticTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(RuntimeCamelException.class, e.getCause());
             assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("Static method with name: doSomething not found on class: org.apache.camel.component.bean.MyStaticClass", e.getCause().getCause().getMessage());

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInvokeStaticTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInvokeStaticTest.java
@@ -54,9 +54,8 @@ public class BeanInvokeStaticTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertIsInstanceOf(RuntimeCamelException.class, e.getCause());
-            assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
-            assertEquals("Static method with name: doSomething not found on class: org.apache.camel.component.bean.MyStaticClass", e.getCause().getCause().getMessage());
+            assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
+            assertEquals("Static method with name: doSomething not found on class: org.apache.camel.component.bean.MyStaticClass", e.getCause().getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanLifecycleTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanLifecycleTest.java
@@ -107,12 +107,12 @@ public class BeanLifecycleTest extends ContextTestSupport {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
             status = "started";
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
             status = "stopped";
         }
     }
@@ -124,12 +124,12 @@ public class BeanLifecycleTest extends ContextTestSupport {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
             fail("Should not be invoked");
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
             fail("Should not be invoked");
         }
     }
@@ -146,11 +146,11 @@ public class BeanLifecycleTest extends ContextTestSupport {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
         }
     }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
@@ -44,8 +44,9 @@ public class BeanRefMethodNotFoundTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("b", e.getRouteId());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("b", failed.getRouteId());
             MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("bye", cause.getMethodName());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
@@ -45,7 +45,7 @@ public class BeanRefMethodNotFoundTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("b", failed.getRouteId());
             MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("bye", cause.getMethodName());

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefMethodNotFoundTest.java
@@ -47,7 +47,7 @@ public class BeanRefMethodNotFoundTest extends ContextTestSupport {
         } catch (Exception e) {
             FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("b", failed.getRouteId());
-            MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
+            MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
             assertEquals("bye", cause.getMethodName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefNotFoundTest.java
@@ -45,9 +45,10 @@ public class BeanRefNotFoundTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("b", e.getRouteId());
-            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("b", failed.getRouteId());
+            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause().getCause());
             assertEquals("bar", cause.getName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanRefNotFoundTest.java
@@ -46,9 +46,9 @@ public class BeanRefNotFoundTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("b", failed.getRouteId());
-            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause().getCause());
+            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause());
             assertEquals("bar", cause.getName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanWithMethodHeaderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanWithMethodHeaderTest.java
@@ -102,7 +102,7 @@ public class BeanWithMethodHeaderTest extends ContextTestSupport {
             });
             fail("Should throw an exception");
         } catch (Exception e) {
-            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
+            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
             assertEquals("ups", mnfe.getMethodName());
             assertSame(bean, mnfe.getBean());
         }
@@ -120,7 +120,7 @@ public class BeanWithMethodHeaderTest extends ContextTestSupport {
             });
             fail("Should throw an exception");
         } catch (Exception e) {
-            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
+            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
             assertEquals("ups", mnfe.getMethodName());
             assertSame(myBean, mnfe.getBean());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanWithMethodHeaderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanWithMethodHeaderTest.java
@@ -22,7 +22,6 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.jndi.JndiContext;
@@ -102,7 +101,7 @@ public class BeanWithMethodHeaderTest extends ContextTestSupport {
                 }
             });
             fail("Should throw an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("ups", mnfe.getMethodName());
             assertSame(bean, mnfe.getBean());
@@ -120,7 +119,7 @@ public class BeanWithMethodHeaderTest extends ContextTestSupport {
                 }
             });
             fail("Should throw an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("ups", mnfe.getMethodName());
             assertSame(myBean, mnfe.getBean());

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/ClassComponentInvalidConfigurationTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/ClassComponentInvalidConfigurationTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.bean;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class ClassComponentInvalidConfigurationTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             ClassNotFoundException not = assertIsInstanceOf(ClassNotFoundException.class, cause.getCause());
             assertEquals("org.apache.camel.component.bean.XXX", not.getMessage());
@@ -62,7 +61,7 @@ public class ClassComponentInvalidConfigurationTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             assertTrue(cause.getMessage().contains("Unknown parameters"));
             assertTrue(cause.getMessage().contains("foo=bar"));

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefMethodNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefMethodNotFoundTest.java
@@ -44,8 +44,9 @@ public class MethodCallBeanRefMethodNotFoundTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("b", e.getRouteId());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("b", failed.getRouteId());
             MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
             assertEquals("bye", cause.getMethodName());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefMethodNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefMethodNotFoundTest.java
@@ -45,9 +45,9 @@ public class MethodCallBeanRefMethodNotFoundTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("b", failed.getRouteId());
-            MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause().getCause());
+            MethodNotFoundException cause = assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
             assertEquals("bye", cause.getMethodName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefNotFoundTest.java
@@ -45,9 +45,10 @@ public class MethodCallBeanRefNotFoundTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("b", e.getRouteId());
-            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("b", failed.getRouteId());
+            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause().getCause());
             assertEquals("bar", cause.getName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallBeanRefNotFoundTest.java
@@ -46,9 +46,9 @@ public class MethodCallBeanRefNotFoundTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("b", failed.getRouteId());
-            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause().getCause());
+            NoSuchBeanException cause = assertIsInstanceOf(NoSuchBeanException.class, e.getCause());
             assertEquals("bar", cause.getName());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/dataset/DataSetTestEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/dataset/DataSetTestEndpointTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.DefaultEndpoint;
 import org.apache.camel.support.DefaultExchange;
@@ -81,15 +82,19 @@ public class DataSetTestEndpointTest extends ContextTestSupport {
                 }
 
                 @Override
-                public void start() throws Exception {
+                public void start() {
                     // when starting then send a message to the processor
                     Exchange exchange = new DefaultExchange(getEndpoint());
                     exchange.getIn().setBody(expectedBody);
-                    processor.process(exchange);
+                    try {
+                        processor.process(exchange);
+                    } catch (Exception e) {
+                        throw RuntimeCamelException.wrapRuntimeCamelException(e);
+                    }
                 }
 
                 @Override
-                public void stop() throws Exception {
+                public void stop() {
                     // noop
                 }
             };

--- a/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectNoMultipleConsumersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectNoMultipleConsumersTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.direct;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -44,7 +43,7 @@ public class DirectNoMultipleConsumersTest extends TestSupport {
         try {
             container.start();
             fail("Should have thrown an FailedToStartRouteException");
-        } catch (FailedToStartRouteException e) {
+        } catch (Exception e) {
             // expected
         } finally {
             container.stop();

--- a/core/camel-core/src/test/java/org/apache/camel/component/directvm/DirectVmTwoCamelContextDuplicateConsumerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/directvm/DirectVmTwoCamelContextDuplicateConsumerTest.java
@@ -35,7 +35,7 @@ public class DirectVmTwoCamelContextDuplicateConsumerTest extends AbstractDirect
             third.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertEquals("A consumer Consumer[direct-vm://foo] already exists from CamelContext: camel-1. Multiple consumers not supported", e.getCause().getMessage());
+            assertEquals("A consumer Consumer[direct-vm://foo] already exists from CamelContext: camel-1. Multiple consumers not supported", e.getMessage());
         }
 
         // stop first camel context then

--- a/core/camel-core/src/test/java/org/apache/camel/component/directvm/DirectVmTwoCamelContextDuplicateConsumerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/directvm/DirectVmTwoCamelContextDuplicateConsumerTest.java
@@ -34,8 +34,8 @@ public class DirectVmTwoCamelContextDuplicateConsumerTest extends AbstractDirect
         try {
             third.start();
             fail("Should have thrown exception");
-        } catch (IllegalStateException e) {
-            assertEquals("A consumer Consumer[direct-vm://foo] already exists from CamelContext: camel-1. Multiple consumers not supported", e.getMessage());
+        } catch (Exception e) {
+            assertEquals("A consumer Consumer[direct-vm://foo] already exists from CamelContext: camel-1. Multiple consumers not supported", e.getCause().getMessage());
         }
 
         // stop first camel context then

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCustomSchedulerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCustomSchedulerTest.java
@@ -135,16 +135,16 @@ public class FileConsumerCustomSchedulerTest extends ContextTestSupport {
         }
 
         @Override
-        public void shutdown() throws Exception {
+        public void shutdown() {
             timerTask.cancel();
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
         }
     }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerFileExpressionThrowExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerFileExpressionThrowExceptionTest.java
@@ -83,7 +83,7 @@ public class FileConsumerFileExpressionThrowExceptionTest extends ContextTestSup
 
         assertNotNull(rollbackCause);
 
-        MethodNotFoundException e = assertIsInstanceOf(MethodNotFoundException.class, rollbackCause.getCause());
+        MethodNotFoundException e = assertIsInstanceOf(MethodNotFoundException.class, rollbackCause);
         assertNotNull(e);
         assertEquals("doNotExistMethod", e.getMethodName());
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentRefTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentRefTest.java
@@ -112,10 +112,10 @@ public class FileConsumerIdempotentRefTest extends ContextTestSupport {
             return;  
         }
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
         }
     }
     

--- a/core/camel-core/src/test/java/org/apache/camel/component/properties/OptionalPropertiesDslInvalidSyntaxTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/properties/OptionalPropertiesDslInvalidSyntaxTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.properties;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -40,7 +39,7 @@ public class OptionalPropertiesDslInvalidSyntaxTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Property with key [xxx] not found in properties from text: {{xxx}}", cause.getMessage());
         }
@@ -59,7 +58,7 @@ public class OptionalPropertiesDslInvalidSyntaxTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("No setter to set property: xxx to: true on: Multicast[[To[mock:a], ThrowException[java.lang.IllegalAccessException], To[mock:b]]]", cause.getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentDefaultTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentDefaultTest.java
@@ -20,7 +20,6 @@ import java.io.FileNotFoundException;
 import java.io.IOError;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
@@ -56,7 +55,7 @@ public class PropertiesComponentDefaultTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             RuntimeCamelException rce = assertIsInstanceOf(RuntimeCamelException.class, cause.getCause());
             FileNotFoundException fnfe = assertIsInstanceOf(FileNotFoundException.class, rce.getCause());
@@ -136,7 +135,7 @@ public class PropertiesComponentDefaultTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertEquals("Cannot find JVM system property with key: my.home", e.getCause().getCause().getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentOnlyUseDefaultValuesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentOnlyUseDefaultValuesTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.properties;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -62,7 +61,7 @@ public class PropertiesComponentOnlyUseDefaultValuesTest extends ContextTestSupp
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             // expected
         }
     }
@@ -81,7 +80,7 @@ public class PropertiesComponentOnlyUseDefaultValuesTest extends ContextTestSupp
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             // expected
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/properties/PropertiesComponentTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.properties;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -213,7 +212,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Property with key [foo.unknown] not found in properties from text: {{foo.unknown}}", iae.getMessage());
@@ -231,7 +230,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Circular reference detected with key [cool.a] from text: {{cool.a}}", iae.getMessage());
@@ -366,7 +365,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
             context.start();
             
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Property with key [cool.doesnotexist] (and original key [doesnotexist]) not found in properties from text: {{doesnotexist}}", iae.getMessage());
@@ -391,7 +390,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
             context.start();
             
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Property with key [cool.cool.end] not found in properties from text: {{cool.end}}", iae.getMessage());
@@ -455,7 +454,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
             context.start();
             
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException cause = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, cause.getCause());
             assertEquals("Property with key [cool.end.end] not found in properties from text: {{cool.end}}", iae.getMessage());
@@ -473,7 +472,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
             });
             context.start();
             fail("Should thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("Cannot find JVM system property with key: xxx", cause.getMessage());
         }
@@ -590,7 +589,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertEquals("Property with key [beer] not found in properties from text: mock:{{beer}}", e.getCause().getMessage());
         }
 
@@ -681,7 +680,7 @@ public class PropertiesComponentTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertEquals("Property with key [UNKNOWN] not found in properties from text: mock:{{UNKNOWN}}", e.getCause().getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SameSedaQueueMultipleConsumersDifferenceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SameSedaQueueMultipleConsumersDifferenceTest.java
@@ -18,12 +18,10 @@ package org.apache.camel.component.seda;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.FailedToCreateRouteException;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
-/**
- *
- */
 public class SameSedaQueueMultipleConsumersDifferenceTest extends ContextTestSupport {
 
     @Test
@@ -57,9 +55,9 @@ public class SameSedaQueueMultipleConsumersDifferenceTest extends ContextTestSup
             });
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToStartRouteException failed = assertIsInstanceOf(FailedToStartRouteException.class, e);
             assertEquals("fail", failed.getRouteId());
-            assertEquals("Cannot use existing queue seda://foo as the existing queue multiple consumers true does not match given multiple consumers false", e.getCause().getCause().getMessage());
+            assertEquals("Cannot use existing queue seda://foo as the existing queue multiple consumers true does not match given multiple consumers false", e.getCause().getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SameSedaQueueMultipleConsumersDifferenceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SameSedaQueueMultipleConsumersDifferenceTest.java
@@ -56,9 +56,10 @@ public class SameSedaQueueMultipleConsumersDifferenceTest extends ContextTestSup
                 }
             });
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("fail", e.getRouteId());
-            assertEquals("Cannot use existing queue seda://foo as the existing queue multiple consumers true does not match given multiple consumers false", e.getCause().getMessage());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("fail", failed.getRouteId());
+            assertEquals("Cannot use existing queue seda://foo as the existing queue multiple consumers true does not match given multiple consumers false", e.getCause().getCause().getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullInvalidConfigurationTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullInvalidConfigurationTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.seda;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class SedaBlockWhenFullInvalidConfigurationTest extends ContextTestSuppor
         try {
             context.start();
             fail("Should fail");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             ResolveEndpointFailedException refe = assertIsInstanceOf(ResolveEndpointFailedException.class, e.getCause());
             assertEquals("Value [true, true] converted to java.lang.Boolean cannot be null", refe.getCause().getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/timer/TimerWithTimeOptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/timer/TimerWithTimeOptionTest.java
@@ -21,7 +21,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -202,7 +201,7 @@ public class TimerWithTimeOptionTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should throw an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(ParseException.class, e.getCause().getCause());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorIllegalImportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/validator/ValidatorIllegalImportTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.validator;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -82,7 +81,7 @@ public class ValidatorIllegalImportTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertTrue(iae.getMessage().startsWith("Resource: org/apache/camel/component/validator/BroadcastMonitor.xsd refers an invalid resource without SystemId."));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/InvalidXsltFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/InvalidXsltFileTest.java
@@ -40,7 +40,7 @@ public class InvalidXsltFileTest extends TestSupport {
             fail("Should have thrown an exception due XSL compilation error");
         } catch (Exception e) {
             // expected
-            assertIsInstanceOf(TransformerConfigurationException.class, e.getCause());
+            assertIsInstanceOf(TransformerConfigurationException.class, e.getCause().getCause());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/InvalidXsltFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/InvalidXsltFileTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.xslt;
 import javax.xml.transform.TransformerConfigurationException;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -39,7 +38,7 @@ public class InvalidXsltFileTest extends TestSupport {
             context.start();
 
             fail("Should have thrown an exception due XSL compilation error");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             // expected
             assertIsInstanceOf(TransformerConfigurationException.class, e.getCause());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltCustomErrorListenerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltCustomErrorListenerTest.java
@@ -20,7 +20,6 @@ import javax.xml.transform.ErrorListener;
 import javax.xml.transform.TransformerException;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -77,7 +76,7 @@ public class XsltCustomErrorListenerTest extends TestSupport {
             context.start();
 
             fail("Should have thrown an exception due XSLT file not found");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             // expected
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFileNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFileNotFoundTest.java
@@ -41,8 +41,8 @@ public class XsltFileNotFoundTest extends TestSupport {
 
             fail("Should have thrown an exception due XSLT file not found");
         } catch (Exception e) {
-            assertIsInstanceOf(TransformerException.class, e.getCause());
-            assertIsInstanceOf(FileNotFoundException.class, e.getCause().getCause());
+            assertIsInstanceOf(TransformerException.class, e.getCause().getCause());
+            assertIsInstanceOf(FileNotFoundException.class, e.getCause().getCause().getCause());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFileNotFoundTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFileNotFoundTest.java
@@ -21,7 +21,6 @@ import java.io.FileNotFoundException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -41,7 +40,7 @@ public class XsltFileNotFoundTest extends TestSupport {
             context.start();
 
             fail("Should have thrown an exception due XSLT file not found");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(TransformerException.class, e.getCause());
             assertIsInstanceOf(FileNotFoundException.class, e.getCause().getCause());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltRouteXsltWithErrorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltRouteXsltWithErrorTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.xslt;
 import javax.xml.transform.TransformerConfigurationException;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.ObjectHelper;
 import org.junit.Test;
@@ -43,7 +42,7 @@ public class XsltRouteXsltWithErrorTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             TransformerConfigurationException cause = ObjectHelper.getException(TransformerConfigurationException.class, e);
             assertNotNull(cause);
             // not sure if XSLT errors may be i18n and not english always so just check for the spelling mistake of select -> slect

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltSaxonTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltSaxonTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.xslt;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.TestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -37,7 +36,7 @@ public class XsltSaxonTest extends TestSupport {
             context.start();
 
             fail("Should have thrown an exception due XSLT saxon not on classpath");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(ClassNotFoundException.class, e.getCause());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltSaxonTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltSaxonTest.java
@@ -37,7 +37,7 @@ public class XsltSaxonTest extends TestSupport {
 
             fail("Should have thrown an exception due XSLT saxon not on classpath");
         } catch (Exception e) {
-            assertIsInstanceOf(ClassNotFoundException.class, e.getCause());
+            assertIsInstanceOf(ClassNotFoundException.class, e.getCause().getCause());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextStopFailureTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextStopFailureTest.java
@@ -53,10 +53,10 @@ public class DefaultCamelContextStopFailureTest extends ContextTestSupport {
             this.fail = fail;
         }
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             stopOrder = stopOrder + name;
 
             if (fail) {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/FromHasNoOutputRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/FromHasNoOutputRouteTest.java
@@ -41,9 +41,9 @@ public class FromHasNoOutputRouteTest extends ContextTestSupport {
             context.start();
             fail("Should throw exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("route1", failed.getRouteId());
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Route route1 has no output processors. You need to add outputs to the route such as to(\"log:foo\").", cause.getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/FromHasNoOutputRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/FromHasNoOutputRouteTest.java
@@ -40,9 +40,10 @@ public class FromHasNoOutputRouteTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("route1", e.getRouteId());
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("route1", failed.getRouteId());
+            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("Route route1 has no output processors. You need to add outputs to the route such as to(\"log:foo\").", cause.getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/GracefulShutdownNoAutoStartOrderClashTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/GracefulShutdownNoAutoStartOrderClashTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.impl;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -40,9 +39,9 @@ public class GracefulShutdownNoAutoStartOrderClashTest extends ContextTestSuppor
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToStartRouteException e) {
+        } catch (Exception e) {
             assertEquals("Failed to start route bar because of startupOrder clash. Route foo already has startupOrder 5 configured"
-                + " which this route have as well. Please correct startupOrder to be unique among all your routes.", e.getMessage());
+                + " which this route have as well. Please correct startupOrder to be unique among all your routes.", e.getCause().getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/GracefulShutdownNoAutoStartOrderClashTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/GracefulShutdownNoAutoStartOrderClashTest.java
@@ -41,7 +41,7 @@ public class GracefulShutdownNoAutoStartOrderClashTest extends ContextTestSuppor
             fail("Should have thrown an exception");
         } catch (Exception e) {
             assertEquals("Failed to start route bar because of startupOrder clash. Route foo already has startupOrder 5 configured"
-                + " which this route have as well. Please correct startupOrder to be unique among all your routes.", e.getCause().getMessage());
+                + " which this route have as well. Please correct startupOrder to be unique among all your routes.", e.getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyFailOnStartupTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyFailOnStartupTest.java
@@ -38,8 +38,8 @@ public class LifecycleStrategyFailOnStartupTest extends TestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (IllegalArgumentException e) {
-            assertEquals("Forced", e.getMessage());
+        } catch (Exception e) {
+            assertEquals("Forced", e.getCause().getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyFailOnStartupTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyFailOnStartupTest.java
@@ -39,7 +39,7 @@ public class LifecycleStrategyFailOnStartupTest extends TestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertEquals("Forced", e.getCause().getMessage());
+            assertEquals("Forced", e.getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyServiceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/LifecycleStrategyServiceTest.java
@@ -48,12 +48,12 @@ public class LifecycleStrategyServiceTest extends TestSupport {
         private volatile boolean started;
 
         @Override
-        public void start() throws Exception {
+        public void start() {
             started = true;
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
             started = false;
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/MultipleConsumersSupportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/MultipleConsumersSupportTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.impl;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.MultipleConsumersSupport;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
@@ -53,8 +52,8 @@ public class MultipleConsumersSupportTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToStartRouteException e) {
-            assertTrue(e.getMessage().endsWith("Multiple consumers for the same endpoint is not allowed: my:endpoint"));
+        } catch (Exception e) {
+            assertTrue(e.getCause().getMessage().endsWith("Multiple consumers for the same endpoint is not allowed: my:endpoint"));
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/MultipleConsumersSupportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/MultipleConsumersSupportTest.java
@@ -53,7 +53,7 @@ public class MultipleConsumersSupportTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertTrue(e.getCause().getMessage().endsWith("Multiple consumers for the same endpoint is not allowed: my:endpoint"));
+            assertTrue(e.getMessage().endsWith("Multiple consumers for the same endpoint is not allowed: my:endpoint"));
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RouteMustHaveOutputOnExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RouteMustHaveOutputOnExceptionTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.impl;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -72,7 +71,7 @@ public class RouteMustHaveOutputOnExceptionTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             // expected
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RouteNoOutputTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RouteNoOutputTest.java
@@ -29,9 +29,10 @@ public class RouteNoOutputTest extends ContextTestSupport {
         try {
             super.setUp();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            assertEquals("route1", e.getRouteId());
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+        } catch (Exception e) {
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            assertEquals("route1", failed.getRouteId());
+            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("Route route1 has no output processors. You need to add outputs to the route such as to(\"log:foo\").", e.getCause().getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RouteNoOutputTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RouteNoOutputTest.java
@@ -30,9 +30,9 @@ public class RouteNoOutputTest extends ContextTestSupport {
             super.setUp();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e.getCause());
+            FailedToCreateRouteException failed = assertIsInstanceOf(FailedToCreateRouteException.class, e);
             assertEquals("route1", failed.getRouteId());
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Route route1 has no output processors. You need to add outputs to the route such as to(\"log:foo\").", e.getCause().getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultFactoryFinderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultFactoryFinderTest.java
@@ -97,7 +97,7 @@ public class DefaultFactoryFinderTest {
             factoryFinder.newInstance("TestImplX");
             fail("NoFactoryAvailableException should have been thrown");
         } catch (final NoFactoryAvailableException e) {
-            assertEquals("Could not find factory class for resource: TestImplX", e.getMessage());
+            assertEquals("Cannot find factory class for resource: TestImplX", e.getMessage());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierServiceStoppingFailedEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierServiceStoppingFailedEventTest.java
@@ -84,10 +84,10 @@ public class EventNotifierServiceStoppingFailedEventTest extends ContextTestSupp
             this.fail = fail;
         }
 
-        public void start() throws Exception {
+        public void start() {
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             stopOrder = stopOrder + name;
 
             if (fail) {

--- a/core/camel-core/src/test/java/org/apache/camel/language/BeanLanguageInvalidOGNLTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/BeanLanguageInvalidOGNLTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.ExpressionIllegalSyntaxException;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.bean.MethodNotFoundException;
@@ -41,7 +40,7 @@ public class BeanLanguageInvalidOGNLTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             RuntimeCamelException rce = assertIsInstanceOf(RuntimeCamelException.class, e.getCause());
             MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, rce.getCause());
             assertEquals("getOther[xx", mnfe.getMethodName());

--- a/core/camel-core/src/test/java/org/apache/camel/language/BeanLanguageInvalidOGNLTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/BeanLanguageInvalidOGNLTest.java
@@ -41,7 +41,7 @@ public class BeanLanguageInvalidOGNLTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            RuntimeCamelException rce = assertIsInstanceOf(RuntimeCamelException.class, e.getCause());
+            RuntimeCamelException rce = assertIsInstanceOf(RuntimeCamelException.class, e);
             MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, rce.getCause());
             assertEquals("getOther[xx", mnfe.getMethodName());
             ExpressionIllegalSyntaxException cause = assertIsInstanceOf(ExpressionIllegalSyntaxException.class, mnfe.getCause());

--- a/core/camel-core/src/test/java/org/apache/camel/language/BeanTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/BeanTest.java
@@ -93,7 +93,7 @@ public class BeanTest extends LanguageTestSupport {
             exp.evaluate(exchange, Object.class);
             fail("Should throw exception");
         } catch (Exception e) {
-            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e.getCause());
+            MethodNotFoundException mnfe = assertIsInstanceOf(MethodNotFoundException.class, e);
             assertSame(user, mnfe.getBean());
             assertEquals("unknown", mnfe.getMethodName());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/model/ProcessorTypeConfigurationTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/ProcessorTypeConfigurationTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.model;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public class ProcessorTypeConfigurationTest extends ContextTestSupport {
                 }
             });
             fail("Should have thrown IllegalArgumentException");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertEquals("No bean could be found in the registry for: hello of type: org.apache.camel.Processor", e.getCause().getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/model/RoutePropertiesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/RoutePropertiesTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.model;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
@@ -71,7 +70,7 @@ public class RoutePropertiesTest extends ContextTestSupport {
             context.start();
 
             fail("");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
         }
     }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/model/StartingRoutesErrorReportedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/StartingRoutesErrorReportedTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.model;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class StartingRoutesErrorReportedTest extends ContextTestSupport {
             });
             context.start();
             fail();
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Failed to create route route1: Route(route1)[From[direct:start?foo=bar] -> [To[mock:result]... because of"));
         }
     }
@@ -50,7 +49,7 @@ public class StartingRoutesErrorReportedTest extends ContextTestSupport {
             });
             context.start();
             fail();
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Failed to create route route2 at: >>> To[direct:result?foo=bar] <<< in route:"));
         }
     }
@@ -66,7 +65,7 @@ public class StartingRoutesErrorReportedTest extends ContextTestSupport {
             });
             context.start();
             fail();
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Failed to create route route2 at: >>> To[direct:result?foo=bar] <<< in route:"));
         }
     }
@@ -84,7 +83,7 @@ public class StartingRoutesErrorReportedTest extends ContextTestSupport {
             });
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Failed to create route route3 at: >>> Bean[ref:] <<< in route:"));
         }
     }
@@ -102,7 +101,7 @@ public class StartingRoutesErrorReportedTest extends ContextTestSupport {
             });
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getMessage().contains("Ensure that the data format is valid and the associated Camel component is present on the classpath"));
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/CreateRouteWithNonExistingEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/CreateRouteWithNonExistingEndpointTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.processor;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.NoSuchEndpointException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Before;
@@ -34,7 +33,7 @@ public class CreateRouteWithNonExistingEndpointTest extends ContextTestSupport {
         try {
             super.setUp();
             fail("Should have failed to create this route!");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             log.debug("Caught expected exception: " + e, e);
             NoSuchEndpointException nse = assertIsInstanceOf(NoSuchEndpointException.class, e.getCause());
             assertEquals("uri", "thisUriDoesNotExist", nse.getUri());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ExchangeIdempotentConsumerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ExchangeIdempotentConsumerTest.java
@@ -159,12 +159,12 @@ public class ExchangeIdempotentConsumerTest extends ContextTestSupport {
         }
 
         @Override
-        public void start() throws Exception {
+        public void start() {
             // noop
         }
 
         @Override
-        public void stop() throws Exception {
+        public void stop() {
             // noop
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/IdempotentConsumerUsingCustomRepositoryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/IdempotentConsumerUsingCustomRepositoryTest.java
@@ -131,11 +131,11 @@ public class IdempotentConsumerUsingCustomRepositoryTest extends ContextTestSupp
             return true;
         }
 
-        public void start() throws Exception {
+        public void start() {
             // noop
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             // noop
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NewProcessorAndServiceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NewProcessorAndServiceTest.java
@@ -53,11 +53,11 @@ public class NewProcessorAndServiceTest extends ContextTestSupport {
             exchange.getOut().setBody("Bye World");
         }
 
-        public void start() throws Exception {
+        public void start() {
             started = true;
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             started = false;
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RouteStartupOrderClashTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RouteStartupOrderClashTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -45,7 +44,7 @@ public class RouteStartupOrderClashTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown an exception");
-        } catch (FailedToStartRouteException e) {
+        } catch (Exception e) {
             // expected
             assertTrue(e.getMessage().contains("startupOrder 2"));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RouteWithConstantFieldFromExchangeFailTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RouteWithConstantFieldFromExchangeFailTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.processor;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +33,7 @@ public class RouteWithConstantFieldFromExchangeFailTest extends ContextTestSuppo
         try {
             super.setUp();
             fail("Should have thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Constant field with name: XXX not found on Exchange.class", iae.getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsCoreAndMaxPoolInvalidTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsCoreAndMaxPoolInvalidTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -41,7 +40,7 @@ public class ThreadsCoreAndMaxPoolInvalidTest extends ContextTestSupport {
             });
 
             fail("Should have thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("MaxPoolSize must be >= corePoolSize, was 2 >= 5", iae.getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsInvalidConfigTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsInvalidConfigTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.ThreadPoolProfile;
 import org.junit.Test;
@@ -53,7 +52,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("ThreadName"));
             return;
@@ -86,7 +85,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("PoolSize"));
             return;
@@ -106,7 +105,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("MaxPoolSize"));
             return;
@@ -126,7 +125,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("KeepAliveTime"));
             return;
@@ -146,7 +145,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("MaxQueueSize"));
             return;
@@ -166,7 +165,7 @@ public class ThreadsInvalidConfigTest extends ContextTestSupport {
                             .to("mock:test");
                 }
             });
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
             assertTrue(e.getCause().getMessage().startsWith("RejectedPolicy"));
             return;

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsZeroInCoreAndMaxPoolTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsZeroInCoreAndMaxPoolTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class ThreadsZeroInCoreAndMaxPoolTest extends ContextTestSupport {
                 }
             });
             fail("Expect FailedToCreateRouteException exception here");
-        } catch (FailedToCreateRouteException ex) {
+        } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof IllegalArgumentException);
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerInvalidConfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerInvalidConfiguredTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public class ThrottlerInvalidConfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertTrue(cause.getMessage().startsWith("MaxRequestsPerPeriod expression must be provided"));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/TryCatchMustHaveExceptionConfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/TryCatchMustHaveExceptionConfiguredTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -42,7 +41,7 @@ public class TryCatchMustHaveExceptionConfiguredTest extends ContextTestSupport 
         try {
             context.start();
             fail("Should throw exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("At least one Exception must be configured to catch", e.getCause().getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRandomLoadBalanceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRandomLoadBalanceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.processor;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Before;
@@ -124,7 +123,7 @@ public class WeightedRandomLoadBalanceTest extends ContextTestSupport {
             });
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Loadbalacing with 3 should match number of distributions 2", iae.getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRandomLoadBalanceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRandomLoadBalanceTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.processor;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -124,7 +125,7 @@ public class WeightedRandomLoadBalanceTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("Loadbalacing with 3 should match number of distributions 2", iae.getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRoundRobinLoadBalanceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRoundRobinLoadBalanceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.processor;
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Before;
@@ -130,7 +129,7 @@ public class WeightedRoundRobinLoadBalanceTest extends ContextTestSupport {
             });
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("Loadbalacing with 3 should match number of distributions 2", iae.getMessage());
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRoundRobinLoadBalanceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/WeightedRoundRobinLoadBalanceTest.java
@@ -130,7 +130,7 @@ public class WeightedRoundRobinLoadBalanceTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("Loadbalacing with 3 should match number of distributions 2", iae.getMessage());
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateUnknownExecutorServiceRefTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateUnknownExecutorServiceRefTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor.aggregator;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.BodyInAggregatingStrategy;
 import org.junit.Test;
@@ -48,8 +47,8 @@ public class AggregateUnknownExecutorServiceRefTest extends ContextTestSupport {
             });
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+        } catch (Exception e) {
+            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertTrue(cause.getMessage().contains("myUnknownProfile"));
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateUnknownExecutorServiceRefTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateUnknownExecutorServiceRefTest.java
@@ -48,7 +48,7 @@ public class AggregateUnknownExecutorServiceRefTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertTrue(cause.getMessage().contains("myUnknownProfile"));
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.processor.onexception;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -45,7 +44,7 @@ public class OnExceptionHandledAndContinueTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should thrown an exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertTrue(e.getCause().getMessage().startsWith("Only one of handled or continued is allowed to be configured"));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
@@ -45,8 +45,8 @@ public class OnExceptionHandledAndContinueTest extends ContextTestSupport {
             context.start();
             fail("Should thrown an exception");
         } catch (Exception e) {
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertTrue(e.getCause().getMessage().startsWith("Only one of handled or continued is allowed to be configured"));
+            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            assertTrue(e.getCause().getCause().getMessage().startsWith("Only one of handled or continued is allowed to be configured"));
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandledAndContinueTest.java
@@ -45,8 +45,8 @@ public class OnExceptionHandledAndContinueTest extends ContextTestSupport {
             context.start();
             fail("Should thrown an exception");
         } catch (Exception e) {
-            assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
-            assertTrue(e.getCause().getCause().getMessage().startsWith("Only one of handled or continued is allowed to be configured"));
+            assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(e.getCause().getMessage().startsWith("Only one of handled or continued is allowed to be configured"));
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import javax.xml.soap.SOAPException;
 
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -48,7 +47,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
@@ -67,7 +66,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
@@ -87,7 +86,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
@@ -107,7 +106,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
@@ -128,7 +127,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
         try {
             context.start();
             fail("Should have thrown exception");
-        } catch (FailedToCreateRouteException e) {
+        } catch (Exception e) {
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertTrue(iae.getMessage().startsWith("At least one exception must be configured"));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
@@ -48,7 +48,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -67,7 +67,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -87,7 +87,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -107,7 +107,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -128,7 +128,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
             assertTrue(iae.getMessage().startsWith("At least one exception must be configured"));
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionMisconfiguredTest.java
@@ -48,7 +48,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -67,7 +67,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -87,7 +87,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -107,7 +107,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertEquals("OnException[[java.lang.Exception] -> []] is not configured.", iae.getMessage());
         }
     }
@@ -128,7 +128,7 @@ public class OnExceptionMisconfiguredTest extends ContextTestSupport {
             context.start();
             fail("Should have thrown exception");
         } catch (Exception e) {
-            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
+            IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
             assertTrue(iae.getMessage().startsWith("At least one exception must be configured"));
         }
     }

--- a/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedDuplicateIdTest.java
+++ b/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedDuplicateIdTest.java
@@ -50,7 +50,7 @@ public class ManagedDuplicateIdTest extends ManagementTestSupport {
             context.start();
             fail("Should fail");
         } catch (Exception e) {
-            assertEquals("Failed to start route foo because of duplicate id detected: clash. Please correct ids to be unique among all your routes.", e.getCause().getMessage());
+            assertEquals("Failed to start route foo because of duplicate id detected: clash. Please correct ids to be unique among all your routes.", e.getMessage());
         }
     }
 

--- a/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedDuplicateIdTest.java
+++ b/core/camel-management-impl/src/test/java/org/apache/camel/management/ManagedDuplicateIdTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.management;
 
-import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
@@ -50,8 +49,8 @@ public class ManagedDuplicateIdTest extends ManagementTestSupport {
         try {
             context.start();
             fail("Should fail");
-        } catch (FailedToStartRouteException e) {
-            assertEquals("Failed to start route foo because of duplicate id detected: clash. Please correct ids to be unique among all your routes.", e.getMessage());
+        } catch (Exception e) {
+            assertEquals("Failed to start route foo because of duplicate id detected: clash. Please correct ids to be unique among all your routes.", e.getCause().getMessage());
         }
     }
 

--- a/core/camel-management-impl/src/test/java/org/apache/camel/management/TwoManagedCamelContextClashTest.java
+++ b/core/camel-management-impl/src/test/java/org/apache/camel/management/TwoManagedCamelContextClashTest.java
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 package org.apache.camel.management;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.TestSupport;
-import org.apache.camel.VetoCamelContextStartException;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.After;
 import org.junit.Test;
@@ -107,8 +107,8 @@ public class TwoManagedCamelContextClashTest extends TestSupport {
         try {
             camel2.start();
             fail("Should have thrown an exception");
-        } catch (VetoCamelContextStartException e) {
-            assertTrue(e.getMessage().contains("is already registered"));
+        } catch (Exception e) {
+            assertTrue(e.getCause().getMessage().contains("is already registered"));
         }
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/AsyncProcessorConverterHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AsyncProcessorConverterHelper.java
@@ -100,11 +100,11 @@ public final class AsyncProcessorConverterHelper {
             }
         }
 
-        public void start() throws Exception {
+        public void start() {
             ServiceHelper.startService(processor);
         }
 
-        public void stop() throws Exception {
+        public void stop() {
             ServiceHelper.stopService(processor);
         }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/ChildServiceSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ChildServiceSupport.java
@@ -19,6 +19,7 @@ package org.apache.camel.support;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.Service;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.support.service.ServiceSupport;
@@ -30,7 +31,7 @@ public abstract class ChildServiceSupport extends ServiceSupport {
 
     protected volatile List<Service> childServices;
 
-    public void start() throws Exception {
+    public void start() {
         synchronized (lock) {
             if (status == STARTED) {
                 log.trace("Service: {} already started", this);
@@ -45,7 +46,7 @@ public abstract class ChildServiceSupport extends ServiceSupport {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while initializing service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
             try {
                 status = STARTING;
@@ -58,12 +59,12 @@ public abstract class ChildServiceSupport extends ServiceSupport {
                 status = FAILED;
                 log.trace("Error while starting service: " + this, e);
                 ServiceHelper.stopService(childServices);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         synchronized (lock) {
             if (status == STOPPED || status == SHUTTINGDOWN || status == SHUTDOWN) {
                 log.trace("Service: {} already stopped", this);
@@ -83,13 +84,13 @@ public abstract class ChildServiceSupport extends ServiceSupport {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error while stopping service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         synchronized (lock) {
             if (status == SHUTDOWN) {
                 log.trace("Service: {} already shut down", this);
@@ -110,7 +111,7 @@ public abstract class ChildServiceSupport extends ServiceSupport {
             } catch (Exception e) {
                 status = FAILED;
                 log.trace("Error shutting down service: " + this, e);
-                throw e;
+                throw RuntimeCamelException.wrapRuntimeCamelException(e);
             }
         }
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/ChildServiceSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ChildServiceSupport.java
@@ -40,9 +40,16 @@ public abstract class ChildServiceSupport extends ServiceSupport {
                 log.trace("Service: {} already starting", this);
                 return;
             }
-            status = STARTING;
-            log.trace("Starting service: {}", this);
             try {
+                initService(childServices);
+            } catch (Exception e) {
+                status = FAILED;
+                log.trace("Error while initializing service: " + this, e);
+                throw e;
+            }
+            try {
+                status = STARTING;
+                log.trace("Starting service: {}", this);
                 ServiceHelper.startService(childServices);
                 doStart();
                 status = STARTED;
@@ -123,6 +130,12 @@ public abstract class ChildServiceSupport extends ServiceSupport {
 
     protected boolean removeChildService(Object childService) {
         return childServices != null && childServices.remove(childService);
+    }
+
+    private void initService(List<Service> services) {
+        if (services != null) {
+            services.forEach(Service::init);
+        }
     }
 
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/ScheduledPollConsumer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ScheduledPollConsumer.java
@@ -399,8 +399,8 @@ public abstract class ScheduledPollConsumer extends DefaultConsumer implements R
     protected abstract int poll() throws Exception;
 
     @Override
-    protected void doStart() throws Exception {
-        super.doStart();
+    protected void doInit() throws Exception {
+        super.doInit();
 
         // validate that if backoff multiplier is in use, the threshold values is set correctly
         if (backoffMultiplier > 0) {
@@ -415,7 +415,6 @@ public abstract class ScheduledPollConsumer extends DefaultConsumer implements R
         }
         scheduler.setCamelContext(getEndpoint().getCamelContext());
         scheduler.onInit(this);
-        scheduler.scheduleTask(this);
 
         // configure scheduler with options from this consumer
         Map<String, Object> properties = new HashMap<>();
@@ -435,11 +434,19 @@ public abstract class ScheduledPollConsumer extends DefaultConsumer implements R
 
         ObjectHelper.notNull(scheduler, "scheduler", this);
         ObjectHelper.notNull(pollStrategy, "pollStrategy", this);
+    }
 
-        ServiceHelper.startService(scheduler);
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
 
-        if (isStartScheduler()) {
-            startScheduler();
+        if (scheduler != null) {
+            scheduler.scheduleTask(this);
+            ServiceHelper.startService(scheduler);
+
+            if (isStartScheduler()) {
+                startScheduler();
+            }
         }
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/SynchronousDelegateProducer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/SynchronousDelegateProducer.java
@@ -19,6 +19,7 @@ package org.apache.camel.support;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
+import org.apache.camel.support.service.ServiceHelper;
 
 /**
  * To process the delegated producer in synchronous mode.
@@ -50,12 +51,12 @@ public class SynchronousDelegateProducer implements Producer {
         producer.init();
     }
 
-    public void start() throws Exception {
-        producer.start();
+    public void start() {
+        ServiceHelper.startService(producer);
     }
 
-    public void stop() throws Exception {
-        producer.stop();
+    public void stop() {
+        ServiceHelper.stopService(producer);
     }
 
     public boolean isSingleton() {

--- a/core/camel-support/src/main/java/org/apache/camel/support/SynchronousDelegateProducer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/SynchronousDelegateProducer.java
@@ -46,6 +46,10 @@ public class SynchronousDelegateProducer implements Producer {
         producer.process(exchange);
     }
 
+    public void init() {
+        producer.init();
+    }
+
     public void start() throws Exception {
         producer.start();
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/management/MBeanInfoAssembler.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/management/MBeanInfoAssembler.java
@@ -64,13 +64,12 @@ public class MBeanInfoAssembler implements Service {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public void start() throws Exception {
+    public void start() {
         cache = LRUCacheFactory.newLRUWeakCache(1000);
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (cache != null) {
             if (LOG.isDebugEnabled() && cache instanceof LRUCache) {
                 LRUCache cache = (LRUCache) this.cache;

--- a/platforms/spring-boot/components-starter/camel-reactive-streams-starter/src/test/java/org/apache/camel/component/reactive/streams/springboot/test/support/ReactiveStreamsServiceTestSupport.java
+++ b/platforms/spring-boot/components-starter/camel-reactive-streams-starter/src/test/java/org/apache/camel/component/reactive/streams/springboot/test/support/ReactiveStreamsServiceTestSupport.java
@@ -150,12 +150,12 @@ public class ReactiveStreamsServiceTestSupport implements CamelReactiveStreamsSe
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
 
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
 
     }
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/idempotent/JdbcIdempotentRepository.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/idempotent/JdbcIdempotentRepository.java
@@ -57,11 +57,11 @@ public class JdbcIdempotentRepository implements IdempotentRepository {
         jdbc.update("DELETE * FROM ProcessedPayments");
     }
 
-    public void start() throws Exception {
+    public void start() {
         // noop
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         // noop
     }
 }


### PR DESCRIPTION
This makes it better for end users to not have to deal with `throws Exception` when they start / stop services. Also Camel's own exceptions migrated to be more runtime based.