### PR TITLE
CAMEL-14032: Make EndpointHelper.matchEndpoint try to URI normalize t…

### DIFF
--- a/core/camel-support/pom.xml
+++ b/core/camel-support/pom.xml
@@ -69,7 +69,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.util.StringHelper.after;
 
-import java.util.function.Function;
-
 /**
  * Some helper methods for working with {@link Endpoint} instances
  */

--- a/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.util.StringHelper.after;
 
+import java.util.function.Function;
+
 /**
  * Some helper methods for working with {@link Endpoint} instances
  */
@@ -101,6 +103,7 @@ public final class EndpointHelper {
      * <li>exact match, returns true</li>
      * <li>wildcard match (pattern ends with a * and the uri starts with the pattern), returns true</li>
      * <li>regular expression match, returns true</li>
+     * <li>exact match with uri normalization of the pattern if possible, returns true</li>
      * <li>otherwise returns false</li>
      * </ul>
      *
@@ -126,24 +129,40 @@ public final class EndpointHelper {
         }
 
         // we need to test with and without scheme separators (//)
-        if (uri.contains("://")) {
-            // try without :// also
-            String scheme = StringHelper.before(uri, "://");
-            String path = after(uri, "://");
-            if (PatternHelper.matchPattern(scheme + ":" + path, pattern)) {
-                return true;
-            }
-        } else {
-            // try with :// also
-            String scheme = StringHelper.before(uri, ":");
-            String path = after(uri, ":");
-            if (PatternHelper.matchPattern(scheme + "://" + path, pattern)) {
-                return true;
+        boolean match = PatternHelper.matchPattern(toggleUriSchemeSeparators(uri), pattern);
+        match |= PatternHelper.matchPattern(uri, pattern);
+        if (!match && pattern != null && pattern.contains("?")) {
+            // try normalizing the pattern as a uri for exact matching, so parameters are ordered the same as in the endpoint uri
+            try {
+                pattern = URISupport.normalizeUri(pattern);
+                // try both with and without scheme separators (//)
+                match = toggleUriSchemeSeparators(uri).equalsIgnoreCase(pattern);
+                return match || uri.equalsIgnoreCase(pattern);
+            } catch (URISyntaxException e) {
+                //Can't normalize and original match failed
+                return false;
+            } catch (Exception e) {
+                throw new ResolveEndpointFailedException(uri, e);
             }
         }
+        return match;
+    }
 
-        // and fallback to test with the uri as is
-        return PatternHelper.matchPattern(uri, pattern);
+    /**
+     * Toggles // separators in the given uri. If the uri does not contain ://, the slashes are added, otherwise they are removed.
+     * @param normalizedUri The uri to add/remove separators in
+     * @return The uri with separators added or removed
+     */
+    private static String toggleUriSchemeSeparators(String normalizedUri) {
+        if (normalizedUri.contains("://")) {
+            String scheme = StringHelper.before(normalizedUri, "://");
+            String path = after(normalizedUri, "://");
+            return scheme + ":" + path;
+        } else {
+            String scheme = StringHelper.before(normalizedUri, ":");
+            String path = after(normalizedUri, ":");
+            return scheme + "://" + path;
+        }
     }
 
     /**

--- a/core/camel-support/src/test/java/org/apache/camel/support/EndpointHelperTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/EndpointHelperTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class EndpointHelperTest {
+
+    @Test
+    public void matchEndpointsShouldIgnoreQueryParamOrder() {
+        String endpointUri = "sjms:queue:my-queue?transacted=true&consumerCount=1";
+        String endpointUriShuffled = "sjms:queue:my-queue?consumerCount=1&transacted=true";
+        String notMatchingEndpointUri = "sjms:queue:my-queue?consumerCount=1";
+
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUri, endpointUri), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUri, endpointUriShuffled), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUriShuffled, endpointUri), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUriShuffled, endpointUriShuffled), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, notMatchingEndpointUri, endpointUriShuffled), is(false));
+        assertThat(EndpointHelper.matchEndpoint(null, notMatchingEndpointUri, endpointUri), is(false));
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUri, notMatchingEndpointUri), is(false));
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUriShuffled, notMatchingEndpointUri), is(false));
+    }
+
+    @Test
+    public void matchEndpointsShouldMatchWildcards() {
+        String endpointUri = "sjms:queue:my-queue?transacted=true&consumerCount=1";
+        String notMatchingEndpointUri = "sjms:queue:my-queue";
+        String pattern = "sjms:queue:my-queue?*";
+
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUri, pattern), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, notMatchingEndpointUri, pattern), is(false));
+    }
+
+    @Test
+    public void matchEndpointsShouldMatchRegex() {
+        String endpointUri = "sjms:queue:my-queue?transacted=true&consumerCount=1";
+        String notMatchingEndpointUri = "sjms:queue:my-queue?transacted=false&consumerCount=1";
+        String pattern = "sjms://.*transacted=true.*";
+
+        assertThat(EndpointHelper.matchEndpoint(null, endpointUri, pattern), is(true));
+        assertThat(EndpointHelper.matchEndpoint(null, notMatchingEndpointUri, pattern), is(false));
+    }
+
+}

--- a/core/camel-support/src/test/java/org/apache/camel/support/EndpointHelperTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/EndpointHelperTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.support;
 
+import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
 
 public class EndpointHelperTest {
 


### PR DESCRIPTION
…he pattern to match, if there is not otherwise a match

See https://issues.apache.org/jira/browse/CAMEL-14032

We only try normalizing the pattern if the string contains '?', since otherwise there are no query parameters to reorder.

The attempt at normalization of the pattern parameter should only happen if matching would otherwise fail, since I think it is risky to try normalizing the pattern before we know if it might contain e.g. a valid regex. This is also why the normalized pattern is only checked for exact match, and not any kind of pattern matching.