### PR TITLE
CAMEL-14025: add muteException option on camel-undertow component

### DIFF
--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -89,6 +89,7 @@ with the following path and query parameters:
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *httpMethodRestrict* (consumer) | Used to only allow consuming if the HttpMethod matches, such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
 | *matchOnUriPrefix* (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | Boolean
+| *muteException* (consumer) | If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace. | false | Boolean
 | *optionsEnabled* (consumer) | Specifies whether to enable HTTP OPTIONS for this Servlet consumer. By default OPTIONS is turned off. | false | boolean
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
@@ -96,7 +97,6 @@ with the following path and query parameters:
 | *cookieHandler* (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler
 | *keepAlive* (producer) | Setting to ensure socket is not closed due to inactivity | true | Boolean
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
-| *muteException* (producer) | If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace. | false | Boolean
 | *options* (producer) | Sets additional channel options. The options that can be used are defined in org.xnio.Options. To configure from endpoint uri, then prefix each option with option., such as option.close-abort=true&option.send-buffer=8192 |  | Map
 | *reuseAddresses* (producer) | Setting to facilitate socket multiplexing | true | Boolean
 | *tcpNoDelay* (producer) | Setting to improve TCP protocol performance | true | Boolean

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -78,7 +78,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (26 parameters):
+=== Query Parameters (27 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -96,6 +96,7 @@ with the following path and query parameters:
 | *cookieHandler* (producer) | Configure a cookie handler to maintain a HTTP session |  | CookieHandler
 | *keepAlive* (producer) | Setting to ensure socket is not closed due to inactivity | true | Boolean
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
+| *muteException* (producer) | If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace. | false | Boolean
 | *options* (producer) | Sets additional channel options. The options that can be used are defined in org.xnio.Options. To configure from endpoint uri, then prefix each option with option., such as option.close-abort=true&option.send-buffer=8192 |  | Map
 | *reuseAddresses* (producer) | Setting to facilitate socket multiplexing | true | Boolean
 | *tcpNoDelay* (producer) | Setting to improve TCP protocol performance | true | Boolean

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHttpBinding.java
@@ -348,7 +348,7 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
         Object body = message.getBody();
         Exception exception = message.getExchange().getException();
 
-        if (exception != null && isMuteException()) {
+        if (exception != null && !isMuteException()) {
             if (isTransferException()) {
                 // we failed due an exception, and transfer it as java serialized object
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -374,6 +374,11 @@ public class DefaultUndertowHttpBinding implements UndertowHttpBinding {
             }
 
             // and mark the exception as failure handled, as we handled it by returning it as the response
+            ExchangeHelper.setFailureHandled(message.getExchange());
+        }
+        else if (exception != null && isMuteException()) {
+        	
+        	// mark the exception as failure handled, as we handled it by actively muting it
             ExchangeHelper.setFailureHandled(message.getExchange());
         }
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowConsumer.java
@@ -182,9 +182,10 @@ public class UndertowConsumer extends DefaultConsumer implements HttpHandler {
         Object body = getResponseBody(httpExchange, camelExchange);
 
         if (body == null) {
+            String message = httpExchange.getStatusCode() == 500 ? "Exception" : "No response available";
             log.trace("No payload to send as reply for exchange: {}", camelExchange);
             httpExchange.getResponseHeaders().put(ExchangeHeaders.CONTENT_TYPE, MimeMappings.DEFAULT_MIME_MAPPINGS.get("txt"));
-            httpExchange.getResponseSender().send("No response available");
+            httpExchange.getResponseSender().send(message);
             return;
         }
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -87,6 +87,8 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private Boolean throwExceptionOnFailure = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "false")
     private Boolean transferException = Boolean.FALSE;
+    @UriParam(label = "producer", defaultValue = "false")
+    private Boolean muteException = Boolean.FALSE;
     @UriParam(label = "producer", defaultValue = "true")
     private Boolean keepAlive = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "true")
@@ -256,12 +258,25 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
         this.transferException = transferException;
     }
 
+    public Boolean getMuteException() {
+        return muteException;
+    }
+
+    /**
+     * If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.
+     *
+     */
+    public void setMuteException(Boolean muteException) {
+        this.muteException = muteException;
+    }
+
     public UndertowHttpBinding getUndertowHttpBinding() {
         if (undertowHttpBinding == null) {
             // create a new binding and use the options from this endpoint
             undertowHttpBinding = new DefaultUndertowHttpBinding(useStreaming);
             undertowHttpBinding.setHeaderFilterStrategy(getHeaderFilterStrategy());
             undertowHttpBinding.setTransferException(getTransferException());
+            undertowHttpBinding.setMuteException(getMuteException());
         }
         return undertowHttpBinding;
     }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -16,15 +16,12 @@
  */
 package org.apache.camel.component.undertow;
 
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.accesslog.AccessLogReceiver;
 import java.net.URI;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
-
-import io.undertow.server.HttpServerExchange;
-import io.undertow.server.handlers.accesslog.AccessLogReceiver;
-
 import org.apache.camel.AsyncEndpoint;
 import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
@@ -87,7 +84,7 @@ public class UndertowEndpoint extends DefaultEndpoint implements AsyncEndpoint, 
     private Boolean throwExceptionOnFailure = Boolean.TRUE;
     @UriParam(label = "producer", defaultValue = "false")
     private Boolean transferException = Boolean.FALSE;
-    @UriParam(label = "producer", defaultValue = "false")
+    @UriParam(label = "consumer", defaultValue = "false")
     private Boolean muteException = Boolean.FALSE;
     @UriParam(label = "producer", defaultValue = "true")
     private Boolean keepAlive = Boolean.TRUE;

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHttpBinding.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHttpBinding.java
@@ -48,4 +48,6 @@ public interface UndertowHttpBinding {
     
     void setTransferException(Boolean transferException);
 
+    void setMuteException(Boolean MuteException);
+
 }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMuteExceptionTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMuteExceptionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class UndertowMuteExceptionTest extends BaseUndertowTest {
+
+    @Test
+    public void muteExceptionTest() throws IOException, ClassNotFoundException {
+        HttpClient client = new HttpClient();
+        GetMethod get = new GetMethod("http://localhost:" + getPort() + "/test/mute");
+        get.setRequestHeader("Accept", "application/text");
+        client.executeMethod(get);
+
+        String body = get.getResponseBodyAsString();
+        Assert.assertNotNull(body);
+        Assert.assertEquals("Exception", body);
+        Assert.assertEquals(500, get.getStatusCode());
+    }
+
+
+    @Test
+    public void muteExceptionWithTransferExceptionTest() throws IOException, ClassNotFoundException {
+        HttpClient client = new HttpClient();
+        GetMethod get = new GetMethod("http://localhost:" + getPort() + "/test/muteWithTransfer");
+        get.setRequestHeader("Accept", "application/text");
+        client.executeMethod(get);
+
+        String body = get.getResponseBodyAsString();
+        Assert.assertNotNull(body);
+        Assert.assertEquals("Exception", body);
+        Assert.assertEquals(500, get.getStatusCode());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            public void configure() {
+
+                from("undertow:http://localhost:" + getPort() + "/test/mute?muteException=true").to("mock:input")
+                    .throwException(new IllegalArgumentException("Camel cannot do this"));
+
+                from("undertow:http://localhost:" + getPort() + "/test/muteWithTransfer?transferException=true&muteException=true").to("mock:input")
+                        .throwException(new IllegalArgumentException("Camel cannot do this"));
+            }
+        };
+    }
+
+}

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/UndertowEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/UndertowEndpointBuilderFactory.java
@@ -641,6 +641,33 @@ public interface UndertowEndpointBuilderFactory {
             return this;
         }
         /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option is a: <code>java.lang.Boolean</code> type.
+         * 
+         * Group: producer
+         */
+        default UndertowEndpointProducerBuilder muteException(
+                Boolean muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option will be converted to a <code>java.lang.Boolean</code>
+         * type.
+         * 
+         * Group: producer
+         */
+        default UndertowEndpointProducerBuilder muteException(
+                String muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
          * Sets additional channel options. The options that can be used are
          * defined in org.xnio.Options. To configure from endpoint uri, then
          * prefix each option with option., such as

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/UndertowEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/UndertowEndpointBuilderFactory.java
@@ -181,6 +181,33 @@ public interface UndertowEndpointBuilderFactory {
             return this;
         }
         /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option is a: <code>java.lang.Boolean</code> type.
+         * 
+         * Group: consumer
+         */
+        default UndertowEndpointConsumerBuilder muteException(
+                Boolean muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option will be converted to a <code>java.lang.Boolean</code>
+         * type.
+         * 
+         * Group: consumer
+         */
+        default UndertowEndpointConsumerBuilder muteException(
+                String muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
          * Specifies whether to enable HTTP OPTIONS for this Servlet consumer.
          * By default OPTIONS is turned off.
          * 
@@ -638,33 +665,6 @@ public interface UndertowEndpointBuilderFactory {
         default UndertowEndpointProducerBuilder lazyStartProducer(
                 String lazyStartProducer) {
             doSetProperty("lazyStartProducer", lazyStartProducer);
-            return this;
-        }
-        /**
-         * If enabled and an Exchange failed processing on the consumer side the
-         * response's body won't contain the exception's stack trace.
-         * 
-         * The option is a: <code>java.lang.Boolean</code> type.
-         * 
-         * Group: producer
-         */
-        default UndertowEndpointProducerBuilder muteException(
-                Boolean muteException) {
-            doSetProperty("muteException", muteException);
-            return this;
-        }
-        /**
-         * If enabled and an Exchange failed processing on the consumer side the
-         * response's body won't contain the exception's stack trace.
-         * 
-         * The option will be converted to a <code>java.lang.Boolean</code>
-         * type.
-         * 
-         * Group: producer
-         */
-        default UndertowEndpointProducerBuilder muteException(
-                String muteException) {
-            doSetProperty("muteException", muteException);
             return this;
         }
         /**


### PR DESCRIPTION
This pull request adds the "muteException" option to the Camel Undertow component.

If enabled and an Exchange fails processing on the consumer side the response's body won't contain the exception's stack trace. Instead it will simply return the body "Exception".

I hope that this implements the idea described in https://issues.apache.org/jira/browse/CAMEL-14023.