### PR TITLE
Camel-Salesforce: Fix integration test.

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiBatchIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiBatchIntegrationTest.java
@@ -155,7 +155,9 @@ public class CompositeApiBatchIntegrationTest extends AbstractSalesforceTestBase
         final Map<String, String> apiRequests = (Map<String, String>) limits.get("DailyApiRequests");
 
         // for JSON value will be Integer, for XML (no type information) it will be String
-        assertEquals("15000", String.valueOf(apiRequests.get("Max")));
+        // This number can be different per org, and future releases,
+        // so let's just make sure it's greater than zero
+        assertTrue(Integer.valueOf(String.valueOf(apiRequests.get("Max"))) > 0);
     }
 
     @Test


### PR DESCRIPTION
Assertion was looking for "15000". My org happened to return "50000". These limits change over time, and salesforce customers can buy limits increases, so we really never know what number to expect, other than it's non-zero.