### PR TITLE
CAMEL-13545: fix netty4-http memory issues

### DIFF
--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConstants.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/NettyHttpConstants.java
@@ -28,6 +28,7 @@ public final class NettyHttpConstants {
     @Deprecated
     public static final String HTTP_RESPONSE_TEXT = Exchange.HTTP_RESPONSE_TEXT;
     public static final String HTTP_AUTHENTICATION = "CamelHttpAuthentication";
+    public static final String PROXY_REQUEST = "NettyHttpProxyRequest";
 
     private NettyHttpConstants() {
     }

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerChannelHandler.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/handlers/HttpServerChannelHandler.java
@@ -41,6 +41,7 @@ import org.apache.camel.component.netty4.NettyHelper;
 import org.apache.camel.component.netty4.handlers.ServerChannelHandler;
 import org.apache.camel.component.netty4.http.HttpPrincipal;
 import org.apache.camel.component.netty4.http.NettyHttpConfiguration;
+import org.apache.camel.component.netty4.http.NettyHttpConstants;
 import org.apache.camel.component.netty4.http.NettyHttpConsumer;
 import org.apache.camel.component.netty4.http.NettyHttpSecurityConfiguration;
 import org.apache.camel.component.netty4.http.SecurityAuthenticator;
@@ -282,6 +283,7 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
 
         final Message in = exchange.getIn();
         if (configuration.isHttpProxy()) {
+            exchange.setProperty(NettyHttpConstants.PROXY_REQUEST, request);
             in.removeHeader("Proxy-Connection");
         }
     }


### PR DESCRIPTION
`DefaultNettyHttpBinding::toNettyRequest` could allocate a new Netty `ByteBuf` (e.g. via `NettyConverter::toByteBuffer`) which in turn might or might not be passed to the `FullHttpRequest` depending on the resulting buffer size: if it's 0 it will not be set as content of the request. In that case this causes a memory leak.

The buffer having the size of 0 is quite common for `GET` or `OPTIONS` HTTP method requests, so releasing the buffer if the incoming request is received when acting as a proxy will cause the any downstream Netty requests (say in a scenario `from("netty-http:proxy:...").toD("netty-http:...")`) to block.

So additional optimization was added to store the proxy HTTP request in the `Exchange` property and to check if the current request in the `NettyHttpMessage` has the same reference; and in that case the proxy HTTP request will be reused, only changes to the HTTP method, protocol or request URL will be applied.

Tests pass, would appreciate if my assumptions would be double checked.