### PR TITLE
CAMEL-14127: avoid file by file target replacement when fileExist=Append

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -278,10 +278,11 @@ public class FileOperations implements GenericFileOperations<File> {
             String charset = endpoint.getCharset();
 
             // we can optimize and use file based if no charset must be used, and the input body is a file
+            // however optimization cannot be applied when content should be appended to target file
             File source = null;
             boolean fileBased = false;
-            if (charset == null) {
-                // if no charset, then we can try using file directly (optimized)
+            if (charset == null && endpoint.getFileExist() != GenericFileExist.Append) {
+                // if no charset and not in appending mode, then we can try using file directly (optimized)
                 Object body = exchange.getIn().getBody();
                 if (body instanceof WrappedFile) {
                     body = ((WrappedFile<?>) body).getFile();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.io.File;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -45,6 +47,26 @@ public class FileProducerFileExistAppendTest extends ContextTestSupport {
         context.getRouteController().startAllRoutes();
 
         assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testAppendFileByFile() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+
+        // Create some test files
+        template.sendBodyAndHeader("file://target/data/file", "Row 1\n", Exchange.FILE_NAME, "test1.txt");
+        template.sendBodyAndHeader("file://target/data/file", "Row 2\n", Exchange.FILE_NAME, "test2.txt");
+
+        // Append test files to the target one
+        template.sendBodyAndHeader("file://target/data/file?fileExist=Append", new File("target/data/file/test1.txt"), Exchange.FILE_NAME, "out.txt");
+        template.sendBodyAndHeader("file://target/data/file?fileExist=Append", new File("target/data/file/test2.txt"), Exchange.FILE_NAME, "out.txt");
+
+        mock.expectedFileExists("target/data/file/out.txt", "Row 1\nRow 2\n");
+
+        context.getRouteController().startAllRoutes();
+
+        assertMockEndpointsSatisfied();
+
     }
 
     @Override


### PR DESCRIPTION
When file producer applies file based optimization it ignores
fileExist=Append mode and always replaces target file.
This change avoids file based optimization when fileExist=Append.