### PR TITLE
CAMEL-13849 camel-atmos - Upgrade to Atmos client 3.x

### DIFF
--- a/components/camel-atmos/pom.xml
+++ b/components/camel-atmos/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- atmos -->
         <dependency>
-            <groupId>com.emc.vipr</groupId>
+            <groupId>com.emc.ecs</groupId>
             <artifactId>atmos-client</artifactId>
             <version>${atmos-client-version}</version>
             <exclusions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@
         <asterisk-java-version>1.0.0-final</asterisk-java-version>
         <asterisk-java-bundle-version>1.0.0-final_1</asterisk-java-bundle-version>
         <atlassian-fugue-version>3.0.0</atlassian-fugue-version>
-        <atmos-client-version>2.2.2</atmos-client-version>
+        <atmos-client-version>3.1.0</atmos-client-version>
         <atmosphere-version>2.5.4</atmosphere-version>
         <atmosphere-version-range>[2.5,3.0)</atmosphere-version-range>
         <atomix-version>1.0.8</atomix-version>


### PR DESCRIPTION
Hi.

I have updated the maven group id and version of the atmos-client dependency (com.emc.vipr: 2.2.2  ---> com.emc.ecs: 3.1.2). I did not find deprecated APIs that need to be changed and all the tests are passing, so I did not make additional changes the rest of the code.

I noticed that the older maven dependency used the Apache 2.0 license and the new one uses BSD 3-clause. Nevertheless, to the best of my knowledge, this license is compliant with the ASF standards.

Could you please give it a look.