### PR TITLE
CAMEL-11011: Make all Services AutoCloseable

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/cluster/FileLockClusterView.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/cluster/FileLockClusterView.java
@@ -78,7 +78,7 @@ public class FileLockClusterView extends AbstractCamelClusterView {
     @Override
     protected void doStart() throws Exception {
         if (file != null) {
-            close();
+            closeInternal();
 
             fireLeadershipChangedEvent(Optional.empty());
         }
@@ -103,14 +103,14 @@ public class FileLockClusterView extends AbstractCamelClusterView {
 
     @Override
     protected void doStop() throws Exception {
-        close();
+        closeInternal();
     }
 
     // *********************************
     //
     // *********************************
 
-    private void close() throws Exception {
+    private void closeInternal() throws Exception {
         if (task != null) {
             task.cancel(true);
         }

--- a/core/camel-api/src/main/java/org/apache/camel/Service.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Service.java
@@ -16,10 +16,12 @@
  */
 package org.apache.camel;
 
+import java.io.IOException;
+
 /**
  * Represents the core lifecycle API for services which can be initialized, started and stopped
  */
-public interface Service {
+public interface Service extends AutoCloseable {
 
     /**
      * Initialize the service
@@ -42,4 +44,21 @@ public interface Service {
      * @throws RuntimeCamelException is thrown if stopping failed
      */
     void stop();
+
+    /**
+     * Delegates to {@link Service#stop()} so it can be used in
+     * try-with-resources expression.
+     * 
+     * @throws IOException per contract of {@link AutoCloseable} if
+     *             {@link Service#stop()} fails
+     */
+    default void close() throws IOException {
+        try {
+            stop();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/AutoCloseableTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/AutoCloseableTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoCloseableTest {
+
+    @Test
+    public void servicesShouldBeAutoCloseable() throws Exception {
+        CamelContext usedContext = null;
+        ProducerTemplate usedProducer = null;
+
+        try (CamelContext context = new DefaultCamelContext();
+             ProducerTemplate producer = context.createProducerTemplate()) {
+            usedContext = context;
+            usedProducer = producer;
+
+            context.addRoutes(new RouteBuilder() {
+                public void configure() {
+                    from("direct:start").log("hello ${body}");
+                }
+            });
+            context.start();
+
+            producer.sendBody("direct:start", "word");
+        }
+
+        assertThat(usedContext.isStopped()).isTrue();
+        assertThat(((DefaultProducerTemplate) usedProducer).isStopped()).isTrue();
+    }
+
+}


### PR DESCRIPTION
Based on previous discussion[1][2] I would like to suggest that we take the opportunity to make Services AutoCloseable in 3.x.

[1] https://mail-archives.apache.org/mod_mbox/camel-dev/201703.mbox/%3CCABD_Zr-V6QVXAMr3xYi0ZfKpSx9YpsZb9iEW4FpCjR6L6SQO7w%40mail.gmail.com%3E  (follow the thread)
[2] https://github.com/apache/camel/pull/1537