### PR TITLE
Add instruction to create unique constraint for JDBC idempotent repository

### DIFF
--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -533,6 +533,9 @@ WARNING: The SQL Server *TIMESTAMP* type is a fixed-length binary-string type. 
 does not map to any of the JDBC time types: *DATE*, *TIME*, or
 *TIMESTAMP*.
 
+When working with concurrent consumers it is crucial to create a unique constraint on the columns processorName and messageId.
+Because the syntax for this constraint differs from database to database, we do not show it here.
+
 ==== Customize the JdbcMessageIdRepository
 
 Starting with *Camel 2.9.1* you have a few options to tune the


### PR DESCRIPTION
This pull request adds an instruction to Camel's SQL component documentation.

Implementing the Idempotent Consumer pattern with the JDBC based idempotent repository from Camel's SQL component requires a unique constraint on the database when there are concurrent consumers. Otherwise it is possible to consume duplicate messages.

