### PR TITLE
Fix examples in aws-s3 component documentation

### DIFF
--- a/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
+++ b/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
@@ -65,7 +65,7 @@ The AWS S3 Storage Service component supports 5 options, which are listed below.
 The AWS S3 Storage Service endpoint is configured using URI syntax:
 
 ----
-aws-s3:bucketNameOrArn
+aws-s3://bucketNameOrArn
 ----
 
 with the following path and query parameters:

--- a/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
+++ b/components/camel-aws-s3/src/main/docs/aws-s3-component.adoc
@@ -27,7 +27,7 @@ For example in order to read file `hello.txt` from bucket `helloBucket`, use the
 
 [source,java]
 --------------------------------------------------------------------------------
-from("aws-s3:helloBucket?accessKey=yourAccessKey&secretKey=yourSecretKey&prefix=hello.txt")
+from("aws-s3://helloBucket?accessKey=yourAccessKey&secretKey=yourSecretKey&prefix=hello.txt")
   .to("file:/var/downloaded");
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes the first example URI in the AWS S3 component documentation, adding two forward-slashes, as is specified in the format for the URI a few lines above. Leaving out the slashes may potentially cause difficult to diagnose Access Denied errors when trying to access the bucket.