### PR TITLE
CAMEL-13943: Fix failing unit tests in camel-kafka

### DIFF
--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -107,6 +107,11 @@
             <version>${commons-lang3-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryEmptyTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryEmptyTest.java
@@ -28,6 +28,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.After;
 import org.junit.Test;
 
+import static org.awaitility.Awaitility.await;
+
 public class KafkaConsumerOffsetRepositoryEmptyTest extends BaseEmbeddedKafkaTest {
     private static final String TOPIC = "offset-initialize";
 
@@ -76,7 +78,7 @@ public class KafkaConsumerOffsetRepositoryEmptyTest extends BaseEmbeddedKafkaTes
         result.assertIsSatisfied(3000);
 
         // to give the local state some buffer
-        TimeUnit.MILLISECONDS.sleep(500);
+        await().atMost(1, TimeUnit.SECONDS).until(stateRepository::isStarted);
 
         assertEquals("partition-0", "4", stateRepository.getState(TOPIC + "/0"));
         assertEquals("partition-1", "4", stateRepository.getState(TOPIC + "/1"));

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryEmptyTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryEmptyTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kafka;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.EndpointInject;
@@ -73,6 +74,9 @@ public class KafkaConsumerOffsetRepositoryEmptyTest extends BaseEmbeddedKafkaTes
                                                 "message-8", "message-9");
 
         result.assertIsSatisfied(3000);
+
+        // to give the local state some buffer
+        TimeUnit.MILLISECONDS.sleep(500);
 
         assertEquals("partition-0", "4", stateRepository.getState(TOPIC + "/0"));
         assertEquals("partition-1", "4", stateRepository.getState(TOPIC + "/1"));

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryResumeTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryResumeTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kafka;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.EndpointInject;
@@ -73,6 +74,9 @@ public class KafkaConsumerOffsetRepositoryResumeTest extends BaseEmbeddedKafkaTe
         result.expectedBodiesReceivedInAnyOrder("message-6", "message-8", "message-9");
 
         result.assertIsSatisfied(5000);
+
+        // to give the local state some buffer
+        TimeUnit.MILLISECONDS.sleep(500);
 
         assertEquals("partition-0", "4", stateRepository.getState(TOPIC + "/0"));
         assertEquals("partition-1", "4", stateRepository.getState(TOPIC + "/1"));

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryResumeTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerOffsetRepositoryResumeTest.java
@@ -28,6 +28,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.After;
 import org.junit.Test;
 
+import static org.awaitility.Awaitility.await;
+
 public class KafkaConsumerOffsetRepositoryResumeTest extends BaseEmbeddedKafkaTest {
     private static final String TOPIC = "offset-resume";
 
@@ -76,7 +78,7 @@ public class KafkaConsumerOffsetRepositoryResumeTest extends BaseEmbeddedKafkaTe
         result.assertIsSatisfied(5000);
 
         // to give the local state some buffer
-        TimeUnit.MILLISECONDS.sleep(500);
+        await().atMost(1, TimeUnit.SECONDS).until(stateRepository::isStarted);
 
         assertEquals("partition-0", "4", stateRepository.getState(TOPIC + "/0"));
         assertEquals("partition-1", "4", stateRepository.getState(TOPIC + "/1"));


### PR DESCRIPTION
This intends to go around with the race condition issue that _sometimes_ occurs with `MemoryStateRepository` in `KafkaConsumerOffsetRepositoryResumeTest` and `KafkaConsumerOffsetRepositoryEmptyTest` which as result cause the tests to fail (not always)