### PR TITLE
Camel-Salesforce: Fix serialization for string MPLs

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/StringMultiSelectPicklistDeserializer.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/StringMultiSelectPicklistDeserializer.java
@@ -36,6 +36,10 @@ public class StringMultiSelectPicklistDeserializer extends StdDeserializer<Objec
 
     private static final long serialVersionUID = 7380774744798254325L;
 
+    public StringMultiSelectPicklistDeserializer() {
+        super(Object.class);
+    }
+
     protected StringMultiSelectPicklistDeserializer(Class<?> vc) {
         super(vc);
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/StringMultiSelectPicklistSerializer.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/StringMultiSelectPicklistSerializer.java
@@ -31,6 +31,10 @@ public class StringMultiSelectPicklistSerializer extends StdSerializer<Object> {
 
     private static final long serialVersionUID = 1406195556960561677L;
 
+    public StringMultiSelectPicklistSerializer() {
+        super(Object.class);
+    }
+
     protected StringMultiSelectPicklistSerializer(Class<Object> t) {
         super(t);
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/api/MultiSelectPicklistJsonTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/api/MultiSelectPicklistJsonTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.camel.component.salesforce.api.utils.JsonUtils;
 import org.apache.camel.component.salesforce.dto.generated.MSPTest;
+import org.apache.camel.component.salesforce.dto.generated.StringMSPTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -58,4 +59,28 @@ public class MultiSelectPicklistJsonTest {
         assertNull(mspTest.getMspField());
     }
 
+    @Test
+    public void testMarshalString() throws Exception {
+        final StringMSPTest mspTest = new StringMSPTest();
+        mspTest.setMspField(new String[] { "Value1", "Value2", "Value3" });
+
+        String json = objectMapper.writeValueAsString(mspTest);
+        assertEquals(TEST_JSON, json);
+
+        // test null
+        mspTest.setMspField(null);
+
+        json = objectMapper.writeValueAsString(mspTest);
+        assertEquals(TEST_NULL_JSON, json);
+    }
+
+    @Test
+    public void testUnmarshalString() throws Exception {
+        StringMSPTest mspTest = objectMapper.readValue(TEST_JSON, StringMSPTest.class);
+        assertArrayEquals(new String[] { "Value1", "Value2", "Value3" }, mspTest.getMspField());
+
+        // test null
+        mspTest = objectMapper.readValue(TEST_NULL_JSON, StringMSPTest.class);
+        assertNull(mspTest.getMspField());
+    }
 }

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/dto/generated/StringMSPTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/dto/generated/StringMSPTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.salesforce.dto.generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+
+import org.apache.camel.component.salesforce.api.MultiSelectPicklistConverter;
+import org.apache.camel.component.salesforce.api.MultiSelectPicklistDeserializer;
+import org.apache.camel.component.salesforce.api.MultiSelectPicklistSerializer;
+import org.apache.camel.component.salesforce.api.StringMultiSelectPicklistConverter;
+import org.apache.camel.component.salesforce.api.StringMultiSelectPicklistDeserializer;
+import org.apache.camel.component.salesforce.api.StringMultiSelectPicklistSerializer;
+import org.apache.camel.component.salesforce.api.dto.AbstractSObjectBase;
+
+/**
+ * Sample POJO for MSP tests using Strings instead of Constants.
+ */
+//CHECKSTYLE:OFF
+@XStreamAlias("MSPTest")
+public class StringMSPTest extends AbstractSObjectBase {
+
+    public StringMSPTest() {
+        getAttributes().setType("MSPTest");
+    }
+
+    @XStreamConverter(StringMultiSelectPicklistConverter.class)
+    private java.lang.String[] MspField;
+
+    @JsonProperty("MspField")
+    @JsonSerialize(using = StringMultiSelectPicklistSerializer.class)
+    @JsonInclude(value = Include.ALWAYS)
+    public java.lang.String[] getMspField() {
+        return MspField;
+    }
+
+    @JsonProperty("MspField")
+    @JsonDeserialize(using = StringMultiSelectPicklistDeserializer.class)
+    public void setMspField(java.lang.String[] mspField) {
+        this.MspField = mspField;
+    }
+}
+//CHECKSTYLE:ON

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/README.md
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/README.md
@@ -19,6 +19,7 @@ The plugin configuration has the following properties.
 * excludePattern - Java RegEx for SObject types to exclude
 * packageName - Java package name for generated DTOs, defaults to org.apache.camel.salesforce.dto.
 * customTypes - override default types in generated DTOs
+* useStringsForPicklists - Use strings instead of enumerations for picklists. Default is false.
 
 Additonal properties to provide proxy information, if behind a firewall.
 


### PR DESCRIPTION
Serialization/deserialization failed when using Strings instead of
enumerations for multiselect pick lists. You can reproduce by running the new test cases without the changes to the Serializer/Deserializer classes.

The error you'd see is: 
```com.fasterxml.jackson.databind.JsonMappingException: 
Class org.apache.camel.component.salesforce.api.StringMultiSelectPicklistDeserializer has no default (no arg) constructor
 at [Source: (String)"{"attributes":{"type":"MSPTest"},"MspField":"Value1;Value2;Value3"}"; line: 1, column: 1]
        at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:306)
```

I added default constructors for the affected classes and it seems to fix things. 