### PR TITLE
CAMEL-13543: Make CamelSpringTestContextLoader set property overrides…

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/CamelContextHelper.java
@@ -702,7 +702,7 @@ public final class CamelContextHelper {
      *                   has been configured.
      * @return the properties component, or <tt>null</tt> if none has been defined, and auto create is <tt>false</tt>.
      */
-    public static Component lookupPropertiesComponent(CamelContext camelContext, boolean autoCreate) {
+    public static PropertiesComponent lookupPropertiesComponent(CamelContext camelContext, boolean autoCreate) {
         // no existing properties component so lookup and add as component if possible
         PropertiesComponent answer = (PropertiesComponent) camelContext.hasComponent("properties");
         if (answer == null) {

--- a/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringTestContextLoader.java
+++ b/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringTestContextLoader.java
@@ -51,7 +51,12 @@ import org.springframework.test.context.support.AbstractContextLoader;
 import org.springframework.test.context.support.AbstractGenericContextLoader;
 import org.springframework.test.context.support.GenericXmlContextLoader;
 import org.springframework.util.StringUtils;
+
 import static org.apache.camel.test.spring.CamelSpringTestHelper.getAllMethods;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.util.CamelContextHelper;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 
 /**
  * Replacement for the default {@link GenericXmlContextLoader} that provides hooks for
@@ -145,8 +150,9 @@ public class CamelSpringTestContextLoader extends AbstractContextLoader {
         AnnotationConfigUtils.registerAnnotationConfigProcessors(context);
         
         // Pre CamelContext(s) instantiation setup
-        handleDisableJmx(context, testClass);
-
+        handleDisableJmx(context, testClass);        
+        handleUseOverridePropertiesWithPropertiesComponent(context, testClass);
+        
         // Temporarily disable CamelContext start while the contexts are instantiated.
         SpringCamelContext.setNoStart(true);
         context.refresh();
@@ -160,7 +166,6 @@ public class CamelSpringTestContextLoader extends AbstractContextLoader {
         handleShutdownTimeout(context, testClass);
         handleMockEndpoints(context, testClass);
         handleMockEndpointsAndSkip(context, testClass);
-        handleUseOverridePropertiesWithPropertiesComponent(context, testClass);
 
         // CamelContext(s) startup
         handleCamelContextStartup(context, testClass);
@@ -435,9 +440,9 @@ public class CamelSpringTestContextLoader extends AbstractContextLoader {
     }
     
     /**
-     * Handles override this method to include and override properties with the Camel {@link org.apache.camel.component.properties.PropertiesComponent}.
+     * Sets property overrides for the Camel {@link org.apache.camel.component.properties.PropertiesComponent}.
      *
-     * @param context the initialized Spring context
+     * @param context the pre-refresh Spring context
      * @param testClass the test class being executed
      */
     protected void handleUseOverridePropertiesWithPropertiesComponent(ConfigurableApplicationContext context, Class<?> testClass) throws Exception {
@@ -469,21 +474,25 @@ public class CamelSpringTestContextLoader extends AbstractContextLoader {
                 }
             }
         }
+        
+        Properties extra = new Properties();
+        for (Properties prop : properties) {
+            extra.putAll(prop);
+        }
 
-        if (properties.size() != 0) {
-            CamelSpringTestHelper.doToSpringCamelContexts(context, new DoToSpringCamelContextsStrategy() {
-                public void execute(String contextName, SpringCamelContext camelContext) throws Exception {
-                    PropertiesComponent pc = camelContext.getComponent("properties", PropertiesComponent.class);
-                    Properties extra = new Properties();
-                    for (Properties prop : properties) {
-                        extra.putAll(prop);
-                    }
-                    if (!extra.isEmpty()) {
-                        LOG.info("Using {} properties to override any existing properties on the PropertiesComponent on CamelContext with name [{}].", extra.size(), contextName);
+        if (!extra.isEmpty()) {
+            context.addBeanFactoryPostProcessor(beanFactory -> beanFactory.addBeanPostProcessor(new BeanPostProcessor() {
+                @Override
+                public Object postProcessAfterInitialization(Object bean, String beanName) {
+                    if (bean instanceof CamelContext) {
+                        CamelContext camelContext = (CamelContext) bean;
+                        PropertiesComponent pc = CamelContextHelper.lookupPropertiesComponent(camelContext, true);
+                        LOG.info("Using {} properties to override any existing properties on the PropertiesComponent on CamelContext with name [{}].", extra.size(), camelContext.getName());
                         pc.setOverrideProperties(extra);
                     }
+                    return bean;
                 }
-            });
+            }));
         }
     }
 

--- a/components/camel-test-spring/src/test/java/org/apache/camel/test/spring/CamelSpringOverridePropertiesForPropertyInjectTest.java
+++ b/components/camel-test-spring/src/test/java/org/apache/camel/test/spring/CamelSpringOverridePropertiesForPropertyInjectTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.spring;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextConfiguration()
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class CamelSpringOverridePropertiesForPropertyInjectTest {
+    
+    private static final String EXPECTED_PROPERTY_VALUE = "The value is overriden";
+    
+    @Produce(uri = "direct:start-override-route")
+    private ProducerTemplate start;
+
+    @UseOverridePropertiesWithPropertiesComponent
+    public static Properties override() {
+        Properties answer = new Properties();
+        answer.put("property.to.override", EXPECTED_PROPERTY_VALUE);
+        return answer;
+    }
+
+    @Test
+    public void testOverride() throws Exception {
+        String response = start.requestBody((Object)"ignored", String.class);
+
+        assertThat(response, is(EXPECTED_PROPERTY_VALUE));
+    }
+
+}

--- a/components/camel-test-spring/src/test/java/org/apache/camel/test/spring/TestPropertyInjectRouteBuilder.java
+++ b/components/camel-test-spring/src/test/java/org/apache/camel/test/spring/TestPropertyInjectRouteBuilder.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.spring;
+
+import org.apache.camel.PropertyInject;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TestPropertyInjectRouteBuilder extends RouteBuilder {
+
+    @PropertyInject("{{property.to.override}}")
+    private String propertyToOverride;
+    
+    @Override
+    public void configure() throws Exception {
+        from("direct:start-override-route")
+            .transform(constant(propertyToOverride));
+    }
+
+}

--- a/components/camel-test-spring/src/test/resources/org/apache/camel/test/spring/CamelSpringOverridePropertiesForPropertyInjectTest-context.xml
+++ b/components/camel-test-spring/src/test/resources/org/apache/camel/test/spring/CamelSpringOverridePropertiesForPropertyInjectTest-context.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+		http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd ">
+
+  <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+    <property name="location" value="classpath:org/apache/camel/test/spring/test.properties"/>
+  </bean>
+  
+  <bean id="testRouteBuilder" class="org.apache.camel.test.spring.TestPropertyInjectRouteBuilder"></bean>
+
+  <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/spring">
+      <routeBuilder ref="testRouteBuilder"/>
+  </camelContext>
+
+</beans>

--- a/components/camel-test-spring/src/test/resources/org/apache/camel/test/spring/test.properties
+++ b/components/camel-test-spring/src/test/resources/org/apache/camel/test/spring/test.properties
@@ -17,3 +17,4 @@
 
 cool.end=mock:test
 mock.skip=seda:*
+property.to.override=This value should be overriden


### PR DESCRIPTION
… before the CamelContext is injected into any other bean

https://issues.apache.org/jira/browse/CAMEL-13543

The change here is to set the property overrides using a Spring BeanPostProcessor for the CamelContext, rather than setting them once the entire Spring context is initialized. My understanding is this will ensure the overrides are set before the CamelContext is injected into other beans during Spring initialization.
