### PR TITLE
[CAMEL-14113] camel-elasticsearch-rest: NullPointer exception if ther…

### DIFF
--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/ElasticsearchProducer.java
@@ -149,24 +149,45 @@ public class ElasticsearchProducer extends DefaultProducer {
 
         if (operation == ElasticsearchOperation.Index) {
             IndexRequest indexRequest = message.getBody(IndexRequest.class);
+            if (indexRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only Map, String, byte[], XContentBuilder or IndexRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.index(indexRequest, RequestOptions.DEFAULT).getId());
         } else if (operation == ElasticsearchOperation.Update) {
             UpdateRequest updateRequest = message.getBody(UpdateRequest.class);
+            if (updateRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only Map, String, byte[], XContentBuilder or UpdateRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.update(updateRequest, RequestOptions.DEFAULT).getId());
         } else if (operation == ElasticsearchOperation.GetById) {
             GetRequest getRequest = message.getBody(GetRequest.class);
+            if (getRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only String or GetRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.get(getRequest, RequestOptions.DEFAULT));
         } else if (operation == ElasticsearchOperation.Bulk) {
             BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+            if (bulkRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only List, Collection or BulkRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.bulk(bulkRequest, RequestOptions.DEFAULT).getItems());
         } else if (operation == ElasticsearchOperation.BulkIndex) {
             BulkRequest bulkRequest = message.getBody(BulkRequest.class);
+            if (bulkRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only List, Collection or BulkRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.bulk(bulkRequest, RequestOptions.DEFAULT).getItems());
         } else if (operation == ElasticsearchOperation.Delete) {
             DeleteRequest deleteRequest = message.getBody(DeleteRequest.class);
+            if (deleteRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only String or DeleteRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.delete(deleteRequest, RequestOptions.DEFAULT).getResult());
         } else if (operation == ElasticsearchOperation.DeleteIndex) {
             DeleteIndexRequest deleteIndexRequest = message.getBody(DeleteIndexRequest.class);
+            if (deleteIndexRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only String or DeleteIndexRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT).isAcknowledged());
         } else if (operation == ElasticsearchOperation.Exists) {
             // ExistsRequest API is deprecated, using SearchRequest instead with size=0 and terminate_after=1
@@ -188,6 +209,9 @@ public class ElasticsearchProducer extends DefaultProducer {
             }
         } else if (operation == ElasticsearchOperation.Search) {
             SearchRequest searchRequest = message.getBody(SearchRequest.class);
+            if (searchRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only Map, String or SearchRequest is allowed as a type");
+            }
             // is it a scroll request ?
             boolean useScroll = message.getHeader(PARAM_SCROLL, configuration.isUseScroll(), Boolean.class);
             if (useScroll) {
@@ -199,6 +223,9 @@ public class ElasticsearchProducer extends DefaultProducer {
             }
         } else if (operation == ElasticsearchOperation.MultiSearch) {
             MultiSearchRequest searchRequest = message.getBody(MultiSearchRequest.class);
+            if (searchRequest == null) {
+                throw new IllegalArgumentException("Wrong body type. Only MultiSearchRequest is allowed as a type");
+            }
             message.setBody(restHighLevelClient.msearch(searchRequest, RequestOptions.DEFAULT).getResponses());
         } else if (operation == ElasticsearchOperation.Ping) {
             message.setBody(restHighLevelClient.ping(RequestOptions.DEFAULT));

--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -111,8 +111,11 @@ public final class ElasticsearchActionRequestConverter {
         if (document instanceof GetRequest) {
             return (GetRequest)document;
         }
-        return new GetRequest(exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class))
-            .id((String)document);
+        if (document instanceof String) {
+            return new GetRequest(exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class))
+                    .id((String) document);
+        }
+        return null;
     }
 
     @Converter
@@ -123,9 +126,8 @@ public final class ElasticsearchActionRequestConverter {
         if (document instanceof String) {
             return new DeleteRequest().index(exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class))
                 .id((String)document);
-        } else {
-            throw new IllegalArgumentException("Wrong body type. Only DeleteRequest or String is allowed as a type");
         }
+        return null;
     }
 
     @Converter
@@ -136,9 +138,8 @@ public final class ElasticsearchActionRequestConverter {
         if (document instanceof String) {
             String index = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class);
             return new DeleteIndexRequest(index);
-        } else {
-            throw new IllegalArgumentException("Wrong body type. Only DeleteIndexRequest or String is allowed as a type");
         }
+        return null;
     }
 
     @Converter
@@ -202,9 +203,8 @@ public final class ElasticsearchActionRequestConverter {
                 request.add(createIndexRequest(document, exchange));
             }
             return request;
-        } else {
-            throw new IllegalArgumentException("Wrong body type. Only BulkRequest or List is allowed as a type");
         }
+        return null;
     }
 
 }


### PR DESCRIPTION
…e is no body in exchange

Issue: https://issues.apache.org/jira/browse/CAMEL-14113

NPE was thrown when body of exchange didn't contain mandatory data. This PR changes behavior in the way, that IllegalArgumentException with explanation is thrown instead.