### PR TITLE
Upgrade Hamcrest to version 2.1

### DIFF
--- a/components/camel-activemq/pom.xml
+++ b/components/camel-activemq/pom.xml
@@ -113,8 +113,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-ahc/pom.xml
+++ b/components/camel-ahc/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-atomix/pom.xml
+++ b/components/camel-atomix/pom.xml
@@ -116,8 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-aws-xray/pom.xml
+++ b/components/camel-aws-xray/pom.xml
@@ -87,8 +87,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-cdi/pom.xml
+++ b/components/camel-cdi/pom.xml
@@ -176,8 +176,7 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-ehcache/pom.xml
+++ b/components/camel-ehcache/pom.xml
@@ -81,8 +81,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-hipchat/pom.xml
+++ b/components/camel-hipchat/pom.xml
@@ -96,8 +96,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-jcache/pom.xml
+++ b/components/camel-jcache/pom.xml
@@ -102,8 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-metrics/pom.xml
+++ b/components/camel-metrics/pom.xml
@@ -98,8 +98,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -97,8 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-pdf/pom.xml
+++ b/components/camel-pdf/pom.xml
@@ -97,8 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-tika/pom.xml
+++ b/components/camel-tika/pom.xml
@@ -93,8 +93,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-wordpress/pom.xml
+++ b/components/camel-wordpress/pom.xml
@@ -35,7 +35,6 @@
     <description>Wordpress REST API support</description>
 
     <properties>
-        <hamcrest-version>1.3</hamcrest-version>
         <camel.osgi.import.additional>
             org.apache.cxf.*;version="${cxf-version-range}"
         </camel.osgi.import.additional>
@@ -78,8 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/camel-cloud/pom.xml
+++ b/core/camel-cloud/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/camel-core/pom.xml
+++ b/core/camel-core/pom.xml
@@ -223,7 +223,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/camel-endpointdsl/pom.xml
+++ b/core/camel-endpointdsl/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/camel-management-impl/pom.xml
+++ b/core/camel-management-impl/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/camel-util/pom.xml
+++ b/core/camel-util/pom.xml
@@ -63,8 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/camel-example-cdi-metrics/pom.xml
+++ b/examples/camel-example-cdi-metrics/pom.xml
@@ -100,8 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/camel-example-cdi-properties/pom.xml
+++ b/examples/camel-example-cdi-properties/pom.xml
@@ -106,8 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/examples/camel-example-cdi-rest-servlet/pom.xml
+++ b/examples/camel-example-cdi-rest-servlet/pom.xml
@@ -110,8 +110,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/camel-example-cdi-test/pom.xml
+++ b/examples/camel-example-cdi-test/pom.xml
@@ -89,8 +89,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/examples/camel-example-cdi-xml/pom.xml
+++ b/examples/camel-example-cdi-xml/pom.xml
@@ -93,8 +93,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -252,7 +252,7 @@
         <hadoop2-bundle-version>2.7.2_1</hadoop2-bundle-version>
         <hadoop2-version>2.7.4</hadoop2-version>
         <hadoop2-protobuf-version>2.5.0</hadoop2-protobuf-version>
-        <hamcrest-version>2.0.0.0</hamcrest-version>
+        <hamcrest-version>2.1</hamcrest-version>
         <hapi-version>2.3</hapi-version>
         <hapi-fhir-version>3.7.0</hapi-fhir-version>
         <hawtbuf-version>1.11</hawtbuf-version>
@@ -4843,7 +4843,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>java-hamcrest</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>${hamcrest-version}</version>
             </dependency>
             <dependency>

--- a/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
+++ b/platforms/spring-boot/spring-boot-dm/camel-spring-boot-dependencies/pom.xml
@@ -3812,8 +3812,8 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>java-hamcrest</artifactId>
-        <version>2.0.0.0</version>
+        <artifactId>hamcrest</artifactId>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>org.jruby</groupId>

--- a/tooling/maven/camel-eip-documentation-enricher-maven-plugin/pom.xml
+++ b/tooling/maven/camel-eip-documentation-enricher-maven-plugin/pom.xml
@@ -123,8 +123,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>${hamcrest-version}</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
>Hamcrest is now a single jar: hamcrest-2.1.jar

See: https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1