### PR TITLE
CAMEL-13747: Added basic auth support to camel-solr

### DIFF
--- a/components/camel-solr/src/main/docs/solr-component.adoc
+++ b/components/camel-solr/src/main/docs/solr-component.adoc
@@ -66,7 +66,7 @@ with the following path and query parameters:
 |===
 
 
-==== Query Parameters (15 parameters):
+==== Query Parameters (17 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -85,6 +85,8 @@ with the following path and query parameters:
 | *streamingThreadCount* (producer) | Set the number of threads for the StreamingUpdateSolrServer | 2 | int
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
+| *password* (security) | Sets password for basic auth plugin enabled servers |  | String
+| *username* (security) | Sets username for basic auth plugin enabled servers |  | String
 | *collection* (solrCloud) | Set the collection name which the solrCloud server could use |  | String
 | *zkHost* (solrCloud) | Set the ZooKeeper host information which the solrCloud could use, such as zkhost=localhost:8123. |  | String
 |===

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrEndpoint.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrEndpoint.java
@@ -67,6 +67,10 @@ public class SolrEndpoint extends DefaultEndpoint {
     private String collection;
     @UriParam
     private String requestHandler;
+    @UriParam(label = "security", secret = true)
+    private String username;
+    @UriParam(label = "security", secret = true)
+    private String password;
 
     public SolrEndpoint(String endpointUri, SolrComponent component, String address) throws Exception {
         super(endpointUri, component);
@@ -271,6 +275,28 @@ public class SolrEndpoint extends DefaultEndpoint {
      */
     public void setAllowCompression(Boolean allowCompression) {
         this.allowCompression = allowCompression;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Sets username for basic auth plugin enabled servers
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Sets password for basic auth plugin enabled servers
+     */
+    public void setPassword(String password) {
+        this.password = password;
     }
 
 }

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
+import java.util.stream.Collectors;
 import javax.activation.MimetypesFileTypeMap;
 
 import org.apache.camel.Exchange;
@@ -28,6 +28,7 @@ import org.apache.camel.WrappedFile;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.request.AbstractUpdateRequest.ACTION;
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest;
 import org.apache.solr.client.solrj.request.DirectXmlRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -76,19 +77,34 @@ public class SolrProducer extends DefaultProducer {
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_INSERT_STREAMING)) {
             insert(exchange, serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_DELETE_BY_ID)) {
-            serverToUse.deleteById(exchange.getIn().getBody(String.class));
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.deleteById(exchange.getIn().getBody(String.class));
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_DELETE_BY_QUERY)) {
-            serverToUse.deleteByQuery(exchange.getIn().getBody(String.class));
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.deleteByQuery(exchange.getIn().getBody(String.class));
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_ADD_BEAN)) {
-            serverToUse.addBean(exchange.getIn().getBody());
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.add(serverToUse.getBinder().toSolrInputDocument(exchange.getIn().getBody()));
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_ADD_BEANS)) {
-            serverToUse.addBeans(exchange.getIn().getBody(Collection.class));
+            UpdateRequest updateRequest = createUpdateRequest();
+            Collection<Object> body = exchange.getIn().getBody(Collection.class);
+            updateRequest.add(body.stream().map(serverToUse.getBinder()::toSolrInputDocument).collect(Collectors.toList()));
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_COMMIT)) {
-            serverToUse.commit();
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.setAction(ACTION.COMMIT, true, true);
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_ROLLBACK)) {
-            serverToUse.rollback();
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.rollback();
+            updateRequest.process(serverToUse);
         } else if (operation.equalsIgnoreCase(SolrConstants.OPERATION_OPTIMIZE)) {
-            serverToUse.optimize();
+            UpdateRequest updateRequest = createUpdateRequest();
+            updateRequest.setAction(ACTION.OPTIMIZE, true, true, 1);
+            updateRequest.process(serverToUse);
         } else {
             throw new IllegalArgumentException(
                     SolrConstants.OPERATION + " header value '" + operation + "' is not supported");
@@ -105,6 +121,7 @@ public class SolrProducer extends DefaultProducer {
         if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class))) {
             String mimeType = exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class);
             ContentStreamUpdateRequest updateRequest = new ContentStreamUpdateRequest(getRequestHandler());
+            updateRequest.setBasicAuthCredentials(getEndpoint().getUsername(), getEndpoint().getPassword());
             updateRequest.addFile((File) body, mimeType);
 
             for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
@@ -121,6 +138,7 @@ public class SolrProducer extends DefaultProducer {
                 MimetypesFileTypeMap mimeTypesMap = new MimetypesFileTypeMap();
                 String mimeType = mimeTypesMap.getContentType((File) body);
                 ContentStreamUpdateRequest updateRequest = new ContentStreamUpdateRequest(getRequestHandler());
+                updateRequest.setBasicAuthCredentials(getEndpoint().getUsername(), getEndpoint().getPassword());
                 updateRequest.addFile((File) body, mimeType);
 
                 for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
@@ -134,7 +152,7 @@ public class SolrProducer extends DefaultProducer {
 
             } else if (body instanceof SolrInputDocument) {
 
-                UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
+                UpdateRequest updateRequest = createUpdateRequest();
                 updateRequest.add((SolrInputDocument) body);
 
                 for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
@@ -150,7 +168,7 @@ public class SolrProducer extends DefaultProducer {
                 List<?> list = (List<?>) body;
 
                 if (list.size() > 0 && list.get(0) instanceof SolrInputDocument) {
-                    UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
+                    UpdateRequest updateRequest = createUpdateRequest();
                     updateRequest.add((List<SolrInputDocument>) list);
 
                     for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
@@ -177,7 +195,7 @@ public class SolrProducer extends DefaultProducer {
 
                 if (hasSolrHeaders) {
 
-                    UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
+                    UpdateRequest updateRequest = createUpdateRequest();
 
                     SolrInputDocument doc = new SolrInputDocument();
                     for (Map.Entry<String, Object> entry : exchange.getIn().getHeaders().entrySet()) {
@@ -198,6 +216,7 @@ public class SolrProducer extends DefaultProducer {
                     }
 
                     DirectXmlRequest xmlRequest = new DirectXmlRequest(getRequestHandler(), bodyAsString);
+                    xmlRequest.setBasicAuthCredentials(getEndpoint().getUsername(), getEndpoint().getPassword());
 
                     solrServer.request(xmlRequest);
                 } else {
@@ -215,6 +234,12 @@ public class SolrProducer extends DefaultProducer {
     private String getRequestHandler() {
         String requestHandler = getEndpoint().getRequestHandler();
         return (requestHandler == null) ? "/update" : requestHandler;
+    }
+
+    private UpdateRequest createUpdateRequest() {
+        UpdateRequest updateRequest = new UpdateRequest(getRequestHandler());
+        updateRequest.setBasicAuthCredentials(getEndpoint().getUsername(), getEndpoint().getPassword());
+        return updateRequest;
     }
 
     @Override

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/InitSolrEndpointTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/InitSolrEndpointTest.java
@@ -49,6 +49,7 @@ public class InitSolrEndpointTest extends SolrTestSupport {
                 + "&maxRetries=1&soTimeout=100&connectionTimeout=100"
                 + "&defaultMaxConnectionsPerHost=100&maxTotalConnections=100"
                 + "&followRedirects=false&allowCompression=true"
-                + "&requestHandler=/update";
+                + "&requestHandler=/update"
+                + "&username=solr&password=SolrRocks";
     }
 }

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrComponentTestSupport.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrComponentTestSupport.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,8 +72,10 @@ public abstract class SolrComponentTestSupport extends SolrTestSupport {
     protected QueryResponse executeSolrQuery(String query) throws SolrServerException, IOException {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
+        QueryRequest queryRequest = new QueryRequest(solrQuery);
+        queryRequest.setBasicAuthCredentials("solr", "SolrRocks");
         SolrClient solrServer = solrFixtures.getServer();
-        return solrServer.query("collection1", solrQuery);
+        return queryRequest.process(solrServer, "collection1");
     }
 
     @BeforeClass

--- a/components/camel-solr/src/test/resources/solr/security.json
+++ b/components/camel-solr/src/test/resources/solr/security.json
@@ -1,0 +1,13 @@
+{
+  "authentication":{
+    "blockUnknown": false,
+    "class":"solr.BasicAuthPlugin",
+    "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="},
+    "realm":"My Solr users"
+  },
+  "authorization":{
+    "class":"solr.RuleBasedAuthorizationPlugin",
+    "permissions":[{"name":"security-edit",
+      "role":"admin"}],
+    "user-role":{"solr":"admin"}
+  }}


### PR DESCRIPTION
This is an attempt of implementing basic auth on solr component according to recommended way mentioned [here](https://lucene.apache.org/solr/guide/7_7/basic-authentication-plugin.html#using-basic-auth-with-solrj). Concurrent client seems to be failing though for some reason when basic auth is enabled.