### PR TITLE
CAMEL-13741 - Allow to convert a Map to an Iterable

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/converter/ObjectConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/ObjectConverterTest.java
@@ -17,8 +17,11 @@
 package org.apache.camel.converter;
 
 import java.math.BigInteger;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,6 +48,14 @@ public class ObjectConverterTest extends Assert {
                 fail();
             }
         }
+
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("A", "AA");
+        map.put("B", "BB");
+        Iterator<?> it = ObjectConverter.iterable(map).iterator();
+        assertEquals(new SimpleEntry<>("A", "AA"), it.next());
+        assertEquals(new SimpleEntry<>("B", "BB"), it.next());
+        assertFalse(it.hasNext());
     }
 
     @Test

--- a/core/camel-support/src/main/java/org/apache/camel/support/ObjectHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ObjectHelper.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 
@@ -611,6 +612,8 @@ public final class ObjectHelper {
                     };
                 };
             }
+        } else if (value instanceof Map) {
+            return ((Map)value).entrySet();
         } else {
             return Collections.singletonList(value);
         }


### PR DESCRIPTION
The conversion from `Map` to `Iterable` used to be handled by the converter `CollectionConverter.toSet(Map<K,V>)`

Now that `ObjectConverterOptimised` is used before searching for a converter the `Map` to `Iterable` converter need to be handled at `ObjectHelper.createIterable()` level.