### PR TITLE
CAMEL-14025: add muteException option to netty-http component

### DIFF
--- a/components/camel-netty-http/src/main/docs/netty-http-component.adoc
+++ b/components/camel-netty-http/src/main/docs/netty-http-component.adoc
@@ -138,7 +138,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (78 parameters):
+=== Query Parameters (79 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -152,6 +152,7 @@ with the following path and query parameters:
 | *sync* (common) | Setting to set endpoint as one-way or request-response | true | boolean
 | *tcpNoDelay* (common) | Setting to improve TCP protocol performance | true | boolean
 | *matchOnUriPrefix* (consumer) | Whether or not Camel should try to find a target consumer by matching the URI prefix if no exact match is found. | false | boolean
+| *muteException* (consumer) | If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace. | false | boolean
 | *send503whenSuspended* (consumer) | Whether to send back HTTP status code 503 when the consumer has been suspended. If the option is false then the Netty Acceptor is unbound when the consumer is suspended, so clients cannot connect anymore. | true | boolean
 | *backlog* (consumer) | Allows to configure a backlog for netty consumer (server). Note the backlog is just a best effort depending on the OS. Setting this option to a value such as 200, 500 or 1000, tells the TCP stack how long the accept queue can be If this option is not configured, then the backlog depends on OS setting. |  | int
 | *bossCount* (consumer) | When netty works on nio mode, it uses default bossCount parameter from Netty, which is 1. User can use this operation to override the default bossCount from Netty | 1 | int

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/DefaultNettyHttpBinding.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/DefaultNettyHttpBinding.java
@@ -394,7 +394,7 @@ public class DefaultNettyHttpBinding implements NettyHttpBinding, Cloneable {
         LOG.trace("HTTP Status Code: {}", code);
 
         // if there was an exception then use that as body
-        if (cause != null) {
+        if (cause != null && !configuration.isMuteException()) {
             if (configuration.isTransferException()) {
                 // we failed due an exception, and transfer it as java serialized object
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -420,6 +420,16 @@ public class DefaultNettyHttpBinding implements NettyHttpBinding, Cloneable {
             }
 
             // and mark the exception as failure handled, as we handled it by returning it as the response
+            ExchangeHelper.setFailureHandled(message.getExchange());
+        }
+        else if (cause != null && configuration.isMuteException()) {
+
+            // the body should hide the stacktrace (muteException enabled)
+            body = NettyConverter.toByteBuffer("Exception".getBytes());
+            // force content type to be text/plain
+            message.setHeader(Exchange.CONTENT_TYPE, "text/plain");
+
+            // and mark the exception as failure handled, as we handled it by actively muting it
             ExchangeHelper.setFailureHandled(message.getExchange());
         }
 

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpConfiguration.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpConfiguration.java
@@ -52,6 +52,8 @@ public class NettyHttpConfiguration extends NettyConfiguration {
     @UriParam(label = "advanced")
     private boolean transferException;
     @UriParam(label = "consumer")
+    private boolean muteException;
+    @UriParam(label = "consumer")
     private boolean matchOnUriPrefix;
     @UriParam
     private boolean bridgeEndpoint;
@@ -174,6 +176,17 @@ public class NettyHttpConfiguration extends NettyConfiguration {
      */
     public void setTransferException(boolean transferException) {
         this.transferException = transferException;
+    }
+
+    public boolean isMuteException() {
+        return muteException;
+    }
+
+    /**
+     * If enabled and an Exchange failed processing on the consumer side the response's body won't contain the exception's stack trace.
+     */
+    public void setMuteException(boolean muteException) {
+        this.muteException = muteException;
     }
 
     public boolean isUrlDecodeHeaders() {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpMuteExceptionTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpMuteExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty.http;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Test;
+
+public class NettyHttpMuteExceptionTest extends BaseNettyTest {
+
+    @Test
+    public void testMuteException() throws Exception {
+
+        HttpClient client = new HttpClient();
+        GetMethod get = new GetMethod("http://localhost:" + getPort() + "/foo");
+        get.setRequestHeader("Accept", "application/text");
+        client.executeMethod(get);
+
+        String body = get.getResponseBodyAsString();
+        assertNotNull(body);
+        assertEquals("Exception", body);
+        assertEquals(500, get.getStatusCode());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("netty-http:http://0.0.0.0:{{port}}/foo?muteException=true")
+                    .to("mock:input")
+                    .throwException(new IllegalArgumentException("Camel cannot do this"));
+            }
+        };
+    }
+
+}

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/NettyHttpEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/NettyHttpEndpointBuilderFactory.java
@@ -263,6 +263,32 @@ public interface NettyHttpEndpointBuilderFactory {
             return this;
         }
         /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option is a: <code>boolean</code> type.
+         * 
+         * Group: consumer
+         */
+        default NettyHttpEndpointConsumerBuilder muteException(
+                boolean muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         * 
+         * The option will be converted to a <code>boolean</code> type.
+         * 
+         * Group: consumer
+         */
+        default NettyHttpEndpointConsumerBuilder muteException(
+                String muteException) {
+            doSetProperty("muteException", muteException);
+            return this;
+        }
+        /**
          * Whether to send back HTTP status code 503 when the consumer has been
          * suspended. If the option is false then the Netty Acceptor is unbound
          * when the consumer is suspended, so clients cannot connect anymore.

--- a/platforms/spring-boot/components-starter/camel-netty-http-starter/src/main/java/org/apache/camel/component/netty/http/springboot/NettyHttpComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-netty-http-starter/src/main/java/org/apache/camel/component/netty/http/springboot/NettyHttpComponentConfiguration.java
@@ -200,6 +200,11 @@ public class NettyHttpComponentConfiguration
          */
         private Boolean transferException = false;
         /**
+         * If enabled and an Exchange failed processing on the consumer side the
+         * response's body won't contain the exception's stack trace.
+         */
+        private Boolean muteException = false;
+        /**
          * If this option is enabled, then during binding from Netty to Camel
          * Message then the header values will be URL decoded (eg %20 will be a
          * space character. Notice this option is used by the default
@@ -333,6 +338,14 @@ public class NettyHttpComponentConfiguration
 
         public void setTransferException(Boolean transferException) {
             this.transferException = transferException;
+        }
+
+        public Boolean getMuteException() {
+            return muteException;
+        }
+
+        public void setMuteException(Boolean muteException) {
+            this.muteException = muteException;
         }
 
         public Boolean getUrlDecodeHeaders() {


### PR DESCRIPTION
This pull request adds the "muteException" option to the Netty HTTP component (see [CAMEL-14025](https://issues.apache.org/jira/browse/CAMEL-14025)).

If enabled the response body will simply contain the text "Exception" instead of a full stack trace (in case an exception is thrown).

The implementation is very similar to the one in PR #3236 in the Undertow component.