### PR TITLE
[CAMEL-14023] Camel-salesforce-maven-plugin generate fails on IBM jdk

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -32,6 +32,7 @@ import org.apache.camel.SSLContextParametersAware;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.dto.AbstractSObjectBase;
+import org.apache.camel.component.salesforce.api.utils.SecurityUtils;
 import org.apache.camel.component.salesforce.internal.OperationName;
 import org.apache.camel.component.salesforce.internal.PayloadFormat;
 import org.apache.camel.component.salesforce.internal.SalesforceSession;
@@ -704,6 +705,8 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
     }
 
     static SalesforceHttpClient createHttpClient(final SslContextFactory sslContextFactory) throws Exception {
+        SecurityUtils.adaptToIBMCipherNames(sslContextFactory);
+
         final SalesforceHttpClient httpClient = new SalesforceHttpClient(sslContextFactory);
         // default settings, use httpClientProperties to set other
         // properties

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/utils/SecurityUtils.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/utils/SecurityUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.component.salesforce.api.utils;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import java.util.Arrays;
+
+public class SecurityUtils {
+
+    public static void adaptToIBMCipherNames(final SslContextFactory sslContextFactory) {
+        //jetty client adds into excluded cipher suites all ciphers starting with SSL_
+        //it makes sense for Oracle jdk, but in IBM jdk all ciphers starts with SSL_, even ciphers for TLS
+        //see https://github.com/eclipse/jetty.project/issues/2921
+        if (System.getProperty("java.vendor").contains("IBM")) {
+            String[] excludedCiphersWithoutSSLExclusion = Arrays.stream(sslContextFactory.getExcludeCipherSuites())
+                    .filter(cipher -> !cipher.equals("^SSL_.*$"))
+                    .toArray(String[]::new);
+            sslContextFactory.setExcludeCipherSuites(excludedCiphersWithoutSSLExclusion);
+        }
+    }
+}

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSalesforceMojo.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
 import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.SalesforceException;
+import org.apache.camel.component.salesforce.api.utils.SecurityUtils;
 import org.apache.camel.component.salesforce.internal.PayloadFormat;
 import org.apache.camel.component.salesforce.internal.SalesforceSession;
 import org.apache.camel.component.salesforce.internal.client.DefaultRestClient;
@@ -229,6 +230,8 @@ abstract class AbstractSalesforceMojo extends AbstractMojo {
         try {
             final SslContextFactory sslContextFactory = new SslContextFactory();
             sslContextFactory.setSslContext(sslContextParameters.createSSLContext(camelContext));
+
+            SecurityUtils.adaptToIBMCipherNames(sslContextFactory);
 
             httpClient = new SalesforceHttpClient(sslContextFactory);
         } catch (final GeneralSecurityException e) {


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14023

Jetty client (for security reasons) disables all ciphers, which starts with "SSL_".
In IBM java it removes all ciphers, because every cipher starts with SSL, even ciphers for TLS 1.2
(see issue reported on jetty https://github.com/eclipse/jetty.project/issues/2921).
This fix changes excluded ciphers, for IBM jdk only, to contain also SSL_* ones.