### PR TITLE
[DynamoDB] Improve Integration Tests

### DIFF
--- a/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/DdbComponentVerifierExtension.java
+++ b/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/DdbComponentVerifierExtension.java
@@ -46,11 +46,18 @@ public class DdbComponentVerifierExtension extends DefaultComponentVerifierExten
     // Parameters validation
     // *********************************
 
+
+    /**
+     * Basic check of the parameters (they are not empty)
+     *
+     * @param parameters
+     * @return
+     */
     @Override
     protected Result verifyParameters(Map<String, Object> parameters) {
 
         ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.PARAMETERS).error(ResultErrorHelper.requiresOption("accessKey", parameters))
-            .error(ResultErrorHelper.requiresOption("secretKey", parameters)).error(ResultErrorHelper.requiresOption("region", parameters));
+                .error(ResultErrorHelper.requiresOption("secretKey", parameters)).error(ResultErrorHelper.requiresOption("region", parameters));
 
         // Validate using the catalog
 
@@ -63,6 +70,13 @@ public class DdbComponentVerifierExtension extends DefaultComponentVerifierExten
     // Connectivity validation
     // *********************************
 
+    /**
+     * To verify the connectivity, we will try a basic test connection to extract the 
+     * list of tables and see if it fails
+     *
+     * @param parameters
+     * @return
+     */
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY);
@@ -75,8 +89,8 @@ public class DdbComponentVerifierExtension extends DefaultComponentVerifierExten
             client.listTables();
         } catch (SdkClientException e) {
             ResultErrorBuilder errorBuilder = ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION, e.getMessage())
-                .detail("aws_ddb_exception_message", e.getMessage()).detail(VerificationError.ExceptionAttribute.EXCEPTION_CLASS, e.getClass().getName())
-                .detail(VerificationError.ExceptionAttribute.EXCEPTION_INSTANCE, e);
+                    .detail("aws_ddb_exception_message", e.getMessage()).detail(VerificationError.ExceptionAttribute.EXCEPTION_CLASS, e.getClass().getName())
+                    .detail(VerificationError.ExceptionAttribute.EXCEPTION_INSTANCE, e);
 
             builder.error(errorBuilder.build());
         } catch (Exception e) {

--- a/components/camel-aws-ddb/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
+++ b/components/camel-aws-ddb/src/test/java/org/apache/camel/component/aws/ddb/integration/DdbComponentIntegrationTest.java
@@ -17,11 +17,10 @@
 package org.apache.camel.component.aws.ddb.integration;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -33,27 +32,105 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("Must be manually tested. Provide your own accessKey and secretKey!")
+
+@Ignore("Must be manually tested. Provide your own credentials below!")
 public class DdbComponentIntegrationTest extends CamelTestSupport {
 
     @EndpointInject("direct:start")
     private ProducerTemplate template;
 
+    //To replace with proper credentials:
+    private final String attributeName = "clave";
+    private final String tableName = "TestTable";
+    private final String secretKey = "-";
+    private final String accessKey = "-";
+    private final String region = Regions.EU_WEST_2.name();
+    //End credentials replacement
+
+    private final String randomId = String.valueOf(System.currentTimeMillis());
+
     @Test
-    public void select() {
+    public void fullLifeCycle() {
+        putItem();
+        getItem();
+        updateItem();
+        deleteItem();
+    }
+
+    public void putItem() {
         final Map<String, AttributeValue> attributeMap = new HashMap<>();
-        AttributeValue attributeValue = new AttributeValue("test value");
-        attributeMap.put("name", attributeValue);
+        AttributeValue attributeValue = new AttributeValue(randomId);
+        attributeMap.put(attributeName, attributeValue);
+        attributeMap.put("secondary_attribute", new AttributeValue("value"));
 
         Exchange exchange = template.send("direct:start", new Processor() {
             public void process(Exchange exchange) throws Exception {
                 exchange.getIn().setHeader(DdbConstants.OPERATION, DdbOperations.PutItem);
+                exchange.getIn().setHeader(DdbConstants.CONSISTENT_READ, "true");
                 exchange.getIn().setHeader(DdbConstants.RETURN_VALUES, "ALL_OLD");
                 exchange.getIn().setHeader(DdbConstants.ITEM, attributeMap);
+                exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, attributeMap.keySet());
             }
         });
 
-        assertNotNull(exchange.getIn().getHeader(DdbConstants.ITEMS, List.class));
+        assertNotNull(exchange.getIn().getHeader(DdbConstants.ITEM));
+    }
+
+
+    public void updateItem() {
+        Map<String, AttributeValue> attributeMap = new HashMap<>();
+        attributeMap.put(attributeName, new AttributeValue(randomId));
+        attributeMap.put("secondary_attribute", new AttributeValue("new"));
+
+        Map<String, ExpectedAttributeValue> expectedAttributeValueMap = new HashMap<>();
+        expectedAttributeValueMap.put(attributeName,
+                new ExpectedAttributeValue(new AttributeValue(randomId)));
+
+        Exchange exchange = template.send("direct:start", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(DdbConstants.ITEM, attributeMap);
+                exchange.getIn().setHeader(DdbConstants.UPDATE_CONDITION, expectedAttributeValueMap);
+                exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, attributeMap.keySet());
+                exchange.getIn().setHeader(DdbConstants.RETURN_VALUES, "ALL_OLD");
+            }
+        });
+
+        assertNotNull(exchange.getIn().getHeader(DdbConstants.ATTRIBUTES));
+    }
+
+    public void getItem() {
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put(attributeName, new AttributeValue(randomId));
+
+        Exchange exchange = template.send("direct:start", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(DdbConstants.OPERATION, DdbOperations.GetItem);
+                exchange.getIn().setHeader(DdbConstants.CONSISTENT_READ, true);
+                exchange.getIn().setHeader(DdbConstants.KEY, key);
+                exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, key.keySet());
+            }
+        });
+
+        assertNotNull(exchange.getIn().getHeader(DdbConstants.ATTRIBUTES));
+        assertEquals(new AttributeValue(randomId),
+                exchange.getIn().getHeader(DdbConstants.ATTRIBUTES, Map.class).get(
+                        attributeName));
+    }
+
+    @Test
+    public void deleteItem() {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put(attributeName, new AttributeValue(randomId));
+
+        Exchange exchange = template.send("direct:start", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(DdbConstants.KEY, key);
+                exchange.getIn().setHeader(DdbConstants.RETURN_VALUES, "ALL_OLD");
+                exchange.getIn().setHeader(DdbConstants.OPERATION, DdbOperations.DeleteItem);
+                exchange.getIn().setHeader(DdbConstants.ATTRIBUTE_NAMES, key.keySet());
+            }
+        });
     }
 
     @Override
@@ -62,7 +139,10 @@ public class DdbComponentIntegrationTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("aws-ddb://TestTable?accessKey=xxx&secretKey=yyy");
+                        .to("aws-ddb://" + tableName + "?"
+                                + "region=" + region
+                                + "&accessKey=" + accessKey
+                                + "&secretKey=RAW(" + secretKey + ")");
             }
         };
     }


### PR DESCRIPTION
Extended the (ignored by default) integration test on DynamoDB to do a minimal lifecycle: create, update, get and delete an item.

Still needs proper credentials, region, table name and key column to run. Also, fix the problem with non raw passwords (if the password contained something like "/", the test was broken).