### PR TITLE
fix: anchor not found error

### DIFF
--- a/components/camel-cxf/src/main/docs/cxf-component.adoc
+++ b/components/camel-cxf/src/main/docs/cxf-component.adoc
@@ -33,7 +33,6 @@ hosted in CXF.
 * <<Attachment Support>>
 * <<Streaming Support in PAYLOAD mode>>
 * <<Using the generic CXF Dispatch mode>>
-* <<See Also>>
 
 Maven users must add the following dependency to their `pom.xml`
 for this component:

--- a/docs/components/modules/ROOT/pages/cxf-component.adoc
+++ b/docs/components/modules/ROOT/pages/cxf-component.adoc
@@ -33,7 +33,6 @@ hosted in CXF.
 * <<Attachment Support>>
 * <<Streaming Support in PAYLOAD mode>>
 * <<Using the generic CXF Dispatch mode>>
-* <<See Also>>
 
 Maven users must add the following dependency to their `pom.xml`
 for this component:


### PR DESCRIPTION
this made camel-website checks fail