### PR TITLE
Set scope=provided

### DIFF
--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- OpenTracing -->


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.