### PR TITLE
Upgrade to OpenTracing java API 0.33

### DIFF
--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -68,12 +68,6 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>io.opentracing.contrib</groupId>
-            <artifactId>opentracing-agent</artifactId>
-            <scope>test</scope>
-            <version>${opentracing-java-agent-version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
             <version>${opentracing-version}</version>
@@ -118,64 +112,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/agent/*Test.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-agent</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.opentracing.contrib</groupId>
-                                    <artifactId>opentracing-agent</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${opentracing-agent.lib}</outputDirectory>
-                                    <destFileName>opentracing-agent.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        -javaagent:${opentracing-agent.lib}/opentracing-agent.jar
-                        -Dorg.jboss.byteman.verbose ${camel.surefire.fork.vmargs}
-                    </argLine>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>run-integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/agent/*Test.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>final-verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel 2.19*
 
 IMPORTANT: Starting with Camel 2.21, it will be necessary to use an OpenTracing complaint tracer that is
-compatible with OpenTracing Java API version 0.31 or higher.
+compatible with OpenTracing Java API version 0.31. From Camel 3.0.0.M4, it will be necessary to use an OpenTracing compliant tracer that is compatible with OpenTracing Java API version 0.32 or higher.
 
 The camel-opentracing component is used for tracing and timing incoming and
 outgoing Camel messages using http://opentracing.io/[OpenTracing].

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -11,7 +11,7 @@ View the individual example READMEs for details.
 ### Examples
 
 // examples: START
-Number of Examples: 111 (0 deprecated)
+Number of Examples: 112 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===

--- a/examples/camel-example-opentracing/README.md
+++ b/examples/camel-example-opentracing/README.md
@@ -25,23 +25,19 @@ $ mvn compile
 
 ### Run the example
 
-Then using three different shells and run service1 and service2 before the client.
+Then using three different shells and run service1 and service2 before the client. These services use an annotation _CamelOpenTracing_ to indicate that the service should be traced.
 
 ```sh
 $ cd service1
 $ mvn compile spring-boot:run
 ```
 
-This service uses an annotation _CamelOpenTracing_ to indicate that the service should be traced.
-
 When service1 is ready then start service2
 
 ```sh
 $ cd service2
-$ mvn compile exec:exec
+$ mvn compile spring-boot:run
 ```
-
-This service is instrumented using an OpenTracing Java Agent, so the code does not need to be modified. The only requirement is that the OpenTracing Tracer and Camel OpenTracing component dependencies are added, and that the _opentracing-agent.jar_ Java Agent is specified when executing the service.
 
 And then start the client that calls service1 every 30 seconds.
 

--- a/examples/camel-example-opentracing/service2/pom.xml
+++ b/examples/camel-example-opentracing/service2/pom.xml
@@ -34,15 +34,22 @@
     </description>
 
     <properties>
-        <opentracing-agent.lib>${project.build.directory}/lib</opentracing-agent.lib>
+        <spring.boot-version>${spring-boot-version}</spring.boot-version>
     </properties>
 
-    <!-- import Camel BOM -->
+    <!-- import Spring-Boot and Camel BOM -->
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.camel</groupId>
-                <artifactId>camel-parent</artifactId>
+                <artifactId>camel-spring-boot-dependencies</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -52,14 +59,28 @@
 
     <dependencies>
 
-        <!-- camel-core -->
+        <!-- spring-boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- camel -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core</artifactId>
+            <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-main</artifactId>
+            <artifactId>camel-opentracing-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jetty-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http4-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -67,89 +88,21 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.xnio</groupId>
-            <artifactId>xnio-nio</artifactId>
-            <version>${jboss-xnio-version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-        </dependency>
-
-        <!-- OpenTracing dependencies -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-opentracing</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel.example</groupId>
             <artifactId>camel-example-opentracing-loggingtracer</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing.contrib</groupId>
-            <artifactId>opentracing-agent</artifactId>
-            <version>${opentracing-java-agent-version}</version>
-            <scope>provided</scope>
         </dependency>
 
     </dependencies>
 
     <build>
-
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-agent</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.opentracing.contrib</groupId>
-                                    <artifactId>opentracing-agent</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${opentracing-agent.lib}</outputDirectory>
-                                    <destFileName>opentracing-agent.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <executable>java</executable>
-                    <arguments>
-                        <argument>-javaagent:${opentracing-agent.lib}/opentracing-agent.jar</argument>
-                        <argument>-classpath</argument>
-                        <classpath/>
-                        <argument>sample.camel.Service2Application</argument>
-                    </arguments>
-                </configuration>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
             </plugin>
         </plugins>
-
     </build>
 
 </project>

--- a/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Application.java
+++ b/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Application.java
@@ -16,18 +16,26 @@
  */
 package sample.camel;
 
-import org.apache.camel.main.Main;
+import org.apache.camel.opentracing.starter.CamelOpenTracing;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-public final class Service2Application {
+//CHECKSTYLE:OFF
+/**
+ * A Spring Boot application that starts the Camel OpenTracing application.
+ * <p/>
+ * Notice we use the `@CamelOpenTracing` annotation to enable Camel with OpenTracing.
+ */
+@SpringBootApplication
+@CamelOpenTracing
+public class Service2Application {
 
-    private Service2Application() {
-      // noop
-    }
-
-    public static void main(String[] args) throws Exception {
-        Main main = new Main();
-        main.addRouteBuilder(new Service2Route());
-        main.run();
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Service2Application.class, args);
     }
 
 }
+//CHECKSTYLE:ON

--- a/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Route.java
+++ b/examples/camel-example-opentracing/service2/src/main/java/sample/camel/Service2Route.java
@@ -17,7 +17,9 @@
 package sample.camel;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Service2Route extends RouteBuilder {
 
     @Override

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -542,9 +542,8 @@
         <openshift-java-client-version>2.7.0.Final</openshift-java-client-version>
         <openstack4j-version>3.0.2</openstack4j-version>
         <openstack4j-guava-version>17.0</openstack4j-guava-version>
-        <opentracing-java-agent-version>0.2.0</opentracing-java-agent-version>
-        <opentracing-version>0.31.0</opentracing-version>
-        <opentracing-tracerresolver-version>0.1.4</opentracing-tracerresolver-version>
+        <opentracing-version>0.33.0</opentracing-version>
+        <opentracing-tracerresolver-version>0.1.8</opentracing-tracerresolver-version>
         <ops4j-base-version>1.5.0</ops4j-base-version>
         <!-- Avoid upgrading to newer version for the moment: see https://issues.apache.org/jira/browse/CAMEL-13654 -->
         <optaplanner-version>7.22.0.Final</optaplanner-version>


### PR DESCRIPTION
This PR also removes use of the opentracing-contrib/opentracing-agent, which is no longer in active development, from the opentracing component tests and the examples.

There is another java agent project in development, that could be used in the future to provide the same capability - but probably better that camel is not tightly coupled with it (even for tests and examples). Use of this agent could be described in a blog post or somewhere.
