### PR TITLE
[CAMEL-14071] [Camel-as2] Integration tests are not working

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Producer.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Producer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.as2;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.as2.api.entity.DispositionNotificationMultipartReportEntity;
+import org.apache.camel.component.as2.api.entity.MultipartSignedEntity;
 import org.apache.camel.component.as2.internal.AS2ApiName;
 import org.apache.camel.component.as2.internal.AS2Constants;
 import org.apache.camel.component.as2.internal.AS2PropertiesHelper;
@@ -41,7 +42,7 @@ public class AS2Producer extends AbstractApiProducer<AS2ApiName, AS2Configuratio
         resultExchange.setProperty(AS2Constants.AS2_INTERCHANGE, context);
         HttpResponse response = context.getResponse();
         HttpEntity entity = response.getEntity();
-        if (entity != null && entity instanceof DispositionNotificationMultipartReportEntity) {
+        if (entity instanceof DispositionNotificationMultipartReportEntity || entity instanceof MultipartSignedEntity) {
             resultExchange.getOut().setBody(entity);
         } else {
             resultExchange.getOut().setBody(null);


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14071

- One class was missing in if condition of AS2Producer in interception method (https://github.com/apache/camel/commit/30192d63f0290639e815df21ae37c9bc85f184d4#diff-090142443d23c06921786a5181ad7517R44), which become evident during fixation of tests. I've added MultipartSignedEntity into if condition (this entity contains signature entity). Without this change all responses containing MultipartSignedEntity won't be added into body of exchange.

- Added closing connection into @AfterClass method of AS2ClientManagerIntegrationTest.

- There were changes in AS2Producer (https://github.com/apache/camel/commit/30192d63f0290639e815df21ae37c9bc85f184d4#diff-090142443d23c06921786a5181ad7517R40-R48) and AS2Consmer (https://github.com/apache/camel/commit/30192d63f0290639e815df21ae37c9bc85f184d4#diff-8c8e31cb62827ee2306130030a00255cR114-R120), which was not reflected in tests. Tests are fixed now.
