### PR TITLE
Docs update - TimerAction should be MetricsTimerAction

### DIFF
--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -439,14 +439,14 @@ component URI.
 |=======================================================================
 |Name |Description |Expected type
 |CamelMetricsTimerAction |Override timer action in URI
-|`org.apache.camel.component.metrics.timer.TimerEndpoint.TimerAction`
+|`org.apache.camel.component.metrics.MetricsTimerAction`
 |=======================================================================
 
 [source,java]
 ----
 // sets timer action using header
 from("direct:in")
-    .setHeader(MetricsConstants.HEADER_TIMER_ACTION, TimerAction.start)
+    .setHeader(MetricsConstants.HEADER_TIMER_ACTION, MetricsTimerAction.start)
     .to("metrics:timer:simple.timer")
     .to("direct:out");
 ----


### PR DESCRIPTION
In https://github.com/apache/camel/commit/4a84f061f74f759e77d45c369a95b704f38c1a92#diff-7dccb1916e4f48ce43acf6ebc21fbbb9 `TimerAction` was replaced by `MetricsTimerAction`.