### PR TITLE
CAMEL-14047: Allow unset producerName to get unique name from Pulsar

### DIFF
--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -98,7 +98,7 @@ with the following path and query parameters:
 | *maxPendingMessagesAcross Partitions* (producer) | Set the number of max pending messages across all the partitions. Default is 50000. | 50000 | int
 | *messageRouter* (producer) | Set a custom Message Router. |  | MessageRouter
 | *messageRoutingMode* (producer) | Set the message routing mode for the producer. | RoundRobinPartition | MessageRoutingMode
-| *producerName* (producer) | Name of the producer, if unset lets Pulsar select a unique identifier | | String
+| *producerName* (producer) | Name of the producer. If unset, lets Pulsar select a unique identifier. |  | String
 | *sendTimeoutMs* (producer) | Send timeout in milliseconds. Defaults to 30,000ms (30 seconds) | 30000 | int
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean

--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -98,7 +98,7 @@ with the following path and query parameters:
 | *maxPendingMessagesAcross Partitions* (producer) | Set the number of max pending messages across all the partitions. Default is 50000. | 50000 | int
 | *messageRouter* (producer) | Set a custom Message Router. |  | MessageRouter
 | *messageRoutingMode* (producer) | Set the message routing mode for the producer. | RoundRobinPartition | MessageRoutingMode
-| *producerName* (producer) | Name of the producer | default-producer | String
+| *producerName* (producer) | Name of the producer, if unset lets Pulsar select a unique identifier | | String
 | *sendTimeoutMs* (producer) | Send timeout in milliseconds. Defaults to 30,000ms (30 seconds) | 30000 | int
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarProducer.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarProducer.java
@@ -57,10 +57,7 @@ public class PulsarProducer extends DefaultProducer {
             final String topicUri = pulsarEndpoint.getUri();
             PulsarConfiguration configuration = pulsarEndpoint.getPulsarConfiguration();
             String producerName = configuration.getProducerName();
-            if (producerName == null) {
-                producerName = topicUri + "-" + Thread.currentThread().getId();
-            }
-            final ProducerBuilder<byte[]> producerBuilder = pulsarEndpoint.getPulsarClient().newProducer().producerName(producerName).topic(topicUri)
+            final ProducerBuilder<byte[]> producerBuilder = pulsarEndpoint.getPulsarClient().newProducer().topic(topicUri)
                 .sendTimeout(configuration.getSendTimeoutMs(), TimeUnit.MILLISECONDS).blockIfQueueFull(configuration.isBlockIfQueueFull())
                 .maxPendingMessages(configuration.getMaxPendingMessages()).maxPendingMessagesAcrossPartitions(configuration.getMaxPendingMessagesAcrossPartitions())
                 .batchingMaxPublishDelay(configuration.getBatchingMaxPublishDelayMicros(), TimeUnit.MICROSECONDS).batchingMaxMessages(configuration.getMaxPendingMessages())
@@ -69,6 +66,9 @@ public class PulsarProducer extends DefaultProducer {
                 producerBuilder.messageRouter(configuration.getMessageRouter());
             } else {
                 producerBuilder.messageRoutingMode(configuration.getMessageRoutingMode());
+            }
+            if (producerName != null) {
+                producerBuilder.producerName(producerName);
             }
             producer = producerBuilder.create();
         }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
@@ -136,7 +136,7 @@ public class PulsarConfiguration {
     }
 
     /**
-     * Name of the producer
+     * Name of the producer. If unset, lets Pulsar select a unique identifier.
      */
     public void setProducerName(String producerName) {
         this.producerName = producerName;

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
@@ -41,8 +41,8 @@ public class PulsarConfiguration {
     private int consumerQueueSize = 10;
     @UriParam(label = "consumer", defaultValue = "sole-consumer")
     private String consumerName = "sole-consumer";
-    @UriParam(label = "producer", defaultValue = "default-producer")
-    private String producerName = "default-producer";
+    @UriParam(label = "producer")
+    private String producerName = null;
     @UriParam(label = "consumer", defaultValue = "cons")
     private String consumerNamePrefix = "cons";
     @UriParam(label = "consumer", defaultValue = "false")

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
@@ -42,7 +42,7 @@ public class PulsarConfiguration {
     @UriParam(label = "consumer", defaultValue = "sole-consumer")
     private String consumerName = "sole-consumer";
     @UriParam(label = "producer")
-    private String producerName = null;
+    private String producerName;
     @UriParam(label = "consumer", defaultValue = "cons")
     private String consumerNamePrefix = "cons";
     @UriParam(label = "consumer", defaultValue = "false")

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarComponentTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarComponentTest.java
@@ -60,7 +60,7 @@ public class PulsarComponentTest extends CamelTestSupport {
         assertEquals("cons", endpoint.getPulsarConfiguration().getConsumerNamePrefix());
         assertEquals(10, endpoint.getPulsarConfiguration().getConsumerQueueSize());
         assertEquals(1, endpoint.getPulsarConfiguration().getNumberOfConsumers());
-        assertEquals("default-producer", endpoint.getPulsarConfiguration().getProducerName());
+        assertNull(endpoint.getPulsarConfiguration().getProducerName());
         assertEquals("subs", endpoint.getPulsarConfiguration().getSubscriptionName());
         assertEquals(SubscriptionType.EXCLUSIVE, endpoint.getPulsarConfiguration().getSubscriptionType());
         assertFalse(endpoint.getPulsarConfiguration().isAllowManualAcknowledgement());

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarProducerUndefinedProducerNameInTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarProducerUndefinedProducerNameInTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.pulsar.utils.AutoConfiguration;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.support.SimpleRegistry;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.junit.Test;
+
+public class PulsarProducerUndefinedProducerNameInTest extends PulsarTestSupport {
+
+    private static final String TOPIC_URI = "persistent://public/default/camel-producer-topic";
+
+    @Produce("direct:start1")
+    private ProducerTemplate producerTemplate1;
+
+    @Produce("direct:start2")
+    private ProducerTemplate producerTemplate2;
+
+    @EndpointInject("pulsar:" + TOPIC_URI
+            + "?numberOfConsumers=1"
+            + "&subscriptionType=Exclusive"
+            + "&subscriptionName=camel-subscription"
+            + "&consumerQueueSize=1"
+            + "&consumerName=camel-consumer"
+    )
+    private Endpoint pulsarEndpoint1;
+
+    @EndpointInject("pulsar:" + TOPIC_URI)
+    private Endpoint pulsarEndpoint2;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint to;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                from("direct:start1").to(pulsarEndpoint1);
+                from("direct:start2").to(pulsarEndpoint2);
+
+                from(pulsarEndpoint1).to(to);
+            }
+        };
+    }
+
+    @Override
+    protected Registry createCamelRegistry() throws Exception {
+        Registry registry = new SimpleRegistry();
+
+        registerPulsarBeans(registry);
+
+        return registry;
+    }
+
+    private void registerPulsarBeans(Registry registry) throws PulsarClientException {
+        PulsarClient pulsarClient = givenPulsarClient();
+        AutoConfiguration autoConfiguration = new AutoConfiguration(null, null);
+
+        registry.bind("pulsarClient", pulsarClient);
+        PulsarComponent comp = new PulsarComponent(context);
+        comp.setAutoConfiguration(autoConfiguration);
+        comp.setPulsarClient(pulsarClient);
+        registry.bind("pulsar", comp);
+    }
+
+    private PulsarClient givenPulsarClient() throws PulsarClientException {
+        return new ClientBuilderImpl()
+                .serviceUrl(getPulsarBrokerUrl())
+                .ioThreads(1)
+                .listenerThreads(1)
+                .build();
+    }
+
+    @Test
+    public void testAMessageToRouteIsSentFromBothProducersAndThenConsumed() throws Exception {
+        to.expectedMessageCount(2);
+
+        producerTemplate1.sendBody("Test First");
+        producerTemplate2.sendBody("Test Second");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+}

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/PulsarEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/PulsarEndpointBuilderFactory.java
@@ -717,7 +717,8 @@ public interface PulsarEndpointBuilderFactory {
             return this;
         }
         /**
-         * Name of the producer.
+         * Name of the producer. If unset, lets Pulsar select a unique
+         * identifier.
          * 
          * The option is a: <code>java.lang.String</code> type.
          * 


### PR DESCRIPTION
Addresses [CAMEL-14047](https://issues.apache.org/jira/browse/CAMEL-14047)

### Motivation
Current default producerName value causes a `null` `producerName` to be impossible when configuring from URI. This causes the code [regarding a null producerName in the PulsarProducer](https://github.com/apache/camel/blob/10de4bab2e76046b9535128bf38bf67b80c3f3f4/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarProducer.java#L60-L62) to be impossible to get to from a URI. This forces anyone wanting to start 2 producers on the same topic in Camel to generate unique IDs and append them to each `producerName` value.

### Modifications
The fix proposed in this PR is defaulting `producerName` to null and, instead of generating a `producerName` on a null within Camel, to use Pulsar `ProducerBuilder`'s automatic generation of a globally unique `producerName` value as described in the [ProducerBuilder documentation](https://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ProducerBuilder.html#producerName-java.lang.String-).

### Testing
`PulsarProducerUndefinedProducerNameInTest`: Used to verify that two producers can bind and send messages when not defining a `producerName` value in the URI.

### Documentation
Modified `pulsar-component.adoc` with updated information.