### PR TITLE
Camel-Salesforce: Fix - Integration tests ignore salesforce.login.url.

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-component/pom.xml
@@ -367,6 +367,11 @@ https://developer.salesforce.com/page/Force.com_Migration_Tool]]></message>
                                         <property name="password" value="${env.SALESFORCE_PASSWORD}"
                                                   if:set="env.SALESFORCE_PASSWORD"/>
 
+                                        <property name="serverurl" value="${prop.salesforce.login.url}"
+                                                  if:set="prop.salesforce.login.url"/>
+                                        <property name="serverurl" value="${env.SALESFORCE_LOGIN_URL}"
+                                                  if:set="env.SALESFORCE_LOGIN_URL"/>
+
                                         <fail unless:set="username" message="To run the migrations you need to specify either `salesforce.username`
 in: ${project.build.directory}/generated-resources/test-salesforce-login.properties
 or set SALESFORCE_USERNAME environment variable"/>
@@ -375,10 +380,15 @@ or set SALESFORCE_USERNAME environment variable"/>
 in: ${project.build.directory}/generated-resources/test-salesforce-login.properties
 or set SALESFORCE_PASSWORD environment variable"/>
 
+                                        <fail unless:set="serverurl" message="To run the migrations you need to specify either `salesforce.login.url`
+in: ${project.build.directory}/generated-resources/test-salesforce-login.properties
+or set SALESFORCE_LOGIN_URL environment variable"/>
+
                                         <sf:deploy xmlns:sf="antlib:com.salesforce" username="${username}"
                                                    password="${password}"
                                                    deployRoot="${salesforce.component.root}/it/resources/salesforce"
-                                                   rollbackOnError="true"/>
+                                                   rollbackOnError="true"
+                                                   serverurl="${serverurl}" />
                                     </target>
                                 </configuration>
                             </execution>

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/LoginConfigHelper.java
@@ -60,6 +60,10 @@ public final class LoginConfigHelper {
         if (ObjectHelper.isNotEmpty(explicitType)) {
             loginConfig.setType(AuthenticationType.valueOf(explicitType));
         }
+        final String loginUrl = configuration.get("salesforce.login.url");
+        if (ObjectHelper.isNotEmpty(loginUrl)) {
+            loginConfig.setLoginUrl(loginUrl);
+        }
         loginConfig.setClientId(configuration.get("salesforce.client.id"));
         loginConfig.setClientSecret(configuration.get("salesforce.client.secret"));
         loginConfig.setUserName(configuration.get("salesforce.username"));


### PR DESCRIPTION
Integration tests ignore the salesforce endpoint setting, so if your endpoint is not https://login.salesforce.com, the tests fail to connect to salesforce.