### PR TITLE
CAMEL-13563: Fix AHC tests after Jetty upgrade

### DIFF
--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcProducerSessionTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcProducerSessionTest.java
@@ -69,7 +69,6 @@ public class AhcProducerSessionTest extends BaseAhcTest {
     }
 
     @Test
-    @org.junit.Ignore("Failing cookie test with Jetty 9.4")
     public void testProducerInstanceSession() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Old New World", "Old Old World");
         template.sendBody("direct:instance", "World");
@@ -78,7 +77,6 @@ public class AhcProducerSessionTest extends BaseAhcTest {
     }
 
     @Test
-    @org.junit.Ignore("Failing cookie test with Jetty 9.4")
     public void testProducerExchangeSession() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Old New World", "Old New World");
         template.sendBody("direct:exchange", "World");


### PR DESCRIPTION
Fix and enable previously skipped tests (PR #2971)