### PR TITLE
CAMEL-13741 - Allow to convert a Map to an Iterable

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/camel-core/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -980,6 +980,8 @@ public final class ObjectHelper {
                     }
                 };
             }
+        } else if (value instanceof Map) {
+            return ((Map)value).entrySet();
         } else {
             return Collections.singletonList(value);
         }

--- a/camel-core/src/test/java/org/apache/camel/converter/ObjectConverterTest.java
+++ b/camel-core/src/test/java/org/apache/camel/converter/ObjectConverterTest.java
@@ -17,9 +17,12 @@
 package org.apache.camel.converter;
 
 import java.math.BigInteger;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,6 +60,14 @@ public class ObjectConverterTest extends Assert {
                 fail();
             }
         }
+
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("A", "AA");
+        map.put("B", "BB");
+        Iterator<?> it = ObjectConverter.iterable(map).iterator();
+        assertEquals(new SimpleEntry<>("A", "AA"), it.next());
+        assertEquals(new SimpleEntry<>("B", "BB"), it.next());
+        assertFalse(it.hasNext());
     }
 
     @Test


### PR DESCRIPTION
The conversion from `Map` to `Iterable` used to be handled by the converter `CollectionConverter.toSet(Map<K,V>)`

Now that `ObjectConverterOptimised` is used before searching for a converter the `Map` to `Iterable` converter need to be handled at `ObjectHelper.createIterable()` level.

Same as #3031 but for camel-2.x branch