### PR TITLE
Do use the client configuration instance if it's given

### DIFF
--- a/components/camel-aws-sqs/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
+++ b/components/camel-aws-sqs/src/main/java/org/apache/camel/component/aws/sqs/SqsEndpoint.java
@@ -328,9 +328,9 @@ public class SqsEndpoint extends ScheduledPollEndpoint implements HeaderFilterSt
             }
         } else {
             if (isClientConfigFound) {
-                clientBuilder = AmazonSQSClientBuilder.standard();
-            } else {
                 clientBuilder = AmazonSQSClientBuilder.standard().withClientConfiguration(clientConfiguration);
+            } else {
+                clientBuilder = AmazonSQSClientBuilder.standard();
             }
         }
         if (ObjectHelper.isNotEmpty(configuration.getRegion())) {


### PR DESCRIPTION
Ensures that the client configuration is set on the SQS Client Builder when it's present.