### PR TITLE
CAMEL-10013: Implemented test validating syntax of endpoint

### DIFF
--- a/components/camel-chatscript/src/main/docs/chatscript-component.adoc
+++ b/components/camel-chatscript/src/main/docs/chatscript-component.adoc
@@ -54,7 +54,7 @@ The ChatScript component supports 2 options, which are listed below.
 The ChatScript endpoint is configured using URI syntax:
 
 ----
-chatscript:host:port/botname
+chatscript:host:port/botName
 ----
 
 with the following path and query parameters:

--- a/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptEndpoint.java
+++ b/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptEndpoint.java
@@ -36,7 +36,7 @@ import static org.apache.camel.component.chatscript.utils.ChatScriptConstants.DE
 /**
  * Represents a ChatScript endpoint.
  */
-@UriEndpoint(firstVersion = "3.0.0", scheme = "chatscript", title = "ChatScript", syntax = "chatscript:host:port/botname",  producerOnly = true, label = "ai,chatscript")
+@UriEndpoint(firstVersion = "3.0.0", scheme = "chatscript", title = "ChatScript", syntax = "chatscript:host:port/botName",  producerOnly = true, label = "ai,chatscript")
 public class ChatScriptEndpoint extends DefaultEndpoint { 
     @UriPath (description = "Hostname or IP of the server on which CS server is running") 
     @Metadata(required = true)

--- a/components/camel-google-bigquery/src/main/docs/google-bigquery-component.adoc
+++ b/components/camel-google-bigquery/src/main/docs/google-bigquery-component.adoc
@@ -76,7 +76,7 @@ The Google BigQuery component supports 5 options, which are listed below.
 The Google BigQuery endpoint is configured using URI syntax:
 
 ----
-google-bigquery:projectId:datasetId:tableName
+google-bigquery:projectId:datasetId:tableId
 ----
 
 with the following path and query parameters:

--- a/components/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
+++ b/components/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
@@ -92,7 +92,7 @@ The Google BigQuery Standard SQL component supports 4 options, which are listed 
 The Google BigQuery Standard SQL endpoint is configured using URI syntax:
 
 ----
-google-bigquery-sql:query
+google-bigquery-sql:projectId:query
 ----
 
 with the following path and query parameters:
@@ -103,8 +103,8 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *projectId* | *Required* Google Cloud Project Id |  | String
 | *query* | *Required* BigQuery standard SQL query |  | String
+| *projectId* | *Required* Google Cloud Project Id |  | String
 |===
 
 

--- a/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryEndpoint.java
+++ b/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryEndpoint.java
@@ -40,7 +40,7 @@ import org.apache.camel.support.DefaultEndpoint;
  * Another consideration is that exceptions are not handled within the class. They are expected to bubble up and be handled
  * by Camel.
  */
-@UriEndpoint(firstVersion = "2.20.0", scheme = "google-bigquery", title = "Google BigQuery", syntax = "google-bigquery:projectId:datasetId:tableName",
+@UriEndpoint(firstVersion = "2.20.0", scheme = "google-bigquery", title = "Google BigQuery", syntax = "google-bigquery:projectId:datasetId:tableId",
     label = "cloud,messaging", producerOnly = true)
 public class GoogleBigQueryEndpoint extends DefaultEndpoint {
 

--- a/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLEndpoint.java
+++ b/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLEndpoint.java
@@ -41,7 +41,7 @@ import org.apache.camel.support.DefaultEndpoint;
  * Another consideration is that exceptions are not handled within the class. They are expected to bubble up and be handled
  * by Camel.
  */
-@UriEndpoint(firstVersion = "2.23.0", scheme = "google-bigquery-sql", title = "Google BigQuery Standard SQL", syntax = "google-bigquery-sql:query", label = "cloud,messaging", producerOnly = true)
+@UriEndpoint(firstVersion = "2.23.0", scheme = "google-bigquery-sql", title = "Google BigQuery Standard SQL", syntax = "google-bigquery-sql:projectId:query", label = "cloud,messaging", producerOnly = true)
 public class GoogleBigQuerySQLEndpoint extends DefaultEndpoint {
 
     @UriParam

--- a/components/camel-ipfs/src/main/docs/ipfs-component.adoc
+++ b/components/camel-ipfs/src/main/docs/ipfs-component.adoc
@@ -44,17 +44,19 @@ The IPFS component supports 2 options, which are listed below.
 The IPFS endpoint is configured using URI syntax:
 
 ----
-ipfs:host:port/cmd
+ipfs:ipfsHost:ipfsPort/ipfsCmd
 ----
 
 with the following path and query parameters:
 
-==== Path Parameters (1 parameters):
+==== Path Parameters (3 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *ipfsHost* | The ipfs host |  | String
+| *ipfsPort* | The ipfs port |  | int
 | *ipfsCmd* | The ipfs command |  | String
 |===
 

--- a/components/camel-ipfs/src/main/java/org/apache/camel/component/ipfs/IPFSConfiguration.java
+++ b/components/camel-ipfs/src/main/java/org/apache/camel/component/ipfs/IPFSConfiguration.java
@@ -32,14 +32,15 @@ public class IPFSConfiguration {
     public enum IPFSCommand {
         add, cat, get, version 
     }
-    
-    @UriPath(description = "The ipfs command")
+
+    @UriPath(description = "The ipfs host")
+    private String ipfsHost = "127.0.0.1";
+    @UriPath(description = "The ipfs port")
+    private int ipfsPort = 5001;
+    @UriPath(description = "The ipfs command", enums = "add,cat,get,version")
     private String ipfsCmd;
     @UriParam(description = "The ipfs output directory")
     private Path outdir;
-
-    private String ipfsHost = "127.0.0.1";
-    private int ipfsPort = 5001;
     
     public IPFSConfiguration(IPFSComponent component) {
         ObjectHelper.notNull(component, "component");

--- a/components/camel-ipfs/src/main/java/org/apache/camel/component/ipfs/IPFSEndpoint.java
+++ b/components/camel-ipfs/src/main/java/org/apache/camel/component/ipfs/IPFSEndpoint.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * The camel-ipfs component provides access to the Interplanetary File System
  * (IPFS).
  */
-@UriEndpoint(firstVersion = "2.23.0", scheme = "ipfs", title = "IPFS", syntax = "ipfs:host:port/cmd", producerOnly = true, label = "file,ipfs")
+@UriEndpoint(firstVersion = "2.23.0", scheme = "ipfs", title = "IPFS", syntax = "ipfs:ipfsHost:ipfsPort/ipfsCmd", producerOnly = true, label = "file,ipfs")
 public class IPFSEndpoint extends DefaultEndpoint {
 
     public static final long DEFAULT_TIMEOUT = 10000L;

--- a/components/camel-pg-replication-slot/src/main/docs/pg-replication-slot-component.adoc
+++ b/components/camel-pg-replication-slot/src/main/docs/pg-replication-slot-component.adoc
@@ -54,7 +54,7 @@ The PostgresSQL Replication Slot component supports 2 options, which are listed 
 The PostgresSQL Replication Slot endpoint is configured using URI syntax:
 
 ----
-pg-replication-slot:host:port/database/slot:plugin
+pg-replication-slot:host:port/database/slot:outputPlugin
 ----
 
 with the following path and query parameters:

--- a/components/camel-pg-replication-slot/src/main/java/org/apache/camel/component/pg/replication/slot/PgReplicationSlotEndpoint.java
+++ b/components/camel-pg-replication-slot/src/main/java/org/apache/camel/component/pg/replication/slot/PgReplicationSlotEndpoint.java
@@ -40,7 +40,7 @@ import org.postgresql.PGProperty;
  * Consumer endpoint to receive from PostgreSQL Replication Slot.
  */
 @UriEndpoint(firstVersion = "3.0.0", scheme = "pg-replication-slot", title = "PostgresSQL Replication Slot",
-        syntax = "pg-replication-slot:host:port/database/slot:plugin", label = "database,sql", consumerOnly = true)
+        syntax = "pg-replication-slot:host:port/database/slot:outputPlugin", label = "database,sql", consumerOnly = true)
 public class PgReplicationSlotEndpoint extends ScheduledPollEndpoint {
 
     private static final Pattern URI_PATTERN = Pattern.compile(

--- a/components/camel-soroush/src/main/docs/soroush-component.adoc
+++ b/components/camel-soroush/src/main/docs/soroush-component.adoc
@@ -67,7 +67,7 @@ The Soroush component supports 3 options, which are listed below.
 The Soroush endpoint is configured using URI syntax:
 
 ----
-soroush:action/authorizationToken
+soroush:action
 ----
 
 with the following path and query parameters:

--- a/components/camel-soroush/src/main/java/org/apache/camel/component/soroushbot/component/SoroushBotEndpoint.java
+++ b/components/camel-soroush/src/main/java/org/apache/camel/component/soroushbot/component/SoroushBotEndpoint.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 /**
  * To integrate with the Soroush chat bot.
  */
-@UriEndpoint(firstVersion = "3.0", scheme = "soroush", title = "Soroush", syntax = "soroush:action/authorizationToken", label = "chat")
+@UriEndpoint(firstVersion = "3.0", scheme = "soroush", title = "Soroush", syntax = "soroush:action", label = "chat")
 public class SoroushBotEndpoint extends DefaultEndpoint {
 
     private static final Logger LOG = LoggerFactory.getLogger(SoroushBotEndpoint.class);

--- a/components/camel-wordpress/src/main/docs/wordpress-component.adoc
+++ b/components/camel-wordpress/src/main/docs/wordpress-component.adoc
@@ -27,7 +27,7 @@ The Wordpress component supports 3 options, which are listed below.
 The Wordpress endpoint is configured using URI syntax:
 
 ----
-wordpress:operationDetail
+wordpress:operation
 ----
 
 with the following path and query parameters:

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressEndpoint.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressEndpoint.java
@@ -45,7 +45,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * Integrates Camel with Wordpress.
  */
-@UriEndpoint(firstVersion = "2.21.0", scheme = "wordpress", title = "Wordpress", syntax = "wordpress:operationDetail", label = "cms")
+@UriEndpoint(firstVersion = "2.21.0", scheme = "wordpress", title = "Wordpress", syntax = "wordpress:operation", label = "cms")
 public class WordpressEndpoint extends DefaultEndpoint {
 
     public static final String ENDPOINT_SERVICE_POST = "post, user";

--- a/components/readme.adoc
+++ b/components/readme.adoc
@@ -161,7 +161,7 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `cql:beanRef:hosts:port/keyspace` | 2.15 | The cql component aims at integrating Cassandra 2.0 using the CQL3 API (not the Thrift API).
 
 | link:camel-chatscript/src/main/docs/chatscript-component.adoc[ChatScript] (camel-chatscript) +
-`chatscript:host:port/botname` | 3.0 | Represents a ChatScript endpoint.
+`chatscript:host:port/botName` | 3.0 | Represents a ChatScript endpoint.
 
 | link:camel-chunk/src/main/docs/chunk-component.adoc[Chunk] (camel-chunk) +
 `chunk:resourceUri` | 2.15 | Transforms the message using a Chunk template.
@@ -299,10 +299,10 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `github:type/branchName` | 2.15 | The github component is used for integrating Camel with github.
 
 | link:camel-google-bigquery/src/main/docs/google-bigquery-component.adoc[Google BigQuery] (camel-google-bigquery) +
-`google-bigquery:projectId:datasetId:tableName` | 2.20 | Google BigQuery data warehouse for analytics.
+`google-bigquery:projectId:datasetId:tableId` | 2.20 | Google BigQuery data warehouse for analytics.
 
 | link:camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc[Google BigQuery Standard SQL] (camel-google-bigquery) +
-`google-bigquery-sql:query` | 2.23 | Google BigQuery data warehouse for analytics (using SQL queries).
+`google-bigquery-sql:projectId:query` | 2.23 | Google BigQuery data warehouse for analytics (using SQL queries).
 
 | link:camel-google-calendar/src/main/docs/google-calendar-component.adoc[Google Calendar] (camel-google-calendar) +
 `google-calendar:apiName/methodName` | 2.15 | The google-calendar component provides access to Google Calendar.
@@ -422,7 +422,7 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `iota:name` | 2.23 | Component for integrate IOTA DLT
 
 | link:camel-ipfs/src/main/docs/ipfs-component.adoc[IPFS] (camel-ipfs) +
-`ipfs:host:port/cmd` | 2.23 | The camel-ipfs component provides access to the Interplanetary File System (IPFS).
+`ipfs:ipfsHost:ipfsPort/ipfsCmd` | 2.23 | The camel-ipfs component provides access to the Interplanetary File System (IPFS).
 
 | link:camel-irc/src/main/docs/irc-component.adoc[IRC] (camel-irc) +
 `irc:hostname:port` | 1.1 | The irc component implements an IRC (Internet Relay Chat) transport.
@@ -668,7 +668,7 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `pgevent:host:port/database/channel` | 2.15 | The pgevent component allows for producing/consuming PostgreSQL events related to the listen/notify commands.
 
 | link:camel-pg-replication-slot/src/main/docs/pg-replication-slot-component.adoc[PostgresSQL Replication Slot] (camel-pg-replication-slot) +
-`pg-replication-slot:host:port/database/slot:plugin` | 3.0 | Consumer endpoint to receive from PostgreSQL Replication Slot.
+`pg-replication-slot:host:port/database/slot:outputPlugin` | 3.0 | Consumer endpoint to receive from PostgreSQL Replication Slot.
 
 | link:camel-printer/src/main/docs/lpr-component.adoc[Printer] (camel-printer) +
 `lpr:hostname:port/printername` | 2.1 | The printer component is used for sending messages to printers as print jobs.
@@ -767,7 +767,7 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `solr:url` | 2.9 | The solr component allows you to interface with an Apache Lucene Solr server.
 
 | link:camel-soroush/src/main/docs/soroush-component.adoc[Soroush] (camel-soroush) +
-`soroush:action/authorizationToken` | 3.0 | To integrate with the Soroush chat bot.
+`soroush:action` | 3.0 | To integrate with the Soroush chat bot.
 
 | link:camel-spark-rest/src/main/docs/spark-rest-component.adoc[Spark Rest] (camel-spark-rest) +
 `spark-rest:verb:path` | 2.14 | The spark-rest component is used for hosting REST services which has been defined using Camel rest-dsl.
@@ -869,7 +869,7 @@ Number of Components: 297 in 234 JAR artifacts (0 deprecated)
 `webhook:endpointUri` | 3.0 | The webhook component allows other Camel components that can receive push notifications to expose webhook endpoints and automatically register them with their own webhook provider.
 
 | link:camel-wordpress/src/main/docs/wordpress-component.adoc[Wordpress] (camel-wordpress) +
-`wordpress:operationDetail` | 2.21 | Integrates Camel with Wordpress.
+`wordpress:operation` | 2.21 | Integrates Camel with Wordpress.
 
 | link:camel-xchange/src/main/docs/xchange-component.adoc[XChange] (camel-xchange) +
 `xchange:name` | 2.21 | The camel-xchange component provide access to many bitcoin and altcoin exchanges for trading and accessing market data.

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/ChatScriptEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/ChatScriptEndpointBuilderFactory.java
@@ -144,7 +144,7 @@ public interface ChatScriptEndpointBuilderFactory {
      * Available as of version: 3.0
      * Maven coordinates: org.apache.camel:camel-chatscript
      * 
-     * Syntax: <code>chatscript:host:port/botname</code>
+     * Syntax: <code>chatscript:host:port/botName</code>
      * 
      * Path parameter: host (required)
      * Hostname or IP of the server on which CS server is running

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/GoogleBigQueryEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/GoogleBigQueryEndpointBuilderFactory.java
@@ -150,7 +150,7 @@ public interface GoogleBigQueryEndpointBuilderFactory {
      * Available as of version: 2.20
      * Maven coordinates: org.apache.camel:camel-google-bigquery
      * 
-     * Syntax: <code>google-bigquery:projectId:datasetId:tableName</code>
+     * Syntax: <code>google-bigquery:projectId:datasetId:tableId</code>
      * 
      * Path parameter: projectId (required)
      * Google Cloud Project Id

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/GoogleBigQuerySQLEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/GoogleBigQuerySQLEndpointBuilderFactory.java
@@ -140,13 +140,13 @@ public interface GoogleBigQuerySQLEndpointBuilderFactory {
      * Available as of version: 2.23
      * Maven coordinates: org.apache.camel:camel-google-bigquery
      * 
-     * Syntax: <code>google-bigquery-sql:query</code>
-     * 
-     * Path parameter: projectId (required)
-     * Google Cloud Project Id
+     * Syntax: <code>google-bigquery-sql:projectId:query</code>
      * 
      * Path parameter: query (required)
      * BigQuery standard SQL query
+     * 
+     * Path parameter: projectId (required)
+     * Google Cloud Project Id
      */
     default GoogleBigQuerySQLEndpointBuilder googleBigQuerySQL(String path) {
         class GoogleBigQuerySQLEndpointBuilderImpl extends AbstractEndpointBuilder implements GoogleBigQuerySQLEndpointBuilder, AdvancedGoogleBigQuerySQLEndpointBuilder {

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/IPFSEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/IPFSEndpointBuilderFactory.java
@@ -133,10 +133,17 @@ public interface IPFSEndpointBuilderFactory {
      * Available as of version: 2.23
      * Maven coordinates: org.apache.camel:camel-ipfs
      * 
-     * Syntax: <code>ipfs:host:port/cmd</code>
+     * Syntax: <code>ipfs:ipfsHost:ipfsPort/ipfsCmd</code>
+     * 
+     * Path parameter: ipfsHost
+     * The ipfs host
+     * 
+     * Path parameter: ipfsPort
+     * The ipfs port
      * 
      * Path parameter: ipfsCmd
      * The ipfs command
+     * The value can be one of: add, cat, get, version
      */
     default IPFSEndpointBuilder iPFS(String path) {
         class IPFSEndpointBuilderImpl extends AbstractEndpointBuilder implements IPFSEndpointBuilder, AdvancedIPFSEndpointBuilder {

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/PgReplicationSlotEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/PgReplicationSlotEndpointBuilderFactory.java
@@ -214,7 +214,8 @@ public interface PgReplicationSlotEndpointBuilderFactory {
      * Available as of version: 3.0
      * Maven coordinates: org.apache.camel:camel-pg-replication-slot
      * 
-     * Syntax: <code>pg-replication-slot:host:port/database/slot:plugin</code>
+     * Syntax:
+     * <code>pg-replication-slot:host:port/database/slot:outputPlugin</code>
      * 
      * Path parameter: slot (required)
      * Replication slot name.

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/SoroushBotEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/SoroushBotEndpointBuilderFactory.java
@@ -1256,7 +1256,7 @@ public interface SoroushBotEndpointBuilderFactory {
      * Available as of version: 3.0
      * Maven coordinates: org.apache.camel:camel-soroush
      * 
-     * Syntax: <code>soroush:action/authorizationToken</code>
+     * Syntax: <code>soroush:action</code>
      * 
      * Path parameter: action (required)
      * The action to do.

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/WordpressEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/WordpressEndpointBuilderFactory.java
@@ -828,7 +828,7 @@ public interface WordpressEndpointBuilderFactory {
      * Available as of version: 2.21
      * Maven coordinates: org.apache.camel:camel-wordpress
      * 
-     * Syntax: <code>wordpress:operationDetail</code>
+     * Syntax: <code>wordpress:operation</code>
      * 
      * Path parameter: operation (required)
      * The endpoint operation.

--- a/docs/components/modules/ROOT/pages/chatscript-component.adoc
+++ b/docs/components/modules/ROOT/pages/chatscript-component.adoc
@@ -54,7 +54,7 @@ The ChatScript component supports 2 options, which are listed below.
 The ChatScript endpoint is configured using URI syntax:
 
 ----
-chatscript:host:port/botname
+chatscript:host:port/botName
 ----
 
 with the following path and query parameters:

--- a/docs/components/modules/ROOT/pages/google-bigquery-component.adoc
+++ b/docs/components/modules/ROOT/pages/google-bigquery-component.adoc
@@ -76,7 +76,7 @@ The Google BigQuery component supports 5 options, which are listed below.
 The Google BigQuery endpoint is configured using URI syntax:
 
 ----
-google-bigquery:projectId:datasetId:tableName
+google-bigquery:projectId:datasetId:tableId
 ----
 
 with the following path and query parameters:

--- a/docs/components/modules/ROOT/pages/google-bigquery-sql-component.adoc
+++ b/docs/components/modules/ROOT/pages/google-bigquery-sql-component.adoc
@@ -92,7 +92,7 @@ The Google BigQuery Standard SQL component supports 4 options, which are listed 
 The Google BigQuery Standard SQL endpoint is configured using URI syntax:
 
 ----
-google-bigquery-sql:query
+google-bigquery-sql:projectId:query
 ----
 
 with the following path and query parameters:
@@ -103,8 +103,8 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *projectId* | *Required* Google Cloud Project Id |  | String
 | *query* | *Required* BigQuery standard SQL query |  | String
+| *projectId* | *Required* Google Cloud Project Id |  | String
 |===
 
 

--- a/docs/components/modules/ROOT/pages/ipfs-component.adoc
+++ b/docs/components/modules/ROOT/pages/ipfs-component.adoc
@@ -44,17 +44,19 @@ The IPFS component supports 2 options, which are listed below.
 The IPFS endpoint is configured using URI syntax:
 
 ----
-ipfs:host:port/cmd
+ipfs:ipfsHost:ipfsPort/ipfsCmd
 ----
 
 with the following path and query parameters:
 
-==== Path Parameters (1 parameters):
+==== Path Parameters (3 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *ipfsHost* | The ipfs host |  | String
+| *ipfsPort* | The ipfs port |  | int
 | *ipfsCmd* | The ipfs command |  | String
 |===
 

--- a/docs/components/modules/ROOT/pages/pg-replication-slot-component.adoc
+++ b/docs/components/modules/ROOT/pages/pg-replication-slot-component.adoc
@@ -54,7 +54,7 @@ The PostgresSQL Replication Slot component supports 2 options, which are listed 
 The PostgresSQL Replication Slot endpoint is configured using URI syntax:
 
 ----
-pg-replication-slot:host:port/database/slot:plugin
+pg-replication-slot:host:port/database/slot:outputPlugin
 ----
 
 with the following path and query parameters:

--- a/docs/components/modules/ROOT/pages/soroush-component.adoc
+++ b/docs/components/modules/ROOT/pages/soroush-component.adoc
@@ -67,7 +67,7 @@ The Soroush component supports 3 options, which are listed below.
 The Soroush endpoint is configured using URI syntax:
 
 ----
-soroush:action/authorizationToken
+soroush:action
 ----
 
 with the following path and query parameters:

--- a/docs/components/modules/ROOT/pages/wordpress-component.adoc
+++ b/docs/components/modules/ROOT/pages/wordpress-component.adoc
@@ -27,7 +27,7 @@ The Wordpress component supports 3 options, which are listed below.
 The Wordpress endpoint is configured using URI syntax:
 
 ----
-wordpress:operationDetail
+wordpress:operation
 ----
 
 with the following path and query parameters:


### PR DESCRIPTION
I have implemented test which validates syntax of endpoints:
 1) Syntax starts with component name
 2) All syntax parts are defined as @UriPath
 3) All @UriPath marked as required are contained in syntax.
 
Now is this assertion wrapped in try-catch, so the problems are reported only to console. 
I would like to confirm with you this approach and get some suggestions if there is some assertion missing. After that I can fix reported problems and remove try-catch to make this tests actually fail on invalid syntax.

Currently it reports following and all seems to be actual problems:

- Component chatscript. Syntax chatscript:host:port/botname. Part botname is not defined as UriPath
- Component google-bigquery. Syntax google-bigquery:projectId:datasetId:tableName. Part tableName is not defined as UriPath
- Component google-bigquery-sql. Syntax google-bigquery-sql:query. Required param projectId is not defined in syntax
- Component ipfs. Syntax ipfs:host:port/cmd. Part host is not defined as UriPath
- Component pg-replication-slot. Syntax pg-replication-slot:host:port/database/slot:plugin. Part plugin is not defined as UriPath
- Component soroush. Syntax soroush:action/authorizationToken. Part authorizationToken is not defined as UriPath
- Component wordpress. Syntax wordpress:operationDetail. Required param operation is not defined in syntax

