### PR TITLE
CAMEL-13234: Use weld3 at maven cdi archetype and cdi integration tests project

### DIFF
--- a/archetypes/camel-archetype-cdi/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-cdi/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -25,13 +25,13 @@
       <defaultValue>${project.version}</defaultValue>
     </requiredProperty>
     <requiredProperty key="cdi-api-version">
-      <defaultValue>${cdi-api-1.2-version}</defaultValue>
+      <defaultValue>${cdi-api-2.0-version}</defaultValue>
     </requiredProperty>
     <requiredProperty key="deltaspike-version">
       <defaultValue>${deltaspike-version}</defaultValue>
     </requiredProperty>
-    <requiredProperty key="weld2-version">
-      <defaultValue>${weld2-version}</defaultValue>
+    <requiredProperty key="weld3-version">
+      <defaultValue>${weld3-version}</defaultValue>
     </requiredProperty>
     <requiredProperty key="maven-compiler-plugin-version">
       <defaultValue>${maven-compiler-plugin-version}</defaultValue>

--- a/archetypes/camel-archetype-cdi/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-cdi/src/main/resources/archetype-resources/pom.xml
@@ -60,6 +60,10 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cdi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
 
     <!-- logging -->
     <dependency>
@@ -122,8 +126,8 @@
           </dependency>
           <dependency>
             <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se</artifactId>
-            <version>${weld2-version}</version>
+            <artifactId>weld-se-shaded</artifactId>
+            <version>${weld3-version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/tests/camel-itest-cdi/pom.xml
+++ b/tests/camel-itest-cdi/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-1.1-version}</version>
+            <version>${cdi-api-2.0-version}</version>
         </dependency>
 
         <!-- logging -->
@@ -96,7 +96,7 @@
     <profiles>
 
         <profile>
-            <id>weld-1.2</id>
+            <id>weld-2.0</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -104,7 +104,7 @@
                 <dependency>
                     <groupId>org.jboss.weld</groupId>
                     <artifactId>weld-core-impl</artifactId>
-                    <version>${weld2-version}</version>
+                    <version>${weld3-version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
1. Fixed archetype's pom.xml: added dependency to camel-core (tried to use camel-support). @davsclaus 
1. Renamed weld-1.2 profile to weld-2.0