### PR TITLE
CAMEL-13734: camel-undertow - Support streaming of large data for HTTP endpoints (2.x)

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/IOHelper.java
@@ -30,7 +30,10 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
@@ -246,6 +249,17 @@ public final class IOHelper {
         }
         output.flush();
         return total;
+    }
+
+    public static void transfer(ReadableByteChannel input, WritableByteChannel output) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE);
+        while (input.read(buffer) >= 0) {
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                output.write(buffer);
+            }
+            buffer.clear();
+        }
     }
 
     /**

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -88,6 +88,7 @@ with the following path and query parameters:
 | *httpMethodRestrict* (consumer) | Used to only allow consuming if the HttpMethod matches, such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
 | *matchOnUriPrefix* (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | Boolean
 | *optionsEnabled* (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
+| *useStreaming* (consumer) | For HTTP endpoint: if true, text and binary messages will be wrapped as java.io.InputStream before they are passed to an Exchange; otherwise they will be passed as byte. For WebSocket endpoint: if true, text and binary messages will be wrapped as java.io.Reader and java.io.InputStream respectively before they are passed to an Exchange; otherwise they will be passed as String and byte respectively. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | *cookieHandler* (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler
@@ -103,7 +104,6 @@ with the following path and query parameters:
 | *fireWebSocketChannelEvents* (websocket) | if true, the consumer will post notifications to the route when a new WebSocket peer connects, disconnects, etc. See UndertowConstants.EVENT_TYPE and EventType. | false | boolean
 | *sendTimeout* (websocket) | Timeout in milliseconds when sending to a websocket channel. The default timeout is 30000 (30 seconds). | 30000 | Integer
 | *sendToAll* (websocket) | To send to all websocket subscribers. Can be used to configure on endpoint level, instead of having to use the UndertowConstants.SEND_TO_ALL header on the message. |  | Boolean
-| *useStreaming* (websocket) | if true, text and binary messages coming through a WebSocket will be wrapped as java.io.Reader and java.io.InputStream respectively before they are passed to an Exchange; otherwise they will be passed as String and byte respectively. | false | boolean
 | *sslContextParameters* (security) | To configure security using SSLContextParameters |  | SSLContextParameters
 |===
 // endpoint options: END

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -84,11 +84,11 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *useStreaming* (common) | For HTTP endpoint: if true, text and binary messages will be wrapped as java.io.InputStream before they are passed to an Exchange; otherwise they will be passed as byte. For WebSocket endpoint: if true, text and binary messages will be wrapped as java.io.Reader and java.io.InputStream respectively before they are passed to an Exchange; otherwise they will be passed as String and byte respectively. | false | boolean
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *httpMethodRestrict* (consumer) | Used to only allow consuming if the HttpMethod matches, such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
 | *matchOnUriPrefix* (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | Boolean
 | *optionsEnabled* (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
-| *useStreaming* (consumer) | For HTTP endpoint: if true, text and binary messages will be wrapped as java.io.InputStream before they are passed to an Exchange; otherwise they will be passed as byte. For WebSocket endpoint: if true, text and binary messages will be wrapped as java.io.Reader and java.io.InputStream respectively before they are passed to an Exchange; otherwise they will be passed as String and byte respectively. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | *cookieHandler* (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -57,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.channels.BlockingReadableByteChannel;
 import org.xnio.channels.StreamSourceChannel;
+import org.xnio.streams.ChannelInputStream;
 
 /**
  * DefaultUndertowHttpBinding represent binding used by default, if user doesn't provide any.
@@ -69,10 +70,16 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
     //use default filter strategy from Camel HTTP
     private HeaderFilterStrategy headerFilterStrategy;
     private Boolean transferException;
+    private boolean useStreaming;
 
     public DefaultUndertowHttpBinding() {
+        this(false);
+    }
+
+    public DefaultUndertowHttpBinding(boolean useStreaming) {
         this.headerFilterStrategy = new UndertowHeaderFilterStrategy();
         this.transferException = Boolean.FALSE;
+        this.useStreaming = useStreaming;
     }
 
     public DefaultUndertowHttpBinding(HeaderFilterStrategy headerFilterStrategy, Boolean transferException) {
@@ -124,7 +131,12 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
             //extract body by myself if undertow parser didn't handle and the method is allowed to have one
             //body is extracted as byte[] then auto TypeConverter kicks in
             if (Methods.POST.equals(httpExchange.getRequestMethod()) || Methods.PUT.equals(httpExchange.getRequestMethod()) || Methods.PATCH.equals(httpExchange.getRequestMethod())) {
-                result.setBody(readFromChannel(httpExchange.getRequestChannel()));
+                StreamSourceChannel source = httpExchange.getRequestChannel();
+                if (useStreaming) {
+                    result.setBody(new ChannelInputStream(source));
+                } else {
+                    result.setBody(readFromChannel(source));
+                }
             } else {
                 result.setBody(null);
             }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -151,7 +151,22 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
         //retrieve response headers
         populateCamelHeaders(clientExchange.getResponse(), result.getHeaders(), exchange);
 
-        result.setBody(readFromChannel(clientExchange.getResponseChannel()));
+        StreamSourceChannel source = clientExchange.getResponseChannel();
+        if (useStreaming) {
+            // client connection can be closed only after input stream is fully read
+            result.setBody(new ChannelInputStream(source) {
+                @Override
+                public void close() throws IOException {
+                    try {
+                        super.close();
+                    } finally {
+                        clientExchange.getConnection().close();
+                    }
+                }
+            });
+        } else {
+            result.setBody(readFromChannel(source));
+        }
 
         return result;
     }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/RestUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/RestUndertowHttpBinding.java
@@ -23,6 +23,14 @@ import org.apache.camel.Exchange;
 
 public class RestUndertowHttpBinding extends DefaultUndertowHttpBinding {
 
+    public RestUndertowHttpBinding() {
+        super();
+    }
+
+    public RestUndertowHttpBinding(boolean useStreaming) {
+        super(useStreaming);
+    }
+
     @Override
     public void populateCamelHeaders(HttpServerExchange httpExchange, Map<String, Object> headersMap, Exchange exchange) throws Exception {
         super.populateCamelHeaders(httpExchange, headersMap, exchange);

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
@@ -94,6 +94,12 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
 
     private static final Logger LOG = LoggerFactory.getLogger(UndertowClientCallback.class);
 
+    protected final UndertowEndpoint endpoint;
+
+    protected final Exchange exchange;
+
+    protected final ClientRequest request;
+
     private final ByteBuffer body;
 
     private final AsyncCallback callback;
@@ -103,12 +109,6 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
      * resources via {@link #deferClose(Closeable)}.
      */
     private final BlockingDeque<Closeable> closables = new LinkedBlockingDeque<>();
-
-    protected final UndertowEndpoint endpoint;
-
-    protected final Exchange exchange;
-
-    protected final ClientRequest request;
 
     private final Boolean throwExceptionOnFailure;
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowClientCallback.java
@@ -55,11 +55,11 @@ import org.xnio.channels.StreamSinkChannel;
  * Undertow {@link ClientCallback} that will get notified when the HTTP
  * connection is ready or when the client failed to connect. It will also handle
  * writing the request and reading the response in
- * {@link #writeRequest(ClientExchange, ByteBuffer)} and
+ * {@link #writeRequest(ClientExchange)} and
  * {@link #setupResponseListener(ClientExchange)}. The main entry point is
  * {@link #completed(ClientConnection)} or {@link #failed(IOException)} in case
  * of errors, every error condition that should terminate Camel {@link Exchange}
- * should go to {@link #hasFailedWith(Exception)} and successful execution of
+ * should go to {@link #hasFailedWith(Throwable)} and successful execution of
  * the exchange should end with {@link #finish(Message)}. Any
  * {@link ClientCallback}s that are added here should extend
  * {@link ErrorHandlingClientCallback}, best way to do that is to use the
@@ -104,11 +104,11 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
      */
     private final BlockingDeque<Closeable> closables = new LinkedBlockingDeque<>();
 
-    private final UndertowEndpoint endpoint;
+    protected final UndertowEndpoint endpoint;
 
-    private final Exchange exchange;
+    protected final Exchange exchange;
 
-    private final ClientRequest request;
+    protected final ClientRequest request;
 
     private final Boolean throwExceptionOnFailure;
 
@@ -119,7 +119,7 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
         this.endpoint = endpoint;
         this.request = request;
         this.body = body;
-        throwExceptionOnFailure = endpoint.getThrowExceptionOnFailure();
+        this.throwExceptionOnFailure = endpoint.getThrowExceptionOnFailure();
     }
 
     @Override
@@ -186,7 +186,7 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
         finish(null);
     }
 
-    <T> ClientCallback<T> on(final Consumer<T> consumer) {
+    protected <T> ClientCallback<T> on(final Consumer<T> consumer) {
         return new ErrorHandlingClientCallback<>(consumer);
     }
 
@@ -196,7 +196,7 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
         setupResponseListener(clientExchange);
 
         // write the request
-        writeRequest(clientExchange, body);
+        writeRequest(clientExchange);
     }
 
     void setupResponseListener(final ClientExchange clientExchange) {
@@ -266,7 +266,7 @@ class UndertowClientCallback implements ClientCallback<ClientConnection> {
         }
     }
 
-    void writeRequest(final ClientExchange clientExchange, final ByteBuffer body) {
+    protected void writeRequest(final ClientExchange clientExchange) {
         final StreamSinkChannel requestChannel = clientExchange.getRequestChannel();
         if (body != null) {
             try {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
@@ -249,7 +249,7 @@ public class UndertowComponent extends DefaultComponent implements RestConsumerF
 
         if (!map.containsKey("undertowHttpBinding")) {
             // use the rest binding, if not using a custom http binding
-            endpoint.setUndertowHttpBinding(new RestUndertowHttpBinding());
+            endpoint.setUndertowHttpBinding(new RestUndertowHttpBinding(endpoint.isUseStreaming()));
         }
 
         // configure consumer properties

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.undertow;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -34,12 +36,14 @@ import io.undertow.websockets.core.WebSocketChannel;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.Processor;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.component.undertow.UndertowConstants.EventType;
 import org.apache.camel.component.undertow.handlers.CamelWebSocketHandler;
 import org.apache.camel.impl.DefaultConsumer;
 import org.apache.camel.util.CollectionStringBuffer;
+import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,6 +152,10 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             doneUoW(camelExchange);
         }
 
+        sendResponse(httpExchange, camelExchange);
+    }
+
+    private void sendResponse(HttpServerExchange httpExchange, Exchange camelExchange) throws IOException, NoTypeConversionAvailableException {
         Object body = getResponseBody(httpExchange, camelExchange);
         TypeConverter tc = getEndpoint().getCamelContext().getTypeConverter();
 
@@ -155,6 +163,16 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
             LOG.trace("No payload to send as reply for exchange: {}", camelExchange);
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_TYPE, MimeMappings.DEFAULT_MIME_MAPPINGS.get("txt"));
             httpExchange.getResponseSender().send("No response available");
+            return;
+        }
+
+        if (body instanceof InputStream) {
+            httpExchange.startBlocking();
+            try (InputStream input = (InputStream) body;
+                 OutputStream output = httpExchange.getOutputStream()) {
+                // flush on each write so that it won't cause OutOfMemoryError
+                IOHelper.copy(input, output, IOHelper.DEFAULT_BUFFER_SIZE, true);
+            }
         } else {
             ByteBuffer bodyAsByteBuffer = tc.mandatoryConvertTo(ByteBuffer.class, body);
             httpExchange.getResponseSender().send(bodyAsByteBuffer);

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -68,6 +68,8 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
 
     @UriPath @Metadata(required = "true")
     private URI httpURI;
+    @UriParam(label = "common", defaultValue = "false")
+    private boolean useStreaming;
     @UriParam(label = "advanced")
     private UndertowHttpBinding undertowHttpBinding;
     @UriParam(label = "advanced")
@@ -78,8 +80,6 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private String httpMethodRestrict;
     @UriParam(label = "consumer", defaultValue = "false")
     private Boolean matchOnUriPrefix = Boolean.FALSE;
-    @UriParam(label = "consumer", defaultValue = "false")
-    private boolean useStreaming;
     @UriParam(label = "producer", defaultValue = "true")
     private Boolean throwExceptionOnFailure = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "false")

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -78,6 +78,8 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private String httpMethodRestrict;
     @UriParam(label = "consumer", defaultValue = "false")
     private Boolean matchOnUriPrefix = Boolean.FALSE;
+    @UriParam(label = "consumer", defaultValue = "false")
+    private boolean useStreaming;
     @UriParam(label = "producer", defaultValue = "true")
     private Boolean throwExceptionOnFailure = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "false")
@@ -98,8 +100,6 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private Boolean sendToAll;
     @UriParam(label = "producer,websocket", defaultValue = "30000")
     private Integer sendTimeout = 30000;
-    @UriParam(label = "consumer,websocket", defaultValue = "false")
-    private boolean useStreaming;
     @UriParam(label = "consumer,websocket", defaultValue = "false")
     private boolean fireWebSocketChannelEvents;
 
@@ -253,7 +253,7 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     public UndertowHttpBinding getUndertowHttpBinding() {
         if (undertowHttpBinding == null) {
             // create a new binding and use the options from this endpoint
-            undertowHttpBinding = new DefaultUndertowHttpBinding();
+            undertowHttpBinding = new DefaultUndertowHttpBinding(useStreaming);
             undertowHttpBinding.setHeaderFilterStrategy(getHeaderFilterStrategy());
             undertowHttpBinding.setTransferException(getTransferException());
         }
@@ -363,9 +363,18 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     }
 
     /**
-     * if {@code true}, text and binary messages coming through a WebSocket will be wrapped as java.io.Reader and
-     * java.io.InputStream respectively before they are passed to an {@link Exchange}; otherwise they will be passed as
-     * String and byte[] respectively.
+     * <p>
+     * For HTTP endpoint:
+     * if {@code true}, text and binary messages will be wrapped as {@link java.io.InputStream}
+     * before they are passed to an {@link Exchange}; otherwise they will be passed as byte[].
+     * </p>
+     *
+     * <p>
+     * For WebSocket endpoint:
+     * if {@code true}, text and binary messages will be wrapped as {@link java.io.Reader} and
+     * {@link java.io.InputStream} respectively before they are passed to an {@link Exchange};
+     * otherwise they will be passed as String and byte[] respectively.
+     * </p>
      */
     public void setUseStreaming(boolean useStreaming) {
         this.useStreaming = useStreaming;

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowStreamingClientCallback.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowStreamingClientCallback.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import io.undertow.client.ClientConnection;
+import io.undertow.client.ClientExchange;
+import io.undertow.client.ClientRequest;
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.util.IOHelper;
+import org.xnio.channels.StreamSinkChannel;
+
+class UndertowStreamingClientCallback extends UndertowClientCallback {
+
+    private InputStream bodyStream;
+
+    UndertowStreamingClientCallback(Exchange exchange, AsyncCallback callback,
+                                    UndertowEndpoint endpoint, ClientRequest request,
+                                    InputStream body) {
+        super(exchange, callback, endpoint, request, null);
+        this.bodyStream = body;
+    }
+
+    @Override
+    public void completed(ClientConnection connection) {
+        // no connection closing registered as streaming continues downstream
+        connection.sendRequest(request, on(this::performClientExchange));
+    }
+
+    @Override
+    protected void writeRequest(ClientExchange clientExchange) {
+        StreamSinkChannel requestChannel = clientExchange.getRequestChannel();
+        try (ReadableByteChannel source = Channels.newChannel(bodyStream)) {
+            IOHelper.transfer(source, requestChannel);
+            flush(requestChannel);
+        } catch (final IOException e) {
+            hasFailedWith(e);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-13734

Should we not backport this to 2.x?  If not, please just ignore and close it unmerged. Thanks.