### PR TITLE
CAMEL-13429: Support expressions in path parameters at REST DSL

### DIFF
--- a/core/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/core/camel-core/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -917,9 +919,11 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
                     } catch (Exception e) {
                         throw RuntimeCamelException.wrapRuntimeCamelException(e);
                     }
-                    if (a.startsWith("{") && a.endsWith("}")) {
-                        String key = a.substring(1, a.length() - 1);
-                        // merge if exists
+
+                    Matcher m = Pattern.compile("\\{(.*?)\\}").matcher(a);
+                    while (m.find()) {
+                        String key = m.group(1);
+                        //  merge if exists
                         boolean found = false;
                         for (RestOperationParamDefinition param : verb.getParams()) {
                             // name is mandatory

--- a/core/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetPlaceholderParamTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetPlaceholderParamTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.rest;
+
+import java.util.List;
+
+import javax.naming.Context;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.ToDefinition;
+import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.rest.RestOperationParamDefinition;
+import org.apache.camel.model.rest.RestParamType;
+import org.junit.Test;
+
+public class FromRestGetPlaceholderParamTest extends ContextTestSupport {
+
+    @Override
+    protected Context createJndiContext() throws Exception {
+        Context context = super.createJndiContext();
+        context.bind("dummy-rest", new DummyRestConsumerFactory());
+        return context;
+    }
+
+    @Test
+    public void testFromRestModelSingleParam() {
+        RestDefinition rest = context.getRestDefinitions().get(0);
+        assertNotNull(rest);
+        assertEquals("items/", rest.getPath());
+        assertEquals(1, rest.getVerbs().size());
+        ToDefinition to = assertIsInstanceOf(ToDefinition.class, rest.getVerbs().get(0).getTo());
+        assertEquals("direct:hello", to.getUri());
+
+        // Validate params
+        List<RestOperationParamDefinition> paramDefinitions = rest.getVerbs().get(0).getParams();
+        assertEquals(1, paramDefinitions.size());
+        assertEquals(RestParamType.path, paramDefinitions.get(0).getType());
+        assertEquals("id", paramDefinitions.get(0).getName());
+    }
+
+    @Test
+    public void testFromRestModelMultipleParams() {
+        RestDefinition rest = context.getRestDefinitions().get(1);
+        assertNotNull(rest);
+        assertEquals("items/", rest.getPath());
+        assertEquals(1, rest.getVerbs().size());
+        ToDefinition to = assertIsInstanceOf(ToDefinition.class, rest.getVerbs().get(0).getTo());
+        assertEquals("direct:hello", to.getUri());
+
+        // Validate params
+        List<RestOperationParamDefinition> paramDefinitions = rest.getVerbs().get(0).getParams();
+        assertEquals(3, paramDefinitions.size());
+        assertEquals(RestParamType.path, paramDefinitions.get(0).getType());
+        assertEquals("id", paramDefinitions.get(0).getName());
+        assertEquals(RestParamType.path, paramDefinitions.get(1).getType());
+        assertEquals("filename", paramDefinitions.get(1).getName());
+        assertEquals(RestParamType.path, paramDefinitions.get(2).getType());
+        assertEquals("content-type", paramDefinitions.get(2).getName());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                restConfiguration().host("localhost");
+                rest("items/")
+                        .get("/{id}")
+                        .to("direct:hello");
+
+                rest("items/")
+                        .get("{id}/{filename}.{content-type}")
+                        .to("direct:hello");
+
+                from("direct:hello")
+                        .transform().constant("Hello World");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/component/rest/RestProducerPathTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/rest/RestProducerPathTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.rest;
+
+import java.util.HashMap;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RestProducerPathTest {
+    private final RestComponent restComponent;
+
+    public RestProducerPathTest() {
+        DefaultCamelContext context = new DefaultCamelContext();
+        context.addComponent("mock-rest", new RestEndpointTest.MockRest());
+
+        restComponent = new RestComponent();
+        restComponent.setCamelContext(context);
+    }
+
+    private RestProducer createProducer(String uri) throws Exception {
+        final RestEndpoint restEndpoint = (RestEndpoint) restComponent.createEndpoint(uri);
+        restEndpoint.setConsumerComponentName("mock-rest");
+        restEndpoint.setParameters(new HashMap<>());
+        restEndpoint.setHost("http://localhost");
+        restEndpoint.setBindingMode("json");
+
+        return (RestProducer) restEndpoint.createProducer();
+    }
+
+    @Test
+    public void testEmptyParam() throws Exception {
+        RestProducer producer = createProducer("rest:get:list//{id}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertEquals("http://localhost/list//1", actual);
+    }
+
+    @Test
+    public void testNoHeaders() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}_{val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testMissingHeader() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}/{val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        // Backward compatibility: if one of the params is resolved
+        Assert.assertEquals("http://localhost/list/1/{val}", actual);
+    }
+
+    @Test
+    public void testMissingHeaderSingleParam() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}_{val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testMissingStartCurlyBrace() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}_val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+        message.setHeader("val", "test");
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testSingleMissingStartCurlyBrace() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/id}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testSingleMissingEndCurlyBrace() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testMissingEndCurlyBrace() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id_{val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+        message.setHeader("val", "test");
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testSingleParam() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertEquals("http://localhost/list/1", actual);
+    }
+
+    @Test
+    public void testUnderscoreSeparator() throws Exception {
+        RestProducer producer = createProducer("rest:get:list/{id}_{val}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("id", 1);
+        message.setHeader("val", "test");
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertEquals("http://localhost/list/1_test", actual);
+    }
+
+    @Test
+    public void testDotSeparator() throws Exception {
+        RestProducer producer = createProducer("rest:get:items/item.{content-type}");
+        Exchange exchange = producer.createExchange();
+        Message message = exchange.getIn();
+        message.setHeader("content-type", "xml");
+
+        producer.process(exchange);
+
+        String actual = (String) message.getHeader(Exchange.REST_HTTP_URI);
+        Assert.assertEquals("http://localhost/items/item.xml", actual);
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
@@ -19,7 +19,7 @@ others that has native REST integration.
 The following Camel components supports the Rest DSL. See the bottom of
 this page for how to integrate a component with the Rest DSL.
 
-* xref:components::rest-component.adoc[came-rest] *required* contains the base rest component needed by Rest DSL
+* xref:components::rest-component.adoc[camel-rest] *required* contains the base rest component needed by Rest DSL
 * xref:components::netty-http-component.adoc[camel-netty-http] (also
 supports Swagger Java)
 * xref:components::jetty-component.adoc[camel-jetty] (also
@@ -149,7 +149,7 @@ And using XML DSL it becomes:
 </rest>
 ----
 
-TIP:The REST DSL will take care of duplicate path separators when using base
+TIP: The REST DSL will take care of duplicate path separators when using base
 path and uri templates. In the example above the rest base path ends
 with a slash ( / ) and the verb starts with a slash ( / ). But Apache
 Camel will take care of this and remove the duplicated slash.
@@ -171,6 +171,15 @@ only. The example above can be defined as:
     <to uri="direct:customerNewOrder"/>
   </post>
 </rest>
+----
+
+TIP: You can combine path parameters to build complex expressions.
+For example:
+[source,java]
+----
+  rest("items/")
+      .get("{id}/{filename}.{content-type}")
+      .to("direct:item")
 ----
 
 == Using Dynamic To in Rest DSL


### PR DESCRIPTION
Improved REST DSL route definition and REST Producer.
I have doubts about:
1. Using regex to iterate over placeholders "{}".
1. New function `resolveHeaderPlaceholders` at `camel-rest` that replaces placeholders with header values. Maybe there is a way to reuse some code from camel-properties component.

Also unit-tests for `camel-rest` component are located at `camel-core`. Maybe it would be better to move them?