### PR TITLE
Fix MongoDB InputStream conversion bug

### DIFF
--- a/components/camel-mongodb3/src/main/java/org/apache/camel/component/mongodb3/converters/MongoDbBasicConverters.java
+++ b/components/camel-mongodb3/src/main/java/org/apache/camel/component/mongodb3/converters/MongoDbBasicConverters.java
@@ -106,6 +106,8 @@ public final class MongoDbBasicConverters {
             } else if (!Character.isWhitespace(input[i])) {
                 return true;
             }
+
+            i++;
         }
         return true;
     }

--- a/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbConversionsTest.java
+++ b/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbConversionsTest.java
@@ -81,6 +81,14 @@ public class MongoDbConversionsTest extends AbstractMongoDbTest {
     }
 
     @Test
+    public void testInsertJsonInputStreamWithSpaces() throws Exception {
+        assertEquals(0, testCollection.count());
+        template.requestBody("direct:insertJsonString", IOConverter.toInputStream("    {\"test\": [\"test\"], \"_id\": \"testInsertJsonStringWithSpaces\"}\n", null));
+        Document b = testCollection.find(eq(MONGO_ID, "testInsertJsonStringWithSpaces")).first();
+        assertNotNull("No record with 'testInsertJsonStringWithSpaces' _id", b);
+    }
+
+    @Test
     public void testInsertBsonInputStream() {
         assertEquals(0, testCollection.count());
 


### PR DESCRIPTION
InputStream with spaces at the begining cause infinite loop.