### PR TITLE
CAMEL-13717 - fixed wrong syntax for websocket-jsr356 endpoints

### DIFF
--- a/components/camel-websocket-jsr356/src/main/java/org/apache/camel/websocket/jsr356/JSR356Endpoint.java
+++ b/components/camel-websocket-jsr356/src/main/java/org/apache/camel/websocket/jsr356/JSR356Endpoint.java
@@ -24,7 +24,7 @@ import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 import org.apache.camel.support.DefaultEndpoint;
 
-@UriEndpoint(firstVersion = "2.23.0", scheme = "websocket-jsr356", title = "Javax Websocket", syntax = "websocket-jsr356:/resourceUri", label = "jsr356")
+@UriEndpoint(firstVersion = "2.23.0", scheme = "websocket-jsr356", title = "Javax Websocket", syntax = "websocket-jsr356:websocketPathOrUri", label = "jsr356")
 public class JSR356Endpoint extends DefaultEndpoint {
     @UriPath(description = "If a path (/foo) it will deploy locally the endpoint, " + "if an uri it will connect to the corresponding server")
     private String websocketPathOrUri;


### PR DESCRIPTION
Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>