### PR TITLE
CAMEL-13980: Deprecate watermarks in model files and change return unchanged javaType

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/ComponentOptionModel.java
@@ -156,6 +156,7 @@ public class ComponentOptionModel {
         return getShortJavaType(40);
     }
 
+    @Deprecated
     public String getShortJavaType(int watermark) {
 
         String text = StringHelper.getClassShortName(javaType);

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/EipOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/EipOptionModel.java
@@ -149,10 +149,10 @@ public class EipOptionModel {
     }
 
     public String getShortJavaType() {
-        // TODO: use watermark in the others
-        return getShortJavaType(40);
+        return StringHelper.getClassShortName(javaType);
     }
 
+    @Deprecated
     public String getShortJavaType(int watermark) {
 
         String text = StringHelper.getClassShortName(javaType);

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/EndpointOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/EndpointOptionModel.java
@@ -188,10 +188,10 @@ public class EndpointOptionModel {
     }
 
     public String getShortJavaType() {
-        // TODO: use watermark in the others
-        return getShortJavaType(40);
+        return StringHelper.getClassShortName(javaType);
     }
 
+    @Deprecated
     public String getShortJavaType(int watermark) {
 
         String text = StringHelper.getClassShortName(javaType);

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/OtherOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/OtherOptionModel.java
@@ -152,10 +152,10 @@ public class OtherOptionModel {
     }
 
     public String getShortJavaType() {
-        // TODO: use watermark in the others
-        return getShortJavaType(40);
+        return StringHelper.getClassShortName(javaType);
     }
 
+    @Deprecated
     public String getShortJavaType(int watermark) {
 
         String text = StringHelper.getClassShortName(javaType);

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/SpringBootAutoConfigureOptionModel.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/model/SpringBootAutoConfigureOptionModel.java
@@ -60,9 +60,10 @@ public class SpringBootAutoConfigureOptionModel {
     }
 
     public String getShortJavaType() {
-        return getShortJavaType(40);
+        return StringHelper.getClassShortName(javaType);
     }
 
+    @Deprecated
     public String getShortJavaType(int watermark) {
 
         String text = StringHelper.getClassShortName(javaType);

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/component-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/component-options.mvel
@@ -8,6 +8,6 @@ The @{title} component supports @{componentOptions.size()} options, which are li
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : componentOptions}| *@{row.getShortName(25)}* (@{row.shortGroup}) @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType(25)}
+@foreach{row : componentOptions}| *@{row.getShortName(25)}* (@{row.shortGroup}) @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===
 @end{}

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/eip-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/eip-options.mvel
@@ -6,6 +6,6 @@ The @{title} EIP supports @{eipOptions.size()} options which are listed below:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : eipOptions}| *@{row.getShortName(30)}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType(25)}
+@foreach{row : eipOptions}| *@{row.getShortName(30)}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===
 @end{}

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/endpoint-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/endpoint-options.mvel
@@ -14,7 +14,7 @@ The @{title} endpoint has no path parameters.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : endpointPathOptions}| *@{row.getShortName(30)}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType(25)}
+@foreach{row : endpointPathOptions}| *@{row.getShortName(30)}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===
 @end{}
 
@@ -26,6 +26,6 @@ The @{title} endpoint has no query parameters.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : endpointOptions}| *@{row.getShortName(30)}* (@{row.shortGroup}) @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType(25)}
+@foreach{row : endpointOptions}| *@{row.getShortName(30)}* (@{row.shortGroup}) @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===
 @end{}

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/spring-boot-auto-configure-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/spring-boot-auto-configure-options.mvel
@@ -22,6 +22,6 @@ The component supports @{options.size()} options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-@foreach{row : options}| *@{row.name}* | @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType(25)}
+@foreach{row : options}| *@{row.name}* | @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===
 @end{}


### PR DESCRIPTION
This will remove watermarks from the model files as we don't need them anymore and deprecated it the old functions. 