### PR TITLE
CAMEL-13209 Upgrading GRPC version to 1.20.0

### DIFF
--- a/components/camel-grpc/src/main/docs/grpc-component.adoc
+++ b/components/camel-grpc/src/main/docs/grpc-component.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 2.19*
 
 The gRPC component allows you to call or expose Remote Procedure Call (RPC) services
-using https://developers.google.com/protocol-buffers/docs/overview[Protocol Buffers (protobuf)] 
+using https://developers.google.com/protocol-buffers/docs/overview[Protocol Buffers (protobuf)]
 exchange format over HTTP/2 transport.
 
 Maven users will need to add the following dependency to their `pom.xml`
@@ -156,6 +156,9 @@ To enable these features the following component properties combinations must be
 TLS with OpenSSL is currently the recommended approach for using gRPC over TLS component.
 Using the JDK for ALPN is generally much slower and may not support the necessary ciphers for HTTP2. This function is not implemented in the component.
 
+There might be a need to install additional libraries according to the Operating System of choice.
+For more information consult https://github.com/grpc/grpc-java/blob/master/SECURITY.md[the Security page of gRPC].
+
 ### gRPC producer resource type mapping
 
 The table below shows the types of objects in the message body, depending on the types (simple or stream) of incoming and outgoing parameters, as well as the invocation style (synchronous or asynchronous). Please note, that invocation of the procedures with incoming stream parameter in asynchronous style are not allowed.
@@ -255,7 +258,7 @@ It's it is recommended to use Maven Protocol Buffers Plugin which calls Protocol
 
 Following steps are required:
 
-Insert operating system and CPU architecture detection extension inside **<build>** tag of the project pom.xml or set ${os.detected.classifier} parameter manually 
+Insert operating system and CPU architecture detection extension inside **<build>** tag of the project pom.xml or set ${os.detected.classifier} parameter manually
 [source,xml]
 -------------------------------------------------------------------------
 <extensions>

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
@@ -57,7 +57,7 @@ public class GrpcConsumer extends DefaultConsumer {
         this.endpoint = endpoint;
         this.configuration = configuration;
     }
-    
+
     public GrpcConfiguration getConfiguration() {
         return configuration;
     }
@@ -89,59 +89,59 @@ public class GrpcConsumer extends DefaultConsumer {
         ProxyFactory serviceProxy = new ProxyFactory();
         ServerInterceptor headerInterceptor = new GrpcHeaderInterceptor();
         MethodHandler methodHandler = new GrpcMethodHandler(endpoint, this);
-        
+
         serviceProxy.setSuperclass(GrpcUtils.constructGrpcImplBaseClass(endpoint.getServicePackage(), endpoint.getServiceName(), endpoint.getCamelContext()));
         try {
             bindableService = (BindableService)serviceProxy.create(new Class<?>[0], new Object[0], methodHandler);
         } catch (NoSuchMethodException | IllegalArgumentException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new IllegalArgumentException("Unable to create bindable proxy service for " + configuration.getService());
         }
-        
+
         if (!ObjectHelper.isEmpty(configuration.getHost()) && !ObjectHelper.isEmpty(configuration.getPort())) {
             log.debug("Building gRPC server on {}:{}", configuration.getHost(), configuration.getPort());
             serverBuilder = NettyServerBuilder.forAddress(new InetSocketAddress(configuration.getHost(), configuration.getPort()));
         } else {
             throw new IllegalArgumentException("No server start properties (host, port) specified");
         }
-        
+
         if (configuration.getNegotiationType() == NegotiationType.TLS) {
             ObjectHelper.notNull(configuration.getKeyCertChainResource(), "keyCertChainResource");
             ObjectHelper.notNull(configuration.getKeyResource(), "keyResource");
-            
+
             ClassResolver classResolver = endpoint.getCamelContext().getClassResolver();
-            
+
             SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(ResourceHelper.resolveResourceAsInputStream(classResolver, configuration.getKeyCertChainResource()),
                                                                               ResourceHelper.resolveResourceAsInputStream(classResolver, configuration.getKeyResource()),
                                                                               configuration.getKeyPassword())
                                                                    .clientAuth(ClientAuth.REQUIRE)
                                                                    .sslProvider(SslProvider.OPENSSL);
-            
+
             if (ObjectHelper.isNotEmpty(configuration.getTrustCertCollectionResource())) {
                 sslContextBuilder = sslContextBuilder.trustManager(ResourceHelper.resolveResourceAsInputStream(classResolver, configuration.getTrustCertCollectionResource()));
             }
-            
+
             serverBuilder = serverBuilder.sslContext(GrpcSslContexts.configure(sslContextBuilder).build());
         }
-        
+
         if (configuration.getAuthenticationType() == GrpcAuthType.JWT) {
             ObjectHelper.notNull(configuration.getJwtSecret(), "jwtSecret");
-            
+
             serverBuilder = serverBuilder.intercept(new JwtServerInterceptor(configuration.getJwtAlgorithm(), configuration.getJwtSecret(),
                                                                              configuration.getJwtIssuer(), configuration.getJwtSubject()));
         }
-        
+
         server = serverBuilder.addService(ServerInterceptors.intercept(bindableService, headerInterceptor))
-                              .maxMessageSize(configuration.getMaxMessageSize())
+                              .maxInboundMessageSize(configuration.getMaxMessageSize())
                               .flowControlWindow(configuration.getFlowControlWindow())
                               .maxConcurrentCallsPerConnection(configuration.getMaxConcurrentCallsPerConnection())
                               .build();
     }
-    
+
     public boolean process(Exchange exchange, AsyncCallback callback) {
         exchange.getIn().setHeader(GrpcConstants.GRPC_EVENT_TYPE_HEADER, GrpcConstants.GRPC_EVENT_TYPE_ON_NEXT);
         return doSend(exchange, callback);
     }
-    
+
     public void onCompleted(Exchange exchange) {
         if (configuration.isForwardOnCompleted()) {
             exchange.getIn().setHeader(GrpcConstants.GRPC_EVENT_TYPE_HEADER, GrpcConstants.GRPC_EVENT_TYPE_ON_COMPLETED);
@@ -154,12 +154,12 @@ public class GrpcConsumer extends DefaultConsumer {
         if (configuration.isForwardOnError()) {
             exchange.getIn().setHeader(GrpcConstants.GRPC_EVENT_TYPE_HEADER, GrpcConstants.GRPC_EVENT_TYPE_ON_ERROR);
             exchange.getIn().setBody(error);
-        
+
             doSend(exchange, done -> {
             });
         }
     }
-        
+
     private boolean doSend(Exchange exchange, AsyncCallback callback) {
         if (this.isRunAllowed()) {
             this.getAsyncProcessor().process(exchange, doneSync -> {

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/auth/jwt/JwtCallCredentials.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/auth/jwt/JwtCallCredentials.java
@@ -27,10 +27,12 @@ import org.apache.camel.component.grpc.GrpcConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.grpc.internal.GrpcAttributes.ATTR_LB_ADDR_AUTHORITY;
+
 /**
- * JSON Web Token client credentials generator and injector 
+ * JSON Web Token client credentials generator and injector
  */
-public class JwtCallCredentials implements CallCredentials {
+public class JwtCallCredentials extends CallCredentials {
     private static final Logger LOG = LoggerFactory.getLogger(JwtCallCredentials.class);
     private final String jwtToken;
 
@@ -39,8 +41,8 @@ public class JwtCallCredentials implements CallCredentials {
     }
 
     @Override
-    public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs, Executor executor, MetadataApplier applier) {
-        String authority = attrs.get(ATTR_AUTHORITY);
+    public void applyRequestMetadata(RequestInfo requestInfo, Executor executor, MetadataApplier metadataApplier) {
+        String authority = requestInfo.getTransportAttrs().get(ATTR_LB_ADDR_AUTHORITY);
 
         LOG.debug("Using authority {} for credentials", authority);
         executor.execute(new Runnable() {
@@ -51,10 +53,10 @@ public class JwtCallCredentials implements CallCredentials {
                     Metadata headers = new Metadata();
                     Metadata.Key<String> jwtKey = GrpcConstants.GRPC_JWT_METADATA_KEY;
                     headers.put(jwtKey, jwtToken);
-                    applier.apply(headers);
+                    metadataApplier.apply(headers);
                 } catch (Throwable e) {
                     LOG.debug("Unable to set metadata credentials header", e);
-                    applier.fail(Status.UNAUTHENTICATED.withCause(e));
+                    metadataApplier.fail(Status.UNAUTHENTICATED.withCause(e));
                 }
             }
         });

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerAsyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerAsyncTest.java
@@ -30,12 +30,10 @@ import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Ignore("TODO: investigate for Camel 3.0")
 public class GrpcProducerAsyncTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerAsyncTest.class);
 
@@ -117,7 +115,7 @@ public class GrpcProducerAsyncTest extends CamelTestSupport {
         assertEquals(asyncPongResponseList.get(1).getPongId(), GRPC_TEST_PONG_ID02);
         assertEquals(asyncPongResponseList.get(0).getPongName(), GRPC_TEST_PING_VALUE + GRPC_TEST_PONG_VALUE);
     }
-    
+
     @Test
     public void testPingAsyncSyncMethodInvocation() throws Exception {
         LOG.info("gRPC PingAsyncSync method test start");
@@ -144,7 +142,7 @@ public class GrpcProducerAsyncTest extends CamelTestSupport {
         assertEquals(asyncPongResponseList.get(0).getPongId(), GRPC_TEST_PING_ID);
         assertEquals(asyncPongResponseList.get(0).getPongName(), GRPC_TEST_PING_VALUE + GRPC_TEST_PONG_VALUE);
     }
-    
+
     @Test
     public void testPingAsyncAsyncMethodInvocation() throws Exception {
         LOG.info("gRPC PingAsyncAsync method test start");
@@ -206,7 +204,7 @@ public class GrpcProducerAsyncTest extends CamelTestSupport {
             responseObserver.onNext(response02);
             responseObserver.onCompleted();
         }
-        
+
         @Override
         public StreamObserver<PingRequest> pingAsyncSync(StreamObserver<PongResponse> responseObserver) {
             StreamObserver<PingRequest> requestObserver = new StreamObserver<PingRequest>() {
@@ -229,7 +227,7 @@ public class GrpcProducerAsyncTest extends CamelTestSupport {
             };
             return requestObserver;
         }
-        
+
         @Override
         public StreamObserver<PingRequest> pingAsyncAsync(StreamObserver<PongResponse> responseObserver) {
             StreamObserver<PingRequest> requestObserver = new StreamObserver<PingRequest>() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -29,12 +29,10 @@ import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Ignore("TODO: investigate for Camel 3.0")
 public class GrpcProducerStreamingTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerStreamingTest.class);
 

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -82,7 +82,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
             template.sendBody("direct:grpc-stream-async-async-route", PingRequest.newBuilder().setPingName(String.valueOf(i)).build());
         }
 
-        template.sendBody("direct:grpc-stream-async-async-route", PingRequest.newBuilder().setPingName(String.valueOf("error")).build());
+        template.sendBody("direct:grpc-stream-async-async-route", PingRequest.newBuilder().setPingName("error").build());
 
 
 
@@ -90,7 +90,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
         replies.expectedMessageCount(messageGroupCount);
         replies.assertIsSatisfied();
 
-        Thread.sleep(200);
+        Thread.sleep(1000);
 
         for (int i = messageGroupCount + 1; i <= 2 * messageGroupCount; i++) {
             template.sendBody("direct:grpc-stream-async-async-route", PingRequest.newBuilder().setPingName(String.valueOf(i)).build());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -253,13 +253,13 @@
         <google-mail-guava-version>17.0</google-mail-guava-version>
         <google-truth-version>0.30</google-truth-version>
         <grizzly-websockets-version>2.3.25</grizzly-websockets-version>
-        <grpc-version>1.15.0</grpc-version>
-        <grpc-google-auth-library-version>0.9.0</grpc-google-auth-library-version>
-        <grpc-guava-version>20.0</grpc-guava-version>
+        <grpc-version>1.20.0</grpc-version>
+        <grpc-google-auth-library-version>0.13.0</grpc-google-auth-library-version>
+        <grpc-guava-version>26.0-android</grpc-guava-version>
         <grpc-java-jwt-version>3.2.0</grpc-java-jwt-version>
-        <grpc-netty-tcnative-boringssl-static-version>2.0.18.Final</grpc-netty-tcnative-boringssl-static-version>
-        <grpc-bundle-version>1.15.0_1</grpc-bundle-version>
-        <grpc-errorprone-version>2.2.0</grpc-errorprone-version>
+        <grpc-netty-tcnative-boringssl-static-version>2.0.22.Final</grpc-netty-tcnative-boringssl-static-version>
+        <grpc-bundle-version>1.20.0_1</grpc-bundle-version>
+        <grpc-errorprone-version>2.3.0</grpc-errorprone-version>
         <gson-version>2.8.5</gson-version>
         <guice3-version>3.0</guice3-version>
         <guice-bundle-version>3.0_1</guice-bundle-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -556,7 +556,7 @@
         <properties-maven-plugin-version>1.0-alpha-2</properties-maven-plugin-version>
         <protobuf-version>3.5.1</protobuf-version>
         <protobuf-javanano-version>3.1.0</protobuf-javanano-version>
-        <protobuf-maven-plugin-version>0.5.1</protobuf-maven-plugin-version>
+        <protobuf-maven-plugin-version>0.6.1</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <pubnub-version>4.21.0</pubnub-version>
         <pulsar-version>2.2.1</pulsar-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -256,7 +256,7 @@
         <grpc-version>1.20.0</grpc-version>
         <grpc-google-auth-library-version>0.13.0</grpc-google-auth-library-version>
         <grpc-guava-version>26.0-android</grpc-guava-version>
-        <grpc-java-jwt-version>3.2.0</grpc-java-jwt-version>
+        <grpc-java-jwt-version>3.7.0</grpc-java-jwt-version>
         <grpc-netty-tcnative-boringssl-static-version>2.0.22.Final</grpc-netty-tcnative-boringssl-static-version>
         <grpc-bundle-version>1.20.0_1</grpc-bundle-version>
         <grpc-errorprone-version>2.3.2</grpc-errorprone-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -259,7 +259,7 @@
         <grpc-java-jwt-version>3.2.0</grpc-java-jwt-version>
         <grpc-netty-tcnative-boringssl-static-version>2.0.22.Final</grpc-netty-tcnative-boringssl-static-version>
         <grpc-bundle-version>1.20.0_1</grpc-bundle-version>
-        <grpc-errorprone-version>2.3.0</grpc-errorprone-version>
+        <grpc-errorprone-version>2.3.2</grpc-errorprone-version>
         <gson-version>2.8.5</gson-version>
         <guice3-version>3.0</guice3-version>
         <guice-bundle-version>3.0_1</guice-bundle-version>

--- a/platforms/spring-boot/components-starter/camel-grpc-starter/pom.xml
+++ b/platforms/spring-boot/components-starter/camel-grpc-starter/pom.xml
@@ -38,14 +38,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-grpc</artifactId>
       <version>${project.version}</version>
-      <!--START OF GENERATED CODE-->
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-      <!--END OF GENERATED CODE-->
     </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>


### PR DESCRIPTION
Also upgrading associated dependencies and needed refactoring.

Addressing https://issues.apache.org/jira/browse/CAMEL-13209

It seems there were some breaking changes from version **1.15.0** to **1.20.0**

**Resources used for the version changes**
- [grpc version 1.20.0 is the latest Tag version](https://github.com/grpc/grpc-java)
- [grpc-google-auth-library-version](https://github.com/grpc/grpc-java/blob/v1.20.x/build.gradle#L111)
- [grpc-guava-version](https://github.com/grpc/grpc-java/blob/v1.20.x/build.gradle#L112)
- [grpc-netty-tcnative-boringssl-static-version](https://github.com/grpc/grpc-java/blob/v1.20.x/build.gradle#L228)
- [grpc-bundle-version](https://mvnrepository.com/artifact/org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc)
- [grpc-errorprone-version](https://github.com/grpc/grpc-java/blob/v1.20.x/build.gradle#L195)
- grpc-java-jwt-version -> Wasn't updated to 3.8.0 as a test was failing.

**Refactoring**

There is one thing in particular that has to be reviewed since I haven't used GRPC myself in the past:
the usage of the `io.grpc.internal.GrpcAttributes.ATTR_LB_ADDR_AUTHORITY` in place of the previous (and currently not available) `ATTR_AUTHORITY`.

**Additional Task per Code Review**
- [x] protobuf-maven-plugin-version -> 0.6.1 (raised by @dmvolod)
- [x] `.maxMessageSize(configuration.getMaxMessageSize()) -> .maxInboundMessageSize(configuration.getMaxMessageSize())` (raised by @dmvolod)
- [x] Untag @ignore("TODO: investigate for Camel 3.0") from tests and try to make them to be running. (raised by @dmvolod) - resolution comment: works out of the box. Only testPingAsyncAsyncRecovery was intermittently failing due to race condition. Increasing the sleep time to 1sec was consistently passing on multiple trials.
- [x] May be investigate why grpc-java-jwt-version update fails tests. (raised by @dmvolod) - resolution comment: works fine for version 3.7.0
- [x] correct grpc-errorprone-version -> 2.3.2 (raised by @dmvolod)
- [ ] Check Karaf feature related to camel-grpc and camel-protobuf under platform/karaf/features and check with the integration test in tests/camel-itest-karaf (raised by @oscerd)
- [ ] Check Spring Boot integration test in tests/camel-itest-spring-boot (raised by @oscerd)
- [x] libxcrypt-compat installation for security options per OS might be needed. It's would be nice to add this info from the https://github.com/grpc/grpc-java/blob/master/SECURITY.md or point this file link to the doc and some info. (raised by @dmvolod)