### PR TITLE
CAMEL-14025: add muteException option to camel-servlet component

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
@@ -79,6 +79,7 @@ public class DefaultHttpBinding implements HttpBinding {
     private boolean useReaderForPayload;
     private boolean eagerCheckContentAvailable;
     private boolean transferException;
+    private boolean muteException;
     private boolean allowJavaSerializedObject;
     private boolean mapHttpMessageBody = true;
     private boolean mapHttpMessageHeaders = true;
@@ -98,6 +99,7 @@ public class DefaultHttpBinding implements HttpBinding {
     public DefaultHttpBinding(HttpCommonEndpoint endpoint) {
         this.headerFilterStrategy = endpoint.getHeaderFilterStrategy();
         this.transferException = endpoint.isTransferException();
+        this.muteException = endpoint.isMuteException();
         if (endpoint.getComponent() != null) {
             this.allowJavaSerializedObject = endpoint.getComponent().isAllowJavaSerializedObject();
         }
@@ -362,6 +364,10 @@ public class DefaultHttpBinding implements HttpBinding {
             response.setStatus(HttpServletResponse.SC_GATEWAY_TIMEOUT);
             response.setContentType("text/plain");
             response.getWriter().write("Timeout error");
+        } else if (isMuteException()) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType("text/plain");
+            response.getWriter().write("Exception");
         } else {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
@@ -633,6 +639,16 @@ public class DefaultHttpBinding implements HttpBinding {
     @Override
     public void setTransferException(boolean transferException) {
         this.transferException = transferException;
+    }
+
+    @Override
+    public boolean isMuteException() {
+        return muteException;
+    }
+
+    @Override
+    public void setMuteException(boolean muteException) {
+        this.muteException = muteException;
     }
 
     @Override

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpBinding.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpBinding.java
@@ -125,6 +125,11 @@ public interface HttpBinding {
     boolean isTransferException();
 
     /**
+     * If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.
+     */
+    boolean isMuteException();
+
+    /**
      * Whether to allow java serialization when a request uses context-type=application/x-java-serialized-object
      * <p/>
      * This is by default turned off. If you enable this then be aware that Java will deserialize the incoming
@@ -169,6 +174,11 @@ public interface HttpBinding {
      * data from the request to Java and that can be a potential security risk.
      */
     void setTransferException(boolean transferException);
+
+    /**
+     * If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.
+     */
+    void setMuteException(boolean muteException);
 
     /**
      * Whether to allow java serialization when a request uses context-type=application/x-java-serialized-object

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpCommonEndpoint.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpCommonEndpoint.java
@@ -81,6 +81,9 @@ public abstract class HttpCommonEndpoint extends DefaultEndpoint implements Head
             + " This is by default turned off. If you enable this then be aware that Java will deserialize the incoming"
             + " data from the request to Java and that can be a potential security risk.")
     boolean transferException;
+    @UriParam(label="consumer",
+            description = "If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.")
+    boolean muteException;
     @UriParam(label = "producer", defaultValue = "false", description = "Specifies whether a Connection Close header must be added to HTTP Request. By default connectionClose is false.")
     boolean connectionClose;
     @UriParam(label = "consumer,advanced",
@@ -230,6 +233,7 @@ public abstract class HttpCommonEndpoint extends DefaultEndpoint implements Head
             httpBinding = new DefaultHttpBinding();
             httpBinding.setHeaderFilterStrategy(getHeaderFilterStrategy());
             httpBinding.setTransferException(isTransferException());
+            httpBinding.setMuteException(isMuteException());
             if (getComponent() != null) {
                 httpBinding.setAllowJavaSerializedObject(getComponent().isAllowJavaSerializedObject());
             }
@@ -377,6 +381,10 @@ public abstract class HttpCommonEndpoint extends DefaultEndpoint implements Head
     public boolean isTransferException() {
         return transferException;
     }
+
+    public boolean isMuteException() {
+        return muteException;
+    }
     
     public boolean isConnectionClose() {
         return connectionClose;
@@ -401,6 +409,11 @@ public abstract class HttpCommonEndpoint extends DefaultEndpoint implements Head
     public void setTransferException(boolean transferException) {
         this.transferException = transferException;
     }
+
+    /**
+     * If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.
+     */
+    public void setMuteException(boolean muteException) { this.muteException = muteException; }
 
     public boolean isTraceEnabled() {
         return this.traceEnabled;

--- a/components/camel-servlet/src/main/docs/servlet-component.adoc
+++ b/components/camel-servlet/src/main/docs/servlet-component.adoc
@@ -85,7 +85,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (23 parameters):
+=== Query Parameters (24 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -99,6 +99,7 @@ with the following path and query parameters:
 | *chunked* (consumer) | If this option is false the Servlet will disable the HTTP streaming and set the content-length header on the response | true | boolean
 | *httpMethodRestrict* (consumer) | Used to only allow consuming if the HttpMethod matches, such as GET/POST/PUT etc. Multiple methods can be specified separated by comma. |  | String
 | *matchOnUriPrefix* (consumer) | Whether or not the consumer should try to find a target consumer by matching the URI prefix if no exact match is found. | false | boolean
+| *muteException* (consumer) | If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace. | false | boolean
 | *responseBufferSize* (consumer) | To use a custom buffer size on the javax.servlet.ServletResponse. |  | Integer
 | *servletName* (consumer) | Name of the servlet to use | CamelServlet | String
 | *transferException* (consumer) | If enabled and an Exchange failed processing on the consumer side, and if the caused Exception was send back serialized in the response as a application/x-java-serialized-object content type. On the producer side the exception will be deserialized and thrown as is, instead of the HttpOperationFailedException. The caused exception is required to be serialized. This is by default turned off. If you enable this then be aware that Java will deserialize the incoming data from the request to Java and that can be a potential security risk. | false | boolean

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
@@ -68,6 +68,7 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
         // must extract well known parameters before we create the endpoint
         Boolean throwExceptionOnFailure = getAndRemoveParameter(parameters, "throwExceptionOnFailure", Boolean.class);
         Boolean transferException = getAndRemoveParameter(parameters, "transferException", Boolean.class);
+        Boolean muteException = getAndRemoveParameter(parameters, "muteException", Boolean.class);
         Boolean bridgeEndpoint = getAndRemoveParameter(parameters, "bridgeEndpoint", Boolean.class);
         HttpBinding binding = resolveAndRemoveReferenceParameter(parameters, "httpBinding", HttpBinding.class);
         Boolean matchOnUriPrefix = getAndRemoveParameter(parameters, "matchOnUriPrefix", Boolean.class);
@@ -121,6 +122,9 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
         // should we transfer exception as serialized object
         if (transferException != null) {
             endpoint.setTransferException(transferException);
+        }
+        if (muteException != null) {
+            endpoint.setMuteException(muteException);
         }
         if (bridgeEndpoint != null) {
             endpoint.setBridgeEndpoint(bridgeEndpoint);
@@ -322,6 +326,7 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
             HttpBinding binding = new ServletRestHttpBinding();
             binding.setHeaderFilterStrategy(endpoint.getHeaderFilterStrategy());
             binding.setTransferException(endpoint.isTransferException());
+            binding.setMuteException(endpoint.isMuteException());
             binding.setEagerCheckContentAvailable(endpoint.isEagerCheckContentAvailable());
             endpoint.setHttpBinding(binding);
         }

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletEndpoint.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletEndpoint.java
@@ -74,6 +74,7 @@ public class ServletEndpoint extends HttpCommonEndpoint {
             }
             this.binding.setFileNameExtWhitelist(getFileNameExtWhitelist());
             this.binding.setTransferException(isTransferException());
+            this.binding.setMuteException(isMuteException());
             if (getComponent() != null) {
                 this.binding.setAllowJavaSerializedObject(getComponent().isAllowJavaSerializedObject());
             }

--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/ServletMuteExceptionTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/ServletMuteExceptionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.servlet;
+
+import com.meterware.httpunit.PostMethodWebRequest;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+import com.meterware.servletunit.ServletUnitClient;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.http.common.HttpConstants;
+import org.apache.camel.http.common.HttpHelper;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+public class ServletMuteExceptionTest extends ServletCamelRouterTestSupport {
+
+    @Test
+    public void testMuteException() throws Exception {
+        WebRequest req = new PostMethodWebRequest(CONTEXT_URL + "/services/mute", new ByteArrayInputStream("".getBytes()), "text/plain");
+        ServletUnitClient client = newClient();
+        client.setExceptionsThrownOnErrorStatus(false);
+        WebResponse response = client.getResponse(req);
+
+        assertEquals(500, response.getResponseCode());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("Exception", response.getText());
+    }
+
+
+    @Test
+    public void testMuteWithTransferException() throws Exception {
+        WebRequest req = new PostMethodWebRequest(CONTEXT_URL + "/services/muteWithTransfer", new ByteArrayInputStream("".getBytes()), "text/plain");
+        ServletUnitClient client = newClient();
+        client.setExceptionsThrownOnErrorStatus(false);
+        WebResponse response = client.getResponse(req);
+
+        assertEquals(500, response.getResponseCode());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("Exception", response.getText());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("servlet:mute?muteException=true")
+                    .throwException(new IllegalArgumentException("Damn"));
+
+                from("servlet:muteWithTransfer?muteException=true&transferException=true")
+                    .throwException(new IllegalArgumentException("Damn"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
This pull request implements the "muteException" option for the camel-servlet component (see [CAMEL-14025](https://issues.apache.org/jira/browse/CAMEL-14025).
If enabled the response body will simply contain the text "Exception" instead of a full stack trace (in case an exception is thrown). 
