### PR TITLE
CAMEL-13783: Fix the camel-archetype-component to inherit from DefaultConsumer instead of ScheduledPollConsumer

### DIFF
--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/EventBusHelper.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/EventBusHelper.java
@@ -1,0 +1,53 @@
+## ------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ------------------------------------------------------------------------
+package ${package};
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public class EventBusHelper {
+
+    private static EventBusHelper INSTANCE;
+
+    final private Set<Consumer> subscribers = ConcurrentHashMap.newKeySet();
+
+    private EventBusHelper(){ }
+
+    public static EventBusHelper getInstance(){
+        if (INSTANCE == null){
+            INSTANCE = new EventBusHelper();
+        }
+
+        return INSTANCE;
+    }
+
+    public <T> void subscribe(final Consumer<T> subscriber) {
+        subscribers.add(subscriber);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> void publish(final T event){
+        // Notify all subscribers
+        subscribers.forEach(consumer -> publishSingleEvent(event, consumer));
+    }
+
+    private <T> void publishSingleEvent(final T event, final Consumer<T> subscriber){
+        subscriber.accept(event);
+    }
+
+}

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
@@ -25,7 +25,7 @@ import org.apache.camel.support.ScheduledPollConsumer;
 /**
  * The ${name} consumer.
  */
-public class ${name}Consumer extends ScheduledPollConsumer {
+public class ${name}Consumer extends DefaultConsumer {
     private final ${name}Endpoint endpoint;
 
     public ${name}Consumer(${name}Endpoint endpoint, Processor processor) {
@@ -34,7 +34,7 @@ public class ${name}Consumer extends ScheduledPollConsumer {
     }
 
     @Override
-    protected int poll() throws Exception {
+    protected void doStart() throws Exception {
         Exchange exchange = endpoint.createExchange();
 
         // create a message body
@@ -44,7 +44,6 @@ public class ${name}Consumer extends ScheduledPollConsumer {
         try {
             // send message to next processor in the route
             getProcessor().process(exchange);
-            return 1; // number of messages polled
         } finally {
             // log exception if an exception occurred and was not handled
             if (exchange.getException() != null) {

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
@@ -20,7 +20,7 @@ import java.util.Date;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.support.ScheduledPollConsumer;
+import org.apache.camel.support.DefaultConsumer;
 
 /**
  * The ${name} consumer.

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Consumer.java
@@ -16,34 +16,64 @@
 ## ------------------------------------------------------------------------
 package ${package};
 
-import java.util.Date;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.support.DefaultConsumer;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * The ${name} consumer.
  */
 public class ${name}Consumer extends DefaultConsumer {
     private final ${name}Endpoint endpoint;
+    private final EventBusHelper eventBusHelper;
+
+    private ExecutorService executorService;
 
     public ${name}Consumer(${name}Endpoint endpoint, Processor processor) {
         super(endpoint, processor);
         this.endpoint = endpoint;
+        eventBusHelper = EventBusHelper.getInstance();
     }
 
     @Override
     protected void doStart() throws Exception {
-        Exchange exchange = endpoint.createExchange();
+        super.doStart();
 
-        // create a message body
-        Date now = new Date();
-        exchange.getIn().setBody("Hello World! The time is " + now);
+        // start a single threaded pool to monitor events
+        executorService = endpoint.createExecutor();
+
+        // submit task to the thread pool
+        executorService.submit(() -> {
+            // subscribe to an event
+            eventBusHelper.subscribe(this::onEventListener);
+        });
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        if(log.isTraceEnabled()){
+            log.trace("Shutting down consumer gracefully");
+        }
+
+        // shutdown the thread pool gracefully
+        getEndpoint().getCamelContext().getExecutorServiceManager().shutdownGraceful(executorService);
+    }
+
+    private void onEventListener(final Object event) {
+        final Exchange exchange = endpoint.createExchange();
+
+        exchange.getIn().setBody("Hello World! The time is " + event);
 
         try {
             // send message to next processor in the route
             getProcessor().process(exchange);
+        } catch (Exception ex){
+            exchange.setException(new RuntimeCamelException("Message forwarding failed", ex));
         } finally {
             // log exception if an exception occurred and was not handled
             if (exchange.getException() != null) {

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Endpoint.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/main/java/__name__Endpoint.java
@@ -25,6 +25,8 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * Represents a ${name} endpoint.
  */
@@ -75,5 +77,9 @@ public class ${name}Endpoint extends DefaultEndpoint {
 
     public int getOption() {
         return option;
+    }
+
+    public ExecutorService createExecutor(){
+        return getCamelContext().getExecutorServiceManager().newSingleThreadExecutor(this, "${name}Consumer");
     }
 }

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/test/java/__name__ComponentTest.java
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/src/test/java/__name__ComponentTest.java
@@ -21,14 +21,23 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
 public class ${name}ComponentTest extends CamelTestSupport {
+
+    final private EventBusHelper eventBusHelper = EventBusHelper.getInstance();
 
     @Test
     public void test${name}() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
-        mock.expectedMinimumMessageCount(1);       
-        
-        assertMockEndpointsSatisfied();
+        mock.expectedMinimumMessageCount(20);
+
+        // Trigger events to subscribers
+        simulateEventTrigger();
+
+        mock.await();
     }
 
     @Override
@@ -40,5 +49,17 @@ public class ${name}ComponentTest extends CamelTestSupport {
                   .to("mock:result");
             }
         };
+    }
+
+    private void simulateEventTrigger() {
+        final TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                final Date now = new Date();
+                eventBusHelper.publish(now);
+            }
+        };
+
+        new Timer().scheduleAtFixedRate(task, 1L, 1000L);
     }
 }


### PR DESCRIPTION
Per the title, this will fix the generated `camel-archetype-component` project to inherit from `DefaultConsumer` instead of `ScheduledPollConsumer`