### PR TITLE
newLinkAdded-FacebookComponentDocs

### DIFF
--- a/components/camel-facebook/src/main/docs/facebook-component.adoc
+++ b/components/camel-facebook/src/main/docs/facebook-component.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 2.14*
 
 The Facebook component provides access to all of the Facebook APIs
-accessible using http://facebook4j.org/en/index.html[Facebook4J]. It
+accessible using https://facebook4j.github.io/en/index.html[Facebook4J]. It
 allows producing messages to retrieve, add, and delete posts, likes,
 comments, photos, albums, videos, photos, checkins, locations, links,
 etc. It also supports APIs that allow polling for posts, users,


### PR DESCRIPTION
Simply updated the Facebook 4J link in the [facebook-component documentation](https://github.com/apache/camel/blob/master/components/camel-facebook/src/main/docs/facebook-component.adoc).
