### PR TITLE
CAMEL-13954: Set file-watch events explicitly instead of relying on relying on the the auto generated property configurator

### DIFF
--- a/components/camel-file-watch/src/main/java/org/apache/camel/component/file/watch/FileWatchComponent.java
+++ b/components/camel-file-watch/src/main/java/org/apache/camel/component/file/watch/FileWatchComponent.java
@@ -104,7 +104,14 @@ public class FileWatchComponent extends DefaultComponent {
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
-        Endpoint endpoint = new FileWatchEndpoint(uri, remaining, this);
+        FileWatchEndpoint endpoint = new FileWatchEndpoint(uri, remaining, this);
+
+        // CAMEL-13954: Due to the auto generated property configurator, this intends to set it manually instead of relying on the auto generated property configurator
+        if (parameters.containsKey("events")) {
+            endpoint.setEvents(parameters.get("events").toString());
+            parameters.remove("events");
+        }
+
         setProperties(endpoint, parameters);
         return endpoint;
     }

--- a/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/FileWatchComponentTest.java
+++ b/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/FileWatchComponentTest.java
@@ -37,6 +37,7 @@ public class FileWatchComponentTest extends FileWatchComponentTestBase {
         MockEndpoint watchModify = getMockEndpoint("mock:watchModify");
         MockEndpoint watchDelete = getMockEndpoint("mock:watchDelete");
         MockEndpoint watchDeleteOrCreate = getMockEndpoint("mock:watchDeleteOrCreate");
+        MockEndpoint watchDeleteOrModify = getMockEndpoint("mock:watchDeleteOrModify");
 
         File newFile = createFile(testPath(), UUID.randomUUID().toString());
 
@@ -52,13 +53,17 @@ public class FileWatchComponentTest extends FileWatchComponentTestBase {
         watchDeleteOrCreate.setAssertPeriod(1000);
         watchDeleteOrCreate.assertIsSatisfied();
 
-        watchModify.expectedMessageCount(1);
+        watchModify.expectedMessageCount(0);
         watchModify.setAssertPeriod(1000);
         watchModify.assertIsSatisfied();
 
-        watchDelete.expectedMessageCount(1);
+        watchDelete.expectedMessageCount(0);
         watchDelete.setAssertPeriod(1000);
         watchDelete.assertIsSatisfied();
+
+        watchDeleteOrModify.expectedMessageCount(0);
+        watchDeleteOrModify.setAssertPeriod(1000);
+        watchDeleteOrModify.assertIsSatisfied();
 
         assertFileEvent(newFile.getName(), FileEventEnum.CREATE, watchAll.getExchanges().get(0));
         assertFileEvent(newFile.getName(), FileEventEnum.CREATE, watchCreate.getExchanges().get(0));
@@ -167,6 +172,9 @@ public class FileWatchComponentTest extends FileWatchComponentTestBase {
 
                 from("file-watch://" + testPath() + "?events=DELETE,CREATE")
                     .to("mock:watchDeleteOrCreate");
+
+                from("file-watch://" + testPath() + "?events=DELETE,MODIFY")
+                    .to("mock:watchDeleteOrModify");
             }
         };
     }

--- a/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/FileWatchComponentTestBase.java
+++ b/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/FileWatchComponentTestBase.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +36,7 @@ import org.junit.rules.TemporaryFolder;
 public class FileWatchComponentTestBase extends CamelTestSupport {
 
     @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder(Paths.get("target").toAbsolutePath().toFile());
 
     protected List<Path> testFiles = new ArrayList<>();
 

--- a/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/SpringFileWatcherTest.java
+++ b/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/SpringFileWatcherTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.file.watch;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -25,7 +24,6 @@ import java.util.UUID;
 
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
@@ -36,13 +34,7 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
     private File springTestFile;
     private File springTestCustomHasherFile;
 
-    @Override
-    public void doPreSetup() throws Exception {
-        super.doPreSetup();
-
-        createTestFiles();
-    }
-
+    @Before
     public void createTestFiles() throws Exception {
         Files.createDirectories(Paths.get("target/fileWatchSpringTest"));
         Files.createDirectories(Paths.get("target/fileWatchSpringTestCustomHasher"));
@@ -50,19 +42,6 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
         springTestCustomHasherFile = new File("target/fileWatchSpringTestCustomHasher", UUID.randomUUID().toString());
         springTestFile.createNewFile();
         springTestCustomHasherFile.createNewFile();
-    }
-
-    @Override
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-
-        cleanTestFiles();
-    }
-
-    public void cleanTestFiles() throws IOException {
-        Files.delete(springTestFile.toPath());
-        Files.delete(springTestCustomHasherFile.toPath());
     }
 
     @Test
@@ -73,7 +52,7 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
         Thread.sleep(50);
         Files.write(springTestFile.toPath(), "modification 2".getBytes(), StandardOpenOption.SYNC);
         MockEndpoint mock = getMockEndpoint("mock:springTest");
-        mock.setExpectedCount(1); // The same with testCustomHasher, that second MODIFY event is discarded
+        mock.setExpectedCount(2); // two MODIFY events
         mock.setResultWaitTime(1000);
         mock.assertIsSatisfied();
 

--- a/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/SpringFileWatcherTest.java
+++ b/components/camel-file-watch/src/test/java/org/apache/camel/component/file/watch/SpringFileWatcherTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file.watch;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -24,6 +25,7 @@ import java.util.UUID;
 
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
@@ -34,7 +36,13 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
     private File springTestFile;
     private File springTestCustomHasherFile;
 
-    @Before
+    @Override
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+
+        createTestFiles();
+    }
+
     public void createTestFiles() throws Exception {
         Files.createDirectories(Paths.get("target/fileWatchSpringTest"));
         Files.createDirectories(Paths.get("target/fileWatchSpringTestCustomHasher"));
@@ -42,6 +50,19 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
         springTestCustomHasherFile = new File("target/fileWatchSpringTestCustomHasher", UUID.randomUUID().toString());
         springTestFile.createNewFile();
         springTestCustomHasherFile.createNewFile();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        cleanTestFiles();
+    }
+
+    public void cleanTestFiles() throws IOException {
+        Files.delete(springTestFile.toPath());
+        Files.delete(springTestCustomHasherFile.toPath());
     }
 
     @Test
@@ -52,7 +73,7 @@ public class SpringFileWatcherTest extends CamelSpringTestSupport {
         Thread.sleep(50);
         Files.write(springTestFile.toPath(), "modification 2".getBytes(), StandardOpenOption.SYNC);
         MockEndpoint mock = getMockEndpoint("mock:springTest");
-        mock.setExpectedCount(2); // two MODIFY events
+        mock.setExpectedCount(1); // The same with testCustomHasher, that second MODIFY event is discarded
         mock.setResultWaitTime(1000);
         mock.assertIsSatisfied();
 


### PR DESCRIPTION
**Scope of changes**

- Due to [CAMEL-13954](https://issues.apache.org/jira/browse/CAMEL-13954), the auto generated property configurator will use the wrong method which is expected due to the param type. However, instead of that, we just set events manually using the correct method.
- Change junit testing directory from the default to the `target` folder. 
- Make sure to delete spring testing files after the tests.
- Add and modify some testing cases 