### PR TITLE
[CAMEL-13121] Route irc->irc cycles the message because of irc.target…

### DIFF
--- a/components/camel-irc/src/main/docs/irc-component.adoc
+++ b/components/camel-irc/src/main/docs/irc-component.adoc
@@ -244,3 +244,15 @@ from("ircs:nick@myserver:1234/#mychannelname?namesOnJoin=true&onReply=true")
 			.filter(header("irc.num").isEqualTo("353"))
 			.to("mock:result").stop();
 -----------------------------------------------------------------------------
+
+== Sending to different channel or a person
+
+If you need to send messages to a different channel (or a person) which is not defined on IRC endpoint, you can specify a different destination in a message header.
+
+You can specify the destination in the following header:
+
+[width="100%",cols="10%,10%,80%",options="header",]
+|=====================================================================
+|Header |Type |Description
+|`irc.sendTo` |`String` |The channel (or the person) name.
+|=====================================================================

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConstants.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConstants.java
@@ -22,6 +22,7 @@ package org.apache.camel.component.irc;
 public final class IrcConstants {
     public static final String IRC_MESSAGE_TYPE = "irc.messageType";
     public static final String IRC_TARGET = "irc.target";
+    public static final String IRC_SEND_TO = "irc.sendTo";
     public static final String IRC_USER_KICKED = "irc.user.kicked";
     public static final String IRC_USER_HOST = "irc.user.host";
     public static final String IRC_USER_NICK = "irc.user.nick";

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcProducer.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -46,7 +46,7 @@ public class IrcProducer extends DefaultProducer {
 
     public void process(Exchange exchange) throws Exception {
         final String msg = exchange.getIn().getBody(String.class);
-        final String targetChannel = exchange.getIn().getHeader(IrcConstants.IRC_TARGET, String.class);
+        final String sendTo = exchange.getIn().getHeader(IrcConstants.IRC_SEND_TO, String.class);
 
         if (!connection.isConnected()) {
             throw new RuntimeCamelException("Lost connection to " + connection.getHost());
@@ -56,9 +56,9 @@ public class IrcProducer extends DefaultProducer {
             if (isMessageACommand(msg)) {
                 LOG.debug("Sending command: {}", msg);
                 connection.send(msg);
-            } else if (targetChannel != null) {
-                LOG.debug("Sending to: {} message: {}", targetChannel, msg);
-                connection.doPrivmsg(targetChannel, msg);
+            } else if (sendTo != null) {
+                LOG.debug("Sending to: {} message: {}", sendTo, msg);
+                connection.doPrivmsg(sendTo, msg);
             } else {
                 for (IrcChannel channel : endpoint.getConfiguration().getChannels()) {
                     LOG.debug("Sending to: {} message: {}", channel, msg);

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcProducerTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcProducerTest.java
@@ -83,7 +83,7 @@ public class IrcProducerTest {
         when(connection.isConnected()).thenReturn(true);
         when(exchange.getIn()).thenReturn(message);
         when(message.getBody(String.class)).thenReturn("PART foo");
-        when(message.getHeader(IrcConstants.IRC_TARGET, String.class)).thenReturn("bottest");
+        when(message.getHeader(IrcConstants.IRC_SEND_TO, String.class)).thenReturn("bottest");
 
         producer.process(exchange);
         verify(connection).send("PART foo");
@@ -93,7 +93,7 @@ public class IrcProducerTest {
         producer.process(exchange);
         verify(connection).doPrivmsg("bottest", "foo");
 
-        when(message.getHeader(IrcConstants.IRC_TARGET, String.class)).thenReturn(null);
+        when(message.getHeader(IrcConstants.IRC_SEND_TO, String.class)).thenReturn(null);
 
         producer.process(exchange);
         verify(connection).doPrivmsg("#chan1", "foo");

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/it/IrcMultiChannelRouteTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/it/IrcMultiChannelRouteTest.java
@@ -75,8 +75,8 @@ public class IrcMultiChannelRouteTest extends IrcIntegrationTestSupport {
      * Lets send messages once the consumer has joined
      */
     protected void sendMessages() {
-        template.sendBodyAndHeader(sendUri(), body1, "irc.target", properties.get("channel1"));
-        template.sendBodyAndHeader(sendUri(), body2, "irc.target", properties.get("channel2"));
+        template.sendBodyAndHeader(sendUri(), body1, "irc.sendTo", properties.get("channel1"));
+        template.sendBodyAndHeader(sendUri(), body2, "irc.sendTo", properties.get("channel2"));
         template.sendBody(sendUri(), body3);
     }
 


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-13121

master PR: https://github.com/apache/camel/pull/3200

Added header "irc.sendTo", which makes "irc.target" read only and removes some unclear behavior as issue describes.

Test are fixed to work with this change (and also to cover it)