### PR TITLE
CAMEL-13990: Add schema name checks in EndpointAnnotationProcessor

### DIFF
--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
@@ -38,6 +38,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
@@ -94,6 +95,7 @@ public class EndpointAnnotationProcessor extends AbstractCamelAnnotationProcesso
             String extendsScheme = uriEndpoint.extendsScheme();
             String title = uriEndpoint.title();
             final String label = uriEndpoint.label();
+            validateSchemaName(scheme, classElement);
             if (!isNullOrEmpty(scheme)) {
                 // support multiple schemes separated by comma, which maps to the exact same component
                 // for example camel-mail has a bunch of component schema names that does that
@@ -119,6 +121,13 @@ public class EndpointAnnotationProcessor extends AbstractCamelAnnotationProcesso
                             writer -> writeJSonSchemeAndPropertyConfigurer(writer, roundEnv, classElement, uriEndpoint, aliasTitle, alias, extendsAlias, label, schemes));
                 }
             }
+        }
+    }
+
+    private void validateSchemaName(final String schemaName, final TypeElement classElement) {
+        // our schema name has to be in lowercase
+        if (!schemaName.equals(schemaName.toLowerCase())) {
+            processingEnv.getMessager().printMessage(Kind.ERROR, String.format("Schema name '%s' in '%s' must be lowercase!", schemaName, classElement.getQualifiedName()));
         }
     }
 

--- a/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
+++ b/tooling/apt/src/main/java/org/apache/camel/tools/apt/EndpointAnnotationProcessor.java
@@ -127,7 +127,7 @@ public class EndpointAnnotationProcessor extends AbstractCamelAnnotationProcesso
     private void validateSchemaName(final String schemaName, final TypeElement classElement) {
         // our schema name has to be in lowercase
         if (!schemaName.equals(schemaName.toLowerCase())) {
-            processingEnv.getMessager().printMessage(Kind.ERROR, String.format("Schema name '%s' in '%s' must be lowercase!", schemaName, classElement.getQualifiedName()));
+            processingEnv.getMessager().printMessage(Kind.WARNING, String.format("Mixed case schema name in '%s' with value '%s' has been deprecated. Please use lowercase only!", classElement.getQualifiedName(), schemaName));
         }
     }
 


### PR DESCRIPTION
In case if the schema name is not lowercase, the compilation will fail with an error message that indicates where it happened and why: For example:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.496 s
[INFO] Finished at: 2019-09-18T13:36:15+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project camel-debezium: Compilation failure
[ERROR] error: Schema name 'debezZum' in 'org.apache.camel.component.debezium.DebeziumEndpoint' must be lowercase!
[ERROR] 
...
-----------------------------------------------------------------------------------------------
```