### PR TITLE
CAMEL-13776 - fixing autoclosable cursor issue

### DIFF
--- a/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbTailableCursorConsumerTest.java
+++ b/components/camel-mongodb3/src/test/java/org/apache/camel/component/mongodb3/MongoDbTailableCursorConsumerTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.bson.Document;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mongodb.client.model.Filters.eq;
@@ -153,7 +152,6 @@ public class MongoDbTailableCursorConsumerTest extends AbstractMongoDbTest {
     }
 
     @Test
-    @Ignore
     public void testPersistentTailTrack() throws Exception {
         assertEquals(0, cappedTestCollection.count());
         final MockEndpoint mock = getMockEndpoint("mock:test");
@@ -227,7 +225,6 @@ public class MongoDbTailableCursorConsumerTest extends AbstractMongoDbTest {
     }
 
     @Test
-    @Ignore
     public void testPersistentTailTrackIncreasingDateField() throws Exception {
         assertEquals(0, cappedTestCollection.count());
         final MockEndpoint mock = getMockEndpoint("mock:test");
@@ -304,7 +301,6 @@ public class MongoDbTailableCursorConsumerTest extends AbstractMongoDbTest {
     }
 
     @Test
-    @Ignore
     public void testCustomTailTrackLocation() throws Exception {
         assertEquals(0, cappedTestCollection.count());
         final MockEndpoint mock = getMockEndpoint("mock:test");


### PR DESCRIPTION
Fixed the autoclosable cursor issue discovered and enabled Junit test related that should now work as expected. From now on, the consumer should be able correctly to resume any tracking stored previously. Also, any stopped consumer will be catched trying to provide a graceful shutdown of the consumer thread.