### PR TITLE
fix typo in salesforce component test

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/AbstractSalesforceTestBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/AbstractSalesforceTestBase.java
@@ -50,7 +50,7 @@ public abstract class AbstractSalesforceTestBase extends CamelTestSupport {
 
         HashMap<String, Object> clientProperties = new HashMap<>();
         clientProperties.put("timeout", "60000");
-        clientProperties.put("maxRetreis", "3");
+        clientProperties.put("maxRetries", "3");
         // 4MB for RestApiIntegrationTest.testGetBlobField()
         clientProperties.put("maxContentLength", String.valueOf(4 * 1024 * 1024));
         component.setHttpClientProperties(clientProperties);


### PR DESCRIPTION
It's just a typo 🤠