### PR TITLE
CAMEL-13750: Omit JMSCorrelationID when sending with useMessageIDAsCo…

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
@@ -374,7 +374,7 @@ public class JmsBinding {
     public void appendJmsProperty(Message jmsMessage, Exchange exchange, org.apache.camel.Message in,
                                   String headerName, Object headerValue) throws JMSException {
         if (isStandardJMSHeader(headerName)) {
-            if (headerName.equals("JMSCorrelationID")) {
+            if (headerName.equals("JMSCorrelationID") && !endpoint.isUseMessageIDAsCorrelationID()) {
                 jmsMessage.setJMSCorrelationID(ExchangeHelper.convertToType(exchange, String.class, headerValue));
             } else if (headerName.equals("JMSReplyTo") && headerValue != null) {
                 if (headerValue instanceof String) {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyCorrelationTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyCorrelationTest.java
@@ -219,6 +219,34 @@ public class JmsRequestReplyCorrelationTest extends CamelTestSupport {
         assertEquals("a", out.getOut().getHeader("JMSCorrelationID"));
     }
 
+    /**
+     * When the setting useMessageIdAsCorrelationid is true for the client and
+     * false for the server and a correlation id is set on the message then
+     * we expect the client to omit the correlation id on the JMS message to force
+     * the server to use the message id. But the correlation id should still be
+     * available on the client exchange message afterwards.
+     */
+    @Test
+    public void testRequestReplyCorrelationByMessageIdWithGivenCorrelationId() throws Exception {
+        MockEndpoint result = getMockEndpoint("mock:result");
+        result.expectedMessageCount(1);
+
+        Exchange out = template.send("jms2:queue:hello", ExchangePattern.InOut, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                Message in = exchange.getIn();
+                in.setBody("Hello World");
+                in.setHeader("JMSCorrelationID", "a");
+            }
+        });
+
+        result.assertIsSatisfied();
+
+        assertNotNull(out);
+
+        assertEquals(REPLY_BODY, out.getOut().getBody(String.class));
+        assertEquals("a", out.getOut().getHeader("JMSCorrelationID"));
+    }
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
@@ -252,7 +280,7 @@ public class JmsRequestReplyCorrelationTest extends CamelTestSupport {
                         assertNotNull(exchange.getIn().getHeader("JMSReplyTo"));
                     }
                 }).to("mock:result");
-                
+
                 from("jms:queue:helloDelay").delay().constant(2000).process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         exchange.getIn().setBody(REPLY_BODY);


### PR DESCRIPTION
When the setting useMessageIdAsCorrelationid is true for the client and false for the server and a correlation id is set on the message then we expect the client to omit the correlation id on the JMS message to force the server to use the message id. But the correlation id should still be available on the client exchange message afterwards.