### PR TITLE
Camel 2.x - CAMEL-13587 backporting from master

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/MessageHistory.java
+++ b/camel-core/src/main/java/org/apache/camel/MessageHistory.java
@@ -48,6 +48,7 @@ public interface MessageHistory {
 
     /**
      * Gets the elapsed time in millis processing the node took
+     * (this is 0 until the node processing is done)
      */
     long getElapsed();
 

--- a/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
+++ b/camel-core/src/main/java/org/apache/camel/impl/DefaultInflightRepository.java
@@ -223,7 +223,12 @@ public class DefaultInflightRepository extends ServiceSupport implements Infligh
             // get latest entry
             MessageHistory history = list.getLast();
             if (history != null) {
-                return history.getElapsed();
+                long elapsed = history.getElapsed();
+                if (elapsed == 0 && history.getTime() > 0) {
+                    // still in progress, so lets compute it via the start time
+                    elapsed = System.currentTimeMillis() - history.getTime();
+                }
+                return elapsed;
             } else {
                 return 0;
             }


### PR DESCRIPTION
CAMEL-13587: Inflight repository browse should compute elapsed if themessage is still inflight at a given node. Thanks to Barbara De Vido for reporting.
Backporting from master