### PR TITLE
Improved docs: file, constant-language, itest-karaf, itest-osgi

### DIFF
--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -963,11 +963,8 @@ spring XML file:
 
 === Filtering using ANT path matcher
 
-The ANT path matcher is shipped out-of-the-box in the *camel-spring*
-jar. So you need to depend on *camel-spring* if you are using Maven. +
- The reasons is that we leverage Spring's
-http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/util/AntPathMatcher.html[AntPathMatcher]
-to do the actual matching.
+The ANT path matcher is based on
+http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/util/AntPathMatcher.html[AntPathMatcher].
 
 The file paths is matched with the following rules:
 

--- a/components/camel-grok/src/main/docs/grok-dataformat.adoc
+++ b/components/camel-grok/src/main/docs/grok-dataformat.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 3.0*
 
 This component provides dataformat for processing inputs with grok patterns.
-Grok patterns are used to process unstructured data into structured objects - `List<Map<String, Object>`.
+Grok patterns are used to process unstructured data into structured objects - `List<Map<String, Object>>`.
 
 This component is based on https://github.com/thekrakken/java-grok[Java Grok library]
 

--- a/core/camel-base/src/main/docs/constant-language.adoc
+++ b/core/camel-base/src/main/docs/constant-language.adoc
@@ -54,6 +54,18 @@ from("seda:a")
   .to("mock:b");
 ----
 
+=== Loading constant from external resource
+
+You can externalize the constant and have Camel load it from a resource
+such as `"classpath:"`, `"file:"`, or `"http:"`. +
+ This is done using the following syntax: `"resource:scheme:location"`,
+eg to refer to a file on the classpath you can do:
+
+[source,java]
+----
+.setHeader("myHeader").constant("resource:classpath:constant.txt")
+----
+
 === Dependencies
 
 The Constant language is part of *camel-core*.

--- a/docs/components/modules/ROOT/pages/file-component.adoc
+++ b/docs/components/modules/ROOT/pages/file-component.adoc
@@ -963,11 +963,8 @@ spring XML file:
 
 === Filtering using ANT path matcher
 
-The ANT path matcher is shipped out-of-the-box in the *camel-spring*
-jar. So you need to depend on *camel-spring* if you are using Maven. +
- The reasons is that we leverage Spring's
-http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/util/AntPathMatcher.html[AntPathMatcher]
-to do the actual matching.
+The ANT path matcher is based on
+http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/util/AntPathMatcher.html[AntPathMatcher].
 
 The file paths is matched with the following rules:
 

--- a/docs/components/modules/ROOT/pages/grok-dataformat.adoc
+++ b/docs/components/modules/ROOT/pages/grok-dataformat.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 3.0*
 
 This component provides dataformat for processing inputs with grok patterns.
-Grok patterns are used to process unstructured data into structured objects - `List<Map<String, Object>`.
+Grok patterns are used to process unstructured data into structured objects - `List<Map<String, Object>>`.
 
 This component is based on https://github.com/thekrakken/java-grok[Java Grok library]
 

--- a/docs/user-manual/modules/ROOT/pages/constant-language.adoc
+++ b/docs/user-manual/modules/ROOT/pages/constant-language.adoc
@@ -54,6 +54,18 @@ from("seda:a")
   .to("mock:b");
 ----
 
+=== Loading constant from external resource
+
+You can externalize the constant and have Camel load it from a resource
+such as `"classpath:"`, `"file:"`, or `"http:"`. +
+ This is done using the following syntax: `"resource:scheme:location"`,
+eg to refer to a file on the classpath you can do:
+
+[source,java]
+----
+.setHeader("myHeader").constant("resource:classpath:constant.txt")
+----
+
 === Dependencies
 
 The Constant language is part of *camel-core*.

--- a/tests/camel-itest-karaf/README.adoc
+++ b/tests/camel-itest-karaf/README.adoc
@@ -13,14 +13,14 @@ https://builds.apache.org/blue/organizations/jenkins/Camel.trunk.itest.karaf/act
 
 Do not use `mvn test`. Run the following script instead.
 ----
-$ ./run-test.sh
+$ ./run-tests.sh
 ----
 
 ****
-The reason for not using `mvn test` is that each test starts up a Karaf instance using Pax Exam, but sometimes the instance doesn't shut down well after the test and the phantom instance causes silent failures of the successive tests. The `run-test.sh` script makes sure to kill the Karaf instance after each test finished.
+The reason for not using `mvn test` is that each test starts up a Karaf instance using Pax Exam, but sometimes the instance doesn't shut down well after the test and the phantom instance causes silent failures of the successive tests. The `run-tests.sh` script makes sure to kill the Karaf instance after each test finished.
 ****
 
 You can also pass in the test name to start testing from the test and onwards, e.g.:
 ----
-$ ./run-test.sh CamelFtpTest
+$ ./run-tests.sh CamelFtpTest
 ----

--- a/tests/camel-itest-osgi/README.adoc
+++ b/tests/camel-itest-osgi/README.adoc
@@ -11,14 +11,14 @@ https://builds.apache.org/blue/organizations/jenkins/Camel.trunk.itest.osgi/acti
 
 Do not use `mvn test`. Run the following script instead.
 ----
-$ ./run-test.sh
+$ ./run-tests.sh
 ----
 
 ****
-The reason for not using `mvn test` is that each test starts up a Karaf instance using Pax Exam, but sometimes the instance doesn't shut down well after the test and the phantom instance causes silent failures of the successive tests. The `run-test.sh` script makes sure to kill the Karaf instance after each test finished.
+The reason for not using `mvn test` is that each test starts up a Karaf instance using Pax Exam, but sometimes the instance doesn't shut down well after the test and the phantom instance causes silent failures of the successive tests. The `run-tests.sh` script makes sure to kill the Karaf instance after each test finished.
 ****
 
 You can also pass in the test name to start testing from the test and onwards, e.g.:
 ----
-$ ./run-test.sh CamelHystrixTest
+$ ./run-tests.sh CamelHystrixTest
 ----


### PR DESCRIPTION
- camel-file ant matcher does not need camel-spring, as it is part of camel-util
- constant-language: Added missing section about resource prefix - http://camel.465427.n5.nabble.com/Possible-bug-in-netty-http-characters-in-body-get-unescaped-td5835669.html
- itest-karaf, itest-osgi fixed command name
- camel-grok typo