### PR TITLE
NPE at org.apache.camel.component.bean.MethodInfo.invoke

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -24,8 +24,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -63,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.util.ObjectHelper.asString;
 import static org.apache.camel.util.ObjectHelper.asList;
+import static org.apache.camel.util.ObjectHelper.invokeMethodSafe;
 
 /**
  * Information about a method to be used for invocation.
@@ -481,7 +480,7 @@ public class MethodInfo {
 
     protected Object invoke(Method mth, Object pojo, Object[] arguments, Exchange exchange) throws InvocationTargetException {
         try {
-            return mth.invoke(pojo, arguments);
+            return invokeMethodSafe(mth, pojo, arguments);
         } catch (IllegalAccessException e) {
             throw new RuntimeExchangeException("IllegalAccessException occurred invoking method: " + mth + " using arguments: " + asList(arguments), exchange, e);
         } catch (IllegalArgumentException e) {

--- a/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/camel-core/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -60,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.util.ObjectHelper.asString;
+import static org.apache.camel.util.ObjectHelper.asList;
 
 /**
  * Information about a method to be used for invocation.
@@ -480,9 +483,9 @@ public class MethodInfo {
         try {
             return mth.invoke(pojo, arguments);
         } catch (IllegalAccessException e) {
-            throw new RuntimeExchangeException("IllegalAccessException occurred invoking method: " + mth + " using arguments: " + Arrays.asList(arguments), exchange, e);
+            throw new RuntimeExchangeException("IllegalAccessException occurred invoking method: " + mth + " using arguments: " + asList(arguments), exchange, e);
         } catch (IllegalArgumentException e) {
-            throw new RuntimeExchangeException("IllegalArgumentException occurred invoking method: " + mth + " using arguments: " + Arrays.asList(arguments), exchange, e);
+            throw new RuntimeExchangeException("IllegalArgumentException occurred invoking method: " + mth + " using arguments: " + asList(arguments), exchange, e);
         }
     }
 

--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -2083,5 +2083,15 @@ public final class ObjectHelper {
 
         return object;
     }
+
+    /**
+     * Turns the input array to a list of objects.
+     * 
+     * @param args an array of objects or null
+     * @return an object list
+     */
+    public static List<Object> asList(Object[] objects) {
+        return objects != null ? Arrays.asList(objects) : Collections.emptyList();
+    }
     
 }

--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -2093,5 +2093,26 @@ public final class ObjectHelper {
     public static List<Object> asList(Object[] objects) {
         return objects != null ? Arrays.asList(objects) : Collections.emptyList();
     }
+
+    /**
+     * A helper method to invoke a method via reflection in a safe way by allowing to invoke
+     * methods that are not accessible by default and wrap any exceptions
+     * as {@link RuntimeCamelException} instances
+     *
+     * @param method the method to invoke
+     * @param instance the object instance (or null for static methods)
+     * @param parameters the parameters to the method
+     * @return the result of the method invocation
+     */
+    public static Object invokeMethodSafe(Method method, Object instance, Object... parameters) throws InvocationTargetException, IllegalAccessException {
+        Object answer;
+        method.setAccessible(true);
+        if (parameters != null) {
+            answer = method.invoke(instance, parameters);
+        } else {
+            answer = method.invoke(instance);
+        }
+        return answer;
+    }
     
 }

--- a/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
+++ b/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
@@ -957,4 +957,23 @@ public class ObjectHelperTest extends Assert {
         Method m2 = InterfaceSize.class.getMethod("size");
         assertFalse(ObjectHelper.isOverridingMethod(InterfaceSize.class, m2, m1, false));
     }
+
+    @Test
+    public void testAsList() {
+        List<Object> out0 = ObjectHelper.asList(null);
+        assertNotNull(out0);
+        assertTrue(out0 instanceof List && out0.size() == 0);
+
+        List<Object> out1 = ObjectHelper.asList(new Object[0]);
+        assertNotNull(out1);
+        assertTrue(out1 instanceof List && out1.size() == 0);
+
+        String[] args = new String[] {"foo", "bar"};
+        List<Object> out2 = ObjectHelper.asList(args);
+        assertNotNull(out2);
+        assertTrue(out2 instanceof List && out2.size() == 2);
+        assertEquals("foo", out2.get(0));
+        assertEquals("bar", out2.get(1));
+    }
+
 }


### PR DESCRIPTION
This happens only for a call with no args that raise an IllegalAccessException, for example using an inner private class in a CamelTest.

In Camel 3 we have the same bug, but it is mitigated by a call to org.apache.camel.support.ObjectHelper.invokeMethodSafe which I also included also in fix.