### PR TITLE
Allow clients to send custom tags to Zipkin server

### DIFF
--- a/components/camel-zipkin/src/main/docs/zipkin.adoc
+++ b/components/camel-zipkin/src/main/docs/zipkin.adoc
@@ -280,6 +280,22 @@ without doing any service name mappings. However, when you have multiple
 systems across your infrastructure, then you should consider using human-readable service names, that you map to instead of using the camel endpoint
 uris.
 
+[[camel-zipkin-CustomTags]]
+== Custom Tags
+
+If you need to send custom tags to Zipkin server, add an exchange property with name "camel.custom.tags" and value as a Map of your custom tags. Refrain from adding too many custom tags in production environment.
+
+Following is one example of how custom tags can be added:
+
+[source,java]
+----
+Map<String, String> customTags = new HashMap<>();
+customTags.put("key1", "value1");
+customTags.put("key2", "value2");
+exchange.setProperty("camel.custom.tags", customTags);
+----
+
+
 [[camel-zipkin-camel-zipin-starter]]
 == camel-zipin-starter
 

--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinClientRequestAdapter.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinClientRequestAdapter.java
@@ -56,5 +56,15 @@ final class ZipkinClientRequestAdapter {
                 cache.reset();
             }
         }
+        
+        Object clientTagsObj = exchange.getProperty("camel.custom.tags");
+        if (clientTagsObj != null) {
+        	Map<String, String> clientTags = (Map)clientTagsObj;
+	        if (clientTags != null && !clientTags.isEmpty()) {
+	        	for (Map.Entry<String, String> tag: clientTags.entrySet()) {
+	        		span.tag("custom." + tag.getKey(), tag.getValue());
+	        	}
+	        }
+        }
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,7 @@
         <bndlib-version>2.4.0</bndlib-version>
         <bouncycastle-version>1.61</bouncycastle-version>
         <box-java-sdk-version>2.37.0</box-java-sdk-version>
-        <braintree-gateway-version>2.103.0</braintree-gateway-version>
+        <braintree-gateway-version>2.104.0</braintree-gateway-version>
         <brave-zipkin-version>5.6.7</brave-zipkin-version>
         <build-helper-maven-plugin-version>1.12</build-helper-maven-plugin-version>
         <c3p0-version>0.9.5.4</c3p0-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,7 +49,6 @@
         <ant-bundle-version>1.7.0_6</ant-bundle-version>
         <antlr-bundle-version>3.5.2_1</antlr-bundle-version>
         <antlr-runtime-bundle-version>3.5.2_1</antlr-runtime-bundle-version>
-        <any23-bundle-version>2.3_1-SNAPSHOT</any23-bundle-version>
         <apacheds-version>2.0.0-M24</apacheds-version>
         <apache-any23-version>2.3</apache-any23-version>
         <apache-drill-version>1.16.0</apache-drill-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -349,7 +349,7 @@
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
         <jettison-version>1.4.0</jettison-version>
         <jgit-version>5.4.2.201908231537-r</jgit-version>
-        <jgroups-version>4.1.2.Final</jgroups-version>
+        <jgroups-version>4.1.4.Final</jgroups-version>
         <jgroups-raft-version>0.4.2.Final</jgroups-raft-version>
         <jgroups-raft-jgroups-version>4.0.15.Final</jgroups-raft-jgroups-version>
         <jgroups-raft-leveldbjni-version>1.8</jgroups-raft-leveldbjni-version>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -2164,6 +2164,7 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle dependency='true'>mvn:javax.validation/validation-api/${validation-1-api-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/${xstream-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${xpp3-bundle-version}</bundle>


### PR DESCRIPTION
Provide clients with capability to send custom tags to Zipkin server.
Client needs to add a map of tags to exchange property camel.custom.tags and camel-zipkin will automatically add these tags to Zipkin span.