### PR TITLE
CAMEL-12983 camel-netty4-http - Allow direct streaming from big files to file output stream to disk

### DIFF
--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpRequest.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpChunkedInput;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.stream.ChunkedInput;
+import io.netty.handler.stream.ChunkedStream;
+
+import java.io.InputStream;
+
+/**
+ * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
+ */
+public class ChunkedHttpRequest extends DefaultHttpRequest implements ChunkedInput<HttpContent> {
+    private HttpChunkedInput input;
+
+    public ChunkedHttpRequest(InputStream in, DefaultHttpRequest request) {
+        super(request.protocolVersion(), request.method(), request.uri());
+        this.input = new HttpChunkedInput(new ChunkedStream(in));
+    }
+
+    public DefaultHttpRequest getRequest() {
+        return new DefaultHttpRequest(this.protocolVersion(), this.method(), this.uri(), this.headers());
+    }
+
+    @Override
+    public boolean isEndOfInput() throws Exception {
+        return input.isEndOfInput();
+    }
+
+    @Override
+    public void close() throws Exception {
+        input.close();
+    }
+
+    @Override
+    @Deprecated
+    public HttpContent readChunk(ChannelHandlerContext channelHandlerContext) throws Exception {
+        return input.readChunk(channelHandlerContext);
+    }
+
+    @Override
+    public HttpContent readChunk(ByteBufAllocator byteBufAllocator) throws Exception {
+        return input.readChunk(byteBufAllocator);
+    }
+
+    @Override
+    public long length() {
+        return input.length();
+    }
+
+    @Override
+    public long progress() {
+        return input.progress();
+    }
+}
+

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpRequest.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpRequest.java
@@ -26,9 +26,6 @@ import io.netty.handler.stream.ChunkedStream;
 
 import java.io.InputStream;
 
-/**
- * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
- */
 public class ChunkedHttpRequest extends DefaultHttpRequest implements ChunkedInput<HttpContent> {
     private HttpChunkedInput input;
 

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpResponse.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpResponse.java
@@ -27,9 +27,6 @@ import io.netty.handler.stream.ChunkedStream;
 
 import java.io.InputStream;
 
-/**
- * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
- */
 public class ChunkedHttpResponse extends DefaultHttpResponse implements ChunkedInput<HttpContent> {
     private HttpChunkedInput input;
 

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpResponse.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/ChunkedHttpResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.component.netty4.http;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpChunkedInput;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.stream.ChunkedInput;
+import io.netty.handler.stream.ChunkedStream;
+
+import java.io.InputStream;
+
+/**
+ * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
+ */
+public class ChunkedHttpResponse extends DefaultHttpResponse implements ChunkedInput<HttpContent> {
+    private HttpChunkedInput input;
+
+    public ChunkedHttpResponse(InputStream in, DefaultHttpResponse response) {
+        super(response.protocolVersion(), response.status());
+        this.input = new HttpChunkedInput(new ChunkedStream(in));
+    }
+
+    public DefaultHttpResponse getResponse() {
+        return new DefaultHttpResponse(this.protocolVersion(), this.status(), this.headers());
+    }
+
+    @Override
+    public boolean isEndOfInput() throws Exception {
+        return input.isEndOfInput();
+    }
+
+    @Override
+    public void close() throws Exception {
+        input.close();
+    }
+
+    @Override
+    @Deprecated
+    public HttpContent readChunk(ChannelHandlerContext channelHandlerContext) throws Exception {
+        return input.readChunk(channelHandlerContext);
+    }
+
+    @Override
+    public HttpContent readChunk(ByteBufAllocator byteBufAllocator) throws Exception {
+        return input.readChunk(byteBufAllocator);
+    }
+
+    @Override
+    public long length() {
+        return input.length();
+    }
+
+    @Override
+    public long progress() {
+        return input.progress();
+    }
+}

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/CustomChunkedWriteHandler.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/CustomChunkedWriteHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty4.http;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+/**
+ * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
+ */
+public class CustomChunkedWriteHandler extends ChunkedWriteHandler {
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof ChunkedHttpRequest) {
+            super.write(ctx, ((ChunkedHttpRequest) msg).getRequest(), promise);
+        } else if (msg instanceof ChunkedHttpResponse) {
+            super.write(ctx, ((ChunkedHttpResponse)msg).getResponse(), promise);
+        }
+        super.write(ctx, msg, promise);
+    }
+
+}

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/CustomChunkedWriteHandler.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/CustomChunkedWriteHandler.java
@@ -20,9 +20,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
-/**
- * @author <a href="mailto:zfeng@redhat.com">Zheng Feng</a>
- */
 public class CustomChunkedWriteHandler extends ChunkedWriteHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpClientInitializerFactory.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpClientInitializerFactory.java
@@ -107,6 +107,7 @@ public class HttpClientInitializerFactory extends ClientInitializerFactory {
             pipeline.addLast("decoder-" + x, decoder);
         }
         pipeline.addLast("aggregator", new HttpObjectAggregator(configuration.getChunkedMaxContentLength()));
+        pipeline.addLast("streamer", new CustomChunkedWriteHandler());
 
         if (producer.getConfiguration().getRequestTimeout() > 0) {
             if (LOG.isTraceEnabled()) {

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerInitializerFactory.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerInitializerFactory.java
@@ -108,6 +108,7 @@ public class HttpServerInitializerFactory extends ServerInitializerFactory {
             pipeline.addLast("encoder-" + x, encoder);
         }
         pipeline.addLast("aggregator", new HttpObjectAggregator(configuration.getChunkedMaxContentLength()));
+        pipeline.addLast("streamer", new CustomChunkedWriteHandler());
         if (supportCompressed()) {
             pipeline.addLast("deflater", new HttpContentCompressor());
         }

--- a/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerSharedInitializerFactory.java
+++ b/components/camel-netty4-http/src/main/java/org/apache/camel/component/netty4/http/HttpServerSharedInitializerFactory.java
@@ -85,6 +85,7 @@ public class HttpServerSharedInitializerFactory extends HttpServerInitializerFac
         pipeline.addLast("encoder", new HttpResponseEncoder());
         if (configuration.isChunked()) {
             pipeline.addLast("aggregator", new HttpObjectAggregator(configuration.getChunkedMaxContentLength()));
+            pipeline.addLast("streamer", new CustomChunkedWriteHandler());
         }
         if (configuration.isCompression()) {
             pipeline.addLast("deflater", new HttpContentCompressor());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-12983

This could be a partial fix of this issue and write the steam into the chunked messages.