### PR TITLE
CAMEL-13969: Remove watermark on Classname when generating inner configuration class name

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentOptionModel.java
@@ -152,8 +152,7 @@ public class ComponentOptionModel {
     }
 
     public String getShortJavaType() {
-        // TODO: use watermark in the others
-        return getShortJavaType(40);
+        return StringHelper.getClassShortName(javaType);
     }
 
     public String getShortJavaType(int watermark) {


### PR DESCRIPTION
Per https://issues.apache.org/jira/browse/CAMEL-13969, this shall fix the naming in a long class names. Note I didn't remove `getShortJavaType(int watermark)` as I _think_ is being used in the `mvel` templates