### PR TITLE
CAMEL-13491: Fixed camel-test with isCreateCamelContextPerClass = tru…

### DIFF
--- a/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringTestSupport.java
+++ b/components/camel-test-spring/src/main/java/org/apache/camel/test/spring/CamelSpringTestSupport.java
@@ -21,7 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.spring.CamelBeanPostProcessor;
+import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.test.ExcludingPackageScanClassResolver;
 import org.apache.camel.test.junit4.CamelTestSupport;
@@ -44,23 +44,12 @@ public abstract class CamelSpringTestSupport extends CamelTestSupport {
     protected AbstractApplicationContext applicationContext;
     protected abstract AbstractApplicationContext createApplicationContext();
 
-    /**
-     * Lets post process this test instance to process any Camel annotations.
-     * Note that using Spring Test or Guice is a more powerful approach.
-     */
     @Override
     public void postProcessTest() throws Exception {
-        super.postProcessTest();
         if (isCreateCamelContextPerClass()) {
             applicationContext = threadAppContext.get();
         }
-
-        // use the bean post processor from camel-spring
-        CamelBeanPostProcessor processor = new CamelBeanPostProcessor();
-        processor.setApplicationContext(applicationContext);
-        processor.setCamelContext(context);
-        processor.postProcessBeforeInitialization(this, getClass().getName());
-        processor.postProcessAfterInitialization(this, getClass().getName());
+        super.postProcessTest();
     }
 
     @Override

--- a/components/camel-test-spring/src/test/java/org/apache/camel/test/patterns/SimpleMockTest.java
+++ b/components/camel-test-spring/src/test/java/org/apache/camel/test/patterns/SimpleMockTest.java
@@ -16,12 +16,22 @@
  */
 package org.apache.camel.test.patterns;
 
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class SimpleMockTest extends CamelSpringTestSupport {
+
+    @EndpointInject("mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce("direct:start")
+    protected ProducerTemplate template;
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {
@@ -30,11 +40,24 @@ public class SimpleMockTest extends CamelSpringTestSupport {
 
     @Test
     public void testMock() throws Exception {
-        getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");
+        String expectedBody = "Hello World";
 
-        template.sendBody("direct:start", "Hello World");
+        resultEndpoint.expectedBodiesReceived(expectedBody);
 
-        assertMockEndpointsSatisfied();
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+    }
+
+    @Test
+    public void testMockAgain() throws Exception {
+        String expectedBody = "Bye World";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
     }
 
 }

--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTearDownRule.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTearDownRule.java
@@ -1,13 +1,13 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,9 @@ package org.apache.camel.test.junit4;
 
 import org.junit.rules.ExternalResource;
 
+/**
+ * A JUnit rule to tear down Camel when using createCamelContextPerClass=true.
+ */
 public class CamelTearDownRule extends ExternalResource {
 
     private final ThreadLocal<CamelTestSupport> testSupport;

--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTearDownRule.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/CamelTearDownRule.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit4;
+
+import org.junit.rules.ExternalResource;
+
+public class CamelTearDownRule extends ExternalResource {
+
+    private final ThreadLocal<CamelTestSupport> testSupport;
+
+    public CamelTearDownRule(ThreadLocal<CamelTestSupport> testSupport) {
+        this.testSupport = testSupport;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before();
+    }
+
+    @Override
+    protected void after() {
+        CamelTestSupport support = testSupport.get();
+        if (support != null && support.isCreateCamelContextPerClass()) {
+            try {
+                support.tearDownCreateCamelContextPerClass();
+            } catch (Throwable e) {
+                // ignore
+            }
+        }
+        super.after();
+    }
+}

--- a/components/camel-test/src/main/java/org/apache/camel/test/junit4/TestSupport.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/junit4/TestSupport.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
@@ -38,6 +39,8 @@ import org.apache.camel.support.PredicateAssertHelper;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +52,8 @@ public abstract class TestSupport extends Assert {
     protected static final String LS = System.lineSeparator();
     private static final Logger LOG = LoggerFactory.getLogger(TestSupport.class);
     protected Logger log = LoggerFactory.getLogger(getClass());
-
     private TestName testName = new TestName();
+    private CamelTestWatcher camelTestWatcher = new CamelTestWatcher();
 
     // Builder methods for expressions used when testing
     // -------------------------------------------------------------------------

--- a/components/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestFalseTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestFalseTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.patterns;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateCamelContextPerTestFalseTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateCamelContextPerTestFalseTest.class);
+
+    private static final AtomicInteger CREATED_CONTEXTS = new AtomicInteger();
+    private static final AtomicInteger POST_TEAR_DOWN = new AtomicInteger();
+
+    @EndpointInject("mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce("direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isCreateCamelContextPerClass() {
+        return false;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        LOG.info("createCamelContext()");
+        CREATED_CONTEXTS.incrementAndGet();
+        return super.createCamelContext();
+    }
+
+    @Override
+    protected void doPostTearDown() throws Exception {
+        LOG.info("doPostTearDown()");
+        POST_TEAR_DOWN.incrementAndGet();
+        super.doPostTearDown();
+    }
+
+    @Test
+    public void testSendMatchingMessage() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertTrue("Should create 1 or more CamelContext per test class", CREATED_CONTEXTS.get() >= 1);
+    }
+
+    @Test
+    public void testSendAnotherMatchingMessage() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertTrue("Should create 1 or more CamelContext per test class", CREATED_CONTEXTS.get() >= 1);
+    }
+
+    @Test
+    public void testSendNotMatchingMessage() throws Exception {
+        resultEndpoint.expectedMessageCount(0);
+
+        template.sendBodyAndHeader("<notMatched/>", "foo", "notMatchedHeaderValue");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertTrue("Should create 1 or more CamelContext per test class", CREATED_CONTEXTS.get() >= 1);
+    }
+
+    @AfterClass
+    public static void validateTearDown() throws Exception {
+        assertEquals(3, CREATED_CONTEXTS.get());
+        assertEquals(3, POST_TEAR_DOWN.get());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").filter(header("foo").isEqualTo("bar")).to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestTrueTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestTrueTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.patterns;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.camel.util.StopWatch;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateCamelContextPerTestTrueTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateCamelContextPerTestTrueTest.class);
+
+    private static final AtomicInteger CREATED_CONTEXTS = new AtomicInteger();
+    private static final AtomicInteger POST_TEAR_DOWN = new AtomicInteger();
+    private static final CountDownLatch LATCH = new CountDownLatch(1);
+
+    @EndpointInject("mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce("direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isCreateCamelContextPerClass() {
+        return true;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        LOG.info("createCamelContext()");
+        CREATED_CONTEXTS.incrementAndGet();
+        return super.createCamelContext();
+    }
+
+    @Override
+    protected void doPostTearDown() throws Exception {
+        LOG.info("doPostTearDown()");
+        POST_TEAR_DOWN.incrementAndGet();
+        super.doPostTearDown();
+        LATCH.await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testSendMatchingMessage() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertEquals("Should only create 1 CamelContext per test class", 1, CREATED_CONTEXTS.get());
+        assertEquals("Should not call postTearDown yet", 0, POST_TEAR_DOWN.get());
+    }
+
+    @Test
+    public void testSendAnotherMatchingMessage() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertEquals("Should only create 1 CamelContext per test class", 1, CREATED_CONTEXTS.get());
+        assertEquals("Should not call postTearDown yet", 0, POST_TEAR_DOWN.get());
+    }
+
+    @Test
+    public void testSendNotMatchingMessage() throws Exception {
+        resultEndpoint.expectedMessageCount(0);
+
+        template.sendBodyAndHeader("<notMatched/>", "foo", "notMatchedHeaderValue");
+
+        resultEndpoint.assertIsSatisfied();
+
+        assertEquals("Should only create 1 CamelContext per test class", 1, CREATED_CONTEXTS.get());
+        assertEquals("Should not call postTearDown yet", 0, POST_TEAR_DOWN.get());
+    }
+
+    @AfterClass
+    public static void shouldTearDown() throws Exception {
+        // we are called before doPostTearDown so lets wait for that to be called
+        Runnable r = () -> {
+            try {
+                StopWatch watch = new StopWatch();
+                while (watch.taken() < 5000) {
+                    LOG.debug("Checking for tear down called correctly");
+                    if (POST_TEAR_DOWN.get() == 1) {
+                        LATCH.countDown();
+                        break;
+                    } else {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            break;
+                        }
+                    }
+                }
+            } finally {
+                LOG.info("Should only call postTearDown 1 time per test class, called: " + POST_TEAR_DOWN.get());
+                assertEquals("Should only call postTearDown 1 time per test class", 1, POST_TEAR_DOWN.get());
+            }
+        };
+        Thread t = new Thread(r);
+        t.setDaemon(false);
+        t.setName("shouldTearDown checker");
+        t.start();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").filter(header("foo").isEqualTo("bar")).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
…e to correctly setup/teardown only once before/after class and reset in between test methods. This is a little bit tricky to do with JUnit 4