### PR TITLE
Enforce non-instantiability of utility classes

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/CamelVersionHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CamelVersionHelper.java
@@ -28,10 +28,10 @@ import java.util.Stack;
 /**
  * A simple util to test Camel versions.
  */
-public final class CamelVersionHelper {
+public class CamelVersionHelper {
 
     private CamelVersionHelper() {
-        // utility class, never constructed
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/CastUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CastUtils.java
@@ -33,10 +33,10 @@ import javax.naming.NamingEnumeration;
  * Utility methods for type casting.
  */
 @SuppressWarnings("unchecked")
-public final class CastUtils {
+public class CastUtils {
 
     private CastUtils() {
-        //utility class, never constructed
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static <T, U> Map<T, U> cast(Map<?, ?> p) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/CollectionHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CollectionHelper.java
@@ -35,12 +35,10 @@ import org.w3c.dom.NodeList;
 /**
  * A number of helper methods for working with collections
  */
-public final class CollectionHelper {
+public class CollectionHelper {
 
-    /**
-     * Utility classes should not have a public constructor.
-     */
     private CollectionHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/FilePathResolver.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FilePathResolver.java
@@ -22,13 +22,14 @@ import java.util.regex.Pattern;
 /**
  * A resolver for file paths that supports resolving with system and environment properties.
  */
-public final class FilePathResolver {
+public class FilePathResolver {
 
     // must be non greedy patterns
     private static final Pattern ENV_PATTERN = Pattern.compile("\\$\\{env:(.*?)\\}", Pattern.DOTALL);
     private static final Pattern SYS_PATTERN = Pattern.compile("\\$\\{(.*?)\\}", Pattern.DOTALL);
 
     private FilePathResolver() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 /**
  * File utilities.
  */
-public final class FileUtil {
+public class FileUtil {
     
     public static final int BUFFER_SIZE = 128 * 1024;
 
@@ -46,7 +46,7 @@ public final class FileUtil {
     private static boolean windowsOs = initWindowsOs();
 
     private FileUtil() {
-        // Utils method
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     private static boolean initWindowsOs() {

--- a/core/camel-util/src/main/java/org/apache/camel/util/HostUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/HostUtils.java
@@ -26,10 +26,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-public final class HostUtils {
+public class HostUtils {
 
     private HostUtils() {
-        //Utility Class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * IO helper class.
  */
-public final class IOHelper {
+public class IOHelper {
 
     public static Supplier<Charset> defaultCharset = Charset::defaultCharset;
 
@@ -62,7 +62,7 @@ public final class IOHelper {
     private static final boolean ZERO_BYTE_EOL_ENABLED = "true".equalsIgnoreCase(System.getProperty("camel.zeroByteEOLEnabled", "true"));
 
     private IOHelper() {
-        // Utility Class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/InetAddressUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/InetAddressUtil.java
@@ -22,10 +22,10 @@ import java.net.UnknownHostException;
 /**
  * Util class for {@link java.net.InetAddress}
  */
-public final class InetAddressUtil {
+public class InetAddressUtil {
 
     private InetAddressUtil() {
-        // util class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/IntrospectionSupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IntrospectionSupport.java
@@ -23,9 +23,10 @@ import java.util.Map;
  * Bridge class for ActiveMQ component
  */
 @Deprecated
-public final class IntrospectionSupport {
+public class IntrospectionSupport {
 
     private IntrospectionSupport() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -48,17 +48,15 @@ import org.slf4j.LoggerFactory;
 /**
  * A number of useful helper methods for working with Objects
  */
-public final class ObjectHelper {
+public class ObjectHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectHelper.class);
 
     private static final Float FLOAT_NAN = Float.NaN;
     private static final Double DOUBLE_NAN = Double.NaN;
 
-    /**
-     * Utility classes should not have a public constructor.
-     */
     private ObjectHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
@@ -24,11 +24,12 @@ import java.util.regex.Pattern;
 /**
  * Helper for Camel OGNL (Object-Graph Navigation Language) expressions.
  */
-public final class OgnlHelper {
+public class OgnlHelper {
 
     private static final Pattern INDEX_PATTERN = Pattern.compile("^(.*)\\[(.*)\\]$");
 
     private OgnlHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/PackageHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/PackageHelper.java
@@ -22,11 +22,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Some helper methods for working with Java packages and versioning.
  */
-public final class PackageHelper {
+public class PackageHelper {
     private static final Logger LOG = LoggerFactory.getLogger(PackageHelper.class);
 
     private PackageHelper() {
-        // Utility Class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/ReflectionHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ReflectionHelper.java
@@ -26,10 +26,10 @@ import java.util.Arrays;
  * <p/>
  * This code is based on org.apache.camel.spring.util.ReflectionUtils class.
  */
-public final class ReflectionHelper {
+public class ReflectionHelper {
 
     private ReflectionHelper() {
-        // utility class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/SedaConstants.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/SedaConstants.java
@@ -16,13 +16,14 @@
  */
 package org.apache.camel.util;
 
-public final class SedaConstants {
+public class SedaConstants {
     
     public static final int MAX_CONCURRENT_CONSUMERS = 500;
     public static final int CONCURRENT_CONSUMERS = 1;
     public static final int QUEUE_SIZE = 1000;
 
     private SedaConstants() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
 }

--- a/core/camel-util/src/main/java/org/apache/camel/util/StreamUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StreamUtils.java
@@ -20,8 +20,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public final class StreamUtils {
+public class StreamUtils {
     private StreamUtils() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -29,12 +29,13 @@ import java.util.regex.Pattern;
 /**
  * Helper methods for working with Strings.
  */
-public final class StringHelper {
+public class StringHelper {
 
     /**
      * Constructor of utility class should be private.
      */
     private StringHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
@@ -22,9 +22,10 @@ import java.util.List;
 /**
  * Utility class for parsing quoted string which is intended for parameters, separated by comma.
  */
-public final class StringQuoteHelper {
+public class StringQuoteHelper {
 
     private StringQuoteHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Time utils.
  */
-public final class TimeUtils {
+public class TimeUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(TimeUtils.class);
     private static final Pattern NUMBERS_ONLY_STRING_PATTERN = Pattern.compile("^[-]?(\\d)+$", Pattern.CASE_INSENSITIVE);
@@ -38,6 +38,7 @@ public final class TimeUtils {
     private static final Pattern SECONDS_REGEX_PATTERN = Pattern.compile("((\\d)*(\\d))s(ec(ond)?(s)?)?", Pattern.CASE_INSENSITIVE);
 
     private TimeUtils() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 /**
  * URI utilities.
  */
-public final class URISupport {
+public class URISupport {
 
     public static final String RAW_TOKEN_PREFIX = "RAW";
     public static final char[] RAW_TOKEN_START = {'(', '{'};
@@ -54,7 +54,7 @@ public final class URISupport {
     private static final String CHARSET = "UTF-8";
 
     private URISupport() {
-        // Helper class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/UnitUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/UnitUtils.java
@@ -19,9 +19,10 @@ package org.apache.camel.util;
 /**
  * Unit utils.
  */
-public final class UnitUtils {
+public class UnitUtils {
 
     private UnitUtils() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/UnsafeUriCharactersEncoder.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/UnsafeUriCharactersEncoder.java
@@ -25,7 +25,7 @@ import java.util.List;
  * <p/>
  * A good source for details is <a href="http://en.wikipedia.org/wiki/Url_encode">wikipedia url encode</a> article.
  */
-public final class UnsafeUriCharactersEncoder {
+public class UnsafeUriCharactersEncoder {
     private static BitSet unsafeCharactersRfc1738;
     private static BitSet unsafeCharactersHttp;
     private static final char[] HEX_DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C',
@@ -68,7 +68,7 @@ public final class UnsafeUriCharactersEncoder {
     }
 
     private UnsafeUriCharactersEncoder() {
-        // util class
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static String encode(String s) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/concurrent/LockHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/concurrent/LockHelper.java
@@ -23,8 +23,9 @@ import java.util.function.Supplier;
 import org.apache.camel.util.function.ThrowingRunnable;
 import org.apache.camel.util.function.ThrowingSupplier;
 
-public final class LockHelper {
+public class LockHelper {
     private LockHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static void doWithReadLock(StampedLock lock, Runnable task) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/concurrent/ThreadHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/concurrent/ThreadHelper.java
@@ -25,13 +25,14 @@ import org.apache.camel.util.StringHelper;
 /**
  * Various helper method for thread naming.
  */
-public final class ThreadHelper {
+public class ThreadHelper {
     public static final String DEFAULT_PATTERN = "Camel Thread ##counter# - #name#";
     private static final Pattern INVALID_PATTERN = Pattern.compile(".*#\\w+#.*");
 
     private static AtomicLong threadCounter = new AtomicLong();
     
     private ThreadHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
     
     private static long nextThreadCounter() {

--- a/core/camel-util/src/main/java/org/apache/camel/util/function/Bindings.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/function/Bindings.java
@@ -21,8 +21,9 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public final class Bindings {
+public class Bindings {
     private Bindings() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static <T1, T2> Consumer<T2> bind(T1 v1, BiConsumer<T1, T2> consumer) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/function/Predicates.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/function/Predicates.java
@@ -23,8 +23,9 @@ import java.util.function.Predicate;
  * Predicate helpers, inspired by http://minborgsjavapot.blogspot.it/2016/03/put-your-java-8-method-references-to.html
  *
  */
-public final class Predicates {
+public class Predicates {
     private Predicates() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/function/Suppliers.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/function/Suppliers.java
@@ -23,8 +23,9 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-public final class Suppliers {
+public class Suppliers {
     private Suppliers() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static <T> Supplier<T> memorize(Supplier<T> supplier) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/function/ThrowingHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/function/ThrowingHelper.java
@@ -24,8 +24,9 @@ import java.util.function.Supplier;
 
 import org.apache.camel.util.ObjectHelper;
 
-public final class ThrowingHelper {
+public class ThrowingHelper {
     private ThrowingHelper() {
+        throw new AssertionError("Utility class can't be instantiated or extended");
     }
 
     public static <V, T extends Throwable> Supplier<V> wrapAsSupplier(ThrowingSupplier<V, T> supplier) {

--- a/core/camel-util/src/test/java/org/apache/camel/util/NoReflectionInstanceTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/NoReflectionInstanceTest.java
@@ -1,0 +1,71 @@
+package org.apache.camel.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class NoReflectionInstanceTest {
+
+    @Parameters
+    public static List<String> data() {
+        //@formatter:off
+        return Arrays.asList(
+            "org.apache.camel.util.CamelVersionHelper",
+            "org.apache.camel.util.CastUtils",
+            "org.apache.camel.util.CollectionHelper",
+            "org.apache.camel.util.concurrent.LockHelper",
+            "org.apache.camel.util.concurrent.ThreadHelper",
+            "org.apache.camel.util.FilePathResolver",
+            "org.apache.camel.util.FileUtil",
+            "org.apache.camel.util.function.Bindings",
+            "org.apache.camel.util.function.Predicates",
+            "org.apache.camel.util.function.Suppliers",
+            "org.apache.camel.util.function.ThrowingHelper",
+            "org.apache.camel.util.HostUtils",
+            "org.apache.camel.util.InetAddressUtil",
+            "org.apache.camel.util.IntrospectionSupport",
+            "org.apache.camel.util.IOHelper",
+            "org.apache.camel.util.ObjectHelper",
+            "org.apache.camel.util.OgnlHelper",
+            "org.apache.camel.util.PackageHelper",
+            "org.apache.camel.util.ReflectionHelper",
+            "org.apache.camel.util.SedaConstants",
+            "org.apache.camel.util.StreamUtils",
+            "org.apache.camel.util.StringHelper",
+            "org.apache.camel.util.StringQuoteHelper",
+            "org.apache.camel.util.TimeUtils",
+            "org.apache.camel.util.UnitUtils",
+            "org.apache.camel.util.UnsafeUriCharactersEncoder",
+            "org.apache.camel.util.URISupport"
+        );
+        //@formatter:on
+    }
+
+    private String className;
+
+    public NoReflectionInstanceTest(String className) {
+        this.className = className;
+    }
+
+    @Test(expected = InvocationTargetException.class)
+    public void testNoReflectionInstanceForUtilities() throws Exception {
+        createInstanceByReflection(className);
+        System.err.printf(">>> Utility class '%s' can be instantiated\n", className);
+
+    }
+
+    private void createInstanceByReflection(String className) throws Exception {
+        Class<?> fooClazz = Class.forName(className);
+        Constructor<?> constructor = fooClazz.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
+
+}


### PR DESCRIPTION
We need to provide an AssertionError in case the constructor is accidentally
invoked from within the class or if there is some reflection trying to call the
private constructor. We also don't need final classes because each subclass
calls the super constructor.