### PR TITLE
CAMEL-13548: Upgrade jaxb-maven-plugin to 2.5.0

### DIFF
--- a/components/camel-blueprint/pom.xml
+++ b/components/camel-blueprint/pom.xml
@@ -248,7 +248,26 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-schema</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>schemagen</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/schema</outputDirectory>
+                    <sources>
+                        <source>${project.build.directory}/schema-src</source>
+                    </sources>
+                    <createJavaDocAnnotations>false</createJavaDocAnnotations>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -474,82 +493,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>(,1.8]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>jaxb2-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>generate-schema</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/schema</outputDirectory>
-                            <sources>
-                                <source>${project.build.directory}/schema-src</source>
-                            </sources>
-                            <createJavaDocAnnotations>false</createJavaDocAnnotations>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk9+-build</id>
-            <activation>
-                <jdk>[9,)</jdk>
-                <property>
-                    <name>!os.unsupported.schemagen</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <reuseForks>true</reuseForks>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <!--Workaround until https://github.com/mojohaus/jaxb2-maven-plugin/pull/126/ is resolved-->
-                        <groupId>com.github.davidmoten</groupId>
-                        <artifactId>jax-maven-plugin</artifactId>
-                        <version>${jax-maven-plugin-version}</version>
-                        <executions>
-                            <execution>
-                                <id>generate schema</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <classpathScope>compile</classpathScope>
-                            <sources>
-                                <source>${project.build.directory}/schema-src</source>
-                            </sources>
-                            <arguments>
-                                <argument>-d</argument>
-                                <argument>${project.build.directory}/schema</argument>
-                                <argument>-episode</argument>
-                                <argument>${project.build.directory}/schema/META-INF/JAXB/episode_generate-schema.xjb</argument>
-                            </arguments>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/components/camel-spring/pom.xml
+++ b/components/camel-spring/pom.xml
@@ -274,7 +274,26 @@
             </plugins>
         </pluginManagement>
         <plugins>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate schema</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>schemagen</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/schema</outputDirectory>
+                    <sources>
+                        <source>${project.build.directory}/schema-src</source>
+                    </sources>
+                    <createJavaDocAnnotations>false</createJavaDocAnnotations>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-package-maven-plugin</artifactId>
@@ -667,74 +686,6 @@
             <properties>
                 <platform.skip.tests>org/apache/camel/spring/management/**/*.java</platform.skip.tests>
             </properties>
-        </profile>
-
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>(,1.8]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>jaxb2-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>generate schema</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/schema</outputDirectory>
-                            <sources>
-                                <source>${project.build.directory}/schema-src</source>
-                            </sources>
-                            <createJavaDocAnnotations>false</createJavaDocAnnotations>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>jdk9+-build</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!--Workaround until https://github.com/mojohaus/jaxb2-maven-plugin/pull/126/ is resolved-->
-                        <groupId>com.github.davidmoten</groupId>
-                        <artifactId>jax-maven-plugin</artifactId>
-                        <version>${jax-maven-plugin-version}</version>
-                        <executions>
-                            <execution>
-                                <id>generate schema</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/schema-src</source>
-                            </sources>
-                            <arguments>
-                                <argument>-d</argument>
-                                <argument>${project.build.directory}/schema</argument>
-                                <argument>-episode</argument>
-                                <argument>${project.build.directory}/schema/META-INF/JAXB/episode_generate-schema.xjb</argument>
-                            </arguments>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -324,8 +324,7 @@
         <jakarta-api-version>2.1.5</jakarta-api-version>
         <jakarta-jaxb-version>2.3.2</jakarta-jaxb-version>
         <glassfish-jaxb-runtime-version>${jakarta-jaxb-version}</glassfish-jaxb-runtime-version>
-        <jax-maven-plugin-version>0.1.6</jax-maven-plugin-version>
-        <jaxb2-maven-plugin-version>2.4</jaxb2-maven-plugin-version>
+        <jaxb2-maven-plugin-version>2.5.0</jaxb2-maven-plugin-version>
         <!-- Avoid upgrading to newer version for the moment: see https://issues.apache.org/jira/browse/CAMEL-13654 -->
         <jbpm-version>7.22.0.Final</jbpm-version>
         <jboss-logging-version>3.3.2.Final</jboss-logging-version>


### PR DESCRIPTION
and remove temporal JDK11 workarounds.

Builds fine on Windows Zulu OpenJDK 11, Windows Oracle JDK 8, Linux OpenJDK 8, and Linux OpenJDK 11.

I have compared generated camel-spring.xsd and latest released https://camel.apache.org/schema/spring/camel-spring-3.0.0-M4.xsd and the only differences are some spacings in CDDATA comments.

I have not compared blueprint schemas ( I couldnt find any released schema since 3.0 in https://camel.apache.org/schema/blueprint/ ), but camel-blueprint tests passes on OpenJDK8,9,11 so it is probably OK.