### PR TITLE
using the correct result set method to get value from blob-type column

### DIFF
--- a/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/ResultSetIterator.java
+++ b/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/ResultSetIterator.java
@@ -207,7 +207,7 @@ public class ResultSetIterator implements Iterator<Map<String, Object>> {
 
         @Override
         public Object getValue(ResultSet resultSet) throws SQLException {
-            return resultSet.getString(columnNumber);
+            return resultSet.getBlob(columnNumber);
         }
 
         public Object getBytes(ResultSet resultSet) throws SQLException {

--- a/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/ResultSetIterator.java
+++ b/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/ResultSetIterator.java
@@ -56,7 +56,10 @@ public class ResultSetIterator implements Iterator<Map<String, Object>> {
             int columnNumber = i + 1;
             String columnName = getColumnName(metaData, columnNumber, isJDBC4);
             int columnType = metaData.getColumnType(columnNumber);
-            if (columnType == Types.CLOB || columnType == Types.BLOB) {
+
+            if(columnType == Types.CLOB) {
+                columns[i] = new ClobColumn(columnName, columnNumber);
+            } else if (columnType == Types.BLOB) {
                 columns[i] = new BlobColumn(columnName, columnNumber);
             } else {
                 columns[i] = new DefaultColumn(columnName, columnNumber);
@@ -212,6 +215,26 @@ public class ResultSetIterator implements Iterator<Map<String, Object>> {
 
         public Object getBytes(ResultSet resultSet) throws SQLException {
             return resultSet.getBytes(columnNumber);
+        }
+    }
+
+    private static final class ClobColumn implements Column {
+        private final int columnNumber;
+        private final String name;
+
+        private ClobColumn(String name, int columnNumber) {
+            this.name = name;
+            this.columnNumber = columnNumber;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Object getValue(ResultSet resultSet) throws SQLException {
+            return resultSet.getClob(columnNumber);
         }
     }
 }

--- a/components/camel-jdbc/src/test/java/org/apache/camel/component/jdbc/JdbcColumnTypeTest.java
+++ b/components/camel-jdbc/src/test/java/org/apache/camel/component/jdbc/JdbcColumnTypeTest.java
@@ -1,0 +1,53 @@
+package org.apache.camel.component.jdbc;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.sql.Clob;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.logging.log4j.core.util.IOUtils;
+import org.junit.Test;
+
+public class JdbcColumnTypeTest extends AbstractJdbcTestSupport {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testClobColumnType() throws SQLException {
+        Endpoint directHelloEndpoint = context.getEndpoint("direct:hello");
+        Exchange directHelloExchange = directHelloEndpoint.createExchange();
+
+        directHelloExchange.getIn().setBody("select * from tableWithClob");
+
+        Exchange out = template.send(directHelloEndpoint, directHelloExchange);
+        assertNotNull(out);
+        assertNotNull(out.getOut());
+
+        List<Map<String, Object>> returnValues = out.getOut().getBody(List.class);
+        assertNotNull(returnValues);
+        assertEquals(1, returnValues.size());
+        Map<String, Object> row = returnValues.get(0);
+        assertEquals("id1", row.get("ID"));
+        assertNotNull(row.get("PICTURE"));
+
+        Set<String> columnNames = (Set<String>) out.getOut().getHeader(JdbcConstants.JDBC_COLUMN_NAMES);
+        assertNotNull(columnNames);
+        assertEquals(2, columnNames.size());
+        assertTrue(columnNames.contains("ID"));
+        assertTrue(columnNames.contains("PICTURE"));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello").to("jdbc:testdb?readSize=100");
+            }
+        };
+    }
+}

--- a/components/camel-jdbc/src/test/resources/sql/init.sql
+++ b/components/camel-jdbc/src/test/resources/sql/init.sql
@@ -22,3 +22,6 @@ insert into customer values('cust3','willem');
 
 create table tableWithAutoIncr (id int not null GENERATED ALWAYS AS IDENTITY, content varchar(10));
 insert into tableWithAutoIncr (content) values ('value1');
+
+create table tableWithClob (id varchar(15), picture clob(10M));
+insert into tableWithClob values ('id1', cast('\x0123456789ABCDEF' as clob));


### PR DESCRIPTION
Problem:

> Caused by: java.sql.SQLException: Tipo de coluna inválido: getString/getNString not implemented for class oracle.jdbc.driver.T4CBlobAccessor
>         at oracle.jdbc.driver.Accessor.unimpl(Accessor.java:296)
>         at oracle.jdbc.driver.BlobAccessor.getString(BlobAccessor.java:238)
>         at oracle.jdbc.driver.GeneratedStatement.getString(GeneratedStatement.java:287)
>         at oracle.jdbc.driver.GeneratedScrollableResultSet.getString(GeneratedScrollableResultSet.java:374)
>         at com.zaxxer.hikari.pool.HikariProxyResultSet.getString(HikariProxyResultSet.java)
>         at org.apache.camel.component.jdbc.ResultSetIterator$BlobColumn.getValue(ResultSetIterator.java:210)
>         at org.apache.camel.component.jdbc.ResultSetIterator.next(ResultSetIterator.java:86)

Solution: 
Use getBlob insted getString from resultSet in BlobColumn class.