### PR TITLE
auto generated page not found link errors fixed

### DIFF
--- a/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
+++ b/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
@@ -87,7 +87,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the xref:registry.adocRegistry. |  | AmazonS3
+| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the registry. |  | AmazonS3
 | *autoCreateBucket* (common) | Setting the autocreation of the bucket | true | boolean
 | *pathStyleAccess* (common) | Whether or not the S3 client should use path style access | false | boolean
 | *policy* (common) | The policy for this queue to set in the com.amazonaws.services.s3.AmazonS3#setBucketPolicy() method. |  | String

--- a/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
+++ b/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
@@ -87,7 +87,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the link:registry.htmlRegistry. |  | AmazonS3
+| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the xref:registry.adocRegistry. |  | AmazonS3
 | *autoCreateBucket* (common) | Setting the autocreation of the bucket | true | boolean
 | *pathStyleAccess* (common) | Whether or not the S3 client should use path style access | false | boolean
 | *policy* (common) | The policy for this queue to set in the com.amazonaws.services.s3.AmazonS3#setBucketPolicy() method. |  | String
@@ -170,7 +170,7 @@ The component supports 38 options, which are listed below.
 | *camel.component.aws-s3.basic-property-binding* | Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | Boolean
 | *camel.component.aws-s3.configuration.accelerate-mode-enabled* | Define if Accelerate Mode enabled is true or false | false | Boolean
 | *camel.component.aws-s3.configuration.access-key* | Amazon AWS Access Key |  | String
-| *camel.component.aws-s3.configuration.amazon-s3-client* | Reference to a `com.amazonaws.services.s3.AmazonS3` in the link:registry.html[Registry]. |  | AmazonS3
+| *camel.component.aws-s3.configuration.amazon-s3-client* | Reference to a `com.amazonaws.services.s3.AmazonS3` in the xref:registry.adoc[Registry]. |  | AmazonS3
 | *camel.component.aws-s3.configuration.auto-create-bucket* | Setting the autocreation of the bucket | true | Boolean
 | *camel.component.aws-s3.configuration.autoclose-body* | If this option is true and includeBody is true, then the S3Object.close() method will be called on exchange completion. This option is strongly related to includeBody option. In case of setting includeBody to true and autocloseBody to false, it will be up to the caller to close the S3Object stream. Setting autocloseBody to true, will close the S3Object stream automatically. | true | Boolean
 | *camel.component.aws-s3.configuration.aws-k-m-s-key-id* | Define the id of KMS key to use in case KMS is enabled |  | String

--- a/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
+++ b/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
@@ -143,7 +143,7 @@ public class S3Configuration implements Cloneable {
 
     /**
      * Reference to a `com.amazonaws.services.s3.AmazonS3` in the
-     * link:registry.html[Registry].
+     * xref:registry.adoc[Registry].
      */
     public void setAmazonS3Client(AmazonS3 amazonS3Client) {
         this.amazonS3Client = amazonS3Client;

--- a/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
+++ b/components/camel-aws-s3/src/main/java/org/apache/camel/component/aws/s3/S3Configuration.java
@@ -143,7 +143,7 @@ public class S3Configuration implements Cloneable {
 
     /**
      * Reference to a `com.amazonaws.services.s3.AmazonS3` in the
-     * xref:registry.adoc[Registry].
+     * registry.
      */
     public void setAmazonS3Client(AmazonS3 amazonS3Client) {
         this.amazonS3Client = amazonS3Client;

--- a/components/camel-cm-sms/src/main/docs/cm-sms-component.adoc
+++ b/components/camel-cm-sms/src/main/docs/cm-sms-component.adoc
@@ -71,10 +71,10 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *defaultFrom* (producer) | This is the sender name. The maximum length is 11 characters. |  | String)
-| *defaultMaxNumberOfParts* (producer) | If it is a multipart message forces the max number. Message can be truncated. Technically the gateway will first check if a message is larger than 160 characters, if so, the message will be cut into multiple 153 characters parts limited by these parameters. | 8 | Max(8L)::Int)
+| *defaultFrom* (producer) | This is the sender name. The maximum length is 11 characters. |  | String
+| *defaultMaxNumberOfParts* (producer) | If it is a multipart message forces the max number. Message can be truncated. Technically the gateway will first check if a message is larger than 160 characters, if so, the message will be cut into multiple 153 characters parts limited by these parameters. | 8 | Max(8L)Int
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
-| *productToken* (producer) | *Required* The unique token to use |  | String)
+| *productToken* (producer) | *Required* The unique token to use |  | String
 | *testConnectionOnStartup* (producer) | Whether to test the connection to the SMS Gateway on startup | false | boolean
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean

--- a/components/camel-dataformat/src/main/docs/dataformat-component.adoc
+++ b/components/camel-dataformat/src/main/docs/dataformat-component.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel version 2.12*
 
-The Dataformat component allows to use link:data-format.html[Data
+The Dataformat component allows to use xref:data-format.adoc[Data
 Format] as a Camel Component.
 
 === URI format

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhirJson-dataformat.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhirJson-dataformat.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 2.21*
 
 The FHIR-JSON Data Format leverages
-link:https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java[HAPI-FHIR's]
+https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java[HAPI-FHIR's]
 JSON parser to parse to/from JSON format to/from a HAPI-FHIR's `IBaseResource`.
 
 === FHIR JSON Format Options

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhirXml-dataformat.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhirXml-dataformat.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 2.21*
 
 The FHIR-XML Data Format leverages
-link:https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java[HAPI-FHIR's]
+https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java[HAPI-FHIR's]
 XML parser to parse to/from XML format to/from a HAPI-FHIR's `IBaseResource`.
 
 === FHIR XML Format Options

--- a/components/camel-http4/src/main/docs/http4-component.adoc
+++ b/components/camel-http4/src/main/docs/http4-component.adoc
@@ -565,7 +565,7 @@ behavior.
 Using the JSSE Configuration Utility
 
 The HTTP4 component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/camel-irc/src/main/docs/irc-component.adoc
+++ b/components/camel-irc/src/main/docs/irc-component.adoc
@@ -150,7 +150,7 @@ The component supports 4 options, which are listed below.
 #### Using the JSSE Configuration Utility
 
 The IRC component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/camel-jetty/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty/src/main/docs/jetty-component.adoc
@@ -326,7 +326,7 @@ public void process(Exchange exchange) throws Exception {
 Using the JSSE Configuration Utility
 
 The Jetty component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel version 2.17*
 
-The OpenShift Build Config component is one of link:kubernetes.adoc[Kubernetes Components] which
+The OpenShift Build Config component is one of xref:kubernetes.adoc[Kubernetes Components] which
 provides a producer to execute kubernetes build config operations. 
 
 

--- a/components/camel-mail/src/main/docs/mail-component.adoc
+++ b/components/camel-mail/src/main/docs/mail-component.adoc
@@ -343,7 +343,7 @@ configuration.
 ==== Using the JSSE Configuration Utility
 
 The mail component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/camel-netty4/src/main/docs/netty4-component.adoc
+++ b/components/camel-netty4/src/main/docs/netty4-component.adoc
@@ -406,7 +406,7 @@ RouteBuilder builder = new RouteBuilder() {
 Using the JSSE Configuration Utility
 
 The Netty component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/camel-servicenow/camel-servicenow-component/src/main/docs/servicenow-component.adoc
+++ b/components/camel-servicenow/camel-servicenow-component/src/main/docs/servicenow-component.adoc
@@ -309,7 +309,7 @@ The component supports 58 options, which are listed below.
 | CREATE | POST | /api/now/import/{table_name}
 |===
 
-NOTE: link:http://wiki.servicenow.com/index.php?title=REST_API#Available_APIs[Fuji REST API Documentation]
+NOTE: http://wiki.servicenow.com/index.php?title=REST_API#Available_APIs[Fuji REST API Documentation]
 
 [[ServiceNow-Helsinki]]
 [cols="10%a,10%a,10%a,10%a,60%a", options="header"]

--- a/components/camel-timer/src/main/docs/timer-component.adoc
+++ b/components/camel-timer/src/main/docs/timer-component.adoc
@@ -29,7 +29,7 @@ advanced scheduling.
 
 TIP:*Specify time in human friendly format*
 You can specify the time in
-link:how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
+xref:how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
 friendly syntax].
 
 

--- a/components/camel-websocket/src/main/docs/websocket-component.adoc
+++ b/components/camel-websocket/src/main/docs/websocket-component.adoc
@@ -206,7 +206,7 @@ from("activemq:topic:newsTopic")
 #### Using the JSSE Configuration Utility
 
 The WebSocket component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -1004,7 +1004,7 @@ Number of Data Formats: 45 in 37 JAR artifacts (0 deprecated)
 ==== Expression Languages
 
 // languages: START
-Number of Languages: 17 in 11 JAR artifacts (0 deprecated)
+Number of Languages: 16 in 10 JAR artifacts (0 deprecated)
 
 [width="100%",cols="4,1,5",options="header"]
 |===
@@ -1037,8 +1037,6 @@ Number of Languages: 17 in 11 JAR artifacts (0 deprecated)
 | link:camel-spring/src/main/docs/spel-language.adoc[SpEL] (camel-spring) | 2.7 | To use Spring Expression Language (SpEL) in Camel expressions or predicates.
 
 | link:camel-base/src/main/docs/tokenize-language.adoc[Tokenize] (camel-base) | 2.0 | To use Camel message body or header with a tokenizer in Camel expressions or predicates.
-
-| link:camel-jaxp/src/main/docs/xtokenize-language.adoc[XML Tokenize] (camel-jaxp) | 2.14 | To use Camel message body or header with a XML tokenizer in Camel expressions or predicates.
 
 | link:camel-xpath/src/main/docs/xpath-language.adoc[XPath] (camel-xpath) | 1.1 | To use XPath (XML) in Camel expressions or predicates.
 

--- a/core/camel-core/src/main/docs/eips/aggregate-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/aggregate-eip.adoc
@@ -2,7 +2,7 @@
 == Aggregate EIP
 
 The
-http://www.enterpriseintegrationpatterns.com/Aggregator.adoc[Aggregator]
+http://www.enterpriseintegrationpatterns.com/Aggregator.html[Aggregator]
 from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows
 you to combine a number of messages together into a single message.
 

--- a/core/camel-core/src/main/docs/eips/aggregate-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/aggregate-eip.adoc
@@ -2,13 +2,13 @@
 == Aggregate EIP
 
 The
-http://www.enterpriseintegrationpatterns.com/Aggregator.html[Aggregator]
-from the link:enterprise-integration-patterns.html[EIP patterns] allows
+http://www.enterpriseintegrationpatterns.com/Aggregator.adoc[Aggregator]
+from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows
 you to combine a number of messages together into a single message.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Aggregator.gif[image]
 
-A correlation link:expression.html[Expression] is used to determine the
+A correlation xref:expression.adoc[Expression] is used to determine the
 messages which should be aggregated together. If you want to aggregate
 all messages into a single message, just use a constant expression. An
 AggregationStrategy is used to combine all the message exchanges for a
@@ -104,7 +104,7 @@ class ArrayListAggregationStrategy implements AggregationStrategy {
 
 === About completion
 
-When aggregation link:exchange.html[Exchange]s at some point you need to
+When aggregation xref:exchange.adoc[Exchange]s at some point you need to
 indicate that the aggregated exchanges is complete, so they can be send
 out of the aggregator. Camel allows you to indicate completion in
 various ways as follows:
@@ -116,7 +116,7 @@ key within the period.
 exchanges are completed.
 * completionSize - Is a number indicating that after X aggregated
 exchanges it's complete.
-* completionPredicate - Runs a link:predicate.html[Predicate] when a new
+* completionPredicate - Runs a xref:predicate.adoc[Predicate] when a new
 exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
@@ -125,7 +125,7 @@ implement `PreCompletionAwareAggregationStrategy` and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * completionFromBatchConsumer - Special option for
-link:batch-consumer.html[Batch Consumer] which allows you to complete
+xref:batch-consumer.adoc[Batch Consumer] which allows you to complete
 when all the messages from the batch has been aggregated.
 * forceCompletionOnStop - Indicates to complete all current
 aggregated exchanges when the context is stopped
@@ -147,9 +147,9 @@ aggregator. If not provided Camel will thrown an Exception on startup.
 *available as of Camel 2.16*
 
 There can be use-cases where you want the incoming
-link:exchange.html[Exchange] to determine if the correlation group
+xref:exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
-link:exchange.html[Exchange] is starting a new group from scratch. To
+xref:exchange.adoc[Exchange] is starting a new group from scratch. To
 determine this the `AggregationStrategy` can
 implement `PreCompletionAwareAggregationStrategy` which has
 a `preComplete` method:
@@ -187,7 +187,7 @@ consumer etc)
 The aggregator provides a pluggable repository which you can implement
 your own `org.apache.camel.spi.AggregationRepository`. +
  If you need persistent repository then you can use either Camel
-link:leveldb.html[LevelDB], or <<sql-component,SQL Component>> components.
+xref:leveldb.adoc[LevelDB], or <<sql-component,SQL Component>> components.
 
 === Using TimeoutAwareAggregationStrategy
 
@@ -573,7 +573,7 @@ without using POJOs then you may have `null` as `oldExchange` or
 Aggregate EIP will invoke the
 `AggregationStrategy` with `oldExchange` as null, for the first
 Exchange incoming to the aggregator. And then for
-subsequent link:exchange.html[Exchange]s then `oldExchange` and
+subsequent xref:exchange.adoc[Exchange]s then `oldExchange` and
 `newExchange` parameters are both not null.
 
 Example with Content Enricher EIP and no data
@@ -629,14 +629,14 @@ public class MyBodyAppender {
 }
 ----
 
-In the example above we use the link:content-enricher.html[Content
-Enricher] EIP using `pollEnrich`. The `newExchange` will be null in the
+In the example above we use the xref:content-enricher.adoc[Content Enricher]
+EIP using `pollEnrich`. The `newExchange` will be null in the
 situation we could not get any data from the "seda:foo" endpoint, and
 therefore the timeout was hit after 1 second. So if we need to do some
 special merge logic we would need to set `setAllowNullNewExchange=true`,
 so the `append` method will be invoked. If we do not do that then when
 the timeout was hit, then the append method would normally not be
-invoked, meaning the link:content-enricher.html[Content Enricher] did
+invoked, meaning the xref:content-enricher.adoc[Content Enricher] did
 not merge/change the message.
 
 In XML DSL you would configure the `strategyMethodAllowNull` option and

--- a/core/camel-core/src/main/docs/eips/bean-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/bean-eip.adoc
@@ -34,10 +34,10 @@ Camel also supports invoking <<bean-component,Bean>> as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
-will use the link:bean-binding.html[Bean Binding] to invoke the bean. +
+will use the xref:bean-binding.adoc[Bean Binding] to invoke the bean. +
  The source for the bean is just a plain POJO:
 
-Camel will use link:bean-binding.html[Bean Binding] to invoke the
+Camel will use xref:bean-binding.adoc[Bean Binding] to invoke the
 `sayHello` method, by converting the Exchange's In body to the `String`
 type and storing the output of the method on the Exchange Out body.
 
@@ -77,13 +77,13 @@ from("direct:start").bean(ExampleBean.class);
 
 How bean methods to be invoked are chosen (if they are not specified
 explicitly through the *method* parameter) and how parameter values are
-constructed from the link:message.html[Message] are all defined by the
-link:bean-binding.html[Bean Binding] mechanism which is used throughout
-all of the various link:bean-integration.html[Bean Integration]
+constructed from the xref:message.adoc[Message] are all defined by the
+xref:bean-binding.adoc[Bean Binding] mechanism which is used throughout
+all of the various xref:bean-integration.adoc[Bean Integration]
 mechanisms in Camel.
 
 === See also
 
 * <<class-component,Class>> component
-* link:bean-binding.html[Bean Binding]
-* link:bean-integration.html[Bean Integration]
+* xref:bean-binding.adoc[Bean Binding]
+* xref:bean-integration.adoc[Bean Integration]

--- a/core/camel-core/src/main/docs/eips/choice-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/choice-eip.adoc
@@ -3,7 +3,7 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] allows you to route messages to the correct destination based
 on the contents of the message exchanges.
 
@@ -26,7 +26,7 @@ The Choice EIP supports 2 options which are listed below:
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----
@@ -44,7 +44,7 @@ RouteBuilder builder = new RouteBuilder() {
 };
 ----
 
-TIP: See link:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.html[Why
+TIP: See xref:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 

--- a/core/camel-core/src/main/docs/eips/claimCheck-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/claimCheck-eip.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel 2.21*
 
-The link:http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html[Claim Check] from the link:../../../../readme-eip.adoc[EIP patterns]
+The http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html[Claim Check] from the xref:../../../../readme-eip.adoc[EIP patterns]
 allows you to replace message content with a claim check (a unique key), which can be used to retrieve the message content at a later time.
 
 image:http://www.enterpriseintegrationpatterns.com/img/StoreInLibrary.gif[image]

--- a/core/camel-core/src/main/docs/eips/content-based-router-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/content-based-router-eip.adoc
@@ -3,7 +3,7 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] allows you to route messages to the correct destination based
 on the contents of the message exchanges.
 
@@ -11,7 +11,7 @@ image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[im
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 === Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>
 
@@ -36,7 +36,7 @@ RouteBuilder builder = new RouteBuilder() {
 [TIP]
 ====
 See
-link:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.html[Why
+xref:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 ====
@@ -74,6 +74,6 @@ https://github.com/apache/camel/blob/master/camel-core/src/test/java/org/apache/
 If you would like to use this EIP Pattern then please read the
 <<GettingStarted-GettingStarted,Getting Started>>. You may also find the
 <<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and link:uris.html[URIs]. Then you could
+of <<Endpoint-Endpoints,Endpoint>> and xref:uris.adoc[URIs]. Then you could
 try out some of the <<Examples-Examples,Examples>> first before trying
 this pattern out.

--- a/core/camel-core/src/main/docs/eips/content-filter-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/content-filter-eip.adoc
@@ -28,8 +28,8 @@ In this example we add our own <<Processor-Processor,Processor>>
 For further examples of this pattern in use you could look at one of the
 JUnit tests
 
-* link:../../../test/java/org/apache/camel/processor/TransformTest.java?[TransformTest]
-* link:../../../test/java/org/apache/camel/processor/TransformViaDSLTest.java[TransformViaDSLTest]
+* xref:../../../test/java/org/apache/camel/processor/TransformTest.java?[TransformTest]
+* xref:../../../test/java/org/apache/camel/processor/TransformViaDSLTest.java[TransformViaDSLTest]
 
 === Using Spring XML
 

--- a/core/camel-core/src/main/docs/eips/delay-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/delay-eip.adoc
@@ -28,7 +28,7 @@ See the Spring DSL samples for Delayer.
 [CAUTION]
 .Using Delayer in Java DSL
 ====
-See this ticket: link:https://issues.apache.org/jira/browse/CAMEL-2654[https://issues.apache.org/jira/browse/CAMEL-2654]
+See this ticket: https://issues.apache.org/jira/browse/CAMEL-2654[https://issues.apache.org/jira/browse/CAMEL-2654]
 ====
 
 === Samples

--- a/core/camel-core/src/main/docs/eips/dynamicRouter-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/dynamicRouter-eip.adoc
@@ -1,7 +1,7 @@
 [[dynamicRouter-eip]]
 == Dynamic Router EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/DynamicRouter.html[Dynamic Router] from the link:../../../../readme-eip.adoc[EIP patterns] allows you to route messages while avoiding the dependency of the router on all possible destinations while maintaining its efficiency.
+The http://www.enterpriseintegrationpatterns.com/DynamicRouter.html[Dynamic Router] from the xref:../../../../readme-eip.adoc[EIP patterns] allows you to route messages while avoiding the dependency of the router on all possible destinations while maintaining its efficiency.
 
 image:http://www.enterpriseintegrationpatterns.com/img/DynamicRouter.gif[image]
 

--- a/core/camel-core/src/main/docs/eips/filter-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/filter-eip.adoc
@@ -2,14 +2,14 @@
 == Filter EIP
 
 The http://www.enterpriseintegrationpatterns.com/Filter.html[Message
-Filter] from the link:enterprise-integration-patterns.html[EIP patterns]
+Filter] from the xref:enterprise-integration-patterns.adoc[EIP patterns]
 allows you to filter messages
 
 image:http://www.enterpriseintegrationpatterns.com/img/MessageFilter.gif[image]
 
 The following example shows how to create a Message Filter route
 consuming messages from an endpoint called *queue:a*, which if the
-link:predicate.html[Predicate] is true will be dispatched to *queue:b*
+xref:predicate.adoc[Predicate] is true will be dispatched to *queue:b*
 
 === EIP options
 
@@ -76,7 +76,7 @@ And the example in XML:
 Stop is a bit different than a message filter as it will filter out all
 messages and end the route entirely (filter only applies to its child
 processor). Stop is convenient to use in a
-link:content-based-router.html[Content Based Router] when you for
+xref:content-based-router.adoc[Content Based Router] when you for
 example need to stop further processing in one of the predicates.
 
 In the example below we do not want to route messages any further that
@@ -87,16 +87,16 @@ the when predicate by using the `.stop()`.
 
 *Available as of Camel 2.5*
 
-The link:message-filter.html[Message Filter] EIP will add a property on
-the link:exchange.html[Exchange] that states if it was filtered or not.
+The xref:message-filter.adoc[Message Filter] EIP will add a property on
+the xref:exchange.adoc[Exchange] that states if it was filtered or not.
 
 The property has the key `Exchange.FILTER_MATCHED`, which has the String
 value of `CamelFilterMatched`. Its value is a boolean indicating `true`
-or `false`. If the value is `true` then the link:exchange.html[Exchange]
+or `false`. If the value is `true` then the xref:exchange.adoc[Exchange]
 was routed in the filter block. This property will be visible within the
-link:message-filter.html[Message Filter] block who's
-link:predicate.html[Predicate] matches (value set to `true`), and to the
-steps immediately following the link:message-filter.html[Message Filter]
+xref:message-filter.adoc[Message Filter] block who's
+xref:predicate.adoc[Predicate] matches (value set to `true`), and to the
+steps immediately following the xref:message-filter.adoc[Message Filter]
 with the value set based on the results of the last
-link:message-filter.html[Message Filter] link:predicate.html[Predicate]
+xref:message-filter.adoc[Message Filter] xref:predicate.adoc[Predicate]
 evaluated.

--- a/core/camel-core/src/main/docs/eips/from-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/from-eip.adoc
@@ -1,6 +1,6 @@
 [[from-eip]]
 == From EIP
-Starting point for a Camel route that starts a route with a given endpoint. The endpoint can be from one of the many Camel link:https://github.com/apache/camel/tree/master/components[Components]. The component creates Camel exchanges from their respective sources and puts them into the route.
+Starting point for a Camel route that starts a route with a given endpoint. The endpoint can be from one of the many Camel https://github.com/apache/camel/tree/master/components[Components]. The component creates Camel exchanges from their respective sources and puts them into the route.
 
 === Options
 

--- a/core/camel-core/src/main/docs/eips/hystrix-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/hystrix-eip.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel 2.18*
 
-The Hystrix EIP provides integration with Netflix link:https://github.com/Netflix/Hystrix[Hystrix] to be used as circuit breaker in the Camel routes. Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.
+The Hystrix EIP provides integration with Netflix https://github.com/Netflix/Hystrix[Hystrix] to be used as circuit breaker in the Camel routes. Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.
 
 Maven users will need to add the following dependency to their pom.xml to use this EIP:
 
@@ -95,8 +95,8 @@ And in XML DSL:
 </camelContext>
 ----
 
-See link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/onFallback-eip.adoc[onFallback]
+See https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/onFallback-eip.adoc[onFallback]
 
 === Other examples
 
-You can find an example with the source code: link:https://github.com/apache/camel/tree/master/examples/camel-example-hystrix[camel-example-hystrix].
+You can find an example with the source code: https://github.com/apache/camel/tree/master/examples/camel-example-hystrix[camel-example-hystrix].

--- a/core/camel-core/src/main/docs/eips/idempotentConsumer-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/idempotentConsumer-eip.adoc
@@ -3,11 +3,11 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/IdempotentReceiver.html[Idempotent
-Consumer] from the link:enterprise-integration-patterns.html[EIP
+Consumer] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] is used to filter out duplicate messages.
 
 The Idempotent Consumer essentially acts like a
-link:message-filter.html[Message Filter] to filter out duplicates.
+xref:message-filter.adoc[Message Filter] to filter out duplicates.
 
 Camel will add the message id eagerly to the repository to detect
 duplication also for Exchanges currently in progress. 
@@ -17,13 +17,13 @@ the Exchange failed, otherwise it stays there.
 Camel provides the following Idempotent Consumer implementations:
 
 * MemoryIdempotentRepository
-* link:file2.html[FileIdempotentRepository]
-* link:hazelcast-component.html[HazelcastIdempotentRepository]
+* xref:file2.adoc[FileIdempotentRepository]
+* xref:hazelcast-component.adoc[HazelcastIdempotentRepository]
 * <<sql-component,JdbcMessageIdRepository>>
 * <<jpa-component,JpaMessageIdRepository>>
 * <<infinispan-component,InfinispanIdempotentRepository>>
 * <<jcache-component,JCacheIdempotentRepository>>
-* link:spring.html[SpringCacheIdempotentRepository]
+* xref:spring.adoc[SpringCacheIdempotentRepository]
 * <<ehcache-component,EhcacheIdempotentRepository>>
 * <<kafka-component,KafkaIdempotentRepository>>
 

--- a/core/camel-core/src/main/docs/eips/log-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/log-eip.adoc
@@ -1,12 +1,12 @@
 [[log-eip]]
 == Log EIP
 
-How can I log the processing of a link:message.html[Message]?
+How can I log the processing of a xref:message.adoc[Message]?
 
 Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
 * You can use the <<log-component,Log>> component which logs the Message content.
-* You can use the link:tracer.html[Tracer] which trace logs message flow.
-* You can also use a link:processor.html[Processor] or link:bean.html[Bean] and log from Java code.
+* You can use the xref:tracer.adoc[Tracer] which trace logs message flow.
+* You can also use a xref:processor.adoc[Processor] or xref:bean.adoc[Bean] and log from Java code.
 * You can use the log DSL.
 
 === Options

--- a/core/camel-core/src/main/docs/eips/marshal-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/marshal-eip.adoc
@@ -1,7 +1,7 @@
 [[marshal-eip]]
 == Marshal EIP
 
-Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel link:https://github.com/apache/camel/tree/master/components[Components]. Marshalling is used in the same way as unmarshalling above; in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry].
+Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel https://github.com/apache/camel/tree/master/components[Components]. Marshalling is used in the same way as unmarshalling above; in the https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry].
 
 == Options
 
@@ -17,7 +17,7 @@ The Marshal EIP supports 1 options which are listed below:
 
 === Samples
 
-The following example unmarshals via serialization then marshals using a named JAXB data format to perform a kind of link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+The following example unmarshals via serialization then marshals using a named JAXB data format to perform a kind of https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 [source,java]
 ----

--- a/core/camel-core/src/main/docs/eips/multicast-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/multicast-eip.adoc
@@ -132,5 +132,5 @@ allows you to do this using the processor
 interface.
 
 Notice the `onPrepare` can be used for any kind of custom logic which
-you would like to execute before the link:exchange.html[Exchange] is
+you would like to execute before the xref:exchange.adoc[Exchange] is
 being multicasted.

--- a/core/camel-core/src/main/docs/eips/otherwise-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/otherwise-eip.adoc
@@ -2,7 +2,7 @@
 == Otherwise EIP
 
 The Otherwise EIP is related to http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns]
 
 image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[image]
@@ -17,7 +17,7 @@ The Otherwise EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/core/camel-core/src/main/docs/eips/pipeline-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/pipeline-eip.adoc
@@ -1,12 +1,12 @@
 [[pipeline-eip]]
 == Pipeline EIP
 
-Camel supports the link:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
+Camel supports the xref:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
 
 image:http://www.enterpriseintegrationpatterns.com/img/PipesAndFilters.gif[image]
 
 With Camel you can split your processing across multiple independent
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] instances which can then be chained
+https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] instances which can then be chained
 together.
 
 === Options
@@ -19,7 +19,7 @@ The Pipeline EIP has no options.
 === Examples
 
 You can create pipelines of logic using multiple
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] or link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message
+https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] or https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message
 Translator] instances as follows
 
 Though pipeline is the default mode of operation when you specify

--- a/core/camel-core/src/main/docs/eips/process-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/process-eip.adoc
@@ -1,7 +1,7 @@
 [[process-eip]]
 == Process EIP
 
-The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 
@@ -31,7 +31,7 @@ public class MyProcessor implements Processor {
 
 You can then easily use this inside a route by declaring the bean in
 Spring, say via the XML (or registering it in JNDI if that is your
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry])
+https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry])
 
 [source,xml]
 --------------------------------------------------------
@@ -57,7 +57,7 @@ Processor myProcessor = new MyProcessor();
 from("activemq:myQueue").process(myProcessor);
 ----
 
-If you need to lookup the processor in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry]
+If you need to lookup the processor in the https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry]
 then you should use the *processRef* DSL:
 
 [source,java]
@@ -91,15 +91,15 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/P
 which supports the full <<Endpoint-Endpoints,Endpoint>> semantics given a
 Processor instance.
 
-So you just need to create a link:https://github.com/apache/camel/tree/master/components[Component] class by
+So you just need to create a https://github.com/apache/camel/tree/master/components[Component] class by
 deriving from
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent]
 which returns instances of ProcessorEndpoint. For more details see
-link:writing-components.html[Writing Components]
+xref:writing-components.adoc[Writing Components]
 
 === See Also
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/enrich-eip.adoc[Content Enricher-Enrich EIP]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/pollEnrich-eip.adoc[Content Enricher-Poll Enrich EIP]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/content-filter.adoc[Content Filter]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/enrich-eip.adoc[Content Enricher-Enrich EIP]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/pollEnrich-eip.adoc[Content Enricher-Poll Enrich EIP]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/content-filter.adoc[Content Filter]

--- a/core/camel-core/src/main/docs/eips/recipientList-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/recipientList-eip.adoc
@@ -1,6 +1,6 @@
 [[recipientList-eip]]
 == Recipient List EIP
-The link:http://www.enterpriseintegrationpatterns.com/RecipientList.html[Recipient List] from the EIP patterns allows you to route messages to a number of dynamically specified recipients.
+The xref:http://www.enterpriseintegrationpatterns.com/RecipientList.html[Recipient List] from the EIP patterns allows you to route messages to a number of dynamically specified recipients.
 
 image:http://www.enterpriseintegrationpatterns.com/img/RecipientList.gif[image]
 

--- a/core/camel-core/src/main/docs/eips/resequence-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/resequence-eip.adoc
@@ -1,7 +1,7 @@
 [[resequence-eip]]
 == Resequence EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the link:https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to reorganise messages based on some comparator. +
+The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
 By default in Camel we use an Expression to create the comparator; so that you can compare by a message header or the body or a piece of a message etc.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Resequencer.gif[image]

--- a/core/camel-core/src/main/docs/eips/resequence-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/resequence-eip.adoc
@@ -1,7 +1,7 @@
 [[resequence-eip]]
 == Resequence EIP
 
-The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
+The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to reorganise messages based on some comparator. +
 By default in Camel we use an Expression to create the comparator; so that you can compare by a message header or the body or a piece of a message etc.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Resequencer.gif[image]

--- a/core/camel-core/src/main/docs/eips/rollback-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/rollback-eip.adoc
@@ -4,12 +4,12 @@ Rollback might be needed if there is a transaction or transactional pieces in yo
 
 Camel recommends supporting the
 http://www.enterpriseintegrationpatterns.com/TransactionalClient.html[Transactional
-Client] from the link:enterprise-integration-patterns.html[EIP patterns]
+Client] from the xref:enterprise-integration-patterns.adoc[EIP patterns]
 using spring transactions.
 
 image:http://www.enterpriseintegrationpatterns.com/img/TransactionalClientSolution.gif[image]
 
-Transaction Oriented Endpoints like link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] support using a
+Transaction Oriented Endpoints like https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] support using a
 transaction for both inbound and outbound message exchanges. Endpoints
 that support transactions will participate in the current transaction
 context that they are called from.
@@ -115,7 +115,7 @@ from("activemq:queue:foo").policy(notsupported).to("activemq:queue:bar");
 
 ==== OSGi Blueprint
 
-If you are using link:https://github.com/apache/camel/blob/master/docs/user-manual/en/using-osgi-blueprint-with-camel.adoc[OSGi
+If you are using https://github.com/apache/camel/blob/master/docs/user-manual/en/using-osgi-blueprint-with-camel.adoc[OSGi
 Blueprint] then you most likely have to explicit declare a policy and
 refer to the policy from the transacted in the route.
 
@@ -159,12 +159,12 @@ configure a transaction policy bean, so we do not have any
 `PROPAGATION_REQUIRED` beans. All the beans needed to be configured is
 *standard* Spring beans only, eg. there are no Camel specific
 configuration at
-all.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]Then
+all.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]Then
 we are ready to define our Camel routes. We have two routes: 1 for
 success conditions, and 1 for a forced rollback condition. +
 This is after all based on a unit test. Notice that we mark each route
 as transacted using the *transacted*
-tag.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]That
+tag.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]That
 is all that is needed to configure a Camel route as being transacted.
 Just remember to use the *transacted* DSL. The rest is standard Spring
 XML to setup the transaction manager.
@@ -173,24 +173,24 @@ XML to setup the transaction manager.
 
 In this sample we want to listen for messages on a queue and process the
 messages with our business logic java code and send them along. Since
-its based on a link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java[TransactionMinimalConfigurationTest.java] the destination is a mock endpoint.
+its based on a https://github.com/apache/camel/blob/master/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java[TransactionMinimalConfigurationTest.java] the destination is a mock endpoint.
 
 First we configure the standard Spring XML to declare a JMS connection
 factory, a JMS transaction manager and our ActiveMQ component that we
 use in our
-routing.link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]And
+routing.https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]And
 then we configure our routes. Notice that all we have to do is mark the
 route as transacted using the *transacted*
-tag.link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]
+tag.https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]
 
 Transaction error handler
 
 When a route is marked as transacted using *transacted* Camel will
 automatic use the
-link:transactionerrorhandler.html[TransactionErrorHandler] as
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]. It supports basically the same
-feature set as the link:defaulterrorhandler.html[DefaultErrorHandler],
-so you can for instance use link:exception-clause.html[Exception Clause]
+xref:transactionerrorhandler.adoc[TransactionErrorHandler] as
+https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]. It supports basically the same
+feature set as the xref:defaulterrorhandler.adoc[DefaultErrorHandler],
+so you can for instance use xref:exception-clause.adoc[Exception Clause]
 as well.
 
 === Integration Testing with Spring
@@ -231,10 +231,10 @@ propagation behaviors for that where you configure it as follows:
 * The second route use `PROPAGATION_REQUIRES_NEW`
 
 This is configured in the Spring XML
-file.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml[MixedTransactionPropagationTest.xml]Then
+file.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml[MixedTransactionPropagationTest.xml]Then
 in the routes you use transacted DSL to indicate which of these two
 propagations it
-uses.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.java[MixedTransactionPropagationTest.java]Notice
+uses.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.java[MixedTransactionPropagationTest.java]Notice
 how we have configured the `onException` in the 2nd route to indicate in
 case of any exceptions we should handle it and just rollback this
 transaction. This is done using the `markRollbackOnlyLast` which tells
@@ -242,10 +242,10 @@ Camel to only do it for the current transaction and not globally.
 
 ==== See Also
 
-* link:error-handling-in-camel.html[Error handling in Camel]
-* link:transactionerrorhandler.html[TransactionErrorHandler]
-* link:https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]
-* link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS]
-* link:https://github.com/apache/camel/blob/master/docs/user-manual/en/oncompletion.adoc[On Completion]
+* xref:error-handling-in-camel.adoc[Error handling in Camel]
+* xref:transactionerrorhandler.adoc[TransactionErrorHandler]
+* https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]
+* https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS]
+* https://github.com/apache/camel/blob/master/docs/user-manual/en/oncompletion.adoc[On Completion]
 
-link:using-this-pattern.html[Using This Pattern]
+xref:using-this-pattern.adoc[Using This Pattern]

--- a/core/camel-core/src/main/docs/eips/routingSlip-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/routingSlip-eip.adoc
@@ -1,6 +1,6 @@
 [[routingSlip-eip]]
 == Routing Slip EIP
-The Routing Slip from the link:https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to route a message consecutively through a series of processing steps where the sequence of steps is not known at design time and can vary for each message.
+The Routing Slip from the https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to route a message consecutively through a series of processing steps where the sequence of steps is not known at design time and can vary for each message.
 
 image:http://www.enterpriseintegrationpatterns.com/img/RoutingTableSimple.gif[image]
 

--- a/core/camel-core/src/main/docs/eips/script-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/script-eip.adoc
@@ -7,7 +7,7 @@ This is useful when you need to invoke some logic that are not in Java code such
 Groovy or any of the other Languages. The message body is not changed (by default) however the scripting
 context has access to the current Exchange and can essentially change the message or headers directly.
 But the return value from the script is discarded and not used.
-If the return value should be used as a changed message body then use link:./message-translator.adoc[Message Translator] EIP instead.
+If the return value should be used as a changed message body then use xref:./message-translator.adoc[Message Translator] EIP instead.
 
 === Options
 

--- a/core/camel-core/src/main/docs/eips/split-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/split-eip.adoc
@@ -1,7 +1,7 @@
 [[split-eip]]
 == Split EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/patterns/messaging/Sequencer.html[Splitter] from the link:enterprise-integration-patterns.html[EIP patterns] allows you split a message into a number of pieces and process them individually.
+The http://www.enterpriseintegrationpatterns.com/patterns/messaging/Sequencer.html[Splitter] from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows you split a message into a number of pieces and process them individually.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Sequencer.gif[image]
 

--- a/core/camel-core/src/main/docs/eips/step-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/step-eip.adoc
@@ -1,7 +1,7 @@
 [[step-eip]]
 == Step EIP
 
-Camel supports the link:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
+Camel supports the http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
 
 image:http://www.enterpriseintegrationpatterns.com/img/PipesAndFilters.gif[image]
 

--- a/core/camel-core/src/main/docs/eips/to-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/to-eip.adoc
@@ -3,12 +3,12 @@
 
 See message related documentation
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message.adoc[Message]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-bus.adoc[Message Bus]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-channel.adoc[Message Channel]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-endpoint.adoc[Message Endpoint]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-router.adoc[Message Router]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message.adoc[Message]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-bus.adoc[Message Bus]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-channel.adoc[Message Channel]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-endpoint.adoc[Message Endpoint]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-router.adoc[Message Router]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 

--- a/core/camel-core/src/main/docs/eips/toD-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/toD-eip.adoc
@@ -3,7 +3,7 @@
 
 There is a new `.toD` / `<toD>` that allows to send a message to a dynamic
 computed <<Endpoint-Endpoints,Endpoint>> using one or
-more link:expression.html[Expression] that are concat together. By
+more xref:expression.adoc[Expression] that are concat together. By
 default the <<simple-language,Simple>> language is used to compute
 the endpoint.
 

--- a/core/camel-core/src/main/docs/eips/transform-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/transform-eip.adoc
@@ -3,7 +3,7 @@
 
 See below for details
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 

--- a/core/camel-core/src/main/docs/eips/unmarshal-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/unmarshal-eip.adoc
@@ -1,7 +1,7 @@
 [[unmarshal-eip]]
 == Unmarshal EIP
 
-If you receive a message from one of the Camel link:https://github.com/apache/camel/tree/master/components[Components] such as link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/file-component.adoc[File], link:https://github.com/apache/camel/blob/master/components/camel-http/src/main/docs/http-component.adoc[HTTP] or link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some link:https://github.com/apache/camel/blob/master/docs/user-manual/en/bean-integration.adoc[Bean Integration] or perform link:https://github.com/apache/camel/blob/master/docs/user-manual/en/expression.adoc#predicate[Predicate] evaluation and so forth. To do this use the *unmarshal* word in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] in Java or the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/camel-configuration-utilities.adoc#xml-configuration[Xml Configuration].
+If you receive a message from one of the Camel https://github.com/apache/camel/tree/master/components[Components] such as https://github.com/apache/camel/blob/master/camel-core/src/main/docs/file-component.adoc[File], https://github.com/apache/camel/blob/master/components/camel-http/src/main/docs/http-component.adoc[HTTP] or https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some https://github.com/apache/camel/blob/master/docs/user-manual/en/bean-integration.adoc[Bean Integration] or perform https://github.com/apache/camel/blob/master/docs/user-manual/en/expression.adoc#predicate[Predicate] evaluation and so forth. To do this use the *unmarshal* word in the https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] in Java or the https://github.com/apache/camel/blob/master/docs/user-manual/en/camel-configuration-utilities.adoc#xml-configuration[Xml Configuration].
 
 == Options
 
@@ -28,11 +28,11 @@ from("activemq:My.Queue").
   to("mqseries:Another.Queue");
 ----
 
-The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry] such as via your link:spring.html[Spring] XML file.
+The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry] such as via your xref:spring.adoc[Spring] XML file.
 
 You can also use the DSL itself to define the data format as you use it.
 For example the following uses Java serialization to unmarshal a binary
-file then send it as an ObjectMessage to link:https://github.com/apache/camel/tree/master/docs/user-manual/en/activemq.adoc[ActiveMQ]
+file then send it as an ObjectMessage to https://github.com/apache/camel/tree/master/docs/user-manual/en/activemq.adoc[ActiveMQ]
 
 [source,java]
 ----

--- a/core/camel-core/src/main/docs/eips/when-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/when-eip.adoc
@@ -2,7 +2,7 @@
 == When EIP
 
 The When EIP is related to http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns]
 
 image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[image]
@@ -17,7 +17,7 @@ The When EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/core/camel-core/src/main/docs/eips/wireTap-eip.adoc
+++ b/core/camel-core/src/main/docs/eips/wireTap-eip.adoc
@@ -2,7 +2,7 @@
 == Wire Tap EIP
 
 http://www.enterpriseintegrationpatterns.com/WireTap.html[Wire Tap]
-(from the link:enterprise-integration-patterns.html[EIP patterns])
+(from the xref:enterprise-integration-patterns.adoc[EIP patterns])
 allows you to route messages to a separate location while they are being
 forwarded to the ultimate destination.
 
@@ -10,10 +10,10 @@ image:http://www.enterpriseintegrationpatterns.com/img/WireTap.gif[image]
 
 === Streams
 
-If you link:wire-tap.html[Wire Tap] a stream message body then you
-should consider enabling link:stream-caching.html[Stream caching] to
+If you xref:wire-tap.adoc[Wire Tap] a stream message body then you
+should consider enabling xref:stream-caching.adoc[Stream caching] to
 ensure the message body can be read at each endpoint. See more details
-at link:stream-caching.html[Stream caching].
+at xref:stream-caching.adoc[Stream caching].
 
 === Options
 
@@ -41,29 +41,29 @@ The Wire Tap EIP supports 11 options which are listed below:
 
 The WireTap uses a thread pool to process the
 tapped messages. This thread pool will by default use the settings
-detailed at link:threading-model.html[Threading Model]. In particular,
+detailed at xref:threading-model.adoc[Threading Model]. In particular,
 when the pool is exhausted (with all threads utilized), further wiretaps
 will be executed synchronously by the calling thread. To remedy this,
-you can configure an explicit thread pool on the link:wire-tap.html[Wire
+you can configure an explicit thread pool on the xref:wire-tap.adoc[Wire
 Tap] having either a different rejection policy, a larger worker queue,
 or more worker threads.
 
 === WireTap Node
 
 Camel's Wire Tap node supports two flavors when tapping an
-link:exchange.html[Exchange]:
+xref:exchange.adoc[Exchange]:
 
 - With the traditional Wire Tap, Camel will copy the original
-link:exchange.html[Exchange] and set its
-link:exchange-pattern.html[Exchange Pattern] to *`InOnly`*, as we want
-the tapped link:exchange.html[Exchange] to be sent in a fire and forget
-style. The tapped link:exchange.html[Exchange] is then sent in a
+xref:exchange.adoc[Exchange] and set its
+xref:exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
+the tapped xref:exchange.adoc[Exchange] to be sent in a fire and forget
+style. The tapped xref:exchange.adoc[Exchange] is then sent in a
 separate thread so it can run in parallel with the original. Beware that
 only the Exchange is copied - Wire Tap won't do a deep clone (unless you
 specify a custom processor via *`onPrepareRef`* which does that). So all
 copies could share objects from the original Exchange.
 - Camel also provides an option of sending a new
-link:exchange.html[Exchange] allowing you to populate it with new
+xref:exchange.adoc[Exchange] allowing you to populate it with new
 values.
 
 === Sending a Copy (traditional wiretap)
@@ -93,27 +93,27 @@ values.
     }
 ----
 
-=== Sending a New link:exchange.html[Exchange]
+=== Sending a New xref:exchange.adoc[Exchange]
 
 *Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>*
 
 Camel supports either a processor or an
-link:expression.html[Expression] to populate the new
-link:exchange.html[Exchange]. Using a processor gives you full power
-over how the link:exchange.html[Exchange] is populated as you can set
-properties, headers, etc. An link:expression.html[Expression] can only
+xref:expression.adoc[Expression] to populate the new
+xref:exchange.adoc[Exchange]. Using a processor gives you full power
+over how the xref:exchange.adoc[Exchange] is populated as you can set
+properties, headers, etc. An xref:expression.adoc[Expression] can only
 be used to set the *`IN`* body.
 
-The link:expression.html[Expression] or
-link:processor.html[Processor] is pre-populated with a copy of the
-original link:exchange.html[Exchange], which allows you to access the
-original message when you prepare a new link:exchange.html[Exchange] to
+The xref:expression.adoc[Expression] or
+xref:processor.adoc[Processor] is pre-populated with a copy of the
+original xref:exchange.adoc[Exchange], which allows you to access the
+original message when you prepare a new xref:exchange.adoc[Exchange] to
 be sent. You can use the *`copy`* option (enabled by default) to
 indicate whether you want this.
 
 Below is the processor variation,
 where we disable *`copy`* by passing in *`false`* to create a new, empty
-link:exchange.html[Exchange]
+xref:exchange.adoc[Exchange]
 
 [source,java]
 ----
@@ -144,7 +144,7 @@ link:exchange.html[Exchange]
 *Available as of Camel 2.16:*
 
 For example to wire tap to a dynamic URI, then it supports the same
-dynamic URIs as documented in link:message-endpoint.html[Message
+dynamic URIs as documented in xref:message-endpoint.adoc[Message
 Endpoint]. For example to wire tap to a JMS queue where the header ID is
 part of the queue name:
 
@@ -158,10 +158,10 @@ part of the queue name:
 
 *Available as of Camel 2.8*
 
-If you send a new message using link:wire-tap.html[Wire Tap], then you
+If you send a new message using xref:wire-tap.adoc[Wire Tap], then you
 could only set the message body using an
-link:expression.html[Expression] from the DSL. If you also need to set
-headers, you would have to use a link:processor.html[Processor].
+xref:expression.adoc[Expression] from the DSL. If you also need to set
+headers, you would have to use a xref:processor.adoc[Processor]. From
 It's possible to set headers as well using the DSL.
 
 The following example sends a new message which has
@@ -206,6 +206,6 @@ The following example sends a new message which has
 
 *Available as of Camel 2.8*
 
-See details at link:multicast.html[Multicast]
+See details at xref:multicast.adoc[Multicast]
 
-link:using-this-pattern.html[Using This Pattern]
+xref:using-this-pattern.adoc[Using This Pattern]

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/S3EndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/S3EndpointBuilderFactory.java
@@ -59,7 +59,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -69,7 +69,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
@@ -1015,7 +1015,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -1025,7 +1025,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
@@ -1548,7 +1548,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -1558,7 +1558,7 @@ public interface S3EndpointBuilderFactory {
         }
         /**
          * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * link:registry.htmlRegistry.
+         * xref:registry.adocRegistry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/S3EndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/S3EndpointBuilderFactory.java
@@ -58,8 +58,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -68,8 +67,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
@@ -1014,8 +1012,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -1024,8 +1021,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
@@ -1547,8 +1543,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option is a <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common
          */
@@ -1557,8 +1552,7 @@ public interface S3EndpointBuilderFactory {
             return this;
         }
         /**
-         * Reference to a com.amazonaws.services.s3.AmazonS3 in the
-         * xref:registry.adocRegistry.
+         * Reference to a com.amazonaws.services.s3.AmazonS3 in the registry.
          * The option will be converted to a
          * <code>com.amazonaws.services.s3.AmazonS3</code> type.
          * @group common

--- a/docs/components/modules/ROOT/pages/aws-s3-component.adoc
+++ b/docs/components/modules/ROOT/pages/aws-s3-component.adoc
@@ -87,7 +87,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the xref:registry.adocRegistry. |  | AmazonS3
+| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the registry. |  | AmazonS3
 | *autoCreateBucket* (common) | Setting the autocreation of the bucket | true | boolean
 | *pathStyleAccess* (common) | Whether or not the S3 client should use path style access | false | boolean
 | *policy* (common) | The policy for this queue to set in the com.amazonaws.services.s3.AmazonS3#setBucketPolicy() method. |  | String

--- a/docs/components/modules/ROOT/pages/aws-s3-component.adoc
+++ b/docs/components/modules/ROOT/pages/aws-s3-component.adoc
@@ -87,7 +87,7 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the link:registry.htmlRegistry. |  | AmazonS3
+| *amazonS3Client* (common) | Reference to a com.amazonaws.services.s3.AmazonS3 in the xref:registry.adocRegistry. |  | AmazonS3
 | *autoCreateBucket* (common) | Setting the autocreation of the bucket | true | boolean
 | *pathStyleAccess* (common) | Whether or not the S3 client should use path style access | false | boolean
 | *policy* (common) | The policy for this queue to set in the com.amazonaws.services.s3.AmazonS3#setBucketPolicy() method. |  | String
@@ -170,7 +170,7 @@ The component supports 38 options, which are listed below.
 | *camel.component.aws-s3.basic-property-binding* | Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | Boolean
 | *camel.component.aws-s3.configuration.accelerate-mode-enabled* | Define if Accelerate Mode enabled is true or false | false | Boolean
 | *camel.component.aws-s3.configuration.access-key* | Amazon AWS Access Key |  | String
-| *camel.component.aws-s3.configuration.amazon-s3-client* | Reference to a `com.amazonaws.services.s3.AmazonS3` in the link:registry.html[Registry]. |  | AmazonS3
+| *camel.component.aws-s3.configuration.amazon-s3-client* | Reference to a `com.amazonaws.services.s3.AmazonS3` in the xref:registry.adoc[Registry]. |  | AmazonS3
 | *camel.component.aws-s3.configuration.auto-create-bucket* | Setting the autocreation of the bucket | true | Boolean
 | *camel.component.aws-s3.configuration.autoclose-body* | If this option is true and includeBody is true, then the S3Object.close() method will be called on exchange completion. This option is strongly related to includeBody option. In case of setting includeBody to true and autocloseBody to false, it will be up to the caller to close the S3Object stream. Setting autocloseBody to true, will close the S3Object stream automatically. | true | Boolean
 | *camel.component.aws-s3.configuration.aws-k-m-s-key-id* | Define the id of KMS key to use in case KMS is enabled |  | String

--- a/docs/components/modules/ROOT/pages/cm-sms-component.adoc
+++ b/docs/components/modules/ROOT/pages/cm-sms-component.adoc
@@ -71,10 +71,10 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *defaultFrom* (producer) | This is the sender name. The maximum length is 11 characters. |  | String)
-| *defaultMaxNumberOfParts* (producer) | If it is a multipart message forces the max number. Message can be truncated. Technically the gateway will first check if a message is larger than 160 characters, if so, the message will be cut into multiple 153 characters parts limited by these parameters. | 8 | Max(8L)::Int)
+| *defaultFrom* (producer) | This is the sender name. The maximum length is 11 characters. |  | String
+| *defaultMaxNumberOfParts* (producer) | If it is a multipart message forces the max number. Message can be truncated. Technically the gateway will first check if a message is larger than 160 characters, if so, the message will be cut into multiple 153 characters parts limited by these parameters. | 8 | Max(8L)Int
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
-| *productToken* (producer) | *Required* The unique token to use |  | String)
+| *productToken* (producer) | *Required* The unique token to use |  | String
 | *testConnectionOnStartup* (producer) | Whether to test the connection to the SMS Gateway on startup | false | boolean
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean

--- a/docs/components/modules/ROOT/pages/dataformat-component.adoc
+++ b/docs/components/modules/ROOT/pages/dataformat-component.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel version 2.12*
 
-The Dataformat component allows to use link:data-format.html[Data
+The Dataformat component allows to use xref:data-format.adoc[Data
 Format] as a Camel Component.
 
 === URI format

--- a/docs/components/modules/ROOT/pages/http4-component.adoc
+++ b/docs/components/modules/ROOT/pages/http4-component.adoc
@@ -565,7 +565,7 @@ behavior.
 Using the JSSE Configuration Utility
 
 The HTTP4 component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/components/modules/ROOT/pages/irc-component.adoc
+++ b/docs/components/modules/ROOT/pages/irc-component.adoc
@@ -150,7 +150,7 @@ The component supports 4 options, which are listed below.
 #### Using the JSSE Configuration Utility
 
 The IRC component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/components/modules/ROOT/pages/jetty-component.adoc
+++ b/docs/components/modules/ROOT/pages/jetty-component.adoc
@@ -326,7 +326,7 @@ public void process(Exchange exchange) throws Exception {
 Using the JSSE Configuration Utility
 
 The Jetty component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/components/modules/ROOT/pages/mail-component.adoc
+++ b/docs/components/modules/ROOT/pages/mail-component.adoc
@@ -343,7 +343,7 @@ configuration.
 ==== Using the JSSE Configuration Utility
 
 The mail component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/components/modules/ROOT/pages/netty4-component.adoc
+++ b/docs/components/modules/ROOT/pages/netty4-component.adoc
@@ -406,7 +406,7 @@ RouteBuilder builder = new RouteBuilder() {
 Using the JSSE Configuration Utility
 
 The Netty component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/components/modules/ROOT/pages/openshift-build-configs-component.adoc
+++ b/docs/components/modules/ROOT/pages/openshift-build-configs-component.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel version 2.17*
 
-The OpenShift Build Config component is one of link:kubernetes.adoc[Kubernetes Components] which
+The OpenShift Build Config component is one of xref:kubernetes.adoc[Kubernetes Components] which
 provides a producer to execute kubernetes build config operations. 
 
 

--- a/docs/components/modules/ROOT/pages/timer-component.adoc
+++ b/docs/components/modules/ROOT/pages/timer-component.adoc
@@ -29,7 +29,7 @@ advanced scheduling.
 
 TIP:*Specify time in human friendly format*
 You can specify the time in
-link:how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
+xref:how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
 friendly syntax].
 
 

--- a/docs/components/modules/ROOT/pages/websocket-component.adoc
+++ b/docs/components/modules/ROOT/pages/websocket-component.adoc
@@ -206,7 +206,7 @@ from("activemq:topic:newsTopic")
 #### Using the JSSE Configuration Utility
 
 The WebSocket component supports SSL/TLS configuration
-through the link:camel-configuration-utilities.adoc[Camel JSSE
+through the xref:camel-configuration-utilities.adoc[Camel JSSE
 Configuration Utility].  This utility greatly decreases the amount of
 component specific code you need to write and is configurable at the
 endpoint and component levels.  The following examples demonstrate how

--- a/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
@@ -2,7 +2,7 @@
 == Aggregate EIP
 
 The
-http://www.enterpriseintegrationpatterns.com/Aggregator.adoc[Aggregator]
+http://www.enterpriseintegrationpatterns.com/Aggregator.html[Aggregator]
 from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows
 you to combine a number of messages together into a single message.
 

--- a/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
@@ -2,13 +2,13 @@
 == Aggregate EIP
 
 The
-http://www.enterpriseintegrationpatterns.com/Aggregator.html[Aggregator]
-from the link:enterprise-integration-patterns.html[EIP patterns] allows
+http://www.enterpriseintegrationpatterns.com/Aggregator.adoc[Aggregator]
+from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows
 you to combine a number of messages together into a single message.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Aggregator.gif[image]
 
-A correlation link:expression.html[Expression] is used to determine the
+A correlation xref:expression.adoc[Expression] is used to determine the
 messages which should be aggregated together. If you want to aggregate
 all messages into a single message, just use a constant expression. An
 AggregationStrategy is used to combine all the message exchanges for a
@@ -104,7 +104,7 @@ class ArrayListAggregationStrategy implements AggregationStrategy {
 
 === About completion
 
-When aggregation link:exchange.html[Exchange]s at some point you need to
+When aggregation xref:exchange.adoc[Exchange]s at some point you need to
 indicate that the aggregated exchanges is complete, so they can be send
 out of the aggregator. Camel allows you to indicate completion in
 various ways as follows:
@@ -116,7 +116,7 @@ key within the period.
 exchanges are completed.
 * completionSize - Is a number indicating that after X aggregated
 exchanges it's complete.
-* completionPredicate - Runs a link:predicate.html[Predicate] when a new
+* completionPredicate - Runs a xref:predicate.adoc[Predicate] when a new
 exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
@@ -125,7 +125,7 @@ implement `PreCompletionAwareAggregationStrategy` and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * completionFromBatchConsumer - Special option for
-link:batch-consumer.html[Batch Consumer] which allows you to complete
+xref:batch-consumer.adoc[Batch Consumer] which allows you to complete
 when all the messages from the batch has been aggregated.
 * forceCompletionOnStop - Indicates to complete all current
 aggregated exchanges when the context is stopped
@@ -147,9 +147,9 @@ aggregator. If not provided Camel will thrown an Exception on startup.
 *available as of Camel 2.16*
 
 There can be use-cases where you want the incoming
-link:exchange.html[Exchange] to determine if the correlation group
+xref:exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
-link:exchange.html[Exchange] is starting a new group from scratch. To
+xref:exchange.adoc[Exchange] is starting a new group from scratch. To
 determine this the `AggregationStrategy` can
 implement `PreCompletionAwareAggregationStrategy` which has
 a `preComplete` method:
@@ -187,7 +187,7 @@ consumer etc)
 The aggregator provides a pluggable repository which you can implement
 your own `org.apache.camel.spi.AggregationRepository`. +
  If you need persistent repository then you can use either Camel
-link:leveldb.html[LevelDB], or <<sql-component,SQL Component>> components.
+xref:leveldb.adoc[LevelDB], or <<sql-component,SQL Component>> components.
 
 === Using TimeoutAwareAggregationStrategy
 
@@ -573,7 +573,7 @@ without using POJOs then you may have `null` as `oldExchange` or
 Aggregate EIP will invoke the
 `AggregationStrategy` with `oldExchange` as null, for the first
 Exchange incoming to the aggregator. And then for
-subsequent link:exchange.html[Exchange]s then `oldExchange` and
+subsequent xref:exchange.adoc[Exchange]s then `oldExchange` and
 `newExchange` parameters are both not null.
 
 Example with Content Enricher EIP and no data
@@ -629,14 +629,14 @@ public class MyBodyAppender {
 }
 ----
 
-In the example above we use the link:content-enricher.html[Content
-Enricher] EIP using `pollEnrich`. The `newExchange` will be null in the
+In the example above we use the xref:content-enricher.adoc[Content Enricher]
+EIP using `pollEnrich`. The `newExchange` will be null in the
 situation we could not get any data from the "seda:foo" endpoint, and
 therefore the timeout was hit after 1 second. So if we need to do some
 special merge logic we would need to set `setAllowNullNewExchange=true`,
 so the `append` method will be invoked. If we do not do that then when
 the timeout was hit, then the append method would normally not be
-invoked, meaning the link:content-enricher.html[Content Enricher] did
+invoked, meaning the xref:content-enricher.adoc[Content Enricher] did
 not merge/change the message.
 
 In XML DSL you would configure the `strategyMethodAllowNull` option and

--- a/docs/user-manual/modules/ROOT/pages/bean-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-eip.adoc
@@ -34,10 +34,10 @@ Camel also supports invoking <<bean-component,Bean>> as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
-will use the link:bean-binding.html[Bean Binding] to invoke the bean. +
+will use the xref:bean-binding.adoc[Bean Binding] to invoke the bean. +
  The source for the bean is just a plain POJO:
 
-Camel will use link:bean-binding.html[Bean Binding] to invoke the
+Camel will use xref:bean-binding.adoc[Bean Binding] to invoke the
 `sayHello` method, by converting the Exchange's In body to the `String`
 type and storing the output of the method on the Exchange Out body.
 
@@ -77,13 +77,13 @@ from("direct:start").bean(ExampleBean.class);
 
 How bean methods to be invoked are chosen (if they are not specified
 explicitly through the *method* parameter) and how parameter values are
-constructed from the link:message.html[Message] are all defined by the
-link:bean-binding.html[Bean Binding] mechanism which is used throughout
-all of the various link:bean-integration.html[Bean Integration]
+constructed from the xref:message.adoc[Message] are all defined by the
+xref:bean-binding.adoc[Bean Binding] mechanism which is used throughout
+all of the various xref:bean-integration.adoc[Bean Integration]
 mechanisms in Camel.
 
 === See also
 
 * <<class-component,Class>> component
-* link:bean-binding.html[Bean Binding]
-* link:bean-integration.html[Bean Integration]
+* xref:bean-binding.adoc[Bean Binding]
+* xref:bean-integration.adoc[Bean Integration]

--- a/docs/user-manual/modules/ROOT/pages/choice-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/choice-eip.adoc
@@ -3,7 +3,7 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] allows you to route messages to the correct destination based
 on the contents of the message exchanges.
 
@@ -26,7 +26,7 @@ The Choice EIP supports 2 options which are listed below:
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----
@@ -44,7 +44,7 @@ RouteBuilder builder = new RouteBuilder() {
 };
 ----
 
-TIP: See link:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.html[Why
+TIP: See xref:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 

--- a/docs/user-manual/modules/ROOT/pages/claimCheck-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/claimCheck-eip.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel 2.21*
 
-The link:http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html[Claim Check] from the link:../../../../readme-eip.adoc[EIP patterns]
+The http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html[Claim Check] from the xref:../../../../readme-eip.adoc[EIP patterns]
 allows you to replace message content with a claim check (a unique key), which can be used to retrieve the message content at a later time.
 
 image:http://www.enterpriseintegrationpatterns.com/img/StoreInLibrary.gif[image]

--- a/docs/user-manual/modules/ROOT/pages/content-based-router-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/content-based-router-eip.adoc
@@ -3,7 +3,7 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] allows you to route messages to the correct destination based
 on the contents of the message exchanges.
 
@@ -11,7 +11,7 @@ image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[im
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 === Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>
 
@@ -36,7 +36,7 @@ RouteBuilder builder = new RouteBuilder() {
 [TIP]
 ====
 See
-link:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.html[Why
+xref:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 ====
@@ -74,6 +74,6 @@ https://github.com/apache/camel/blob/master/camel-core/src/test/java/org/apache/
 If you would like to use this EIP Pattern then please read the
 <<GettingStarted-GettingStarted,Getting Started>>. You may also find the
 <<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and link:uris.html[URIs]. Then you could
+of <<Endpoint-Endpoints,Endpoint>> and xref:uris.adoc[URIs]. Then you could
 try out some of the <<Examples-Examples,Examples>> first before trying
 this pattern out.

--- a/docs/user-manual/modules/ROOT/pages/content-filter-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/content-filter-eip.adoc
@@ -28,8 +28,8 @@ In this example we add our own <<Processor-Processor,Processor>>
 For further examples of this pattern in use you could look at one of the
 JUnit tests
 
-* link:../../../test/java/org/apache/camel/processor/TransformTest.java?[TransformTest]
-* link:../../../test/java/org/apache/camel/processor/TransformViaDSLTest.java[TransformViaDSLTest]
+* xref:../../../test/java/org/apache/camel/processor/TransformTest.java?[TransformTest]
+* xref:../../../test/java/org/apache/camel/processor/TransformViaDSLTest.java[TransformViaDSLTest]
 
 === Using Spring XML
 

--- a/docs/user-manual/modules/ROOT/pages/delay-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/delay-eip.adoc
@@ -28,7 +28,7 @@ See the Spring DSL samples for Delayer.
 [CAUTION]
 .Using Delayer in Java DSL
 ====
-See this ticket: link:https://issues.apache.org/jira/browse/CAMEL-2654[https://issues.apache.org/jira/browse/CAMEL-2654]
+See this ticket: https://issues.apache.org/jira/browse/CAMEL-2654[https://issues.apache.org/jira/browse/CAMEL-2654]
 ====
 
 === Samples

--- a/docs/user-manual/modules/ROOT/pages/dynamicRouter-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dynamicRouter-eip.adoc
@@ -1,7 +1,7 @@
 [[dynamicRouter-eip]]
 == Dynamic Router EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/DynamicRouter.html[Dynamic Router] from the link:../../../../readme-eip.adoc[EIP patterns] allows you to route messages while avoiding the dependency of the router on all possible destinations while maintaining its efficiency.
+The http://www.enterpriseintegrationpatterns.com/DynamicRouter.html[Dynamic Router] from the xref:../../../../readme-eip.adoc[EIP patterns] allows you to route messages while avoiding the dependency of the router on all possible destinations while maintaining its efficiency.
 
 image:http://www.enterpriseintegrationpatterns.com/img/DynamicRouter.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/filter-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/filter-eip.adoc
@@ -2,14 +2,14 @@
 == Filter EIP
 
 The http://www.enterpriseintegrationpatterns.com/Filter.html[Message
-Filter] from the link:enterprise-integration-patterns.html[EIP patterns]
+Filter] from the xref:enterprise-integration-patterns.adoc[EIP patterns]
 allows you to filter messages
 
 image:http://www.enterpriseintegrationpatterns.com/img/MessageFilter.gif[image]
 
 The following example shows how to create a Message Filter route
 consuming messages from an endpoint called *queue:a*, which if the
-link:predicate.html[Predicate] is true will be dispatched to *queue:b*
+xref:predicate.adoc[Predicate] is true will be dispatched to *queue:b*
 
 === EIP options
 
@@ -76,7 +76,7 @@ And the example in XML:
 Stop is a bit different than a message filter as it will filter out all
 messages and end the route entirely (filter only applies to its child
 processor). Stop is convenient to use in a
-link:content-based-router.html[Content Based Router] when you for
+xref:content-based-router.adoc[Content Based Router] when you for
 example need to stop further processing in one of the predicates.
 
 In the example below we do not want to route messages any further that
@@ -87,16 +87,16 @@ the when predicate by using the `.stop()`.
 
 *Available as of Camel 2.5*
 
-The link:message-filter.html[Message Filter] EIP will add a property on
-the link:exchange.html[Exchange] that states if it was filtered or not.
+The xref:message-filter.adoc[Message Filter] EIP will add a property on
+the xref:exchange.adoc[Exchange] that states if it was filtered or not.
 
 The property has the key `Exchange.FILTER_MATCHED`, which has the String
 value of `CamelFilterMatched`. Its value is a boolean indicating `true`
-or `false`. If the value is `true` then the link:exchange.html[Exchange]
+or `false`. If the value is `true` then the xref:exchange.adoc[Exchange]
 was routed in the filter block. This property will be visible within the
-link:message-filter.html[Message Filter] block who's
-link:predicate.html[Predicate] matches (value set to `true`), and to the
-steps immediately following the link:message-filter.html[Message Filter]
+xref:message-filter.adoc[Message Filter] block who's
+xref:predicate.adoc[Predicate] matches (value set to `true`), and to the
+steps immediately following the xref:message-filter.adoc[Message Filter]
 with the value set based on the results of the last
-link:message-filter.html[Message Filter] link:predicate.html[Predicate]
+xref:message-filter.adoc[Message Filter] xref:predicate.adoc[Predicate]
 evaluated.

--- a/docs/user-manual/modules/ROOT/pages/from-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/from-eip.adoc
@@ -1,6 +1,6 @@
 [[from-eip]]
 == From EIP
-Starting point for a Camel route that starts a route with a given endpoint. The endpoint can be from one of the many Camel link:https://github.com/apache/camel/tree/master/components[Components]. The component creates Camel exchanges from their respective sources and puts them into the route.
+Starting point for a Camel route that starts a route with a given endpoint. The endpoint can be from one of the many Camel https://github.com/apache/camel/tree/master/components[Components]. The component creates Camel exchanges from their respective sources and puts them into the route.
 
 === Options
 

--- a/docs/user-manual/modules/ROOT/pages/hystrix-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/hystrix-eip.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel 2.18*
 
-The Hystrix EIP provides integration with Netflix link:https://github.com/Netflix/Hystrix[Hystrix] to be used as circuit breaker in the Camel routes. Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.
+The Hystrix EIP provides integration with Netflix https://github.com/Netflix/Hystrix[Hystrix] to be used as circuit breaker in the Camel routes. Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.
 
 Maven users will need to add the following dependency to their pom.xml to use this EIP:
 
@@ -95,8 +95,8 @@ And in XML DSL:
 </camelContext>
 ----
 
-See link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/onFallback-eip.adoc[onFallback]
+See https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/onFallback-eip.adoc[onFallback]
 
 === Other examples
 
-You can find an example with the source code: link:https://github.com/apache/camel/tree/master/examples/camel-example-hystrix[camel-example-hystrix].
+You can find an example with the source code: https://github.com/apache/camel/tree/master/examples/camel-example-hystrix[camel-example-hystrix].

--- a/docs/user-manual/modules/ROOT/pages/idempotentConsumer-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/idempotentConsumer-eip.adoc
@@ -3,11 +3,11 @@
 
 The
 http://www.enterpriseintegrationpatterns.com/IdempotentReceiver.html[Idempotent
-Consumer] from the link:enterprise-integration-patterns.html[EIP
+Consumer] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] is used to filter out duplicate messages.
 
 The Idempotent Consumer essentially acts like a
-link:message-filter.html[Message Filter] to filter out duplicates.
+xref:message-filter.adoc[Message Filter] to filter out duplicates.
 
 Camel will add the message id eagerly to the repository to detect
 duplication also for Exchanges currently in progress. 
@@ -17,13 +17,13 @@ the Exchange failed, otherwise it stays there.
 Camel provides the following Idempotent Consumer implementations:
 
 * MemoryIdempotentRepository
-* link:file2.html[FileIdempotentRepository]
-* link:hazelcast-component.html[HazelcastIdempotentRepository]
+* xref:file2.adoc[FileIdempotentRepository]
+* xref:hazelcast-component.adoc[HazelcastIdempotentRepository]
 * <<sql-component,JdbcMessageIdRepository>>
 * <<jpa-component,JpaMessageIdRepository>>
 * <<infinispan-component,InfinispanIdempotentRepository>>
 * <<jcache-component,JCacheIdempotentRepository>>
-* link:spring.html[SpringCacheIdempotentRepository]
+* xref:spring.adoc[SpringCacheIdempotentRepository]
 * <<ehcache-component,EhcacheIdempotentRepository>>
 * <<kafka-component,KafkaIdempotentRepository>>
 

--- a/docs/user-manual/modules/ROOT/pages/log-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/log-eip.adoc
@@ -1,12 +1,12 @@
 [[log-eip]]
 == Log EIP
 
-How can I log the processing of a link:message.html[Message]?
+How can I log the processing of a xref:message.adoc[Message]?
 
 Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
 * You can use the <<log-component,Log>> component which logs the Message content.
-* You can use the link:tracer.html[Tracer] which trace logs message flow.
-* You can also use a link:processor.html[Processor] or link:bean.html[Bean] and log from Java code.
+* You can use the xref:tracer.adoc[Tracer] which trace logs message flow.
+* You can also use a xref:processor.adoc[Processor] or xref:bean.adoc[Bean] and log from Java code.
 * You can use the log DSL.
 
 === Options

--- a/docs/user-manual/modules/ROOT/pages/marshal-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/marshal-eip.adoc
@@ -1,7 +1,7 @@
 [[marshal-eip]]
 == Marshal EIP
 
-Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel link:https://github.com/apache/camel/tree/master/components[Components]. Marshalling is used in the same way as unmarshalling above; in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry].
+Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel https://github.com/apache/camel/tree/master/components[Components]. Marshalling is used in the same way as unmarshalling above; in the https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry].
 
 == Options
 
@@ -17,7 +17,7 @@ The Marshal EIP supports 1 options which are listed below:
 
 === Samples
 
-The following example unmarshals via serialization then marshals using a named JAXB data format to perform a kind of link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+The following example unmarshals via serialization then marshals using a named JAXB data format to perform a kind of https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/multicast-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/multicast-eip.adoc
@@ -132,5 +132,5 @@ allows you to do this using the processor
 interface.
 
 Notice the `onPrepare` can be used for any kind of custom logic which
-you would like to execute before the link:exchange.html[Exchange] is
+you would like to execute before the xref:exchange.adoc[Exchange] is
 being multicasted.

--- a/docs/user-manual/modules/ROOT/pages/otherwise-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/otherwise-eip.adoc
@@ -2,7 +2,7 @@
 == Otherwise EIP
 
 The Otherwise EIP is related to http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns]
 
 image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[image]
@@ -17,7 +17,7 @@ The Otherwise EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/pipeline-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/pipeline-eip.adoc
@@ -1,12 +1,12 @@
 [[pipeline-eip]]
 == Pipeline EIP
 
-Camel supports the link:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
+Camel supports the xref:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
 
 image:http://www.enterpriseintegrationpatterns.com/img/PipesAndFilters.gif[image]
 
 With Camel you can split your processing across multiple independent
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] instances which can then be chained
+https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] instances which can then be chained
 together.
 
 === Options
@@ -19,7 +19,7 @@ The Pipeline EIP has no options.
 === Examples
 
 You can create pipelines of logic using multiple
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] or link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message
+https://github.com/apache/camel/blob/master/docs/user-manual/en/endpoint.adoc[Endpoint] or https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message
 Translator] instances as follows
 
 Though pipeline is the default mode of operation when you specify

--- a/docs/user-manual/modules/ROOT/pages/process-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/process-eip.adoc
@@ -1,7 +1,7 @@
 [[process-eip]]
 == Process EIP
 
-The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 
@@ -31,7 +31,7 @@ public class MyProcessor implements Processor {
 
 You can then easily use this inside a route by declaring the bean in
 Spring, say via the XML (or registering it in JNDI if that is your
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry])
+https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry])
 
 [source,xml]
 --------------------------------------------------------
@@ -57,7 +57,7 @@ Processor myProcessor = new MyProcessor();
 from("activemq:myQueue").process(myProcessor);
 ----
 
-If you need to lookup the processor in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry]
+If you need to lookup the processor in the https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry]
 then you should use the *processRef* DSL:
 
 [source,java]
@@ -91,15 +91,15 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/P
 which supports the full <<Endpoint-Endpoints,Endpoint>> semantics given a
 Processor instance.
 
-So you just need to create a link:https://github.com/apache/camel/tree/master/components[Component] class by
+So you just need to create a https://github.com/apache/camel/tree/master/components[Component] class by
 deriving from
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent]
 which returns instances of ProcessorEndpoint. For more details see
-link:writing-components.html[Writing Components]
+xref:writing-components.adoc[Writing Components]
 
 === See Also
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/enrich-eip.adoc[Content Enricher-Enrich EIP]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/pollEnrich-eip.adoc[Content Enricher-Poll Enrich EIP]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/content-filter.adoc[Content Filter]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/enrich-eip.adoc[Content Enricher-Enrich EIP]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/pollEnrich-eip.adoc[Content Enricher-Poll Enrich EIP]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/content-filter.adoc[Content Filter]

--- a/docs/user-manual/modules/ROOT/pages/recipientList-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/recipientList-eip.adoc
@@ -1,6 +1,6 @@
 [[recipientList-eip]]
 == Recipient List EIP
-The link:http://www.enterpriseintegrationpatterns.com/RecipientList.html[Recipient List] from the EIP patterns allows you to route messages to a number of dynamically specified recipients.
+The xref:http://www.enterpriseintegrationpatterns.com/RecipientList.html[Recipient List] from the EIP patterns allows you to route messages to a number of dynamically specified recipients.
 
 image:http://www.enterpriseintegrationpatterns.com/img/RecipientList.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/resequence-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/resequence-eip.adoc
@@ -1,7 +1,7 @@
 [[resequence-eip]]
 == Resequence EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the link:https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to reorganise messages based on some comparator. +
+The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
 By default in Camel we use an Expression to create the comparator; so that you can compare by a message header or the body or a piece of a message etc.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Resequencer.gif[image]

--- a/docs/user-manual/modules/ROOT/pages/resequence-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/resequence-eip.adoc
@@ -1,7 +1,7 @@
 [[resequence-eip]]
 == Resequence EIP
 
-The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
+The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to reorganise messages based on some comparator. +
 By default in Camel we use an Expression to create the comparator; so that you can compare by a message header or the body or a piece of a message etc.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Resequencer.gif[image]

--- a/docs/user-manual/modules/ROOT/pages/rollback-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rollback-eip.adoc
@@ -4,12 +4,12 @@ Rollback might be needed if there is a transaction or transactional pieces in yo
 
 Camel recommends supporting the
 http://www.enterpriseintegrationpatterns.com/TransactionalClient.html[Transactional
-Client] from the link:enterprise-integration-patterns.html[EIP patterns]
+Client] from the xref:enterprise-integration-patterns.adoc[EIP patterns]
 using spring transactions.
 
 image:http://www.enterpriseintegrationpatterns.com/img/TransactionalClientSolution.gif[image]
 
-Transaction Oriented Endpoints like link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] support using a
+Transaction Oriented Endpoints like https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] support using a
 transaction for both inbound and outbound message exchanges. Endpoints
 that support transactions will participate in the current transaction
 context that they are called from.
@@ -115,7 +115,7 @@ from("activemq:queue:foo").policy(notsupported).to("activemq:queue:bar");
 
 ==== OSGi Blueprint
 
-If you are using link:https://github.com/apache/camel/blob/master/docs/user-manual/en/using-osgi-blueprint-with-camel.adoc[OSGi
+If you are using https://github.com/apache/camel/blob/master/docs/user-manual/en/using-osgi-blueprint-with-camel.adoc[OSGi
 Blueprint] then you most likely have to explicit declare a policy and
 refer to the policy from the transacted in the route.
 
@@ -159,12 +159,12 @@ configure a transaction policy bean, so we do not have any
 `PROPAGATION_REQUIRED` beans. All the beans needed to be configured is
 *standard* Spring beans only, eg. there are no Camel specific
 configuration at
-all.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]Then
+all.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]Then
 we are ready to define our Camel routes. We have two routes: 1 for
 success conditions, and 1 for a forced rollback condition. +
 This is after all based on a unit test. Notice that we mark each route
 as transacted using the *transacted*
-tag.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]That
+tag.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml[springTransactionalClientDataSourceMinimalConfiguration]That
 is all that is needed to configure a Camel route as being transacted.
 Just remember to use the *transacted* DSL. The rest is standard Spring
 XML to setup the transaction manager.
@@ -173,24 +173,24 @@ XML to setup the transaction manager.
 
 In this sample we want to listen for messages on a queue and process the
 messages with our business logic java code and send them along. Since
-its based on a link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java[TransactionMinimalConfigurationTest.java] the destination is a mock endpoint.
+its based on a https://github.com/apache/camel/blob/master/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java[TransactionMinimalConfigurationTest.java] the destination is a mock endpoint.
 
 First we configure the standard Spring XML to declare a JMS connection
 factory, a JMS transaction manager and our ActiveMQ component that we
 use in our
-routing.link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]And
+routing.https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]And
 then we configure our routes. Notice that all we have to do is mark the
 route as transacted using the *transacted*
-tag.link:https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]
+tag.https://github.com/apache/camel/blob/master/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.xml[TransactionMinimalConfigurationTest.xml]
 
 Transaction error handler
 
 When a route is marked as transacted using *transacted* Camel will
 automatic use the
-link:transactionerrorhandler.html[TransactionErrorHandler] as
-link:https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]. It supports basically the same
-feature set as the link:defaulterrorhandler.html[DefaultErrorHandler],
-so you can for instance use link:exception-clause.html[Exception Clause]
+xref:transactionerrorhandler.adoc[TransactionErrorHandler] as
+https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]. It supports basically the same
+feature set as the xref:defaulterrorhandler.adoc[DefaultErrorHandler],
+so you can for instance use xref:exception-clause.adoc[Exception Clause]
 as well.
 
 === Integration Testing with Spring
@@ -231,10 +231,10 @@ propagation behaviors for that where you configure it as follows:
 * The second route use `PROPAGATION_REQUIRES_NEW`
 
 This is configured in the Spring XML
-file.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml[MixedTransactionPropagationTest.xml]Then
+file.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml[MixedTransactionPropagationTest.xml]Then
 in the routes you use transacted DSL to indicate which of these two
 propagations it
-uses.link:https://github.com/apache/camel/blob/master/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.java[MixedTransactionPropagationTest.java]Notice
+uses.https://github.com/apache/camel/blob/master/components/camel-spring/src/test/java/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.java[MixedTransactionPropagationTest.java]Notice
 how we have configured the `onException` in the 2nd route to indicate in
 case of any exceptions we should handle it and just rollback this
 transaction. This is done using the `markRollbackOnlyLast` which tells
@@ -242,10 +242,10 @@ Camel to only do it for the current transaction and not globally.
 
 ==== See Also
 
-* link:error-handling-in-camel.html[Error handling in Camel]
-* link:transactionerrorhandler.html[TransactionErrorHandler]
-* link:https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]
-* link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS]
-* link:https://github.com/apache/camel/blob/master/docs/user-manual/en/oncompletion.adoc[On Completion]
+* xref:error-handling-in-camel.adoc[Error handling in Camel]
+* xref:transactionerrorhandler.adoc[TransactionErrorHandler]
+* https://github.com/apache/camel/blob/master/docs/user-manual/en/error-handler.adoc[Error Handler]
+* https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS]
+* https://github.com/apache/camel/blob/master/docs/user-manual/en/oncompletion.adoc[On Completion]
 
-link:using-this-pattern.html[Using This Pattern]
+xref:using-this-pattern.adoc[Using This Pattern]

--- a/docs/user-manual/modules/ROOT/pages/routingSlip-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routingSlip-eip.adoc
@@ -1,6 +1,6 @@
 [[routingSlip-eip]]
 == Routing Slip EIP
-The Routing Slip from the link:https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to route a message consecutively through a series of processing steps where the sequence of steps is not known at design time and can vary for each message.
+The Routing Slip from the https://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] allows you to route a message consecutively through a series of processing steps where the sequence of steps is not known at design time and can vary for each message.
 
 image:http://www.enterpriseintegrationpatterns.com/img/RoutingTableSimple.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/script-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/script-eip.adoc
@@ -7,7 +7,7 @@ This is useful when you need to invoke some logic that are not in Java code such
 Groovy or any of the other Languages. The message body is not changed (by default) however the scripting
 context has access to the current Exchange and can essentially change the message or headers directly.
 But the return value from the script is discarded and not used.
-If the return value should be used as a changed message body then use link:./message-translator.adoc[Message Translator] EIP instead.
+If the return value should be used as a changed message body then use xref:./message-translator.adoc[Message Translator] EIP instead.
 
 === Options
 

--- a/docs/user-manual/modules/ROOT/pages/split-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/split-eip.adoc
@@ -1,7 +1,7 @@
 [[split-eip]]
 == Split EIP
 
-The link:http://www.enterpriseintegrationpatterns.com/patterns/messaging/Sequencer.html[Splitter] from the link:enterprise-integration-patterns.html[EIP patterns] allows you split a message into a number of pieces and process them individually.
+The http://www.enterpriseintegrationpatterns.com/patterns/messaging/Sequencer.html[Splitter] from the xref:enterprise-integration-patterns.adoc[EIP patterns] allows you split a message into a number of pieces and process them individually.
 
 image:http://www.enterpriseintegrationpatterns.com/img/Sequencer.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/step-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/step-eip.adoc
@@ -1,7 +1,7 @@
 [[step-eip]]
 == Step EIP
 
-Camel supports the link:http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
+Camel supports the http://www.enterpriseintegrationpatterns.com/PipesAndFilters.html[Pipes and Filters] from the https://github.com/apache/camel/blob/master/docs/user-manual/en/enterprise-integration-patterns.adoc[EIP patterns] in various ways.
 
 image:http://www.enterpriseintegrationpatterns.com/img/PipesAndFilters.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/to-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/to-eip.adoc
@@ -3,12 +3,12 @@
 
 See message related documentation
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message.adoc[Message]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-bus.adoc[Message Bus]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-channel.adoc[Message Channel]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-endpoint.adoc[Message Endpoint]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-router.adoc[Message Router]
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message.adoc[Message]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-bus.adoc[Message Bus]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-channel.adoc[Message Channel]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-endpoint.adoc[Message Endpoint]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-router.adoc[Message Router]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 

--- a/docs/user-manual/modules/ROOT/pages/toD-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/toD-eip.adoc
@@ -3,7 +3,7 @@
 
 There is a new `.toD` / `<toD>` that allows to send a message to a dynamic
 computed <<Endpoint-Endpoints,Endpoint>> using one or
-more link:expression.html[Expression] that are concat together. By
+more xref:expression.adoc[Expression] that are concat together. By
 default the <<simple-language,Simple>> language is used to compute
 the endpoint.
 

--- a/docs/user-manual/modules/ROOT/pages/transform-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transform-eip.adoc
@@ -3,7 +3,7 @@
 
 See below for details
 
-* link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
+* https://github.com/apache/camel/blob/master/camel-core/src/main/docs/eips/message-translator.adoc[Message Translator]
 
 === Options
 

--- a/docs/user-manual/modules/ROOT/pages/unmarshal-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/unmarshal-eip.adoc
@@ -1,7 +1,7 @@
 [[unmarshal-eip]]
 == Unmarshal EIP
 
-If you receive a message from one of the Camel link:https://github.com/apache/camel/tree/master/components[Components] such as link:https://github.com/apache/camel/blob/master/camel-core/src/main/docs/file-component.adoc[File], link:https://github.com/apache/camel/blob/master/components/camel-http/src/main/docs/http-component.adoc[HTTP] or link:https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some link:https://github.com/apache/camel/blob/master/docs/user-manual/en/bean-integration.adoc[Bean Integration] or perform link:https://github.com/apache/camel/blob/master/docs/user-manual/en/expression.adoc#predicate[Predicate] evaluation and so forth. To do this use the *unmarshal* word in the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] in Java or the link:https://github.com/apache/camel/blob/master/docs/user-manual/en/camel-configuration-utilities.adoc#xml-configuration[Xml Configuration].
+If you receive a message from one of the Camel https://github.com/apache/camel/tree/master/components[Components] such as https://github.com/apache/camel/blob/master/camel-core/src/main/docs/file-component.adoc[File], https://github.com/apache/camel/blob/master/components/camel-http/src/main/docs/http-component.adoc[HTTP] or https://github.com/apache/camel/blob/master/components/camel-jms/src/main/docs/jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some https://github.com/apache/camel/blob/master/docs/user-manual/en/bean-integration.adoc[Bean Integration] or perform https://github.com/apache/camel/blob/master/docs/user-manual/en/expression.adoc#predicate[Predicate] evaluation and so forth. To do this use the *unmarshal* word in the https://github.com/apache/camel/blob/master/docs/user-manual/en/dsl.adoc[DSL] in Java or the https://github.com/apache/camel/blob/master/docs/user-manual/en/camel-configuration-utilities.adoc#xml-configuration[Xml Configuration].
 
 == Options
 
@@ -28,11 +28,11 @@ from("activemq:My.Queue").
   to("mqseries:Another.Queue");
 ----
 
-The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your link:https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry] such as via your link:spring.html[Spring] XML file.
+The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your https://github.com/apache/camel/blob/master/docs/user-manual/en/registry.adoc[Registry] such as via your xref:spring.adoc[Spring] XML file.
 
 You can also use the DSL itself to define the data format as you use it.
 For example the following uses Java serialization to unmarshal a binary
-file then send it as an ObjectMessage to link:https://github.com/apache/camel/tree/master/docs/user-manual/en/activemq.adoc[ActiveMQ]
+file then send it as an ObjectMessage to https://github.com/apache/camel/tree/master/docs/user-manual/en/activemq.adoc[ActiveMQ]
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/when-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/when-eip.adoc
@@ -2,7 +2,7 @@
 == When EIP
 
 The When EIP is related to http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html[Content
-Based Router] from the link:enterprise-integration-patterns.html[EIP
+Based Router] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns]
 
 image:http://www.enterpriseintegrationpatterns.com/img/ContentBasedRouter.gif[image]
@@ -17,7 +17,7 @@ The When EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various link:predicate.html[Predicate] expressions
+the evaluation of various xref:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/wireTap-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/wireTap-eip.adoc
@@ -2,7 +2,7 @@
 == Wire Tap EIP
 
 http://www.enterpriseintegrationpatterns.com/WireTap.html[Wire Tap]
-(from the link:enterprise-integration-patterns.html[EIP patterns])
+(from the xref:enterprise-integration-patterns.adoc[EIP patterns])
 allows you to route messages to a separate location while they are being
 forwarded to the ultimate destination.
 
@@ -10,10 +10,10 @@ image:http://www.enterpriseintegrationpatterns.com/img/WireTap.gif[image]
 
 === Streams
 
-If you link:wire-tap.html[Wire Tap] a stream message body then you
-should consider enabling link:stream-caching.html[Stream caching] to
+If you xref:wire-tap.adoc[Wire Tap] a stream message body then you
+should consider enabling xref:stream-caching.adoc[Stream caching] to
 ensure the message body can be read at each endpoint. See more details
-at link:stream-caching.html[Stream caching].
+at xref:stream-caching.adoc[Stream caching].
 
 === Options
 
@@ -41,29 +41,29 @@ The Wire Tap EIP supports 11 options which are listed below:
 
 The WireTap uses a thread pool to process the
 tapped messages. This thread pool will by default use the settings
-detailed at link:threading-model.html[Threading Model]. In particular,
+detailed at xref:threading-model.adoc[Threading Model]. In particular,
 when the pool is exhausted (with all threads utilized), further wiretaps
 will be executed synchronously by the calling thread. To remedy this,
-you can configure an explicit thread pool on the link:wire-tap.html[Wire
+you can configure an explicit thread pool on the xref:wire-tap.adoc[Wire
 Tap] having either a different rejection policy, a larger worker queue,
 or more worker threads.
 
 === WireTap Node
 
 Camel's Wire Tap node supports two flavors when tapping an
-link:exchange.html[Exchange]:
+xref:exchange.adoc[Exchange]:
 
 - With the traditional Wire Tap, Camel will copy the original
-link:exchange.html[Exchange] and set its
-link:exchange-pattern.html[Exchange Pattern] to *`InOnly`*, as we want
-the tapped link:exchange.html[Exchange] to be sent in a fire and forget
-style. The tapped link:exchange.html[Exchange] is then sent in a
+xref:exchange.adoc[Exchange] and set its
+xref:exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
+the tapped xref:exchange.adoc[Exchange] to be sent in a fire and forget
+style. The tapped xref:exchange.adoc[Exchange] is then sent in a
 separate thread so it can run in parallel with the original. Beware that
 only the Exchange is copied - Wire Tap won't do a deep clone (unless you
 specify a custom processor via *`onPrepareRef`* which does that). So all
 copies could share objects from the original Exchange.
 - Camel also provides an option of sending a new
-link:exchange.html[Exchange] allowing you to populate it with new
+xref:exchange.adoc[Exchange] allowing you to populate it with new
 values.
 
 === Sending a Copy (traditional wiretap)
@@ -93,27 +93,27 @@ values.
     }
 ----
 
-=== Sending a New link:exchange.html[Exchange]
+=== Sending a New xref:exchange.adoc[Exchange]
 
 *Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>*
 
 Camel supports either a processor or an
-link:expression.html[Expression] to populate the new
-link:exchange.html[Exchange]. Using a processor gives you full power
-over how the link:exchange.html[Exchange] is populated as you can set
-properties, headers, etc. An link:expression.html[Expression] can only
+xref:expression.adoc[Expression] to populate the new
+xref:exchange.adoc[Exchange]. Using a processor gives you full power
+over how the xref:exchange.adoc[Exchange] is populated as you can set
+properties, headers, etc. An xref:expression.adoc[Expression] can only
 be used to set the *`IN`* body.
 
-The link:expression.html[Expression] or
-link:processor.html[Processor] is pre-populated with a copy of the
-original link:exchange.html[Exchange], which allows you to access the
-original message when you prepare a new link:exchange.html[Exchange] to
+The xref:expression.adoc[Expression] or
+xref:processor.adoc[Processor] is pre-populated with a copy of the
+original xref:exchange.adoc[Exchange], which allows you to access the
+original message when you prepare a new xref:exchange.adoc[Exchange] to
 be sent. You can use the *`copy`* option (enabled by default) to
 indicate whether you want this.
 
 Below is the processor variation,
 where we disable *`copy`* by passing in *`false`* to create a new, empty
-link:exchange.html[Exchange]
+xref:exchange.adoc[Exchange]
 
 [source,java]
 ----
@@ -144,7 +144,7 @@ link:exchange.html[Exchange]
 *Available as of Camel 2.16:*
 
 For example to wire tap to a dynamic URI, then it supports the same
-dynamic URIs as documented in link:message-endpoint.html[Message
+dynamic URIs as documented in xref:message-endpoint.adoc[Message
 Endpoint]. For example to wire tap to a JMS queue where the header ID is
 part of the queue name:
 
@@ -158,10 +158,10 @@ part of the queue name:
 
 *Available as of Camel 2.8*
 
-If you send a new message using link:wire-tap.html[Wire Tap], then you
+If you send a new message using xref:wire-tap.adoc[Wire Tap], then you
 could only set the message body using an
-link:expression.html[Expression] from the DSL. If you also need to set
-headers, you would have to use a link:processor.html[Processor].
+xref:expression.adoc[Expression] from the DSL. If you also need to set
+headers, you would have to use a xref:processor.adoc[Processor]. From
 It's possible to set headers as well using the DSL.
 
 The following example sends a new message which has
@@ -206,6 +206,6 @@ The following example sends a new message which has
 
 *Available as of Camel 2.8*
 
-See details at link:multicast.html[Multicast]
+See details at xref:multicast.adoc[Multicast]
 
-link:using-this-pattern.html[Using This Pattern]
+xref:using-this-pattern.adoc[Using This Pattern]

--- a/platforms/spring-boot/components-starter/camel-aws-s3-starter/src/main/java/org/apache/camel/component/aws/s3/springboot/S3ComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-aws-s3-starter/src/main/java/org/apache/camel/component/aws/s3/springboot/S3ComponentConfiguration.java
@@ -140,8 +140,7 @@ public class S3ComponentConfiguration
          */
         private String secretKey;
         /**
-         * Reference to a `com.amazonaws.services.s3.AmazonS3` in the
-         * xref:registry.adoc[Registry].
+         * Reference to a `com.amazonaws.services.s3.AmazonS3` in the registry.
          */
         private AmazonS3 amazonS3Client;
         /**

--- a/platforms/spring-boot/components-starter/camel-aws-s3-starter/src/main/java/org/apache/camel/component/aws/s3/springboot/S3ComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-aws-s3-starter/src/main/java/org/apache/camel/component/aws/s3/springboot/S3ComponentConfiguration.java
@@ -141,7 +141,7 @@ public class S3ComponentConfiguration
         private String secretKey;
         /**
          * Reference to a `com.amazonaws.services.s3.AmazonS3` in the
-         * link:registry.html[Registry].
+         * xref:registry.adoc[Registry].
          */
         private AmazonS3 amazonS3Client;
         /**


### PR DESCRIPTION
Problem: - There were some linking errors like "page not found <<from some page>> to <<some other page>>" when I run "yarn run check" after run "yarn build" to locally build camel-website repository in my pc.

Solution: -  To fix that I had to fix .adoc files in camel repository. Even I fixed those .adoc files when I run "./mvnw -Pfastinstall install" in camel root directory some changes revert back to error giving state. So I fixed those .adocs in "core/camel-core/src/main/docs/eips" and "camel/components" then ran "./mvnw -Pfastinstall install" to regenerate  doc files correctly

Output: - This reduced the  number of "page not found" errors when I run "yarn run check" after "yarn build" locally in camel-website repository