### PR TITLE
Added compatibility notes for server 5 and beyond

### DIFF
--- a/components/camel-couchbase/src/main/docs/couchbase-component.adoc
+++ b/components/camel-couchbase/src/main/docs/couchbase-component.adoc
@@ -148,3 +148,10 @@ The component supports 3 options, which are listed below.
 |===
 // spring-boot-auto-configure options: END
 
+=== Couchbase SDK compatibility
+This component is currently using a "Legacy SDK" version of couchbase-client.
+
+In order to authenticate with newer versions of Couchbase Server 5.0 and beyond, as per instructions on the  https://docs.couchbase.com/java-sdk/2.7/sdk-authentication-overview.html/[CouchBase Java SDK Authentication]:
+
+ * The value formerly interpreted as a bucket-name is now interpreted as a username. The username must correspond to a user defined on the cluster that is being accessed.
+ * The value formerly interpreted as a bucket-password is now interpreted as the password of the defined user.


### PR DESCRIPTION
I struggled a bit with the couchbase component, where it constantly complained about authentication failure. Once I discovered that the camel component is utilizing an older version of the couchbase sdk (1.4.13), I thought I won't be able to use the component until it is upgraded to version 2.4+. But with the notes on using the legacy SDK, I managed to utilize this couchbase component with my current version of couchbase.