### PR TITLE
anchor not found errors fixed inside camel/user-manual

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/aggregate-eip.adoc
@@ -187,7 +187,7 @@ consumer etc)
 The aggregator provides a pluggable repository which you can implement
 your own `org.apache.camel.spi.AggregationRepository`. +
  If you need persistent repository then you can use either Camel
-xref:leveldb.adoc[LevelDB], or <<sql-component,SQL Component>> components.
+xref:leveldb.adoc[LevelDB], or xref:sql-component.adoc[SQL Component] components.
 
 === Using TimeoutAwareAggregationStrategy
 

--- a/docs/user-manual/modules/ROOT/pages/async.adoc
+++ b/docs/user-manual/modules/ROOT/pages/async.adoc
@@ -47,7 +47,7 @@ event message.
 
 The Request Reply is when the caller sends a
 message and then *waits for a reply*. This is like the
-<<http-component,HTTP>> protocol that we use every day when we surf the
+xref:http-component.adoc[HTTP] protocol that we use every day when we surf the
 web. We send a request to fetch a web page and wait until the reply message
 comes with the web content.
 
@@ -72,9 +72,9 @@ diagram below:
 image:async.data/camel_sync_request_reply.png[image]
 
 \1. The client sends a sync Request Reply
-message over <<http-component,HTTP>> to Camel. The client application will
+message over xref:http-component.adoc[HTTP] to Camel. The client application will
 wait for the response that Camel routes and processes. +
- 2. The message invokes an external <<mina-component,TCP>> service using
+ 2. The message invokes an external xref:mina-component.adoc[TCP] service using
 synchronous Request Reply. The client
 application still waits for the response. +
  3. The response is send back to the client.
@@ -95,7 +95,7 @@ image:async.data/camel_async_request_reply.png[image]
 Request Reply message over HTTP
 to Camel. The control is immediately returned to the client application,
 that can continue and do other work while Camel routes the message. +
- 2. Camel invokes an external <<mina-component,TCP>> service using
+ 2. Camel invokes an external xref:mina-component.adoc[TCP] service using
 synchronous Request Reply. The client
 application can do other work simultaneously. +
  3. The client wants to get the reply so it uses the Future handle it
@@ -113,9 +113,9 @@ completely. This is illustrated in the diagram below:
 image:async.data/camel_sync_request_only.png[image]
 
 \1. The client sends a Request only and we can
-still use <<http-component,HTTP>> despite http being
+still use xref:http-component.adoc[HTTP] despite http being
 Request Reply by nature. +
- 2. Camel invokes an external <<mina-component,TCP>> service using
+ 2. Camel invokes an external xref:mina-component.adoc[TCP] service using
 synchronous Request Reply. The client
 application is still waiting. +
  3. The message is processed completely and the control is returned to
@@ -141,11 +141,11 @@ processed in Camel. This is illustrated in the diagram below:
 image:async.data/camel_async_request_only.png[image]
 
 \1. The client sends a Request only and we can
-still use <<http-component,HTTP>> despite http being
+still use xref:http-component.adoc[HTTP] despite http being
 Request Reply by nature. The control is
 immediately returned to the client application, that can continue and do
 other work while Camel routes the message. +
- 2. Camel invokes an external <<mina-component,TCP>> service using
+ 2. Camel invokes an external xref:mina-component.adoc[TCP] service using
 synchronous Request Reply. The client
 application can do other work simultaneously. +
  3. The message completes but no result is returned to the client.
@@ -253,19 +253,19 @@ exception.
 [[Async-Example:AsynchronousRequestReply]]
 ==== Example: Asynchronous Request Reply
 
-Suppose we want to call a <<http-component,HTTP>> service but it is usually
+Suppose we want to call a xref:http-component.adoc[HTTP] service but it is usually
 slow and thus we do not want to block and wait for the response, as we
 can do other important computation. So we can initiate an
 Async exchange to the HTTP endpoint and
-then do other stuff while the slow <<http-component,HTTP>> service is
+then do other stuff while the slow xref:http-component.adoc[HTTP] service is
 processing our request. And then a bit later we can use the `Future`
-handle to get the response from the <<http-component,HTTP>> service. Yeah
+handle to get the response from the xref:http-component.adoc[HTTP] service. Yeah
 nice so lets do it:
 
-First we define some routes in Camel. One for the <<http-component,HTTP>>
+First we define some routes in Camel. One for the xref:http-component.adoc[HTTP]
 service where we simulate a slow server as it takes at least 1 second to
 reply. And then other route that we want to invoke while the
-<<http-component,HTTP>> service is on route. This allows you to be able to
+xref:http-component.adoc[HTTP] service is on route. This allows you to be able to
 process the two routes simultaneously:
 
 [source,java]
@@ -347,13 +347,13 @@ assertMockEndpointsSatisfied();
 [[Async-UsingtheAPIwithcallbacks]]
 ==== Using the Async API with callbacks
 
-Suppose we want to call a <<http-component,HTTP>> service but it is usually
+Suppose we want to call a xref:http-component.adoc[HTTP] service but it is usually
 slow and thus we do not want to block and wait for the response, but
 instead let a callback gather the response. This allows us to send
 multiple requests without waiting for the replies before we can send the
 next request.
 
-First we define a route in Camel for the <<http-component,HTTP>> service
+First we define a route in Camel for the xref:http-component.adoc[HTTP] service
 where we simulate a slow server as it takes at least 1 second to reply.
 
 [source,java]
@@ -404,7 +404,7 @@ private static class MyCallback extends SynchronizationAdapter {
 }
 ---------------------------------------------------------------------------
 
-And then we have the client API where we call the <<http-component,HTTP>>
+And then we have the client API where we call the xref:http-component.adoc[HTTP]
 service using `asyncCallback` 3 times with different input. As the
 invocation is Async the client will send 3 requests
 right after each other, so we have 3 concurrent exchanges in progress.
@@ -628,8 +628,8 @@ transaction.
 * Request Only
 * http://davsclaus.blogspot.com/2009/05/on-road-to-camel-20-concurrency-with.html[Blog
 entry on using async for concurrent file processing]
-* <<seda-component,SEDA>>
-* <<direct-component,Direct>>
+* xref:seda-component.adoc[SEDA]
+* xref:direct-component.adoc[Direct]
 * To Async for non blocking
 Request Reply
 

--- a/docs/user-manual/modules/ROOT/pages/asynchronous-routing-engine.adoc
+++ b/docs/user-manual/modules/ROOT/pages/asynchronous-routing-engine.adoc
@@ -8,37 +8,37 @@ All the xref:enterprise-integration-patterns.adoc[Enterprise Integration Pattern
 are supported as well a selected number of
 Components:
 
-* <<ahc-component,AHC>> *Camel 2.8:* (only producer)
+* xref:ahc-component.adoc[AHC] *Camel 2.8:* (only producer)
 * AWS *Camel 2.11:* (only consumer) for S3 and SNS.
-* <<avro-component,Avro>> *Camel 2.10:* (only producer)
-* <<cxf-component,CXF>> *Camel 2.5:* (both consumer and producer)
-* <<cxfrs-component,CXFRS>> *Camel 2.5:* (only consumer)
-* <<direct-vm-component,Direct-VM>> *Camel 2.10.5/2.11.0:* (both consumer
+* xref:avro-component.adoc[Avro] *Camel 2.10:* (only producer)
+* xref:cxf-component.adoc[CXF] *Camel 2.5:* (both consumer and producer)
+* xref:cxfrs-component.adoc[CXFRS] *Camel 2.5:* (only consumer)
+* xref:direct-vm-component.adoc[Direct-VM] *Camel 2.10.5/2.11.0:* (both consumer
 and producer)
-* <<file-component,File>> - (only consumer)
-* <<ftp-component,FTP>> - (only consumer)
-* <<guava-eventbus-component,Guava EventBus>> *Camel 2.10:* (only consumer)
+* xref:file-component.adoc[File] - (only consumer)
+* xref:ftp-component.adoc[FTP] - (only consumer)
+* xref:guava-eventbus-component.adoc[Guava EventBus] *Camel 2.10:* (only consumer)
 * JBI (both consumer and producer)
-* <<jetty-component,Jetty>> (both consumer and producer)
-* <<jgroups-component,JGroups>> *Camel 2.10:* (only consumer)
-* <<jms-component,JMS>> *Camel 2.5:* (only producer for
+* xref:jetty-component.adoc[Jetty] (both consumer and producer)
+* xref:jgroups-component.adoc[JGroups] *Camel 2.10:* (only consumer)
+* xref:jms-component.adoc[JMS] *Camel 2.5:* (only producer for
 Request Reply messaging over JMS). *Camel 2.9:*
 (consumer, if option `asyncConsumer=true` is used).
-* <<jms-component,JMS>> *Camel 2.9:* (also consumer)
-* <<mqtt-component,MQTT>> *Camel 2.10.2:* (only producer)
+* xref:jms-component.adoc[JMS] *Camel 2.9:* (also consumer)
+* xref:mqtt-component.adoc[MQTT] *Camel 2.10.2:* (only producer)
 * NMR (both consumer and producer)
-* <<netty-component,Netty>> only producer (*Camel 2.10:* also consumer)
-* <<restlet-component,Restlet>> *Camel 2.8:* (only producer)
-* <<seda-component,SEDA>> (both consumer and producer) SEDA was mistakenly
+* xref:netty-component.adoc[Netty] only producer (*Camel 2.10:* also consumer)
+* xref:restlet-component.adoc[Restlet] *Camel 2.8:* (only producer)
+* xref:seda-component.adoc[SEDA] (both consumer and producer) SEDA was mistakenly
 in this list until November 3rd 2012. As of Camel 2.10.x, it still does
 not leverage the Async Routing Engine, but support is planned for
 http://camel.apache.org/camel-30-roadmap.html#Camel3.0-Roadmap-SEDA%2FVMcomponentstoleverageasyncroutingengine[Camel
 3.0].
 
-* <<timer-component,Timer>> *Camel 2.12:* (only consumer)
+* xref:timer-component.adoc[Timer] *Camel 2.12:* (only consumer)
 
 When we say a component is supported, that means, the component is
-leveraging the asynchronous model. For example <<jetty-component,Jetty>>
+leveraging the asynchronous model. For example xref:jetty-component.adoc[Jetty]
 uses continuations and the async http client to be fully asynchronous
 and non blocked. That means no threads will ever be blocked while
 waiting for a reply.
@@ -51,10 +51,10 @@ supported as well where it's applicable.
 
 You can configure the endpoints with the option `synchronous=true` to
 force using synchronous processing. For example when sending a web
-service request using <<cxf-component,CXF>>, the caller will wait for the
+service request using xref:cxf-component.adoc[CXF], the caller will wait for the
 reply if `synchronous=true` was configured. Currently this option is
 supported by the all the producers. If you don't want to let the
-<<cxf-component,CXF>> consumer leverage the CXF continuation API to use the
+xref:cxf-component.adoc[CXF] consumer leverage the CXF continuation API to use the
 asynchronous processing, you can also use this option `synchronous=true`
 to disable it. The JBI and NMR component
 are always asynchronous and doesn't support this option.

--- a/docs/user-manual/modules/ROOT/pages/backlog-tracer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-tracer.adoc
@@ -56,7 +56,7 @@ do "to*" to match any to. Or use "route-foo*" to match any foo routes.
 
 |traceFilter |`null` |Allow to configure a filter as a xref:predicate.adoc[Predicate] using
 any of the Camel xref:languages.adoc[languages]. But default the
-<<simple-language,Simple>> language is used. For example to filter on
+xref:simple-language.adoc[Simple] language is used. For example to filter on
 messages with a given header, use `${header.foo} != null`. To use
 xref:groovy.adoc[Groovy] then prefix the value with "groovy:". And
 similar for the other languages.
@@ -110,5 +110,5 @@ You would need to enable this using the JMX API.
 * xref:tracer-example.adoc[Tracer Example]
 * xref:debugger.adoc[Debugger]
 * xref:delay-interceptor.adoc[Delay Interceptor]
-* <<log-component,Log>>
+* xref:log-component.adoc[Log]
 

--- a/docs/user-manual/modules/ROOT/pages/backlogdebugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlogdebugger.adoc
@@ -98,5 +98,5 @@ You would need to enable this using the JMX API.
 
 * BacklogTracer
 * xref:debugger.adoc[Debugger]
-* <<log-component,Log>>
+* xref:log-component.adoc[Log]
 

--- a/docs/user-manual/modules/ROOT/pages/bam-example.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bam-example.adoc
@@ -76,17 +76,17 @@ the Camel Components
 correlate together the purchase order and invoice messages which can be
 any Expression via any of the
 Languages Supported. In this case we are
-using <<xpath-language,XPath>>.
+using xref:xpath-language.adoc[XPath].
 
 Then the final line of code defines the temporal rules to use; namely
 that it is considered to be an error if an invoice is not received
 within 2 seconds of a purchase order being received. When a failure
-occurs in this example we just send it to the <<log-component,Log>>
+occurs in this example we just send it to the xref:log-component.adoc[Log]
 component to log out an error level message to commons-logging / log4j.
 You could change this to use some of the other
 Components such as ActiveMQ,
-<<jms-component,JMS>>, <<jms-component,IRC>>, <<jms-component,Mail>>,
-<<xmpp-component,XMPP>> etc.
+xref:jms-component,JMS>>, <<jms-component,IRC>>, <<jms-component.adoc[Mail],
+xref:xmpp-component.adoc[XMPP] etc.
 
 [[BAMExample-Runningtheexample]]
 ==== Running the example

--- a/docs/user-manual/modules/ROOT/pages/batch-consumer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/batch-consumer.adoc
@@ -12,19 +12,19 @@ that a consumer can implement to indicate it support batching as well.
 The following components supports xref:batch-consumer.adoc[Batch
 Consumer] by its consumer:
 
-* <<atom-component,Atom>>
+* xref:atom-component.adoc[Atom]
 * File
 * FTP
-* <<hbase-component,hbase>>
-* <<ibatis-component,iBatis>>
-* <<jpa-component,JPA>>
-* <<jclouds-component,JCLOUDS>>
-* <<mail-component,Mail>>
-* <<mybatis-component,MyBatis>>
-* <<snmp-component,SNMP>>
-* <<sql-component,SQL>>
-* <<aws-sqs-component,SQS>>
-* <<aws-s3-component,S3>>
+* xref:hbase-component.adoc[hbase]
+* xref:ibatis-component.adoc[iBatis]
+* xref:jpa-component.adoc[JPA]
+* xref:jclouds-component.adoc[JCLOUDS]
+* xref:mail-component.adoc[Mail]
+* xref:mybatis-component.adoc[MyBatis]
+* xref:snmp-component.adoc[SNMP]
+* xref:sql-component.adoc[SQL]
+* xref:aws-sqs-component.adoc[SQS]
+* xref:aws-s3-component.adoc[S3]
 
 [[BatchConsumer-ConsumerOptions]]
 ==== Consumer Options

--- a/docs/user-manual/modules/ROOT/pages/bean-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-eip.adoc
@@ -11,7 +11,7 @@ bean:beanID[?options]
 ----
 
 Where *beanID* can be any string which is used to look up the bean in
-the <<Registry-Registry,Registry>>
+the xref:Registry-Registry.adoc[Registry]
 
 === EIP options
 
@@ -30,7 +30,7 @@ The Bean EIP supports 4 options which are listed below:
 
 === Bean as endpoint
 
-Camel also supports invoking <<bean-component,Bean>> as an Endpoint. In the
+Camel also supports invoking xref:bean-component.adoc[Bean] as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
@@ -43,7 +43,7 @@ type and storing the output of the method on the Exchange Out body.
 
 === Java DSL bean syntax
 
-Java DSL comes with syntactic sugar for the <<bean-component,Bean>>
+Java DSL comes with syntactic sugar for the xref:bean-component.adoc[Bean]
 component. Instead of specifying the bean explicitly as the endpoint
 (i.e. `to("bean:beanName")`) you can use the following syntax:
 
@@ -84,6 +84,6 @@ mechanisms in Camel.
 
 === See also
 
-* <<class-component,Class>> component
+* xref:class-component.adoc[Class] component
 * xref:bean-binding.adoc[Bean Binding]
 * xref:bean-integration.adoc[Bean Integration]

--- a/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
@@ -64,8 +64,8 @@ to use the annotations for routing and messaging.
 [[BeanIntegration-BeanComponent]]
 ==== Bean Component
 
-The <<bean-component,Bean>> component allows one to invoke a particular
-method. Alternately the <<bean-component,Bean>> component supports the
+The xref:bean-component.adoc[Bean] component allows one to invoke a particular
+method. Alternately the xref:bean-component.adoc[Bean] component supports the
 creation of a proxy via
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/bean/ProxyHelper.html[ProxyHelper]
 to a Java interface; which the implementation just sends a message
@@ -90,7 +90,7 @@ headers and so forth.
 *Bean binding*
 
 Whenever Camel invokes a bean method via one of the above methods
-(<<bean-component,Bean>> component, xref:spring-remoting.adoc[Spring
+(xref:bean-component.adoc[Bean] component, xref:spring-remoting.adoc[Spring
 Remoting] or POJO Consuming) then the
 *Bean Binding* mechanism is used to figure out
 what method to use (if it is not explicit) and how to bind the

--- a/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
@@ -8,9 +8,9 @@ which are pending or have been sent on it.
 
 Some example implementations include
 
-* <<jms-component,JMS>> for queues only (as of 1.3.0)
+* xref:jms-component.adoc[JMS] for queues only (as of 1.3.0)
 * List
-* <<mock-component,Mock>>
-* <<seda-component,Seda>>
-* <<vm-component,VM>>
+* xref:mock-component.adoc[Mock]
+* xref:seda-component.adoc[Seda]
+* xref:vm-component.adoc[VM]
 

--- a/docs/user-manual/modules/ROOT/pages/camel-boot.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-boot.adoc
@@ -15,19 +15,19 @@ The following camel boot options are supported:
 [[CamelBoot-CDI]]
 ==== CDI
 
-Using the <<cdi-component,camel-cdi module>> you can boot up your Camel
+Using the xref:cdi-component.adoc[camel-cdi module] you can boot up your Camel
 Java process using the *org.apache.camel.cdi.Main* class
 
 [[CamelBoot-Spring]]
 ==== Spring
 
-Using the <<SpringSupport-SpringSupport,camel-spring module>> you can boot your
+Using the xref:SpringSupport-SpringSupport.adoc[camel-spring module] you can boot your
 Camel Java process using the *org.apache.camel.spring.Main* class
 
 [[CamelBoot-SpringBoot]]
 ==== Spring Boot
 
 You can combine Spring Boot with Camel using
-<<SpringBoot-SpringBoot,Camel's Spring Boot integration>>. In this case
+xref:SpringBoot-SpringBoot.adoc[Camel's Spring Boot integration]. In this case
 your application looks and feels like a regular Spring Boot application
 but with full Camel integration.

--- a/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
@@ -13,21 +13,21 @@ of custom transport layer security (TLS) settings on Camel components.
 The following Camel components directly support the use of this
 configuration utility:
 
-* <<http4-component,HTTP4>>
-* <<jetty-component,Jetty>>
-* <<ahc-component,AHC>>
-* <<netty-component,Netty>>
-* <<cometd-component,Cometd>>
+* xref:http4-component.adoc[HTTP4]
+* xref:jetty-component.adoc[Jetty]
+* xref:ahc-component.adoc[AHC]
+* xref:netty-component.adoc[Netty]
+* xref:cometd-component.adoc[Cometd]
 * FTP2
-* <<irc-component,IRC>>
-* <<mail-component,Mail>>
+* xref:irc-component.adoc[IRC]
+* xref:mail-component.adoc[Mail]
 * MINA 2
 
 The following Camel components indirectly support the use of this
 configuration utility:
 
-* <<cxf-component,CXF>>
-* <<http-component,HTTP>>
+* xref:cxf-component.adoc[CXF]
+* xref:http-component.adoc[HTTP]
 
 [[CamelConfigurationUtilities-Configuration]]
 ==== Configuration

--- a/docs/user-manual/modules/ROOT/pages/configuring-route-startup-ordering-and-autostartup.adoc
+++ b/docs/user-manual/modules/ROOT/pages/configuring-route-startup-ordering-and-autostartup.adoc
@@ -90,7 +90,7 @@ from("activemq:queue:special").noAutoStartup().to("file://backup");
 *Available as of Camel 2.9*
 
 To startup based on a boolean, String or
-<<properties-component,Property>>, do one of the following:
+xref:properties-component.adoc[Property], do one of the following:
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/content-based-router-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/content-based-router-eip.adoc
@@ -13,7 +13,7 @@ The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
 the evaluation of various xref:predicate.adoc[Predicate] expressions
 
-=== Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>
+=== Using the xref:FluentBuilders-FluentBuilders.adoc[Fluent Builders]
 
 [source,java]
 ----
@@ -41,7 +41,7 @@ can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 ====
 
-=== Using the <<SpringXMLExtensions-SpringXMLExtensions,Spring XML Extensions>>
+=== Using the xref:SpringXMLExtensions-SpringXMLExtensions.adoc[Spring XML Extensions]
 
 [source,java]
 ----
@@ -72,8 +72,8 @@ https://github.com/apache/camel/blob/master/camel-core/src/test/java/org/apache/
 === Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-<<GettingStarted-GettingStarted,Getting Started>>. You may also find the
-<<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and xref:uris.adoc[URIs]. Then you could
-try out some of the <<Examples-Examples,Examples>> first before trying
+xref:GettingStarted-GettingStarted.adoc[Getting Started]. You may also find the
+xref:Architecture-Architecture.adoc[Architecture] useful particularly the description
+of xref:Endpoint-Endpoints.adoc[Endpoint] and xref:uris.adoc[URIs]. Then you could
+try out some of the xref:Examples-Examples.adoc[Examples] first before trying
 this pattern out.

--- a/docs/user-manual/modules/ROOT/pages/content-filter-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/content-filter-eip.adoc
@@ -4,26 +4,26 @@
 Camel supports the
 http://www.enterpriseintegrationpatterns.com/ContentFilter.html[Content
 Filter] from the
-<<EnterpriseIntegrationPatterns-EnterpriseIntegrationPatterns,EIP patterns>>
+xref:EnterpriseIntegrationPatterns-EnterpriseIntegrationPatterns.adoc[EIP patterns]
 using one of the following mechanisms in the routing logic to transform
 content from the inbound message.
 
-* <<messageTranslator-eip,Message Translator>>
-* invoking a <<BeanIntegration-BeanIntegration,Java bean>>
-* <<Processor-Processor,Processor>> object
+* xref:messageTranslator-eip.adoc[Message Translator]
+* invoking a xref:BeanIntegration-BeanIntegration.adoc[Java bean]
+* xref:Processor-Processor.adoc[Processor] object
 
 image:http://www.enterpriseintegrationpatterns.com/img/ContentFilter.gif[image]
 
 A common way to filter messages is to use an
-<<Expression-Expressions,Expression>> in the <<DSL-DSL,DSL>> like
-<<xquery-language,XQuery>>, <<sql-language,SQL>> or one of the supported
-<<ScriptingLanguages-ScriptingLanguages,Scripting Languages>>.
+xref:Expression-Expressions,Expression>> in the <<DSL-DSL.adoc[DSL] like
+xref:xquery-language,XQuery>>, <<sql-language.adoc[SQL] or one of the supported
+xref:ScriptingLanguages-ScriptingLanguages.adoc[Scripting Languages].
 
-=== Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>
+=== Using the xref:FluentBuilders-FluentBuilders.adoc[Fluent Builders]
 
-Here is a simple example using the <<DSL-DSL,DSL>> directly
+Here is a simple example using the xref:DSL-DSL.adoc[DSL] directly
 
-In this example we add our own <<Processor-Processor,Processor>>
+In this example we add our own xref:Processor-Processor.adoc[Processor]
 
 For further examples of this pattern in use you could look at one of the
 JUnit tests
@@ -58,8 +58,8 @@ interested in:
 === Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-<<GettingStarted-GettingStarted,Getting Started>>, you may also find the
-<<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and <<URIs-URIs,URIs>>. Then you could
-try out some of the <<Examples-Examples,Examples>> first before trying
+xref:GettingStarted-GettingStarted.adoc[Getting Started], you may also find the
+xref:Architecture-Architecture.adoc[Architecture] useful particularly the description
+of xref:Endpoint-Endpoints,Endpoint>> and <<URIs-URIs.adoc[URIs]. Then you could
+try out some of the xref:Examples-Examples.adoc[Examples] first before trying
 this pattern out.

--- a/docs/user-manual/modules/ROOT/pages/correlation-identifier.adoc
+++ b/docs/user-manual/modules/ROOT/pages/correlation-identifier.adoc
@@ -18,7 +18,7 @@ image:http://www.enterpriseintegrationpatterns.com/img/CorrelationIdentifierSolu
 The use of a Correlation Identifier is key to working with the
 xref:bam.adoc[Camel Business Activity Monitoring Framework] and can also
 be highly useful when testing with simulation or canned data such as
-with the <<mock-component,Mock testing framework>>
+with the xref:mock-component.adoc[Mock testing framework]
 
 Some xref:eip.adoc[EIP] patterns will spin off a sub message, and in
 those cases, Camel will add a correlation id on the
@@ -31,7 +31,7 @@ Tap] EIP does this.
 
 The following example demonstrates using the Camel JMSMessageID as the
 Correlation Identifier within a request/reply pattern in
-the <<jms-component,JMS>> component
+the xref:jms-component.adoc[JMS] component
 
 === Samples
 

--- a/docs/user-manual/modules/ROOT/pages/data-format.adoc
+++ b/docs/user-manual/modules/ROOT/pages/data-format.adoc
@@ -3,74 +3,74 @@
 
 Camel supports a pluggable DataFormat to allow messages to be marshalled
 to and from binary or text formats to support a kind of
-<<messageTranslator-eip,Message Translator>>.
+xref:messageTranslator-eip.adoc[Message Translator].
 
 The following data formats are currently supported:
 
 * Standard JVM object marshalling
-** <<serialization-dataformat,Serialization>>
-** <<string-dataformat,String>>
+** xref:serialization-dataformat.adoc[Serialization]
+** xref:string-dataformat.adoc[String]
 
 * Object marshalling
-** <<avro-dataformat,Avro>>
-** <<boon-dataformat,Boon>>
-** <<hessian-dataformat,Hessian>>
+** xref:avro-dataformat.adoc[Avro]
+** xref:boon-dataformat.adoc[Boon]
+** xref:hessian-dataformat.adoc[Hessian]
 ** xref:json.adoc[JSON]
-** <<protobuf-dataformat,Protobuf>>
-** <<yaml-snakeyaml-dataformat,YAML>>
+** xref:protobuf-dataformat.adoc[Protobuf]
+** xref:yaml-snakeyaml-dataformat.adoc[YAML]
 
 * Object/XML marshalling
-** <<castor-dataformat,Castor>>
-** <<jaxb-dataformat,JAXB>>
-** <<xmlBeans-dataformat,XmlBeans>>
-** <<xstream-dataformat,XStream>>
-** <<jibx-dataformat,JiBX>>
-** <<jacksonxml-dataformat,Jackson XML>>
+** xref:castor-dataformat.adoc[Castor]
+** xref:jaxb-dataformat.adoc[JAXB]
+** xref:xmlBeans-dataformat.adoc[XmlBeans]
+** xref:xstream-dataformat.adoc[XStream]
+** xref:jibx-dataformat.adoc[JiBX]
+** xref:jacksonxml-dataformat.adoc[Jackson XML]
 
 * Object/XML/Webservice marshalling
-** <<soap-dataformat,SOAP>>
+** xref:soap-dataformat.adoc[SOAP]
 
 * Direct JSON / XML marshalling
-** <<xmljson-dataformat,XmlJson>>
+** xref:xmljson-dataformat.adoc[XmlJson]
 
 * Flat data structure marshalling
-** <<beanio-dataformat,BeanIO>>
-** <<bindy-dataformat,Bindy>>
-** <<csv-dataformat,CSV>>
-** <<edi-dataformat,EDI>>
-** <<flatpack-dataformat,Flatpack DataFormat>>
-** uniVocity DataFormats <<univocity-csv-dataformat,CSV>> / <<univocity-tsv-dataformat,TSV>> / <<univocity-fixed-dataformat,Fixed Length>>
+** xref:beanio-dataformat.adoc[BeanIO]
+** xref:bindy-dataformat.adoc[Bindy]
+** xref:csv-dataformat.adoc[CSV]
+** xref:edi-dataformat.adoc[EDI]
+** xref:flatpack-dataformat.adoc[Flatpack DataFormat]
+** uniVocity DataFormats xref:univocity-csv-dataformat,CSV>> / <<univocity-tsv-dataformat,TSV>> / <<univocity-fixed-dataformat.adoc[Fixed Length]
 
 * Domain specific marshalling
-** <<hl7-dataformat,HL7 DataFormat>>
+** xref:hl7-dataformat.adoc[HL7 DataFormat]
 
 * Compression
-** <<gzip-dataformat,GZip DataFormat>>
-** <<zip-dataformat,Zip DataFormat>>
-** <<zipfile-dataformat,Zip File DataFormat>>
-** <<lzf-dataformat,LZF Data Format>>
-** <<tar-dataformat,Tar DataFormat>>
+** xref:gzip-dataformat.adoc[GZip DataFormat]
+** xref:zip-dataformat.adoc[Zip DataFormat]
+** xref:zipfile-dataformat.adoc[Zip File DataFormat]
+** xref:lzf-dataformat.adoc[LZF Data Format]
+** xref:tar-dataformat.adoc[Tar DataFormat]
 
 * Security
-** <<crypto-component,Crypto>>
-** <<crypto-component,PGP>>
-** <<secureXML-dataformat,XMLSecurity DataFormat>>
+** xref:crypto-component.adoc[Crypto]
+** xref:crypto-component.adoc[PGP]
+** xref:secureXML-dataformat.adoc[XMLSecurity DataFormat]
 
 * Misc.
-** <<base64-dataformat,Base64>>
-** <<custom-dataformat,Custom DataFormat>> -- to use your own
+** xref:base64-dataformat.adoc[Base64]
+** xref:custom-dataformat.adoc[Custom DataFormat] -- to use your own
 custom implementation
-** <<mime-multipart-dataformat,MIME-Multipart>>
-** <<rss-dataformat,RSS>>
-** <<tidymarkup-dataformat,TidyMarkup>>
-** <<syslog-dataformat,Syslog>>
-** <<ical-dataformat,ICal>>
-** <<barcode-dataformat,Barcode>> -- to read and generate barcodes
+** xref:mime-multipart-dataformat.adoc[MIME-Multipart]
+** xref:rss-dataformat.adoc[RSS]
+** xref:tidymarkup-dataformat.adoc[TidyMarkup]
+** xref:syslog-dataformat.adoc[Syslog]
+** xref:ical-dataformat.adoc[ICal]
+** xref:barcode-dataformat.adoc[Barcode] -- to read and generate barcodes
 (QR-Code, PDF417, ...)
 
 And related is the following:
 
-* <<dataformat-component,DataFormat Component>> for working with
+* xref:dataformat-component.adoc[DataFormat Component] for working with
   Data Formats as if it was a regular xref:component.adoc[Component]
   supporting xref:endpoint.adoc[Endpoints] and xref:uris.adoc[URIs].
 * xref:dozer-type-conversion.adoc[Dozer Type Conversion] using Dozer for
@@ -80,8 +80,8 @@ And related is the following:
 ==== Unmarshalling
 
 If you receive a message from one of the Camel
-xref:component.adoc[Components] such as <<file-component,File>>,
-<<http-component,HTTP>> or <<jms-component,JMS>> you often want to unmarshal
+xref:component.adoc[Components] such as xref:file-component.adoc[File],
+xref:http-component,HTTP>> or <<jms-component.adoc[JMS] you often want to unmarshal
 the payload into some bean so that you can process it using some
 xref:bean-integration.adoc[Bean Integration] or perform
 xref:predicate.adoc[Predicate] evaluation and so forth. To do this use
@@ -129,7 +129,7 @@ xref:registry.adoc[Registry].
 
 The following example unmarshals via serialization then marshals using a
 named JAXB data format to perform a kind of
-<<messageTranslator-eip,Message Translator>>:
+xref:messageTranslator-eip.adoc[Message Translator]:
 
 [source,java]
 ----

--- a/docs/user-manual/modules/ROOT/pages/dead-letter-channel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dead-letter-channel.adoc
@@ -67,13 +67,13 @@ forwarded to the dead letter queue.
 [[deadLetterChannel-AboutmovingExchangetodeadletterqueueandusinghandled]]
 === About moving Exchange to dead letter queue and using handled
 
-*Handled* on <<deadLetterChannel-eip,Dead Letter Channel>>
+*Handled* on xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 
 When all attempts of redelivery have failed the
 xref:exchange.adoc[Exchange] is moved to the dead letter queue (the dead
 letter endpoint). The exchange is then complete and from the client
 point of view it was processed. As such the
-<<deadLetterChannel-eip,Dead Letter Channel>> have handled the
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] have handled the
 xref:exchange.adoc[Exchange].
 
 For instance configuring the dead letter channel as:
@@ -103,7 +103,7 @@ And in XML:
 </bean>
 ----
 
-The <<deadLetterChannel-eip,Dead Letter Channel>> above will clear
+The xref:deadLetterChannel-eip.adoc[Dead Letter Channel] above will clear
 the caused exception (`setException(null)`), by moving the caused
 exception to a property on the xref:exchange.adoc[Exchange], with the
 key `Exchange.EXCEPTION_CAUGHT`. Then the xref:exchange.adoc[Exchange]
@@ -131,7 +131,7 @@ The route listen for JMS messages and validates, transforms and handle
 it. During this the xref:exchange.adoc[Exchange] payload is
 transformed/modified. So in case something goes wrong and we want to
 move the message to another JMS destination, then we can configure our
-<<deadLetterChannel-eip,Dead Letter Channel>> with the
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] with the
 *useOriginalMessage* option. But when we move the
 xref:exchange.adoc[Exchange] to this destination we do not know in which
 state the message is in. Did the error happen in before the
@@ -154,7 +154,7 @@ original we received.
 [[deadLetterChannel-OnRedelivery]]
 === OnRedelivery
 
-When <<deadLetterChannel-eip,Dead Letter Channel>> is doing
+When xref:deadLetterChannel-eip.adoc[Dead Letter Channel] is doing
 redeliver its possible to configure a xref:processor.adoc[Processor]
 that is executed just *before* every redelivery attempt. This can be
 used for the situations where you need to alter the message before its
@@ -164,7 +164,7 @@ TIP: *onException and onRedeliver*
 We also support for per xref:exception-clause.adoc[*onException*] to set
 a *onRedeliver*. That means you can do special on redelivery for
 different exceptions, as opposed to onRedelivery set on
-<<deadLetterChannel-eip,Dead Letter Channel>> can be viewed as a
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] can be viewed as a
 global scope.
 
 
@@ -303,7 +303,7 @@ So if it exists its the *last* endpoint which Camel send the Exchange
 to.
 
 When for example processing the xref:exchange.adoc[Exchange] at a given
-<<Endpoint-Endpoints,Endpoint>> and the message is to be moved into the
+xref:Endpoint-Endpoints.adoc[Endpoint] and the message is to be moved into the
 dead letter queue, then Camel also decorates the Exchange with another
 property that contains that *last* endpoint:
 
@@ -323,7 +323,7 @@ failed.
 
 These information is kept on the Exchange even if the message
 was successfully processed by a given endpoint, and then later fails for
-example in a local <<bean-component,Bean>> processing instead. So beware
+example in a local xref:bean-component.adoc[Bean] processing instead. So beware
 that this is a hint that helps pinpoint errors.
 
 [source,java]
@@ -384,7 +384,7 @@ The onPrepare is also available using the default error handler.
 *Available as of Camel 2.10.4/2.11*
 
 When Camel error handler handles an error such as
-<<deadLetterChannel-eip,Dead Letter Channel>> or using
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] or using
 xref:exception-clause.adoc[Exception Clause] with handled=true, then
 Camel will decorate +
  the xref:exchange.adoc[Exchange] with the route id where the error
@@ -444,13 +444,13 @@ We support directly in xref:dead-letter-channel.adoc[Dead Letter
 Channel] to set a xref:processor.adoc[Processor] that is executed
 *before* each redelivery attempt.
 
-When <<deadLetterChannel-eip,Dead Letter Channel>> is doing
+When xref:deadLetterChannel-eip.adoc[Dead Letter Channel] is doing
 redeliver its possible to configure a xref:processor.adoc[Processor]
 that is executed just *before* every redelivery attempt. This can be
 used for the situations where you need to alter the message before its
 redelivered.
 
-Here we configure the <<deadLetterChannel-eip,Dead Letter Channel>>
+Here we configure the xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 to use our processor `MyRedeliveryProcessor` to be executed before each
 redelivery.
 
@@ -472,10 +472,10 @@ also http://stackoverflow.com/questions/13711462/logging-camel-exceptions-and-s
 ==== Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-<<GettingStarted-GettingStarted,Getting Started>>, you may also find the
-<<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and xref:uris.adoc[URIs]. Then you could
-try out some of the <<Examples-Examples,Examples>> first before trying
+xref:GettingStarted-GettingStarted.adoc[Getting Started], you may also find the
+xref:Architecture-Architecture.adoc[Architecture] useful particularly the description
+of xref:Endpoint-Endpoints.adoc[Endpoint] and xref:uris.adoc[URIs]. Then you could
+try out some of the xref:Examples-Examples.adoc[Examples] first before trying
 this pattern out.
 
 * xref:error-handler.adoc[Error Handler]

--- a/docs/user-manual/modules/ROOT/pages/defaulterrorhandler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/defaulterrorhandler.adoc
@@ -3,12 +3,12 @@
 
 This is the new default error handler in Camel 2.0 onwards.
 
-It has the same power as the <<deadLetterChannel-eip,Dead Letter Channel>>,
+It has the same power as the xref:deadLetterChannel-eip.adoc[Dead Letter Channel],
 however it does *not* support a _dead letter queue_, which is
 the only difference between the two of them.
 
 The DefaultErrorHandler is configured differently from
-<<deadLetterChannel-eip,Dead Letter Channel>> as
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] as
 it is configured to:
 
 * not redeliver
@@ -63,4 +63,4 @@ jetty endpoint that returns it to the original caller.
 ==== See Also
 
 * xref:error-handler.adoc[Error Handler]
-* <<deadLetterChannel-eip,Dead Letter Channel>>
+* xref:deadLetterChannel-eip.adoc[Dead Letter Channel]

--- a/docs/user-manual/modules/ROOT/pages/dynamic-router.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dynamic-router.adoc
@@ -60,7 +60,7 @@ from("direct:start")
     .dynamicRouter(method(DynamicRouterTest.class, "slip"));
 ----
 
-Which will leverage a <<bean-component,Bean>> to compute the slip
+Which will leverage a xref:bean-component.adoc[Bean] to compute the slip
 _on-the-fly_, which could be implemented as follows:
 
 [source,java]
@@ -191,12 +191,12 @@ In the above we can use the
 Parameter Binding Annotations
 to bind different parts of the Message to method
 parameters or use an Expression such as using
-<<xpath-language,XPath>> or <<xpath-language,XQuery>>.
+xref:xpath-language,XPath>> or <<xpath-language.adoc[XQuery].
 
 The method can be invoked in a number of ways as described in the
 Bean Integration such as
 
 * POJO Producing
 * Spring Remoting
-* <<bean-component,Bean>> component
+* xref:bean-component.adoc[Bean] component
 

--- a/docs/user-manual/modules/ROOT/pages/enterprise-integration-patterns.adoc
+++ b/docs/user-manual/modules/ROOT/pages/enterprise-integration-patterns.adoc
@@ -195,7 +195,7 @@ that should be either completed successfully (all of them) or not-executed/compe
 of endpoints at the same time?
 
 |image:http://cwiki.apache.org/confluence/download/attachments/49204/clear.png[image]
-|<<loop-eip,Loop>> |How can I repeat processing a message in a loop?
+|xref:loop-eip.adoc[Loop] |How can I repeat processing a message in a loop?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessageTransformation]]
@@ -222,12 +222,12 @@ content?
 semantically equivalent, but arrive in a different format?
 
 |image:http://cwiki.apache.org/confluence/download/attachments/49204/clear.png[image]
-|<<sort-eip,Sort>> |How can I sort the body of a message?
+|xref:sort-eip.adoc[Sort] |How can I sort the body of a message?
 
 |  |Script |How do I execute a script which may not change the message?
 
 |image:http://cwiki.apache.org/confluence/download/attachments/49204/clear.png[image]
-|<<validate-eip,Validate>> |How can I validate a message?
+|xref:validate-eip.adoc[Validate] |How can I validate a message?
 |=======================================================================
 
 [[EnterpriseIntegrationPatterns-MessagingEndpoints]]
@@ -288,7 +288,7 @@ and via non-messaging techniques?
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
 |image:http://www.eaipatterns.com/img/ControlBusIcon.gif[image]
-|<<controlbus-component,ControlBus>> |How can we effectively administer a
+|xref:controlbus-component.adoc[ControlBus] |How can we effectively administer a
 messaging system that is distributed across multiple platforms and a
 wide geographic area?
 

--- a/docs/user-manual/modules/ROOT/pages/error-handling-in-camel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/error-handling-in-camel.adoc
@@ -43,7 +43,7 @@ better suit you needs.
 [[ErrorhandlinginCamel-Camel1.xdefaulterrorhandler]]
 ==== Camel 1.x default error handler
 
-In Camel 1.x a global <<deadLetterChannel-eip,Dead Letter Channel>>
+In Camel 1.x a global xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 is setup as the xref:error-handler.adoc[Error Handler] by default. It's
 configured as:
 
@@ -61,7 +61,7 @@ ERROR level :star:
 A dead letter queue is like a black hole, it will consume the
 xref:exchange.adoc[Exchange] and the xref:exchange.adoc[Exchange]
 routing is ended with no indication that it failed. +
-This works great in the <<jms-component,JMS>> Messaging world where we
+This works great in the xref:jms-component.adoc[JMS] Messaging world where we
 don't want a bad message to cause endless retries and causing the system
 to exhaust. The message is said to be poison and thus we want to move it
 to a dead letter queue so the system can continue to operate and work
@@ -119,7 +119,7 @@ multiple RouteBuilder classes. See more details at
 https://issues.apache.org/jira/browse/CAMEL-5456[CAMEL-5456].
 
 [[ErrorhandlinginCamel-Howdoestheerrorhandlerwork]]
-==== How does the <<deadLetterChannel-eip,Dead Letter Channel>> error handler work
+==== How does the xref:deadLetterChannel-eip.adoc[Dead Letter Channel] error handler work
 
 When Camel is started it will inspect the routes and weave in the error
 handling into the routing. With up to 3 supported scopes, the error
@@ -157,14 +157,14 @@ stuff). So when an order arrives on the seda queue we consume it and
 send it to the validateOrder bean. In case the validation bean processed
 ok, we move on to the next node. In case the storeOrder bean failed and
 throws an exception it's caught by the
-<<deadLetterChannel-eip,Dead Letter Channel>> that decides what to
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] that decides what to
 do next. Either it does a:
 
 * redeliver
 * or move it to dead letter queue
 
 It will continue to do redeliveries based on the policy configured. By
-default <<deadLetterChannel-eip,Dead Letter Channel>> will attempt
+default xref:deadLetterChannel-eip.adoc[Dead Letter Channel] will attempt
 at most 6 redeliveries with 1 second delay. So if the storeOrder bean
 did succeed at the 3rd attempt the routing will continue to the next
 node the confirmOrder bean. In case all redeliveries failed the Exchange
@@ -175,9 +175,9 @@ just a ERROR logger.
 [NOTE]
 ====
 This applies to all kind of xref:component.adoc[Components] in Camel.
-The sample above only uses <<bean-component,Bean>> but it's the same for
-<<file-component,File>>, <<mail-component,Mail>>,
-<<velocity-component,Velocity>> or whatever component you use.
+The sample above only uses xref:bean-component.adoc[Bean] but it's the same for
+xref:file-component,File>>, <<mail-component.adoc[Mail],
+xref:velocity-component.adoc[Velocity] or whatever component you use.
 ====
 
 [[ErrorhandlinginCamel-Transactional]]
@@ -219,17 +219,17 @@ xref:transactionerrorhandler.adoc[TransactionErrorHandler] does *not*
 attempt any local redeliveries. You have to configure it to do so, for
 instance to set a maximum redelivers to a number > 0.
 
-See <<transactionalClient-eip,Transactional Client>>
+See xref:transactionalClient-eip.adoc[Transactional Client]
 for more.
 
 [[ErrorhandlinginCamel-Seealso]]
 ==== See also
 
 * xref:error-handler.adoc[Error Handler]
-* <<deadLetterChannel-eip,Dead Letter Channel>>
+* xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 * xref:exception-clause.adoc[Exception Clause]
-* <<transactionalClient-eip,Transactional Client>>
+* xref:transactionalClient-eip.adoc[Transactional Client]
 * xref:transactionerrorhandler.adoc[TransactionErrorHandler]
 * xref:defaulterrorhandler.adoc[DefaultErrorHandler]
 * xref:try-catch-finally.adoc[Try Catch Finally]
-* <<loadBalance-eip,Failover Load Balancer>>
+* xref:loadBalance-eip.adoc[Failover Load Balancer]

--- a/docs/user-manual/modules/ROOT/pages/event-message.adoc
+++ b/docs/user-manual/modules/ROOT/pages/event-message.adoc
@@ -12,8 +12,8 @@ implement this pattern using the underlying transport or protocols.
 image:http://www.enterpriseintegrationpatterns.com/img/EventMessageSolution.gif[image]
 
 The default behaviour of many xref:components.adoc[Components] is InOnly
-such as for <<jms-component,JMS>>, <<jms-component,File>> or
-<<seda-component,SEDA>>
+such as for xref:jms-component,JMS>>, <<jms-component.adoc[File] or
+xref:seda-component.adoc[SEDA]
 
 TIP: See the related xref:request-reply.adoc[Request Reply] message.
 

--- a/docs/user-manual/modules/ROOT/pages/eventDrivenConsumer-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/eventDrivenConsumer-eip.adoc
@@ -4,7 +4,7 @@
 Camel supports the
 http://www.enterpriseintegrationpatterns.com/EventDrivenConsumer.html[Event Driven Consumer]
 from the
-<<EnterpriseIntegrationPatterns-EnterpriseIntegrationPatterns,EIP patterns>>.
+xref:EnterpriseIntegrationPatterns-EnterpriseIntegrationPatterns.adoc[EIP patterns].
 The default consumer model is event based (i.e. asynchronous)
 as this means that the Camel container can then manage pooling,
 threading and concurrency for you in a declarative manner.
@@ -13,18 +13,18 @@ image:http://www.enterpriseintegrationpatterns.com/img/EventDrivenConsumerSoluti
 
 The Event Driven Consumer is implemented by consumers implementing the
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
-interface which is invoked by the <<messageEndpoint-eip,Message Endpoint>>
-when a <<message-eip,Message>> is available for processing.
+interface which is invoked by the xref:messageEndpoint-eip.adoc[Message Endpoint]
+when a xref:message-eip.adoc[Message] is available for processing.
 
 [[eventDrivenConsumer-Example]]
 === Example
 
 The following demonstrates a
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
-defined in the Camel <<Registry-Registry,Registry>> which is
-invoked when an event occurs from a <<jms-component,JMS>> queue.
+defined in the Camel xref:Registry-Registry.adoc[Registry] which is
+invoked when an event occurs from a xref:jms-component.adoc[JMS] queue.
 
-*Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>*
+*Using the xref:FluentBuilders-FluentBuilders.adoc[Fluent Builders]*
 
 [source,java]
 ----
@@ -32,7 +32,7 @@ from("jms:queue:foo")
     .processRef("processor");
 ----
 
-**Using the <<SpringXMLExtensions-SpringXMLExtensions,Spring XML Extensions>>**
+**Using the xref:SpringXMLExtensions-SpringXMLExtensions.adoc[Spring XML Extensions]**
 
 [source,xml]
 ----
@@ -44,15 +44,15 @@ from("jms:queue:foo")
 
 For more details see:
 
-* <<message-eip,Message>>
-* <<messageEndpoint-eip,Message Endpoint>>
+* xref:message-eip.adoc[Message]
+* xref:messageEndpoint-eip.adoc[Message Endpoint]
 
 [[eventDrivenConsumer-UsingThisPattern]]
 === Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-<<GettingStarted-GettingStarted,Getting Started>>, you may also find the
-<<Architecture-Architecture,Architecture>> useful particularly the description
-of <<Endpoint-Endpoints,Endpoint>> and <<URIs-URIs,URIs>>. Then you could
-try out some of the <<Examples-Examples,Examples>> first before trying
+xref:GettingStarted-GettingStarted.adoc[Getting Started], you may also find the
+xref:Architecture-Architecture.adoc[Architecture] useful particularly the description
+of xref:Endpoint-Endpoints,Endpoint>> and <<URIs-URIs.adoc[URIs]. Then you could
+try out some of the xref:Examples-Examples.adoc[Examples] first before trying
 this pattern out.

--- a/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
@@ -24,8 +24,8 @@ from("seda:inputB")
 
 Here if the processing of *`seda:inputA`* or *`seda:inputB`* cause
 a *`ValidationException`* to be thrown (such as due to the XSD
-validation of the <<validator-components,Validation>> component or the
-Relax NG Compact syntax validation of the <<jing-component,Jing>>
+validation of the xref:validator-components.adoc[Validation] component or the
+Relax NG Compact syntax validation of the xref:jing-component.adoc[Jing]
 component), then the message will be sent to the
 *`activemq:validationFailed`* queue.
 
@@ -160,11 +160,11 @@ select the *`onException(IOException.class)`* clause.
 ==== Configuring RedeliveryPolicy (redeliver options)
 
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
-requires to use the <<deadLetterChannel-eip,Dead Letter Channel>>
+requires to use the xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 as the xref:error-handler.adoc[Error Handler]. Dead Letter Channel
 supports attempting to redeliver the message exchange a number of times
 before sending it to a dead letter endpoint. See
-<<deadLetterChannel-eip,Dead Letter Channel>> for further
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] for further
 information about redeliver and which redeliver options exists.
 
 ===== No redelivery is default for onException
@@ -177,7 +177,7 @@ type basis. By default in the top examples, if an
 *`org.apache.camel.ValidationException`* occurs then the message will
 not be redelivered; however if some other exception occurs, e.g.,
 *`IOException`* or whatever, the route will be retried according to the
-settings from the <<deadLetterChannel-eip,Dead Letter Channel>>.
+settings from the xref:deadLetterChannel-eip.adoc[Dead Letter Channel].
 
 However if you want to customize any methods on the
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
@@ -313,7 +313,7 @@ is being routed to our processor *`MyFunctionFailureHandler`*. So you
 can say that the exchange is diverted when a *`MyFunctionalException`*
 is thrown during processing. It's important to distinct this as perfect
 valid. The default redelivery policy from the
-<<deadLetterChannel-eip,Dead Letter Channel>> will not kick in, so
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] will not kick in, so
 our processor receives the Exchange directly, without any redeliver
 attempted. In our processor we need to determine what to do. Camel
 regards the Exchange as *failure handled*. So our processor is the end
@@ -334,7 +334,7 @@ using a producer template from Exchange.
 
 ===== Continued
 
-See also the section <<ExceptionClause-HandleandContinueExceptions,Handle and continue exceptions>> below.
+See also the section xref:ExceptionClause-HandleandContinueExceptions.adoc[Handle and continue exceptions] below.
 
 Using *`onException`* to handle known exceptions is a very powerful
 feature in Camel. However prior to Camel 1.5 you could not mark the
@@ -407,7 +407,7 @@ In the route above we handled the exception but routed it to a different
 endpoint. What if you need to alter the response and send a fixed
 response back to the original caller (the client). No secret here just
 do as you do in normal Camel routing, use
-<<messageTranslator-eip,transform>> to set the response, as shown in
+xref:messageTranslator-eip.adoc[transform] to set the response, as shown in
 the sample below:
 
 /camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionHandleAndTransformTest.java
@@ -613,15 +613,15 @@ default error handler will kick in.
 
 *Available as of Camel 2.0*
 
-<<deadLetterChannel-eip,Dead Letter Channel>> has support
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] has support
 for *`onRedelivery`* to allow custom processing of a Message before its
 being redelivered. It can be used to add some customer header or
 whatnot. In Camel 2.0 we have added this feature to
 xref:exception-clause.adoc[Exception Clause] as well, so you can use per
 exception scoped on redelivery. Camel will fallback to use the one
-defined on <<deadLetterChannel-eip,Dead Letter Channel>> if any, if
+defined on xref:deadLetterChannel-eip.adoc[Dead Letter Channel] if any, if
 none exists on the xref:exception-clause.adoc[Exception Clause]. See
-<<deadLetterChannel-eip,Dead Letter Channel>> for more details on
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] for more details on
 *`onRedelivery`*.
 
 In the code below we want to do some custom code before redelivering any
@@ -654,7 +654,7 @@ class as this code is based on unit testing):
 
 *Available as of Camel 2.17*
 
-<<deadLetterChannel-eip,Dead Letter Channel>> has support
+xref:deadLetterChannel-eip.adoc[Dead Letter Channel] has support
 for *`onExceptionOccurred`* to allow custom processing of a Message just
 after the exception was thrown. It can be used to do some custom logging
 or whatnot. The difference between *`onRedelivery`* processor
@@ -732,7 +732,7 @@ Where the bean *`myRetryHandler`* is computing if we should retry or not:
 The default
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/exceptionpolicy/ExceptionPolicyStrategy.html[ExceptionPolicyStrategy]
 in Camel should be sufficient in nearly all use-cases (see section
-<<ExceptionClause-HowDoesCamelSelectWhichClauseShouldHandleaGivenThrownException,How does Camel select which clause should handle a given thrown Exception>>).
+xref:ExceptionClause-HowDoesCamelSelectWhichClauseShouldHandleaGivenThrownException.adoc[How does Camel select which clause should handle a given thrown Exception]).
 However, if you need to use your own this can be configured as the
 sample below illustrates:
 
@@ -761,5 +761,5 @@ Spring DSL as well. Here are a few examples:
 ==== See also
 
 * The xref:error-handler.adoc[Error Handler] for the general error handling documentation
-* The <<deadLetterChannel-eip,Dead Letter Channel>> for further details
-* The <<transactionalClient-eip,Transactional Client>> for transactional behavior
+* The xref:deadLetterChannel-eip.adoc[Dead Letter Channel] for further details
+* The xref:transactionalClient-eip.adoc[Transactional Client] for transactional behavior

--- a/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
@@ -17,7 +17,7 @@ the Message Exchange indicating if a message
 exchange is a one way Event Message (InOnly) or
 a Request Reply message exchange (InOut).
 
-For example to override the default pattern on a <<jms-component,JMS>>
+For example to override the default pattern on a xref:jms-component.adoc[JMS]
 endpoint you could use this URI
 
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/expression.adoc
+++ b/docs/user-manual/modules/ROOT/pages/expression.adoc
@@ -68,31 +68,31 @@ public interface Predicate {
 
 The following languages are supported out of the box
 
-* <<bean-language,Bean Language>> for using Java for expressions
-* <<constant-language,Constant>>
-* the unified <<el-language,EL>> from JSP and JSF
-* <<header-language,Header>>
-* <<jsonpath-language,JSonPath>>
-* <<jxpath-language,JXPath>>
-* <<mvel-component,Mvel>>
-* <<ognl-language,OGNL>>
-* <<ref-language,Ref Language>>
+* xref:bean-language.adoc[Bean Language] for using Java for expressions
+* xref:constant-language.adoc[Constant]
+* the unified xref:el-language.adoc[EL] from JSP and JSF
+* xref:header-language.adoc[Header]
+* xref:jsonpath-language.adoc[JSonPath]
+* xref:jxpath-language.adoc[JXPath]
+* xref:mvel-component.adoc[Mvel]
+* xref:ognl-language.adoc[OGNL]
+* xref:ref-language.adoc[Ref Language]
 * ExchangeProperty
 / Property
 * Scripting Languages such as
 ** BeanShell
 ** JavaScript
-** <<groovy-language,Groovy>>
-** <<python-language,Python>>
-** <<php-language,PHP>>
-** <<ruby-language,Ruby>>
-* <<simple-language,Simple>>
-** <<file-language,File Language>>
-* <<spel-language,Spring Expression Language>>
-* <<sql-component,SQL>>
+** xref:groovy-language.adoc[Groovy]
+** xref:python-language.adoc[Python]
+** xref:php-language.adoc[PHP]
+** xref:ruby-language.adoc[Ruby]
+* xref:simple-language.adoc[Simple]
+** xref:file-language.adoc[File Language]
+* xref:spel-language.adoc[Spring Expression Language]
+* xref:sql-component.adoc[SQL]
 * Tokenizer
-* <<xpath-language,XPath>>
-* <<xquery-component,XQuery>>
+* xref:xpath-language.adoc[XPath]
+* xref:xquery-component.adoc[XQuery]
 * https://github.com/camel-extra/camel-extra/blob/master/components/camel-vtdxml/src/main/docs/vtdxml-component.adoc[VTD-XML]
 
 Most of these languages is also supported used as
@@ -112,14 +112,14 @@ wish to use.
 
 |Scripting Languages such as
 BeanShell, JavaScript,
-<<groovy-language,Groovy>>, <<groovy-language,PHP>>, <<groovy-language,Python>>
-and <<ruby-language,Ruby>> |http://camel.apache.org/maven/current/camel-script/apidocs/org/apache/camel/builder/script/ScriptBuilder.html[org.apache.camel.builder.script.ScriptBuilder]
+xref:groovy-language,Groovy>>, <<groovy-language,PHP>>, <<groovy-language.adoc[Python]
+and xref:ruby-language.adoc[Ruby] |http://camel.apache.org/maven/current/camel-script/apidocs/org/apache/camel/builder/script/ScriptBuilder.html[org.apache.camel.builder.script.ScriptBuilder]
 
-|<<sql-component,SQL>> |http://camel.apache.org/maven/current/camel-josql/apidocs/org/apache/camel/builder/sql/SqlBuilder.html[org.apache.camel.builder.josql.SqlBuilder]
+|xref:sql-component.adoc[SQL] |http://camel.apache.org/maven/current/camel-josql/apidocs/org/apache/camel/builder/sql/SqlBuilder.html[org.apache.camel.builder.josql.SqlBuilder]
 
-|<<xpath-language,XPath>> |http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/builder/xml/XPathBuilder.html[org.apache.camel.builder.xml.XPathBuilder]
+|xref:xpath-language.adoc[XPath] |http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/builder/xml/XPathBuilder.html[org.apache.camel.builder.xml.XPathBuilder]
 
-|<<xquery-component,XQuery>> |http://camel.apache.org/maven/current/camel-saxon/apidocs/org/apache/camel/builder/saxon/XQueryBuilder.html[org.apache.camel.builder.saxon.XQueryBuilder]
+|xref:xquery-component.adoc[XQuery] |http://camel.apache.org/maven/current/camel-saxon/apidocs/org/apache/camel/builder/saxon/XQueryBuilder.html[org.apache.camel.builder.saxon.XQueryBuilder]
 |=======================================================================
 
 [[Expression-SeeAlso]]

--- a/docs/user-manual/modules/ROOT/pages/faq.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq.adoc
@@ -124,7 +124,7 @@ Questions on using Apache Camel
 ==== Logging Questions
 
 Questions on logging output from Camel to a console, using the
-<<log-component,Log>> endpoint or JDK 1.4 logging or Log4j etc
+xref:log-component.adoc[Log] endpoint or JDK 1.4 logging or Log4j etc
 
 * xref:faq/how-do-i-enable-debug-logging.adoc[How do I enable debug logging?]
 * xref:faq/how-do-i-use-java-14-logging.adoc[How do I use Java 1.4 logging?]
@@ -150,7 +150,7 @@ Questions on using specific components
 [[FAQ-JMSQuestions]]
 ===== JMS Questions
 
-Questions on using the <<jms-component,JMS>> endpoints in Camel
+Questions on using the xref:jms-component.adoc[JMS] endpoints in Camel
 
 * xref:faq/why-does-my-jms-route-only-consume-one-message-at-once.adoc[Why does my JMS route only consume one message at once?]
 

--- a/docs/user-manual/modules/ROOT/pages/faq/how-can-i-stop-a-route-from-a-route.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-can-i-stop-a-route-from-a-route.adoc
@@ -58,7 +58,7 @@ A route must have been stopped prior to be shutdown.
 
 See more details about the xref:../lifecycle.adoc[Lifecycle].
 
-NOTE: You can also use the <<controlbus-component,ControlBus>> component to let
+NOTE: You can also use the xref:controlbus-component.adoc[ControlBus] component to let
 it stop/start routes.
 
 [[HowcanIstoparoutefromaroute-SeeAlso]]
@@ -67,4 +67,4 @@ it stop/start routes.
 * xref:routepolicy.adoc[RoutePolicy]
 * xref:../graceful-shutdown.adoc[Graceful Shutdown]
 * xref:../lifecycle.adoc[Lifecycle]
-* <<controlbus-component,ControlBus>>
+* xref:controlbus-component.adoc[ControlBus]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-configure-endpoints.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-configure-endpoints.adoc
@@ -11,7 +11,7 @@ You can explicitly configure a Component using Java
 code as shown in this example
 
 Or you can explicitly get hold of an Endpoint and
-configure it using Java code as shown in the <<mock-component,Mock endpoint examples>>.
+configure it using Java code as shown in the xref:mock-component.adoc[Mock endpoint examples].
 
 [source,java]
 ----
@@ -115,7 +115,7 @@ URIs
 ==== Using Endpoint URIs
 
 Another approach is to use the URI syntax. The URI syntax supports the
-query notation. So for example with the <<mail-component,Mail>> component
+query notation. So for example with the xref:mail-component.adoc[Mail] component
 you can configure the password property via the URI
 
 [source]
@@ -311,7 +311,7 @@ can have multiple options in one line, eg this is the same:
 ==== See Also
 
 * xref:../configuring-camel.adoc[How do I add a component?]
-* <<cdi-component,CDI>>
+* xref:cdi-component.adoc[CDI]
 * xref:../spring.adoc[Spring]
 * xref:../uris.adoc[URIs]
 * xref:../using-propertyplaceholder.adoc[Using `PropertyPlaceholder`]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-handle-failures-when-consuming-for-example-from-a-ftp-server.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-handle-failures-when-consuming-for-example-from-a-ftp-server.adoc
@@ -14,18 +14,18 @@ based on when a message is *being* routed.
 In this case the error occurs *before* a message has been initiated and
 routed. So how can I control the error handling?
 
-The <<ftp-component,FTP>> component have a few options
+The xref:ftp-component.adoc[FTP] component have a few options
 (`maximumReconnectAttempts, reconnectDelay` to control number of retries
 and delay in between.
 
 But you can also plugin your own implementation and determine what to do
 using the `pollStrategy` option which has more documentation
-<<pollingConsumer-eip,Polling Consumer>>.
+xref:pollingConsumer-eip.adoc[Polling Consumer].
 Notice that the option `pollStrategy` applies for all consumers which is
 a `ScheduledPollConsumer` consumer. The page lists those.
 
 [[HowdoIhandlefailureswhenconsumingforexamplefromaFTPserver-Seealso]]
 ==== See also
 
-* <<ftp-component,FTP>>
-* <<pollingConsumer-eip,Polling Consumer>>
+* xref:ftp-component.adoc[FTP]
+* xref:pollingConsumer-eip.adoc[Polling Consumer]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-let-jetty-match-wildcards.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-let-jetty-match-wildcards.adoc
@@ -1,7 +1,7 @@
 [[HowdoIletJettymatchwildcards-HowdoIletJettymatchwildcards]]
 === How do I let Jetty match wildcards?
 
-By default <<jetty-component,Jetty>> will only match on exact uri's. But
+By default xref:jetty-component.adoc[Jetty] will only match on exact uri's. But
 you can instruct Jetty to match prefixes. For example:
 
 [source,java]
@@ -9,7 +9,7 @@ you can instruct Jetty to match prefixes. For example:
 from("jetty://0.0.0.0:8123/foo").to("mock:foo");
 ----
 
-In the route above <<jetty-component,Jetty>> will only match if the uri is
+In the route above xref:jetty-component.adoc[Jetty] will only match if the uri is
 an exact match, so it will match if you enter
 `http://0.0.0.0:8123/foo` but not match if you do
 `http://0.0.0.0:8123/foo/bar`.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-make-my-jms-endpoint-transactional.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-make-my-jms-endpoint-transactional.adoc
@@ -17,9 +17,9 @@ How Do I Make It Transactional?
 [[HowDoIMakeMyJMSEndpointTransactional-Answer]]
 ==== Answer:
 
-There are examples in the <<transactionalClient-eip,Transactional Client>>
+There are examples in the xref:transactionalClient-eip.adoc[Transactional Client]
 and it is described in the _Enabling Transacted Consumption_
-section of <<jms-component,JMS>>. To make a session transactional
+section of xref:jms-component.adoc[JMS]. To make a session transactional
 set `transacted=true` flag on the JMS endpoint and configure
 a `transactionManager` on the xref:../component.adoc[Component] or
 xref:../endpoint.adoc[Endpoint].
@@ -27,5 +27,5 @@ xref:../endpoint.adoc[Endpoint].
 [[HowDoIMakeMyJMSEndpointTransactional-SeeAlso]]
 ==== See Also
 
-* <<transactionalClient-eip,Transactional Client>>
-* <<jms-component,JMS>>
+* xref:transactionalClient-eip.adoc[Transactional Client]
+* xref:jms-component.adoc[JMS]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-retry-failed-messages-forever.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-retry-failed-messages-forever.adoc
@@ -8,7 +8,7 @@ message.
 By default Camel will retry consuming a message up til 6 times before
 its moved to the default dead letter queue.
 
-If you configure the <<deadLetterChannel-eip,Dead Letter Channel>>
+If you configure the xref:deadLetterChannel-eip.adoc[Dead Letter Channel]
 to use `maximumRedeliveries = -1` then Camel will retry forever.
 
 When you consume a message you can check the in message header

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-retry-processing-a-message-from-a-certain-point-back-or-an-entire-route.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-retry-processing-a-message-from-a-certain-point-back-or-an-entire-route.adoc
@@ -9,7 +9,7 @@ In the example above we have 2 routes (`direct:start`, `direct:sub`). In
 case of a failure anywhere in the `direct:sub` route, then the entire
 route is retried. This happens because we have instructed the `direct:sub`
 route to not use any error handler (eg the no error handler). Then we
-link the routes using the <<direct-component,Direct>> component by calling
+link the routes using the xref:direct-component.adoc[Direct] component by calling
 the sub route from the 1st route.
 
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-reuse-the-contexttestsupport-class-in-my-unit-tests.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-reuse-the-contexttestsupport-class-in-my-unit-tests.adoc
@@ -2,7 +2,7 @@
 === How do I reuse the ContextTestSupport class in my unit tests?
 
 You might want to look at the various xref:../testing.adoc[Testing]
-options, in particular <<test-component,Camel Test>> and
+options, in particular xref:test-component.adoc[Camel Test] and
 xref:../spring-testing.adoc[Spring Testing] to see if those are better,
 more powerful options. We see `ContextTestSupport` as an older, less
 powerful option.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc
@@ -22,7 +22,7 @@ You can use the following short syntax, which is most common to use:
 |s |second
 |============
 
-So for example the <<timer-component,Timer>> endpoint can be configured as
+So for example the xref:timer-component.adoc[Timer] endpoint can be configured as
 follows:
 
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-specify-which-method-to-use-when-using-beans-in-routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-specify-which-method-to-use-when-using-beans-in-routes.adoc
@@ -1,7 +1,7 @@
 [[HodoIspecifywhichmethodtousewhenusingbeansinroutes-HodoIspecifywhichmethodtousewhenusingbeansinroutes]]
 === Ho do I specify which method to use when using beans in routes?
 
-See <<bean-component,Bean>>, xref:../bean-integration.adoc[Bean Integration]
+See xref:bean-component.adoc[Bean], xref:../bean-integration.adoc[Bean Integration]
 and xref:bean-binding.adoc[Bean Binding]
 
 However if you have overloaded methods you need to specify which of

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-use-spring-property-placeholder-with-camel-xml.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-use-spring-property-placeholder-with-camel-xml.adoc
@@ -30,7 +30,7 @@ Camel XML. For example at the time of writing this is *NOT* supported
 
 However you can use the `<endpoint/>` element to define endpoints which
 does support the property resolving which you can then refer to by name,
-using the <<ref-component,Ref>> component as shown below (notice the `ref:`
+using the xref:ref-component.adoc[Ref] component as shown below (notice the `ref:`
 in the URI):
 
 *SUPPORTED*
@@ -72,6 +72,6 @@ Here is a trick that you can use to define the uri in a property file
 using Spring injection and Camel endpoint:
 http://cmoulliard.blogspot.com/2009/05/trick-to-pass-uri-declared-in-property.html.
 
-From Camel 2.3 onwards there is a <<properties-component,Properties>>
+From Camel 2.3 onwards there is a xref:properties-component.adoc[Properties]
 component build in Camel core which allows you to use properties in the
 same way as Spring property placeholders, and even more.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-i-write-a-custom-processor-which-sends-multiple-messages.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-i-write-a-custom-processor-which-sends-multiple-messages.adoc
@@ -1,8 +1,8 @@
 [[HowdoIwriteacustomProcessorwhichsendsmultiplemessages-HowdoIwriteacustomProcessorwhichsendsmultiplemessages]]
 === How do I write a custom Processor which sends multiple messages?
 
-You could use a <<split-eip,Splitter>> or use multiple
-<<messageTranslator-eip,Message Translator>> instances in your
+You could use a xref:split-eip.adoc[Splitter] or use multiple
+xref:messageTranslator-eip.adoc[Message Translator] instances in your
 route.
 
 Or you could write a custom processor which is injected with a

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-the-direct-event-seda-and-vm-endpoints-compare.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-the-direct-event-seda-and-vm-endpoints-compare.adoc
@@ -1,14 +1,14 @@
 [[Howdothedirecteventsedaandvmendpointscompare-Howdothedirecteventsedaandvmendpointscompare]]
 === How do the `direct`, `event`, `seda`, and `vm` endpoints compare?
 
-* <<vm-component,VM>> and <<seda-component,SEDA>> endpoints are basically the
+* xref:vm-component,VM>> and <<seda-component.adoc[SEDA] endpoints are basically the
 same; they both offer asychronous in memory SEDA queues; they differ in
 visibility -- endpoints are visible inside the same JVM or within the same
 CamelContext respectively.
-* <<direct-component,Direct>> uses no threading; it directly invokes the
+* xref:direct-component.adoc[Direct] uses no threading; it directly invokes the
 consumer when sending.
-* <<spring-event-component,Spring Event>> adds a listener to Spring's
+* xref:spring-event-component.adoc[Spring Event] adds a listener to Spring's
 application events; so the consumer is invoked the same thread as Spring
 notifies events. Event differs in that the payload should be a Spring
-`ApplicationEvent` object whereas <<direct-component,Direct>>,
-<<seda-component,SEDA>> and <<vm-component,VM>> can use any payload.
+`ApplicationEvent` object whereas xref:direct-component.adoc[Direct],
+xref:seda-component,SEDA>> and <<vm-component.adoc[VM] can use any payload.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-do-the-timer-and-quartz-endpoints-compare.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-do-the-timer-and-quartz-endpoints-compare.adoc
@@ -1,8 +1,8 @@
 [[HowdotheTimerandQuartzendpointscompare-HowdotheTimerandQuartzendpointscompare]]
 === How do the Timer and Quartz endpoints compare?
 
-<<timer-component,Timer>> is a simple, non persistence timer using the
+xref:timer-component.adoc[Timer] is a simple, non persistence timer using the
 JDK's in built timer mechanism.
 
-<<quartz-component,Quartz>> uses the Quartz library which uses a database
+xref:quartz-component.adoc[Quartz] uses the Quartz library which uses a database
 to store timer events and supports distributed timers and cron notation.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-compare-to-mule.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-compare-to-mule.adoc
@@ -13,8 +13,8 @@ routing/mediation engines. The main differences are as follows:
   xref:../enterprise-integration-patterns.adoc[Enterprise Integration
   Patterns]
 * Camel's API is smaller & cleaner (IMHO) and is closely aligned with
-  the APIs of JBI, <<cxf-component,CXF>> and
-  <<jms-component,JMS>>; based around message exchanges (with in and optional
+  the APIs of JBI, xref:cxf-component.adoc[CXF] and
+  xref:jms-component.adoc[JMS]; based around message exchanges (with in and optional
   out messages) which more closely maps to REST, WS, WSDL & JBI than the
   UMO model Mule is based on
 * Camel allows the underlying transport details to be easily exposed

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-compare-to-servicemix-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-compare-to-servicemix-eip.adoc
@@ -8,7 +8,7 @@ The main difference with ServiceMix EIP is its integrated into the
 existing ServiceMix XBean XML configuration whereas Camel has more
 xref:../enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and can be used outside of JBI (e.g. just with pure
-<<jms-component,JMS>> or <<mina-component,MINA>>). Also Camel supports a
+xref:jms-component,JMS>> or <<mina-component.adoc[MINA]). Also Camel supports a
 xref:../dsl.adoc[Java DSL] or xref:../spring.adoc[XML configuration].
 
 [[HowdoesCamelcomparetoServiceMixEIP-ConvertingfromServiceMixEIPtoCamel]]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-look-up-beans-and-endpoints.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-look-up-beans-and-endpoints.adoc
@@ -2,8 +2,8 @@
 === How does Camel look up beans, components or endpoints?
 
 There are many times using Camel that a name is used for a bean such as
-using the <<bean-component,Bean>> endpoint or using the
-<<bean-language,Bean Language>> to create a
+using the xref:bean-component.adoc[Bean] endpoint or using the
+xref:bean-language.adoc[Bean Language] to create a
 xref:../expression.adoc[Expression] or xref:../predicate.adoc[Predicate] or
 referring to any xref:../component.adoc[Component] or
 xref:../endpoint.adoc[Endpoint].
@@ -19,5 +19,5 @@ camel-spring do.
 
 So you can just define beans, components or endpoints in your
 xref:../registry.adoc[Registry] implementation then you can refer to them
-by name in the xref:../endpoint.adoc[Endpoint] URIs or <<bean-component,Bean>>
-endpoints or <<bean-language,Bean Language>> expressions.
+by name in the xref:../endpoint.adoc[Endpoint] URIs or xref:bean-component.adoc[Bean]
+endpoints or xref:bean-language.adoc[Bean Language] expressions.

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-work-with-activemq.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-camel-work-with-activemq.adoc
@@ -8,13 +8,13 @@ Patterns] inside:
 * the ActiveMQ message broker
 * the ActiveMQ JMS client
 
-So Camel can route messages to and from <<mail-component,Mail>>,
-<<file-component,File>>, <<ftp-component,FTP>>, <<jpa-component,JPA>>,
-<<xmpp-component,XMPP>> other <<jms-component,JMS>> providers and any of the
+So Camel can route messages to and from xref:mail-component.adoc[Mail],
+xref:file-component,File>>, <<ftp-component,FTP>>, <<jpa-component.adoc[JPA],
+xref:xmpp-component,XMPP>> other <<jms-component.adoc[JMS] providers and any of the
 other Camel xref:../component.adoc[Components] as well as implementating
 all of the xref:../enterprise-integration-patterns.adoc[Enterprise
 Integration Patterns] such as xref:content-based-router.adoc[Content
-Based Router] or <<messageTranslator-eip,Message Translator>>.
+Based Router] or xref:messageTranslator-eip.adoc[Message Translator].
 
 For more details see
 http://activemq.apache.org/enterprise-integration-patterns.html[ActiveMQ

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-the-camel-api-compare-to.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-the-camel-api-compare-to.adoc
@@ -6,8 +6,8 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchan
 and
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Message.html[Message]
 map very closely to JBI in particular but also
-<<cxf-component,CXF>>, <<http-component,HTTP>>, <<jms-component,JMS>>,
-<<mail-component,Mail>>, <<xmpp-component,XMPP>> and most other integration
+xref:cxf-component,CXF>>, <<http-component,HTTP>>, <<jms-component.adoc[JMS],
+xref:mail-component,Mail>>, <<xmpp-component.adoc[XMPP] and most other integration
 abstractions. We want to prevent leaky abstractions, so the Camel API
 exposes the underlying APIs so that a xref:../processor.adoc[Processor] can
 make use of the underlying abstractions if they make sense.
@@ -17,11 +17,11 @@ For example:
 [width="100%",cols="50%,50%",options="header",]
 |=======================================================================
 |Component |Inbound exchange exposes
-|<<cxf-component,CXF>> |Each Inbound
+|xref:cxf-component.adoc[CXF] |Each Inbound
 http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfExchange.html[CxfExchange]
 has access to the underlying Exchange and Message from CXF
 
-|<<http-component,HTTP>> |Each inbound
+|xref:http-component.adoc[HTTP] |Each inbound
 http://camel.apache.org/maven/current/camel-http/apidocs/org/apache/camel/component/http/HttpExchange.html[HttpExchange]
 has access to the underlying HttpServletRequest and HttpServletResponse
 
@@ -30,7 +30,7 @@ http://camel.apache.org/maven/current/camel-jbi/apidocs/org/apache/camel/compone
 has access to the underlying JBI MessageExchange and NormalizedMessage
 objects
 
-|<<jms-component,JMS>> |Each inbound
+|xref:jms-component.adoc[JMS] |Each inbound
 http://camel.apache.org/maven/current/camel-jms/apidocs/org/apache/camel/component/jms/JmsExchange.html[JmsExchange]
 has access to the underlying JMS Message objects
 |=======================================================================

--- a/docs/user-manual/modules/ROOT/pages/faq/how-to-avoid-sending-some-or-all-message-headers.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-to-avoid-sending-some-or-all-message-headers.adoc
@@ -2,7 +2,7 @@
 === How to avoid sending some or all message headers?
 
 When I send a message to a Camel endpoint such as the
-<<mail-component,Mail>> component, then the mail include some message
+xref:mail-component.adoc[Mail] component, then the mail include some message
 headers I do not want. How can I avoid this?
 
 [[Howtoavoidsendingsomeorallmessageheaders-UseremoveHeadersintheroute]]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-to-send-the-same-message-to-multiple-endpoints.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-to-send-the-same-message-to-multiple-endpoints.adoc
@@ -2,12 +2,12 @@
 === How to send the same message to multiple endpoints?
 
 When you need to send the *same* message to multiple endpoints then you
-should use <<multicast-eip,Multicast>>.
+should use xref:multicast-eip.adoc[Multicast].
 
 In the sample below we consume messages from the activemq queue `foo`
 and want to send the *same message* to both `seda:foo` and `seda:bar`.
 Sending the same message requires that we use
-<<multicast-eip,Multicast>>. This is done by adding the `multicast()`
+xref:multicast-eip.adoc[Multicast]. This is done by adding the `multicast()`
 before the to type:
 
 [source,java]
@@ -26,8 +26,8 @@ If you have a route such as:
 from("activemq:queue:foo").to("seda:foo", "seda:bar");
 ----
 
-It is by default a <<pipesandFilters-eip,pipeline>> in Camel (that is
-the opposite to <<multicast-eip,Multicast>>). In the above example
+It is by default a xref:pipesandFilters-eip.adoc[pipeline] in Camel (that is
+the opposite to xref:multicast-eip.adoc[Multicast]). In the above example
 using pipes and filters then the result from seda:foo is sent to
 seda:bar, ie. its not the *same* message sent to multiple destinations,
 but a sent through a chain (the pipes and the filters).

--- a/docs/user-manual/modules/ROOT/pages/faq/how-to-use-a-dynamic-uri-in-to.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-to-use-a-dynamic-uri-in-to.adoc
@@ -10,7 +10,7 @@ body, the Camel Context, etc.
 *Dynamic To - out of the box*
 
 From *Camel 2.16* onwards there is a new `<toD>` which is a dynamic to.
-See more details at <<messageEndpoint-eip,Message Endpoint>>.
+See more details at xref:messageEndpoint-eip.adoc[Message Endpoint].
 ====
 
 For example, if you're using a Freemarker producer and the template
@@ -32,10 +32,10 @@ This snippet is not valid code. Read on.
 In this case, you must use an EIP (Enterprise Integration Pattern) that
 is capable of computing a dynamic URI using
 an xref:../expression.adoc[Expression], such as
-the <<recipientList-eip,Recipient List>> EIP pattern.
+the xref:recipientList-eip.adoc[Recipient List] EIP pattern.
 
 For example, rewriting the snippet above to use the
-<<simple-language,Simple>> expression language:
+xref:simple-language.adoc[Simple] expression language:
 
 [TIP]
 ====
@@ -53,7 +53,7 @@ Or you could use any other of Camel xref:../languages.adoc[Languages].
 
 [NOTE]
 ====
-Notice that the <<recipientList-eip,Recipient List>> can send to
+Notice that the xref:recipientList-eip.adoc[Recipient List] can send to
 multiple
 xref:../endpoint.adoc[Endpoints]
 if the expression returns either a `java.util.List`, array,
@@ -61,7 +61,7 @@ if the expression returns either a `java.util.List`, array,
 `String` then you can specify multiple endpoints separated by comma. So
 if you only want to send to *one* endpoint and use a `String` type, then
 beware of the comma. If you need to use a comma, then you can change or
-turn off the separator on the <<recipientList-eip,Recipient List>>.
+turn off the separator on the xref:recipientList-eip.adoc[Recipient List].
 
 For example, to turn it, when using *Camel 2.13* onwards:
 

--- a/docs/user-manual/modules/ROOT/pages/faq/if-i-use-servicemix-when-should-i-use-camel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/if-i-use-servicemix-when-should-i-use-camel.adoc
@@ -7,7 +7,7 @@ So if you are already using http://servicemix.apache.org/[ServiceMix]
 then you can use Camel implement the
 xref:../enterprise-integration-patterns.adoc[Enterprise Integration Patterns]
 inside JBI such as
-<<contentBasedRouter-eip,Content Based Router>>, routing messages
+xref:contentBasedRouter-eip.adoc[Content Based Router], routing messages
 between your existing JBI endpoints.
 
 You can also reuse any of the Camel xref:../component.adoc[Components]

--- a/docs/user-manual/modules/ROOT/pages/faq/should-i-deploy-camel-inside-the-activemq-broker-or-in-another-application.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/should-i-deploy-camel-inside-the-activemq-broker-or-in-another-application.adoc
@@ -15,7 +15,7 @@ to deploy something.
 databases and bridging them to queues or topics then its usually more
 efficient to host in the broker; as there's less contention and there's
 no network communication between the EIP rules and the message broker as
-its all in the same JVM (so you can use the <<vm-component,VM Transport>>
+its all in the same JVM (so you can use the xref:vm-component.adoc[VM Transport]
 to avoid network overhead.
 
 [[ShouldIdeployCamelinsidetheActiveMQbrokerorinanotherapplication-AdvantagesofdeployingEIPinsideaseparateapplication]]

--- a/docs/user-manual/modules/ROOT/pages/faq/using-getin-or-getout-methods-on-exchange.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/using-getin-or-getout-methods-on-exchange.adoc
@@ -7,8 +7,8 @@ http://cxf.apache.org/[CXF] which defines a concept
 called Message Exchange Patterns (MEP for short).
 
 The MEP defines the messaging style used such as one-way
-(<<eventMessage-eip,InOnly>>) or request-reply
-(<<requestReply-eip,InOut>>),
+(xref:eventMessage-eip.adoc[InOnly]) or request-reply
+(xref:requestReply-eip.adoc[InOut]),
 which means you have IN and optionally OUT messages. This closely maps
 to other APIs such as WS, WSDL, REST, JBI and the likes.
 
@@ -55,7 +55,7 @@ public void process(Exchange exchange) throws Exception {
 This seems intuitive and is what you would expect is the _right_
 approach to change a message from a xref:../processor.adoc[Processor].
 However there is an big issue -- the `getOut` method will create a new
-<<message-eip,Message>>, which means any other information
+xref:message-eip.adoc[Message], which means any other information
 from the IN message will not be propagated; which means you will lose
 that data.
 
@@ -72,7 +72,7 @@ public void process(Exchange exchange) throws Exception {
 }
 ----
 
-Well that is not all, a <<message-eip,Message>> can also contain
+Well that is not all, a xref:message-eip.adoc[Message] can also contain
 attachments so to be sure you need to propagate those as well:
 
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/faq/what-is-a-router.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/what-is-a-router.adoc
@@ -4,20 +4,20 @@
 We often talk about that Camel is a mediation and routing framework; so
 what exactly is a router and what does it do?
 
-Basically a router just consumes <<message-eip,Message>> exchanges
+Basically a router just consumes xref:message-eip.adoc[Message] exchanges
 from some xref:../endpoint.adoc[Endpoint], then sends them on to some other
 xref:../endpoint.adoc[Endpoint] using some kind of
 xref:../enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns].
 
 For example a router could implement the
-<<contentBasedRouter-eip,Content Based Router>> pattern, to route
+xref:contentBasedRouter-eip.adoc[Content Based Router] pattern, to route
 from an endpoint to one or more destination endpoints using a
 xref:../predicate.adoc[Predicate] based on the message content.
 
 Typically a route or router consists of one or more consumers; either an
-<<eventDrivenConsumer-eip,Event Driven Consumer>> or a
-<<pollingConsumer-eip,Polling Consumer>> or possibly a
-<<transactionalClient-eip,Transactional Client>>. Then there are one
+xref:eventDrivenConsumer-eip.adoc[Event Driven Consumer] or a
+xref:pollingConsumer-eip.adoc[Polling Consumer] or possibly a
+xref:transactionalClient-eip.adoc[Transactional Client]. Then there are one
 or more xref:../processor.adoc[Processor] instances which could send the
 message to one or more endpoints.

--- a/docs/user-manual/modules/ROOT/pages/faq/what-is-camel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/what-is-camel.adoc
@@ -14,8 +14,8 @@ routing rules in your IDE, whether in a Java, Scala or XML editor.
 
 Apache Camel uses xref:../uris.adoc[URIs] to work directly with any kind of
 xref:../transport.adoc[Transport] or messaging model such as
-<<http-component,HTTP>>, xref:activemq.adoc[ActiveMQ], <<jms-component,JMS>>,
-JBI, SCA, <<mina-component,MINA>> or <<cxf-component,CXF>>, as
+xref:http-component,HTTP>>, xref:activemq.adoc[ActiveMQ], <<jms-component.adoc[JMS],
+JBI, SCA, xref:mina-component,MINA>> or <<cxf-component.adoc[CXF], as
 well as pluggable xref:../component.adoc[Components] and
 xref:../data-format.adoc[Data Format] options. Apache Camel is a small
 library with minimal xref:what-are-the-dependencies.adoc[dependencies]
@@ -27,7 +27,7 @@ out-of-box.
 
 Apache Camel provides support for xref:bean-binding.adoc[Bean Binding]
 and seamless integration with popular frameworks such as
-<<cdi-component,CDI>>, xref:../spring.adoc[Spring],
+xref:cdi-component.adoc[CDI], xref:../spring.adoc[Spring],
 xref:../using-osgi-blueprint-with-camel.adoc[Blueprint] and
 xref:../guice.adoc[Guice]. Camel also has extensive support for
 xref:../testing.adoc[unit testing] your routes.

--- a/docs/user-manual/modules/ROOT/pages/faq/why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc
@@ -1,7 +1,7 @@
 [[WhycanInotusewhenorotherwiseinaJavaCamelroute-WhycanInotusewhenotherwiseinaJavaCamelroute]]
 === Why can I not use when/otherwise in a Java Camel route?
 
-When using the <<contentBasedRouter-eip,Content Based Router>> in
+When using the xref:contentBasedRouter-eip.adoc[Content Based Router] in
 the Java DSL you may have a situation where the compiler will not accept
 the following `when()` or `otherwise()` statement.
 
@@ -10,12 +10,12 @@ the following `when()` or `otherwise()` statement.
 **Quick tip**
 
 Use `.endChoice()` to return "back" to the
-<<contentBasedRouter-eip,Content Based Router>>.
+xref:contentBasedRouter-eip.adoc[Content Based Router].
 ====
 
 For example as shown in the route below where we use the
-<<loadBalance-eip,Load Balancer>> inside the
-<<contentBasedRouter-eip,Content Based Router>> in the first when:
+xref:loadBalance-eip.adoc[Load Balancer] inside the
+xref:contentBasedRouter-eip.adoc[Content Based Router] in the first when:
 
 *Code will not compile*
 
@@ -29,7 +29,7 @@ from("direct:start")
             .to("mock:result");
 ----
 
-Well the first issue is that the <<loadBalance-eip,Load Balancer>>
+Well the first issue is that the xref:loadBalance-eip.adoc[Load Balancer]
 uses the additional routing to know what to use in the load balancing.
 In this example that would be the:
 
@@ -59,7 +59,7 @@ xref:../dsl.adoc[DSL]. In a more modern language such as
 xref:../scala-dsl.adoc[Scala] or xref:../groovy-dsl.adoc[Groovy] you would be able
 to let it be stack based, so the `.end()` will pop the last type of the
 stack, and you would return back to the scope of the
-<<contentBasedRouter-eip,Content Based Router>>. However that's not
+xref:contentBasedRouter-eip.adoc[Content Based Router]. However that's not
 easily doable in Java. So we need to help Java a bit, which you do by
 using `.endChoice()`, which tells Camel to "pop the stack" and return
 back to the scope of the xref:content-based-router.adoc[Content Based
@@ -81,17 +81,17 @@ You only need to use `.endChoice()` when using certain
 xref:../enterprise-integration-patterns.adoc[EIP]s which often have additional
 methods to configure or as part of the
 xref:../enterprise-integration-patterns.adoc[EIP] itself. For example the
-<<split-eip,Splitter>> EIP has a sub-route which denotes the
+xref:split-eip.adoc[Splitter] EIP has a sub-route which denotes the
 routing of each splitted message. You would also have to use
 `.endChoice()` to indicate the end of the sub-route and to return back
-to the <<contentBasedRouter-eip,Content Based Router>>. Note
+to the xref:contentBasedRouter-eip.adoc[Content Based Router]. Note
 `.endChoice()` is *available as of Camel 2.7*.
 
 [[WhycanInotusewhenorotherwiseinaJavaCamelroute-Stillproblems]]
 ==== Still problems
 
 If there are still problems, then you can split your route into multiple
-routes, and link them together using the <<direct-component,Direct>>
+routes, and link them together using the xref:direct-component.adoc[Direct]
 component.
 There can be some combinations of xref:../enterprise-integration-patterns.adoc[EIP]s
 that can hit limits in how far we can take the fluent builder DSL with

--- a/docs/user-manual/modules/ROOT/pages/faq/why-does-ftp-component-not-download-any-files.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-does-ftp-component-not-download-any-files.adoc
@@ -1,7 +1,7 @@
 [[WhydoesFTPcomponentnotdownloadanyfiles-WhydoesFTPcomponentnotdownloadanyfiles]]
 === Why does FTP component not download any files?
 
-The <<ftp-component,FTP>> component has many options. So make sure you
+The xref:ftp-component.adoc[FTP] component has many options. So make sure you
 have configured it properly.
 Also a common issue is that you have to use either active or passive
 mode. So you may have to set `passiveMode=true` on the endpoint

--- a/docs/user-manual/modules/ROOT/pages/faq/why-does-my-file-consumer-not-pick-up-the-file-and-how-do-i-let-the-file-consumer-use-the-camel-error-handler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-does-my-file-consumer-not-pick-up-the-file-and-how-do-i-let-the-file-consumer-use-the-camel-error-handler.adoc
@@ -1,7 +1,7 @@
 [[WhydoesmyfileconsumernotpickupthefileandhowdoIletthefileconsumerusetheCamelerrorhandler-WhydoesmyfileconsumernotpickupthefileandhowdoIletthefileconsumerusetheCamelerrorhandler]]
 === Why does my file consumer not pick up the file, and how do I let the file consumer use the Camel error handler?
 
-There could be several reasons why the <<file-component,File>> consumer is
+There could be several reasons why the xref:file-component.adoc[File] consumer is
 not picking up files. For example it may not run at all, or it cannot
 acquire a read lock on the file.
 xref:../faq.adoc#logging-questions[Check the logs] for any exceptions or other
@@ -31,7 +31,7 @@ xref:../component.adoc[component]-specific.
 
 From Camel 2.10 onwards the file and ftp consumers can now bridge to the
 Camel routing engine's error handler. See more details at the
-`consumer.bridgeErrorHandler` option on the <<file-component,File>>
+`consumer.bridgeErrorHandler` option on the xref:file-component.adoc[File]
 documentation.
 ====
 
@@ -45,7 +45,7 @@ https://github.com/apache/camel/blob/master/camel-core/src/main/java/org/apache/
 that will log the exception at `ERROR`/`WARN` level, and then ignore the
 exception.
 
-See the <<file-component,File>> page in the bottom for an example how to
+See the xref:file-component.adoc[File] page in the bottom for an example how to
 use a custom `ExceptionHandler` that sends a new message to the Camel
 routing engine, which then allows the routing engine to trigger its own
 error handling to deal with the exception.

--- a/docs/user-manual/modules/ROOT/pages/faq/why-does-my-jms-route-only-consume-one-message-at-once.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-does-my-jms-route-only-consume-one-message-at-once.adoc
@@ -1,7 +1,7 @@
 [[WhydoesmyJMSrouteonlyconsumeonemessageatonce-WhydoesmyJMSrouteonlyconsumeonemessageatonce]]
 === Why does my JMS route only consume one message at once?
 
-The default <<jms-component,JMS>> endpoint configuration defines
+The default xref:jms-component.adoc[JMS] endpoint configuration defines
 *concurrentConsumers* to be 1 so only 1 message is processed
 concurrently at any point in time. To change this to make things more
 concurrent, just configure this value; either at the JMS component level
@@ -18,4 +18,4 @@ from("activemq:SomeQueue?concurrentConsumers=25").
 [[WhydoesmyJMSrouteonlyconsumeonemessageatonce-SeeAlso]]
 ==== See Also
 
-* <<jms-component,JMS>> for more configuration details
+* xref:jms-component.adoc[JMS] for more configuration details

--- a/docs/user-manual/modules/ROOT/pages/faq/why-does-useoriginalmessage-with-error-handler-not-work-as-expected.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-does-useoriginalmessage-with-error-handler-not-work-as-expected.adoc
@@ -5,12 +5,12 @@ If you use the xref:../exception-clause.adoc[useOriginalMessage] option
 from the Camel xref:../exception-clause.adoc[Error Handler] then it matters
 if you use this with xref:../enterprise-integration-patterns.adoc[EIP]s such as:
 
-* <<recipientList-eip,Recipient List>>
-* <<split-eip,Splitter>>
-* <<multicast-eip,Multicast>>
+* xref:recipientList-eip.adoc[Recipient List]
+* xref:split-eip.adoc[Splitter]
+* xref:multicast-eip.adoc[Multicast]
 
 Then the option `shareUnitOfWork` on these xref:../enterprise-integration-patterns.adoc[EIP]s
 influence the message in use by the `useOriginalMessage` option.
 
-See more details at <<split-eip,Splitter>> and further below with
+See more details at xref:split-eip.adoc[Splitter] and further below with
 the examples explaining this in more detail.

--- a/docs/user-manual/modules/ROOT/pages/faq/why-use-multiple-camelcontext.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/why-use-multiple-camelcontext.adoc
@@ -12,5 +12,5 @@ other Camel applications.
 
 If you want the endpoints or producers in different camel contexts to
 communicate with another, there are a number of solutions. You can use
-the ServiceMix NMR, or you can use <<jms-component,JMS>>, or
-you can use Camel's <<vm-component,VM>> transport.
+the ServiceMix NMR, or you can use xref:jms-component.adoc[JMS], or
+you can use Camel's xref:vm-component.adoc[VM] transport.

--- a/docs/user-manual/modules/ROOT/pages/file-language.adoc
+++ b/docs/user-manual/modules/ROOT/pages/file-language.adoc
@@ -4,11 +4,11 @@
 *Available as of Camel version 1.1*
 
 The file language is merged with
-<<simple-language,Simple>> language which means you can use all the file
+xref:simple-language.adoc[Simple] language which means you can use all the file
 syntax directly within the simple language.
 
 The File Expression Language is an extension to the
-<<simple-language,Simple>> language, adding file related capabilities.
+xref:simple-language.adoc[Simple] language, adding file related capabilities.
 These capabilities are related to common use cases working with file
 path and names. The goal is to allow expressions to be used with the
 File and FTP components for setting
@@ -31,18 +31,18 @@ The File language supports 2 options, which are listed below.
 
 === Syntax
 
-This language is an *extension* to the <<simple-language,Simple>> language
-so the <<simple-language,Simple>> syntax applies also. So the table below
+This language is an *extension* to the xref:simple-language.adoc[Simple] language
+so the xref:simple-language.adoc[Simple] syntax applies also. So the table below
 only lists the additional.  +
- As opposed to <<simple-language,Simple>> language
-<<file-language,File Language>> also supports
-<<constant-language,Constant>> expressions so you can enter a fixed
+ As opposed to xref:simple-language.adoc[Simple] language
+xref:file-language.adoc[File Language] also supports
+xref:constant-language.adoc[Constant] expressions so you can enter a fixed
 filename.
 
 All the file tokens use the same expression name as the method on the
 `java.io.File` object, for instance `file:absolute` refers to the
 `java.io.File.getAbsolute()` method. Notice that not all expressions are
-supported by the current Exchange. For instance the <<ftp-component,FTP>>
+supported by the current Exchange. For instance the xref:ftp-component.adoc[FTP]
 component supports some of the options, where as the
 File component supports all of them.
 
@@ -94,9 +94,9 @@ this expression strips only the last part, and keep the others.
 |file:modified |Date |yes |no |yes |no |Refers to the file last modified returned as a Date type
 
 |date:_command:pattern_ |String |yes |yes |yes |yes |for date formatting using the `java.text.SimpleDateFormat` patterns. Is
-an *extension* to the <<simple-language,Simple>> language. Additional
+an *extension* to the xref:simple-language.adoc[Simple] language. Additional
 command is: *file* (consumers only) for the last modified timestamp of
-the file. Notice: all the commands from the <<simple-language,Simple>>
+the file. Notice: all the commands from the xref:simple-language.adoc[Simple]
 language can also be used.
 |===
 
@@ -170,7 +170,7 @@ return as:
 
 === Samples
 
-You can enter a fixed <<constant-language,Constant>> expression such as
+You can enter a fixed xref:constant-language.adoc[Constant] expression such as
 `myfile.txt`:
 
 [source]
@@ -195,7 +195,7 @@ should be a sibling folder then you can append .. as:
 fileName="../backup/${date:now:yyyyMMdd}/${file:name.noext}.bak"
 ----
 
-As this is an extension to the <<simple-language,Simple>> language we have
+As this is an extension to the xref:simple-language.adoc[Simple] language we have
 access to all the goodies from this language also, so in this use case
 we want to use the in.header.type as a parameter in the dynamic
 expression:
@@ -222,14 +222,14 @@ fileName="uniquefile-${bean:myguidgenerator.generateid}.txt"
 ----
 
 And of course all this can be combined in one expression where you can
-use the <<file-language,File Language>>, <<file-language,Simple>>
-and the <<bean-component,Bean>> language in one combined expression. This
+use the xref:file-language,File Language>>, <<file-language.adoc[Simple]
+and the xref:bean-component.adoc[Bean] language in one combined expression. This
 is pretty powerful for those common file path patterns.
 
 === Using Spring PropertyPlaceholderConfigurer together with the File component
 
-In Camel you can use the <<file-language,File Language>> directly
-from the <<simple-language,Simple>> language which makes a
+In Camel you can use the xref:file-language.adoc[File Language] directly
+from the xref:simple-language.adoc[Simple] language which makes a
 Content Based Router easier to do in
 Spring XML, where we can route based on file extensions as shown below:
 
@@ -252,7 +252,7 @@ Spring XML, where we can route based on file extensions as shown below:
 ----
 
 If you use the `fileName` option on the File endpoint
-to set a dynamic filename using the <<file-language,File Language>> then make sure you  +
+to set a dynamic filename using the xref:file-language.adoc[File Language] then make sure you  +
  use the alternative syntax to avoid
 clashing with Springs `PropertyPlaceholderConfigurer`.
 

--- a/docs/user-manual/modules/ROOT/pages/graceful-shutdown.adoc
+++ b/docs/user-manual/modules/ROOT/pages/graceful-shutdown.adoc
@@ -159,7 +159,7 @@ For example in the route below we have two routes, where route 1 is
 dependent upon route 2. At shutdown we want route 1 to complete all its
 current messages and we also want the 2nd route to do this as well. So
 we can mark both routes to `Defer` but since route 1 is a
-<<seda-component,SEDA>> based route its `Defer` by default (it uses
+xref:seda-component.adoc[SEDA] based route its `Defer` by default (it uses
 `ShutdownAware`).
 
 A Java DSL based example to defer shutting down the 2nd
@@ -410,7 +410,7 @@ The interface `org.apache.camel.spi.ShutdownAware` is an optional
 interface consumers can implement to have fine grained control during
 shutdown. The `ShutdownStrategy` must be able to deal with consumers
 which implement this interface. This interface was introduced to cater
-for in memory consumers such as <<seda-component,SEDA>> which potentially
+for in memory consumers such as xref:seda-component.adoc[SEDA] which potentially
 have a number of pending messages on its internal in memory queues. What
 this allows is to let it control the shutdown process to let it complete
 its pending messages.

--- a/docs/user-manual/modules/ROOT/pages/guaranteed-delivery.adoc
+++ b/docs/user-manual/modules/ROOT/pages/guaranteed-delivery.adoc
@@ -8,13 +8,13 @@ patterns] using among others the following components:
 
 * xref:file2.adoc[File] for using file systems as a persistent store of
 messages
-* <<jms-component,JMS>> when using persistent delivery (the default) for
+* xref:jms-component.adoc[JMS] when using persistent delivery (the default) for
 working with JMS Queues and Topics for high performance, clustering and
 load balancing
-* <<jpa-component,JPA>> for using a database as a persistence layer, or use
-any of the many other database component such as <<sql-component,SQL>>,
-<<jdbc-component,JDBC>>,
-<<mybatis-component,MyBatis>>,
+* xref:jpa-component.adoc[JPA] for using a database as a persistence layer, or use
+any of the many other database component such as xref:sql-component.adoc[SQL],
+xref:jdbc-component.adoc[JDBC],
+xref:mybatis-component.adoc[MyBatis],
 xref:hibernate.adoc[Hibernate]
 * xref:hawtdb.adoc[HawtDB] for a lightweight key-value persistent store
 
@@ -25,7 +25,7 @@ image:http://www.enterpriseintegrationpatterns.com/img/GuaranteedMessagingSoluti
 
 The following example demonstrates illustrates the use
 of http://www.enterpriseintegrationpatterns.com/GuaranteedMessaging.html[Guaranteed
-Delivery] within the <<jms-component,JMS>> component. By default, a message
+Delivery] within the xref:jms-component.adoc[JMS] component. By default, a message
 is not considered successfully delivered until the recipient has
 persisted the message locally guaranteeing its receipt in the event the
 destination becomes unavailable.

--- a/docs/user-manual/modules/ROOT/pages/idempotentConsumer-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/idempotentConsumer-eip.adoc
@@ -19,13 +19,13 @@ Camel provides the following Idempotent Consumer implementations:
 * MemoryIdempotentRepository
 * xref:file2.adoc[FileIdempotentRepository]
 * xref:hazelcast-component.adoc[HazelcastIdempotentRepository]
-* <<sql-component,JdbcMessageIdRepository>>
-* <<jpa-component,JpaMessageIdRepository>>
-* <<infinispan-component,InfinispanIdempotentRepository>>
-* <<jcache-component,JCacheIdempotentRepository>>
+* xref:sql-component.adoc[JdbcMessageIdRepository]
+* xref:jpa-component.adoc[JpaMessageIdRepository]
+* xref:infinispan-component.adoc[InfinispanIdempotentRepository]
+* xref:jcache-component.adoc[JCacheIdempotentRepository]
 * xref:spring.adoc[SpringCacheIdempotentRepository]
-* <<ehcache-component,EhcacheIdempotentRepository>>
-* <<kafka-component,KafkaIdempotentRepository>>
+* xref:ehcache-component.adoc[EhcacheIdempotentRepository]
+* xref:kafka-component.adoc[KafkaIdempotentRepository]
 
 === Options
 

--- a/docs/user-manual/modules/ROOT/pages/index.adoc
+++ b/docs/user-manual/modules/ROOT/pages/index.adoc
@@ -1,9 +1,9 @@
 = Summary
 
-* <<#overview,Overview>>
-* <<#documentation,Documentation>>
-* <<#community,Community>>
-* <<#developers,Developers>>
+* xref:#overview.adoc[Overview]
+* xref:#documentation.adoc[Documentation]
+* xref:#community.adoc[Community]
+* xref:#developers.adoc[Developers]
 
 == Overview
 
@@ -16,18 +16,18 @@
 
 == Documentation
 
-* <<#user-guide,User Guide>>
+* xref:#user-guide.adoc[User Guide]
 * Manual
 * xref:books.adoc[Books]
 * Tutorials
-* <<#examples,Examples>>
+* xref:#examples.adoc[Examples]
 * Cookbook
-* <<#architecture,Architecture>>
+* xref:#architecture.adoc[Architecture]
 * xref:enterprise-integration-patterns.adoc[Enterprise Integration Patterns]
-* <<#dsl,DSL>>
-* <<#components,Components>>
-* <<#data-formats,Data Formats>>
-* <<#languages,Languages>>
+* xref:#dsl.adoc[DSL]
+* xref:#components.adoc[Components]
+* xref:#data-formats.adoc[Data Formats]
+* xref:#languages.adoc[Languages]
 * xref:security.adoc[Security]
 * xref:security-advisories.adoc[Security Advisories]
 
@@ -37,7 +37,7 @@
 * xref:book-getting-started.adoc[Longer Getting Started Guide]
 * xref:camel-jar-dependencies.adoc[Camel JAR Dependencies]
 * xref:camel-boot.adoc[Camel Boot]
-* <<cdi-component,Working with Camel and CDI>>
+* xref:cdi-component.adoc[Working with Camel and CDI]
 * xref:spring.adoc[Working with Camel and Spring]
 * xref:guice.adoc[Working with Camel and Guice]
 * xref:karaf.adoc[Working with Camel and Karaf]

--- a/docs/user-manual/modules/ROOT/pages/injector.adoc
+++ b/docs/user-manual/modules/ROOT/pages/injector.adoc
@@ -17,7 +17,7 @@ Endpoint in your Spring XML file; or let Camel find
 the defaults then use the Injector to create and inject any of its
 dependencies.
 
-As an example; consider the <<jms-component,JMS>> component. Rather than
+As an example; consider the xref:jms-component.adoc[JMS] component. Rather than
 explicitly configuring the JMS component in Spring XML you can just
 provide a ConnectionFactory in your Spring XML which the Injector will
 use to properly configure the JmsComponent when it is instantiated.

--- a/docs/user-manual/modules/ROOT/pages/intercept.adoc
+++ b/docs/user-manual/modules/ROOT/pages/intercept.adoc
@@ -113,7 +113,7 @@ particular route.
 
 So lets start with the logging example. We want to log all the
 *incoming* requests so we use `interceptFrom` to route to the
-<<log-component,Log>> component. As `proceed` is default then the
+xref:log-component.adoc[Log] component. As `proceed` is default then the
 Exchange will continue its route, and thus it will
 continue to `mock:first`.
 
@@ -186,7 +186,7 @@ Intercept endpoint is of course also available using Spring DSL.
 
 We start with the first example from above in Spring DSL:
 
-And the 2nd. Notice how we can leverage the <<simple-language,Simple>>
+And the 2nd. Notice how we can leverage the xref:simple-language.adoc[Simple]
 language for the Predicate:
 
 And the 3rd with the `skip`, notice skip is set with the

--- a/docs/user-manual/modules/ROOT/pages/json.adoc
+++ b/docs/user-manual/modules/ROOT/pages/json.adoc
@@ -21,7 +21,7 @@ XStream library.
 *Direct, bi-directional JSON <=> XML conversions*
 
 As of Camel 2.10, Camel supports direct, bi-directional JSON <=> XML
-conversions via the <<xmljson-dataformat,camel-xmljson>> data format, which
+conversions via the xref:xmljson-dataformat.adoc[camel-xmljson] data format, which
 is documented separately.
 
 [[JSON-UsingJSONdataformatwiththeXStreamlibrary]]

--- a/docs/user-manual/modules/ROOT/pages/languages.adoc
+++ b/docs/user-manual/modules/ROOT/pages/languages.adoc
@@ -19,30 +19,30 @@ For more information, see xref:predicate.adoc[Compound Predicates].
 
 The following is the list of currently supported languages:
 
-* <<bean-language,Bean Language>> for using Java for expressions
-* <<constant-language,Constant>>
-* the unified <<el-language,EL>> from JSP and JSF
-* <<header-language,Header>>
-* <<jsonpath-language,JSonPath>>
-* <<jxpath-language,JXPath>>
-* <<mvel-language,Mvel>>
-* <<ognl-language,OGNL>>
-* <<ref-language,Ref Language>>
-* <<exchangeproperty-language,ExchangeProperty>> / <<property-language,Property>>
-* <<scripting-languages-language,Scripting Languages>> such as:
-** <<beanshell-language,BeanShell>>
-** <<javascript-language,JavaScript>>
-** <<groovy-language,Groovy>>
-** <<python-language,Python>>
-** <<php-language,PHP>>
-** <<ruby-language,Ruby>>
-* <<simple-language,Simple>>
-** <<file-language,File Language>>
-* <<spel-language,Spring Expression Language>>
-* <<sql-language,SQL>>
-* <<tokenizer-language,Tokenizer>>
-* <<xpath-language,XPath>>
-* <<xquery-language,XQuery>>
+* xref:bean-language.adoc[Bean Language] for using Java for expressions
+* xref:constant-language.adoc[Constant]
+* the unified xref:el-language.adoc[EL] from JSP and JSF
+* xref:header-language.adoc[Header]
+* xref:jsonpath-language.adoc[JSonPath]
+* xref:jxpath-language.adoc[JXPath]
+* xref:mvel-language.adoc[Mvel]
+* xref:ognl-language.adoc[OGNL]
+* xref:ref-language.adoc[Ref Language]
+* xref:exchangeproperty-language,ExchangeProperty>> / <<property-language.adoc[Property]
+* xref:scripting-languages-language.adoc[Scripting Languages] such as:
+** xref:beanshell-language.adoc[BeanShell]
+** xref:javascript-language.adoc[JavaScript]
+** xref:groovy-language.adoc[Groovy]
+** xref:python-language.adoc[Python]
+** xref:php-language.adoc[PHP]
+** xref:ruby-language.adoc[Ruby]
+* xref:simple-language.adoc[Simple]
+** xref:file-language.adoc[File Language]
+* xref:spel-language.adoc[Spring Expression Language]
+* xref:sql-language.adoc[SQL]
+* xref:tokenizer-language.adoc[Tokenizer]
+* xref:xpath-language.adoc[XPath]
+* xref:xquery-language.adoc[XQuery]
 * https://github.com/camel-extra/camel-extra/blob/master/components/camel-vtdxml/src/main/docs/vtdxml-component.adoc[VTD-XML]
 
 Most of these languages are also supported used as

--- a/docs/user-manual/modules/ROOT/pages/log-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/log-eip.adoc
@@ -4,7 +4,7 @@
 How can I log the processing of a xref:message.adoc[Message]?
 
 Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
-* You can use the <<log-component,Log>> component which logs the Message content.
+* You can use the xref:log-component.adoc[Log] component which logs the Message content.
 * You can use the xref:tracer.adoc[Tracer] which trace logs message flow.
 * You can also use a xref:processor.adoc[Processor] or xref:bean.adoc[Bean] and log from Java code.
 * You can use the log DSL.
@@ -31,7 +31,7 @@ The log DSL is much lighter and meant for logging human logs such as Starting to
 
 === Samples
 
-You can use the log DSL which allows you to use <<simple-language,Simple>> language to construct a dynamic message which gets logged.
+You can use the log DSL which allows you to use xref:simple-language.adoc[Simple] language to construct a dynamic message which gets logged.
 
 For example you can do
 
@@ -165,7 +165,7 @@ In some scenarios it is required that the bundle associated with logger should b
 *Available as of Camel 2.19*
 
 You can enable security masking for logging by setting `logMask` flag to `true`.
-Note that this option also affects <<log-component,Log>> component.
+Note that this option also affects xref:log-component.adoc[Log] component.
 
 To enable mask in Java DSL at CamelContext level:
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/message-bus.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message-bus.adoc
@@ -10,7 +10,7 @@ consumers to be decoupled.
 image:http://www.enterpriseintegrationpatterns.com/img/MessageBusSolution.gif[image]
 
 Folks often assume that a Message Bus is a JMS though so you may wish to
-refer to the <<jms-component,JMS>> component for traditional MOM support. +
+refer to the xref:jms-component.adoc[JMS] component for traditional MOM support. +
 
 
 [[MessageBus-Example]]

--- a/docs/user-manual/modules/ROOT/pages/message-channel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message-channel.adoc
@@ -23,7 +23,7 @@ jms:queue:foo
 -------------
 
 This message channel can be then used within the
-<<jms-component,JMS>> component
+xref:jms-component.adoc[JMS] component
 
 And the following shows a little Java route snippet:
 
@@ -48,4 +48,4 @@ And in XML:
 For more details see
 
 * xref:message.adoc[Message]
-* <<messageEndpoint-eip,Message Endpoint>>
+* xref:messageEndpoint-eip.adoc[Message Endpoint]

--- a/docs/user-manual/modules/ROOT/pages/message-translator.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message-translator.adoc
@@ -16,7 +16,7 @@ image:http://www.enterpriseintegrationpatterns.com/img/MessageTranslator.gif[ima
 
 You can transform a message using Camel's
 xref:bean-integration.adoc[Bean Integration] to call any method on a
-bean in your <<Registry-Registry,Registry>> such as your
+bean in your xref:Registry-Registry.adoc[Registry] such as your
 xref:spring.adoc[Spring] XML configuration file as follows
 
 [source,java]
@@ -36,7 +36,7 @@ the transformation
 
 or you can use the DSL to explicitly configure the transformation
 
-You can also use <<SpringXMLExtensions-SpringXMLExtensions,Spring XML Extensions>>
+You can also use xref:SpringXMLExtensions-SpringXMLExtensions.adoc[Spring XML Extensions]
 to do a transformation. Basically any xref:expression.adoc[Expression]
 language can be substituted inside the transform element as shown below
 
@@ -54,7 +54,7 @@ invoke a bean
 
 You can also use xref:templating.adoc[Templating] to consume a message
 from one destination, transform it with something like
-<<velocity-component,Velocity>> or <<velocity-component,XQuery>> and then send
+xref:velocity-component,Velocity>> or <<velocity-component.adoc[XQuery] and then send
 it on to another destination. For example using InOnly (one way
 messaging)
 

--- a/docs/user-manual/modules/ROOT/pages/point-to-point-channel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/point-to-point-channel.adoc
@@ -6,18 +6,18 @@ http://www.enterpriseintegrationpatterns.com/PointToPointChannel.html[Point
 to Point Channel] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the following components
 
-* <<seda-component,SEDA>> for in-VM seda based messaging
-* <<jms-component,JMS>> for working with JMS Queues for high performance,
+* xref:seda-component.adoc[SEDA] for in-VM seda based messaging
+* xref:jms-component.adoc[JMS] for working with JMS Queues for high performance,
 clustering and load balancing
-* <<jpa-component,JPA>> for using a database as a simple message queue
-* <<xmpp-component,XMPP>> for point-to-point communication over XMPP
+* xref:jpa-component.adoc[JPA] for using a database as a simple message queue
+* xref:xmpp-component.adoc[XMPP] for point-to-point communication over XMPP
 (Jabber)
 * and others
 
 image:http://www.enterpriseintegrationpatterns.com/img/PointToPointSolution.gif[image]
 
 The following example demonstrates point to point messaging using
-the <<jms-component,JMS>> component 
+the xref:jms-component.adoc[JMS] component 
 
 [[PointtoPointChannel-Samples]]
 === Samples

--- a/docs/user-manual/modules/ROOT/pages/predicate.adoc
+++ b/docs/user-manual/modules/ROOT/pages/predicate.adoc
@@ -5,8 +5,8 @@ Camel supports a pluggable interface called
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Predicate.html[Predicate]
 which can be used to integrate a dynamic predicate into
 xref:enterprise-integration-patterns.adoc[Enterprise Integration
-Patterns] such as when using the <<filter-eip,Message Filter>>
-or <<contentBasedRouter-eip,Content Based Router>>.
+Patterns] such as when using the xref:filter-eip.adoc[Message Filter]
+or xref:contentBasedRouter-eip.adoc[Content Based Router].
 
 A Predicate is being evaluated to a boolean value so the result is
 either `true` or `false`. This makes xref:predicate.adoc[Predicate] so

--- a/docs/user-manual/modules/ROOT/pages/process-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/process-eip.adoc
@@ -88,7 +88,7 @@ refactor it into a separate class.
 
 There is a base class called
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/ProcessorEndpoint.html[ProcessorEndpoint]
-which supports the full <<Endpoint-Endpoints,Endpoint>> semantics given a
+which supports the full xref:Endpoint-Endpoints.adoc[Endpoint] semantics given a
 Processor instance.
 
 So you just need to create a https://github.com/apache/camel/tree/master/components[Component] class by

--- a/docs/user-manual/modules/ROOT/pages/processor.adoc
+++ b/docs/user-manual/modules/ROOT/pages/processor.adoc
@@ -4,7 +4,7 @@
 The
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
 interface is used to implement consumers of message exchanges or to
-implement a <<messageTranslator-eip,Message Translator>>.
+implement a xref:messageTranslator-eip.adoc[Message Translator].
 
 [[Processor-Usingaprocessorinaroute]]
 ==== Using a processor in a route
@@ -94,6 +94,6 @@ xref:writing-components.adoc[Writing Components]
 [[Processor-SeeAlso]]
 ==== See Also
 
-* <<messageTranslator-eip,Message Translator>>
-* <<enrich-eip,Content Enricher>>
-* <<ContentFilter-eip,Content Filter>>
+* xref:messageTranslator-eip.adoc[Message Translator]
+* xref:enrich-eip.adoc[Content Enricher]
+* xref:ContentFilter-eip.adoc[Content Filter]

--- a/docs/user-manual/modules/ROOT/pages/publish-subscribe-channel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/publish-subscribe-channel.adoc
@@ -7,13 +7,13 @@ Subscribe Channel] from the
 xref:enterprise-integration-patterns.adoc[EIP patterns] using for
 example the following components:
 
-* <<jms-component,JMS>> for working with JMS Topics for high performance,
+* xref:jms-component.adoc[JMS] for working with JMS Topics for high performance,
 clustering and load balancing
-* <<xmpp-component,XMPP>> when using rooms for group communication
-* <<seda-component,SEDA>> for working with SEDA in the same
+* xref:xmpp-component.adoc[XMPP] when using rooms for group communication
+* xref:seda-component.adoc[SEDA] for working with SEDA in the same
 xref:camelcontext.adoc[CamelContext] which can work in pub-sub, but
 allowing multiple consumers.
-* <<vm-component,VM>> as SEDA but for intra-JVM.
+* xref:vm-component.adoc[VM] as SEDA but for intra-JVM.
 
 image:http://www.enterpriseintegrationpatterns.com/img/PublishSubscribeSolution.gif[image]
 

--- a/docs/user-manual/modules/ROOT/pages/requestReply-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/requestReply-eip.adoc
@@ -11,7 +11,7 @@ this pattern using the underlying transport or protocols.
 
 image:http://www.enterpriseintegrationpatterns.com/img/RequestReply.gif[image]
 
-For example when using <<jms-component,JMS>> with InOut the component will
+For example when using xref:jms-component.adoc[JMS] with InOut the component will
 by default perform these actions
 
 * create by default a temporary inbound queue
@@ -27,7 +27,7 @@ TIP: *Related* See the related Event Message message
 [[RequestReply-ExplicitlyspecifyingInOut]]
 === Explicitly specifying InOut
 
-When consuming messages from <<jms-component,JMS>> a Request-Reply is
+When consuming messages from xref:jms-component.adoc[JMS] a Request-Reply is
 indicated by the presence of the *JMSReplyTo* header.
 
 You can explicitly force an endpoint to be in Request Reply mode by

--- a/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
@@ -8,10 +8,10 @@ REST style with verbs such as get, post, delete etc.
 
 === How it works
 
-The Rest DSL is a facade that builds <<rest-component,Rest>> endpoints as
+The Rest DSL is a facade that builds xref:rest-component.adoc[Rest] endpoints as
 consumers for Camel routes. The actual REST transport is leveraged by
 using Camel REST components such
-as <<restlet-component,Restlet>>, <<restlet-component,Spark-rest>>, and
+as xref:restlet-component,Restlet>>, <<restlet-component.adoc[Spark-rest], and
 others that has native REST integration.
 
 === Components supporting Rest DSL
@@ -19,20 +19,20 @@ others that has native REST integration.
 The following Camel components supports the Rest DSL. See the bottom of
 this page for how to integrate a component with the Rest DSL.
 
-* <<rest-component,came-rest>> *required* contains the base rest component needed by Rest DSL
-* <<netty-http-component,camel-netty-http>> (also
+* xref:rest-component.adoc[came-rest] *required* contains the base rest component needed by Rest DSL
+* xref:netty-http-component.adoc[camel-netty-http] (also
 supports Swagger Java)
-* <<netty4-http-component,camel-netty4-http>> (also
+* xref:netty4-http-component.adoc[camel-netty4-http] (also
 supports Swagger Java)
-* <<jetty-component,camel-jetty>> (also
+* xref:jetty-component.adoc[camel-jetty] (also
 supports Swagger Java)
-* <<restlet-component,camel-restlet>> (also
+* xref:restlet-component.adoc[camel-restlet] (also
 supports Swagger Java)
-* <<servlet-component,camel-servlet>> (also
+* xref:servlet-component.adoc[camel-servlet] (also
 supports Swagger Java)
-* <<spark-rest-component,camel-spark-rest>> (also
+* xref:spark-rest-component.adoc[camel-spark-rest] (also
 supports Swagger Java from Camel 2.17 onwards)
-* <<undertow-component,camel-undertow>> (also
+* xref:undertow-component.adoc[camel-undertow] (also
 supports Swagger Java from Camel 2.17 onwards)
 
 === Rest DSL with Java
@@ -181,7 +181,7 @@ only. The example above can be defined as:
 
 The Rest DSL supports the new .toD <toD> as dynamic
 to in the rest-dsl. For example to do a request/reply
-over <<jms-component,JMS>> where the queue name is dynamic defined
+over xref:jms-component.adoc[JMS] where the queue name is dynamic defined
 
 [source,java]
 ----
@@ -204,7 +204,7 @@ over <<jms-component,JMS>> where the queue name is dynamic defined
 
 See more details at Message Endpoint about
 the dynamic to, and what syntax it supports. By default it uses
-the <<simple-language,Simple>> language, but it has more power than so.
+the xref:simple-language.adoc[Simple] language, but it has more power than so.
 
 === Embedding Camel routes
 

--- a/docs/user-manual/modules/ROOT/pages/return-address.adoc
+++ b/docs/user-manual/modules/ROOT/pages/return-address.adoc
@@ -7,7 +7,7 @@ patterns] by using the `JMSReplyTo` header.
 
 image:http://www.enterpriseintegrationpatterns.com/img/ReturnAddressSolution.gif[image]
 
-For example when using <<jms-component,JMS>> with InOut the component will
+For example when using xref:jms-component.adoc[JMS] with InOut the component will
 by default return to the address given in `JMSReplyTo`.
 
 *Requestor Code*

--- a/docs/user-manual/modules/ROOT/pages/scala-dsl-supported-languages.adoc
+++ b/docs/user-manual/modules/ROOT/pages/scala-dsl-supported-languages.adoc
@@ -11,7 +11,7 @@ You can use any of the supported Camel Languages in
 the Scala DSL; see below for a couple of examples:
 
 [[ScalaDSL-Supportedlanguages-Using]]
-Using <<xpath-language,XPath>>
+Using xref:xpath-language.adoc[XPath]
 ----------------------------
 
 With the XPath trait, you have an additional method available on an
@@ -31,7 +31,7 @@ Splitter example, where the `xpath` method is used in a
 ----------------------------------------------------------
 
 [[ScalaDSL-Supportedlanguages-Using.1]]
-Using <<jxpath-language,JXPath>>
+Using xref:jxpath-language.adoc[JXPath]
 ------------------------------
 
 With the `org.apache.camel.scala.dsl.languages.JXPath` trait, you can an

--- a/docs/user-manual/modules/ROOT/pages/scripting-languages.adoc
+++ b/docs/user-manual/modules/ROOT/pages/scripting-languages.adoc
@@ -63,7 +63,7 @@ following attributes all set at `ENGINE_SCOPE`:
 IN message instead.
 
 |properties |`org.apache.camel.builder.script.PropertiesFunction` |*Camel 2.9:* Function with a `resolve` method to make it easier to use
-Camels <<properties-component,Properties>> component from scripts. See
+Camels xref:properties-component.adoc[Properties] component from scripts. See
 further below for example.
 |=======================================================================
 
@@ -84,7 +84,7 @@ See this example:
 
 *Available as of Camel 2.9*
 
-If you need to use the <<properties-component,Properties>> component from a
+If you need to use the xref:properties-component.adoc[Properties] component from a
 script to lookup property placeholders, then its a bit cumbersome to do
 so. For example to set a header name myHeader with a value from a property
 placeholder, which key is provided in a header named "foo".

--- a/docs/user-manual/modules/ROOT/pages/servlet-tomcat-example.adoc
+++ b/docs/user-manual/modules/ROOT/pages/servlet-tomcat-example.adoc
@@ -17,14 +17,14 @@ mvn package
 [[ServletTomcatExample-About]]
 ==== About
 
-This example demonstrates how you can use <<servlet-component,Servlet>> to expose
+This example demonstrates how you can use xref:servlet-component.adoc[Servlet] to expose
 a http service in a Camel route.
 
 [[ServletTomcatExample-Implementation]]
 ==== Implementation
 
 In the `web.xml` file in the `src/main/webapp/WEB-INF` folder the `CamelServlet`
-is defined. This is mandatory to do when using the <<servlet-component,Servlet>>
+is defined. This is mandatory to do when using the xref:servlet-component.adoc[Servlet]
 component.
 
 [source,xml]
@@ -62,7 +62,7 @@ component.
 </web-app>
 ----
 
-The route is a simple <<contentBasedRouter-eip,Content Based Router>> defined
+The route is a simple xref:contentBasedRouter-eip.adoc[Content Based Router] defined
 in the DSL XML as shown:
 
 [source,xml]
@@ -117,5 +117,5 @@ http://localhost:8080/camel-example-servlet-tomcat/camel/hello URL.
 ==== See Also
 
 * xref:examples.adoc[Examples]
-*  <<servlet-component,Servlet>>
-*  <<http-component,HTTP>>
+*  xref:servlet-component.adoc[Servlet]
+*  xref:http-component.adoc[HTTP]

--- a/docs/user-manual/modules/ROOT/pages/simple-language.adoc
+++ b/docs/user-manual/modules/ROOT/pages/simple-language.adoc
@@ -8,17 +8,17 @@ created, but has since grown more powerful. It is primarily intended for
 being a really small and simple language for evaluating
 Expressions and Predicates
 without requiring any new dependencies or knowledge of
-<<xpath-language,XPath>>; so it is ideal for testing in camel-core. The
+xref:xpath-language.adoc[XPath]; so it is ideal for testing in camel-core. The
 idea was to cover 95% of the common use cases when you need a little bit
 of expression based script in your Camel routes.
 
 However for much more complex use cases you are generally recommended to
 choose a more expressive and powerful language such as:
 
-* <<groovy-language,Groovy>>
-* <<spel-language,SpEL>>
-* <<mvel-component,MVEL>>
-* <<ognl-language,OGNL>>
+* xref:groovy-language.adoc[Groovy]
+* xref:spel-language.adoc[SpEL]
+* xref:mvel-component.adoc[MVEL]
+* xref:ognl-language.adoc[OGNL]
 
 The simple language uses `${body`} placeholders for complex expressions
 where the expression contains constant literals. The $\{ } placeholders
@@ -188,9 +188,9 @@ Command accepts offsets such as: *now-24h* or *in.header.xxx+1h* or even *now+1h
 
 |date-with-timezone:_command:timezone:pattern_ |String |Date formatting using `java.text.SimpleDataFormat` timezones and patterns.
 
-|bean:_bean expression_ |Object |Invoking a bean expression using the <<bean-component,Bean>> language.
+|bean:_bean expression_ |Object |Invoking a bean expression using the xref:bean-component.adoc[Bean] language.
 Specifying a method name you must use dot as separator. We also support
-the ?method=methodname syntax that is used by the <<bean-component,Bean>>
+the ?method=methodname syntax that is used by the xref:bean-component.adoc[Bean]
 component.
 
 |properties-location:_http://locationskey[locations:key]_ |String |Lookup a property with the given key. The `locations`
@@ -250,7 +250,7 @@ INFO:Camel's OGNL support is for invoking methods only. You cannot access
 fields. Camel support accessing the length field of Java arrays.
 
 
-The <<simple-language,Simple>> and <<simple-language,Bean>> language now
+The xref:simple-language,Simple>> and <<simple-language.adoc[Bean] language now
 supports a Camel OGNL notation for invoking beans in a chain like
 fashion. Suppose the Message IN body contains a POJO which has a `getAddress()`
 method.
@@ -471,7 +471,7 @@ function, otherwise parsed as literal.
 |\ |To escape a value, eg \$, to indicate a $ sign.
 Special: Use \n for new line, \t for tab, and \r for carriage return.
 *Notice:* Escaping is *not* supported using the
-<<file-language,File Language>>. *Notice:* The escape character is not supported, use the
+xref:file-language.adoc[File Language]. *Notice:* The escape character is not supported, use the
 following three special escaping instead.
 
 |\n |To use newline character.
@@ -759,7 +759,7 @@ from("direct:order")
 ----
 
 We can use the `?method=methodname` option that we are familiar with the
-<<bean-component,Bean>> component itself:
+xref:bean-component.adoc[Bean] component itself:
 
 [source,java]
 ----
@@ -811,7 +811,7 @@ You can nest functions, such as shown below:
 Suppose you have an enum for customers
 
 And in a Content Based Router we can use
-the <<simple-language,Simple>> language to refer to this enum, to check
+the xref:simple-language.adoc[Simple] language to refer to this enum, to check
 the message which enum it matches.
 
 === Using new lines or tabs in XML DSLs
@@ -842,7 +842,7 @@ whitespace characters.
 
 === Setting result type
 
-You can now provide a result type to the <<simple-language,Simple>>
+You can now provide a result type to the xref:simple-language.adoc[Simple]
 expression, which means the result of the evaluation will be converted
 to the desired type. This is most usable to define types such as
 booleans, integers, etc.

--- a/docs/user-manual/modules/ROOT/pages/spring-testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/spring-testing.adoc
@@ -6,8 +6,8 @@ integration work. The Spring Framework offers a number of features that
 makes it easy to test while using Spring for Inversion of Control which
 works with JUnit 3.x, JUnit 4.x, and http://testng.org[TestNG].
 
-We can use Spring for IoC and the Camel <<mock-component,Mock>> and
-<<test-component,Test>> endpoints to create sophisticated integration/unit
+We can use Spring for IoC and the Camel xref:mock-component.adoc[Mock] and
+xref:test-component.adoc[Test] endpoints to create sophisticated integration/unit
 tests that are easy to run and debug inside your IDE.  There are three
 supported approaches for testing with Spring in Camel.
 
@@ -323,7 +323,7 @@ public class CamelSpringJUnit4ClassRunnerPlainTest {
 
 If you wish to programmatically add any new assertions to your test you
 can easily do so with the following. Notice how we use @EndpointInject
-to inject a Camel endpoint into our code then the <<mock-component,Mock>>
+to inject a Camel endpoint into our code then the xref:mock-component.adoc[Mock]
 API to add an expectation on a specific message.
 
 [source,java]
@@ -349,7 +349,7 @@ public class MyCamelTest extends AbstractJUnit38SpringContextTests {
 [[SpringTesting-Furtherprocessingthereceivedmessages]]
 ==== Further processing the received messages
 
-Sometimes once a <<mock-component,Mock>> endpoint has received some
+Sometimes once a xref:mock-component.adoc[Mock] endpoint has received some
 messages you want to then process them further to add further assertions
 that your test case worked as you expect.
 
@@ -388,7 +388,7 @@ It might be that the
 xref:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] you have defined in either Spring XML or
 using the Java DSL do all of the sending and receiving
-and you might just work with the <<mock-component,Mock>> endpoints as
+and you might just work with the xref:mock-component.adoc[Mock] endpoints as
 described above. However sometimes in a test case its useful to
 explicitly send or receive messages directly.
 
@@ -428,6 +428,6 @@ example test case using Mock and Spring] along with its
 https://svn.apache.org/repos/asf/camel/trunk/components/camel-spring/src/test/resources/org/apache/camel/spring/mock/InterceptSendToMockEndpointStrategyTest.xml[Spring
 XML]
 * Bean Integration
-* <<mock-component,Mock>> endpoint
-* <<test-component,Test>> endpoint
+* xref:mock-component.adoc[Mock] endpoint
+* xref:test-component.adoc[Test] endpoint
 

--- a/docs/user-manual/modules/ROOT/pages/stream-caching.adoc
+++ b/docs/user-manual/modules/ROOT/pages/stream-caching.adoc
@@ -13,12 +13,12 @@ Streams are caching in memory. In Camel 2.0, large stream messages (over 64 KB i
 *StreamCache Affects your payload object*
 
 The `StreamCache` will affect your payload object as it will replace the `Stream` payload with a `org.apache.camel.StreamCache` object.
-This `StreamCache` is capable of being re-readable and thus possible to better be routed within Camel using redelivery or <<contentBasedRouter-eip,Content Based Router>> or the likes.
+This `StreamCache` is capable of being re-readable and thus possible to better be routed within Camel using redelivery or xref:contentBasedRouter-eip.adoc[Content Based Router] or the likes.
 
 However to not change the payload under the covers without the end user really knowing we changed the default in Camel 2.0 to *disabled*. So in Camel 2.0 you have to explicit enable it if you want to use it.
 ====
 
-TIP: If using Camel 2.12 onwards then see <<Streamcaching-UsingStreamCachingStrategy,Using StreamCachingStrategy>> further below which is the recommended way to configure stream caching options.
+TIP: If using Camel 2.12 onwards then see xref:Streamcaching-UsingStreamCachingStrategy.adoc[Using StreamCachingStrategy] further below which is the recommended way to configure stream caching options.
 
 [[Streamcaching-Enablingstreamcaching]]
 ==== Enabling stream caching

--- a/docs/user-manual/modules/ROOT/pages/testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/testing.adoc
@@ -229,20 +229,20 @@ Camel provides a number of endpoints which can make testing easier.
 [width="100%",cols="1,3",options="header",]
 |=======================================================================
 |Name |Description
-|<<dataset-component,DataSet>> |For load & soak testing this endpoint
+|xref:dataset-component.adoc[DataSet] |For load & soak testing this endpoint
 provides a way to create huge numbers of messages for sending to
 Components and asserting that they are consumed
 correctly
 
-|<<mock-component,Mock>> |For testing routes and mediation rules using
+|xref:mock-component.adoc[Mock] |For testing routes and mediation rules using
 mocks and allowing assertions to be added to an endpoint
 
-|<<test-component,Test>> |Creates a <<test-component,Mock>> endpoint which
+|xref:test-component,Test>> |Creates a <<test-component.adoc[Mock] endpoint which
 expects to receive all the message bodies that could be polled from the
 given underlying endpoint
 |=======================================================================
 
-The main endpoint is the <<mock-component,Mock>> endpoint which allows
+The main endpoint is the xref:mock-component.adoc[Mock] endpoint which allows
 expectations to be added to different endpoints; you can then run your
 tests and assert that your expectations are met at the end.
 
@@ -257,16 +257,16 @@ endpoints can be useful:
 [width="100%",cols="1,3",options="header",]
 |=======================================================================
 |Name |Description
-|<<direct-component,Direct>> |Direct invocation of the consumer from the
+|xref:direct-component.adoc[Direct] |Direct invocation of the consumer from the
 producer so that single threaded (non-SEDA) in VM invocation is
 performed which can be useful to mock out physical transports
 
-|<<seda-component,SEDA>> |Delivers messages asynchronously to consumers via
+|xref:seda-component.adoc[SEDA] |Delivers messages asynchronously to consumers via
 a
 http://java.sun.com/j2se/1.5.0/docs/api/java/util/concurrent/BlockingQueue.html[`java.util.concurrent.BlockingQueue`]
 which is good for testing asynchronous transports
 
-|<<stub-component,Stub>> |Works like <<stub-component,SEDA>> but does not
+|xref:stub-component,Stub>> |Works like <<stub-component.adoc[SEDA] but does not
 validate the endpoint URI, which makes stubbing much easier.
 |=======================================================================
 
@@ -274,7 +274,7 @@ validate the endpoint URI, which makes stubbing much easier.
 ==== Testing existing routes
 
 Camel provides some features to aid during testing of existing routes
-where you cannot or will not use <<mock-component,Mock>> etc. For example
+where you cannot or will not use xref:mock-component.adoc[Mock] etc. For example
 you may have a production ready route which you want to test with some
 3rd party API which sends messages into this route.
 

--- a/docs/user-manual/modules/ROOT/pages/toD-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/toD-eip.adoc
@@ -2,9 +2,9 @@
 == To D EIP
 
 There is a new `.toD` / `<toD>` that allows to send a message to a dynamic
-computed <<Endpoint-Endpoints,Endpoint>> using one or
+computed xref:Endpoint-Endpoints.adoc[Endpoint] using one or
 more xref:expression.adoc[Expression] that are concat together. By
-default the <<simple-language,Simple>> language is used to compute
+default the xref:simple-language.adoc[Simple] language is used to compute
 the endpoint.
 
 === Options
@@ -45,7 +45,7 @@ And in XML:
 ----
 
 You can also prefix the uri with a value because by default the uri is
-evaluated using the <<simple-language,Simple>> language
+evaluated using the xref:simple-language.adoc[Simple] language
 
 [source,java]
 ----
@@ -67,8 +67,8 @@ In the example above we compute an endpoint that has prefix "mock:" and
 then the header foo is appended. So for example if the header foo has
 value order, then the endpoint is computed as "mock:order".
 
-You can also use other languages than <<simple-language,Simple>> such
-as <<xpath-language,XPath>> - this requires to prefix with language: as
+You can also use other languages than xref:simple-language.adoc[Simple] such
+as xref:xpath-language.adoc[XPath] - this requires to prefix with language: as
 shown below (simple language is the default language). If you do not
 specify language: then the endpoint is a component name. And in some
 cases there is both a component and language with the same name such as
@@ -90,7 +90,7 @@ from("direct:start")
   .toD("language:xpath:/order/@uri");
 ----
 
-You can also concat multiple <<language-component,Language>>(s) together
+You can also concat multiple xref:language-component.adoc[Language](s) together
 using the plus sign `+` such as shown below:
 
 [source,xml]
@@ -102,7 +102,7 @@ using the plus sign `+` such as shown below:
 ----
 
 In the example above the uri is a combination
-of <<simple-language,Simple>> language and <<simple-language,XPath>> where
+of xref:simple-language,Simple>> language and <<simple-language.adoc[XPath] where
 the first part is simple (simple is default language). And then the plus
 sign separate to another language, where we specify the language name
 followed by a colon

--- a/docs/user-manual/modules/ROOT/pages/transactional-client.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transactional-client.adoc
@@ -8,7 +8,7 @@ using spring transactions.
 
 image:http://www.enterpriseintegrationpatterns.com/img/TransactionalClientSolution.gif[image]
 
-Transaction Oriented Endpoints like <<jms-component,JMS>> support using a
+Transaction Oriented Endpoints like xref:jms-component.adoc[JMS] support using a
 transaction for both inbound and outbound message exchanges. Endpoints
 that support transactions will participate in the current transaction
 context that they are called from.
@@ -110,7 +110,7 @@ from("activemq:queue:foo").policy(notsupported)
 === OSGi Blueprint
 
 If you are using
-<<UsingOSGiblueprintwithCamel-UsingOSGiblueprintwithCamel,OSGi Blueprint>>
+xref:UsingOSGiblueprintwithCamel-UsingOSGiblueprintwithCamel.adoc[OSGi Blueprint]
 then you most likely have to explicit declare a policy and
 refer to the policy from the transacted in the route.
 
@@ -289,12 +289,12 @@ route as transacted using the *transacted* tag.
 
 When a route is marked as transacted using *transacted* Camel will
 automatic use the
-<<TransactionErrorHandler-TransactionErrorHandler,TransactionErrorHandler>>
-as <<ErrorHandler-ErrorHandler,Error Handler>>.
+xref:TransactionErrorHandler-TransactionErrorHandler.adoc[TransactionErrorHandler]
+as xref:ErrorHandler-ErrorHandler.adoc[Error Handler].
 It supports basically the same feature set as the
-<<DefaultErrorHandler-DefaultErrorHandler,DefaultErrorHandler>>,
+xref:DefaultErrorHandler-DefaultErrorHandler.adoc[DefaultErrorHandler],
 so you can for instance use
-<<ExceptionClause-ExceptionClause,Exception Clause>>
+xref:ExceptionClause-ExceptionClause.adoc[Exception Clause]
 as well.
 
 [[TransactionalClient-IntegrationTestingwithSpring]]
@@ -386,8 +386,8 @@ Camel to only do it for the current transaction and not globally.
 [[TransactionalClient-SeeAlso]]
 === See Also
 
-* <<ErrorhandlinginCamel-ErrorhandlinginCamel,Error handling in Camel>>
-* <<TransactionErrorHandler-TransactionErrorHandler,TransactionErrorHandler>>
-* <<ErrorHandler-ErrorHandler,Error Handler>>
-* <<jms-component,JMS>>
+* xref:ErrorhandlinginCamel-ErrorhandlinginCamel.adoc[Error handling in Camel]
+* xref:TransactionErrorHandler-TransactionErrorHandler.adoc[TransactionErrorHandler]
+* xref:ErrorHandler-ErrorHandler.adoc[Error Handler]
+* xref:jms-component.adoc[JMS]
 * xref:using-this-pattern.html[Using This Pattern]

--- a/docs/user-manual/modules/ROOT/pages/transactionerrorhandler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transactionerrorhandler.adoc
@@ -175,4 +175,4 @@ from("direct:fail")
 
 * xref:error-handler.adoc[Error Handler]
 * xref:error-handling-in-camel.adoc[Error handling in Camel]
-* <<transactionalClient-eip,Transactional Client>>
+* xref:transactionalClient-eip.adoc[Transactional Client]

--- a/docs/user-manual/modules/ROOT/pages/transformer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transformer.adoc
@@ -51,9 +51,9 @@ All transformers have following common options to specify which data type is sup
 
 | scheme | Type of data model like `xml` or `json`. For example if `xml` is specified, the transformer is applied for all java -&gt; xml and xml -&gt; java transformation.
  
-| fromType | <<Transformer-DataTypeFormat,Data type>> to transform from.
+| fromType | xref:Transformer-DataTypeFormat.adoc[Data type] to transform from.
  
-| toType | <<Transformer-DataTypeFormat,Data type>> to transform to.
+| toType | xref:Transformer-DataTypeFormat.adoc[Data type] to transform to.
 |===
 
 

--- a/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
+++ b/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
@@ -63,7 +63,7 @@ reattach the exception on the xref:exchange.adoc[Exchange].
 ==== Using try .. catch .. finally in Java DSL
 
 In the route below we have all keywords in action. As the code is based
-on a unit test we route using <<mock-component,Mock>>.
+on a unit test we route using xref:mock-component.adoc[Mock].
 
 https://github.com/apache/camel/tree/master/camel-core/src/test/java/org/apache/camel/processor/TryProcessorMultipleExceptionTest.java[TryProcessorMultipleExceptionTest.java]
 
@@ -100,7 +100,7 @@ to indicate the end there.
 We show the three sample samples using Spring DSL instead.
 
 In the route below we have all keywords in action. As the code is based
-on a unit test we route using <<mock-component,Mock>>.
+on a unit test we route using xref:mock-component.adoc[Mock].
 
 https://github.com/apache/camel/tree/master/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/SpringTryProcessorMultipleExceptionTest.xml[SpringTryProcessorMultipleExceptionTest.xml]
 

--- a/docs/user-manual/modules/ROOT/pages/using-propertyplaceholder.adoc
+++ b/docs/user-manual/modules/ROOT/pages/using-propertyplaceholder.adoc
@@ -27,7 +27,7 @@ following:
 * Lookup of beans in the xref:registry.adoc[Registry]
 * Additional supported in Spring XML (see below in examples)
 * Using Blueprint `PropertyPlaceholder` with Camel
-<<properties-component,Properties>> component
+xref:properties-component.adoc[Properties] component
 * Using `@PropertyInject` to inject a property in a POJO
 * *Camel 2.14.1* Using default value if a property does not exists
 * *Camel 2.14.1* Include out of the box functions, to lookup property
@@ -363,9 +363,9 @@ template.sendBody("{{cool.start}}", "Hello World");
 
 
 [[UsingPropertyPlaceholder-Examplewithlanguage]]
-==== Example with <<simple-language,Simple>> language
+==== Example with xref:simple-language.adoc[Simple] language
 
-The <<simple-language,Simple>> language now also support using property
+The xref:simple-language.adoc[Simple] language now also support using property
 placeholders, for example in the route below:
 
 
@@ -378,7 +378,7 @@ cheese.quote=Camel rocks
     .transform().simple("Hi ${body} do you think ${properties:cheese.quote}?");
 ----
 
-You can also specify the location in the <<simple-language,Simple>>
+You can also specify the location in the xref:simple-language.adoc[Simple]
 language for example:
 
 
@@ -929,10 +929,10 @@ the `${}` notation. And in the Camel routes we use the Camel
 placeholder notation with `{{ }}`.
 
 [[UsingPropertyPlaceholder-ClashingSpringPropertyPlaceholderswithCamelsLanguage]]
-==== Clashing Spring Property Placeholders with Camels <<simple-language,Simple>> Language
+==== Clashing Spring Property Placeholders with Camels xref:simple-language.adoc[Simple] Language
 
 Take notice when using Spring bridging placeholder then the
-spring `${}` syntax clashes with the <<simple-language,Simple>> in
+spring `${}` syntax clashes with the xref:simple-language.adoc[Simple] in
 Camel, and therefore take care.
 
 Example:
@@ -945,7 +945,7 @@ Example:
 ----
 
 clashes with Spring property placeholders, and you should
-use `$simple{}` to indicate using the <<simple-language,Simple>>
+use `$simple{}` to indicate using the xref:simple-language.adoc[Simple]
 language in Camel.
 
 
@@ -1208,4 +1208,4 @@ pc.addFunction(new MyBeerFunction());
 [[UsingPropertyPlaceholder-SeeAlso]]
 ==== See Also
 
-* <<properties-component,Properties>> component
+* xref:properties-component.adoc[Properties] component

--- a/docs/user-manual/modules/ROOT/pages/validator.adoc
+++ b/docs/user-manual/modules/ROOT/pages/validator.adoc
@@ -45,7 +45,7 @@ All validators have following common options to specify which data type is suppo
 |===
 | Name | Description
 
-| type | <<Validator-DataTypeFormat,Data type>> to validate.
+| type | xref:Validator-DataTypeFormat.adoc[Data type] to validate.
 |===
 
 

--- a/docs/user-manual/modules/ROOT/pages/wireTap-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/wireTap-eip.adoc
@@ -68,7 +68,7 @@ values.
 
 === Sending a Copy (traditional wiretap)
 
-* Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>
+* Using the xref:FluentBuilders-FluentBuilders.adoc[Fluent Builders]
 
 [source,java]
 ----
@@ -95,7 +95,7 @@ values.
 
 === Sending a New xref:exchange.adoc[Exchange]
 
-*Using the <<FluentBuilders-FluentBuilders,Fluent Builders>>*
+*Using the xref:FluentBuilders-FluentBuilders.adoc[Fluent Builders]*
 
 Camel supports either a processor or an
 xref:expression.adoc[Expression] to populate the new

--- a/docs/user-manual/modules/ROOT/pages/writing-components.adoc
+++ b/docs/user-manual/modules/ROOT/pages/writing-components.adoc
@@ -130,7 +130,7 @@ DefaultComponent:
 protected abstract Endpoint<E> createEndpoint(String uri, String remaining, Map parameters)
 ----
 
-The code is an example from the <<seda-component,SEDA>> component that removes the size
+The code is an example from the xref:seda-component.adoc[SEDA] component that removes the size
 parameter:
 
 [source,java]


### PR DESCRIPTION
Problem: - There were some linking errors like "anchor not found from <> to <>" when I run "yarn run check" after run "yarn build" to locally build camel-website repository in my pc.

Solution: - To fix that I had to fix .adoc files in camel repository. this is 1/3 of solution. I ran $ find <folder name> -name '*.adoc' -exec sed -i 's/<<\(.*\),\(.*\)>>/xref:\1\.adoc[\2]/g' {} \; so it converted Cross reference with custom xreflabel text in to Inline xref macro
Ex:
 <<cdi-component,Working with Camel and CDI>> 
converted to
 xref:cdi-component.adoc[Working with Camel and CDI]

Output: - This reduced the number of "anchor not found " errors when I run "yarn run check" after "yarn build" locally in camel-website repository