### PR TITLE
CAMEL-13400 Camel FTP Cannot list directory with 'File not found' prepending additional '/' in front of directory automatically

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
@@ -187,7 +187,7 @@ public class FtpConsumer extends RemoteFileConsumer<FTPFile> {
                 if (endpoint.isRecursive() && depth < endpoint.getMaxDepth() && isValidFile(remote, true, files)) {
                     // recursive scan and add the sub files and folders
                     String subDirectory = file.getName();
-                    String path = absolutePath + "/" + subDirectory;
+                    String path = ObjectHelper.isNotEmpty(absolutePath) ? absolutePath + "/" + subDirectory : subDirectory;
                     boolean canPollMore = pollSubDirectory(path, subDirectory, fileList, depth);
                     if (!canPollMore) {
                         return false;

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConsumer.java
@@ -174,7 +174,7 @@ public class SftpConsumer extends RemoteFileConsumer<SftpRemoteFile> {
                 if (endpoint.isRecursive() && depth < endpoint.getMaxDepth() && isValidFile(remote, true, files)) {
                     // recursive scan and add the sub files and folders
                     String subDirectory = file.getFilename();
-                    String path = absolutePath + "/" + subDirectory;
+                    String path = ObjectHelper.isNotEmpty(absolutePath) ? absolutePath + "/" + subDirectory : subDirectory;
                     boolean canPollMore = pollSubDirectory(path, subDirectory, fileList, depth);
                     if (!canPollMore) {
                         return false;

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FromFtpRecursiveNotStepwiseNoBasePath.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FromFtpRecursiveNotStepwiseNoBasePath.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FromFtpRecursiveNotStepwiseNoBasePath extends FtpServerTestSupport {
+
+  protected String getFtpUrl() {
+    return "ftp://admin@localhost:" + getPort() + "?password=admin&initialDelay=3000&stepwise=false"
+        + "&recursive=true";
+  }
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    prepareFtpServer();
+  }
+
+  @Test
+  public void testRecursiveNotStepwiseNoBasePath() throws Exception {
+    //CAMEL-13400
+    MockEndpoint mock = getMockEndpoint("mock:result");
+    mock.expectedBodiesReceivedInAnyOrder("Bye World", "Hello World", "Goodday World");
+    assertMockEndpointsSatisfied();
+  }
+
+  @Override
+  protected RouteBuilder createRouteBuilder() throws Exception {
+    return new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+        from(getFtpUrl())
+            .convertBodyTo(String.class)
+            .to("log:ftp")
+            .to("mock:result");
+      }
+    };
+  }
+
+  private void prepareFtpServer() throws Exception {
+    sendFile(getFtpUrl(), "Bye World", "bye.txt");
+    sendFile(getFtpUrl(), "Hello World", "sub/hello.txt");
+    sendFile(getFtpUrl(), "Goodday World", "sub/sub2/godday.txt");
+  }
+}

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/FromSftpRecursiveNotStepwiseNoBasePath.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/FromSftpRecursiveNotStepwiseNoBasePath.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote.sftp;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FromSftpRecursiveNotStepwiseNoBasePath extends SftpServerTestSupport {
+
+  protected String getSftpUrl() {
+    return "sftp://admin@localhost:" + getPort() + "?password=admin&initialDelay=3000&stepwise=false"
+        + "&recursive=true";
+  }
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    rootDirMode = true;
+    super.setUp();
+    prepareFtpServer();
+  }
+
+  @Test
+  public void testRecursiveNotStepwiseNoBasePath() throws Exception {
+    //CAMEL-13400
+    MockEndpoint mock = getMockEndpoint("mock:result");
+    mock.expectedBodiesReceivedInAnyOrder("Bye World", "Hello World", "Goodday World");
+    assertMockEndpointsSatisfied();
+  }
+
+  @Override
+  protected RouteBuilder createRouteBuilder() throws Exception {
+    return new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+        from(getSftpUrl())
+            .convertBodyTo(String.class)
+            .to("mock:result");
+      }
+    };
+  }
+
+  private void prepareFtpServer() throws Exception {
+    sendFile("Bye World", "bye.txt");
+    sendFile("Hello World", "sub/hello.txt");
+    sendFile("Goodday World", "sub/sub2/godday.txt");
+  }
+
+  public void sendFile(Object body, String fileName) {
+    template.sendBodyAndHeader("file://" + FTP_ROOT_DIR, body, Exchange.FILE_NAME, fileName);
+  }
+}

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpServerTestSupport.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/SftpServerTestSupport.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file.remote.sftp;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.List;
 import org.apache.camel.component.file.remote.BaseServerTestSupport;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.commons.io.FileUtils;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
 import org.apache.sshd.common.session.helpers.AbstractSession;
 import org.apache.sshd.server.SshServer;
@@ -40,6 +42,7 @@ public class SftpServerTestSupport extends BaseServerTestSupport {
     protected SshServer sshd;
     protected boolean canTest;
     protected String oldUserHome;
+    protected boolean rootDirMode = false;
 
     @Override
     @Before
@@ -73,6 +76,9 @@ public class SftpServerTestSupport extends BaseServerTestSupport {
             sshd.setCommandFactory(new ScpCommandFactory());
             sshd.setPasswordAuthenticator((username, password, session) -> true);
             sshd.setPublickeyAuthenticator((username, password, session) -> true);
+            if (rootDirMode) {
+              sshd.setFileSystemFactory(new VirtualFileSystemFactory(FileSystems.getDefault().getPath(System.getProperty("user.dir") + "/target/res")));
+            }
             sshd.start();
         } catch (Exception e) {
             // ignore if algorithm is not on the OS


### PR DESCRIPTION
-Check empty base path before adding '/' (FtpConsumer) .
-Add a new test.