### PR TITLE
CAMEL-14145: Fix camel-debezium-mongodb not populating correct values…

### DIFF
--- a/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
+++ b/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
@@ -204,10 +204,11 @@ The following headers are available when consuming change events from Debezium.
 | DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
-| DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.
+| DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` for read (in the case of a initial sync).
 | DebeziumConstants.HEADER_TIMESTAMP        | "CamelDebeziumTimestamp"                       | Long        | If presents, the time (using the system clock in the JVM) at which the connector processed the event.
-| DebeziumConstants.HEADER_BEFORE           | "CamelDebeziumBefore"                          | Struct     | If presents, contains the state of the row before the event occurred.
 |===
+
+*Note*: Debezium Mongodb uses MongoDB’s oplog to populate the CDC events, the update events in MongoDB’s oplog don’t have the before or after states of the changed document, so there’s no way for the Debezium connector to provide this information, therefore header key `CamelDebeziumBefore` is not available in this component.
 
 == Message body
 The message body if is not `null` (in case of tombstones), it contains the state of the row after the event occurred as `String` JSON format and you can unmarchal using Camel JSON Data Format.
@@ -220,16 +221,20 @@ Here is a very simple route that you can use in order to listen to Debezium even
 [source,java]
 ----
 from("debezium-mongodb:dbz-test-1?offsetStorageFileName=/usr/offset-file-1.dat&mongodbHosts=rs0/localhost:27017&mongodbUser=debezium&mongodbPassword=dbz&mongodbName=dbserver1&databaseHistoryFileName=/usr/history-file-1.dat")
-    .unmarshal().json()
     .log("Event received from Debezium : ${body}")
     .log("    with this identifier ${headers.CamelDebeziumIdentifier}")
     .log("    with these source metadata ${headers.CamelDebeziumSourceMetadata}")
     .log("    the event occured upon this operation '${headers.CamelDebeziumSourceOperation}'")
     .log("    on this database '${headers.CamelDebeziumSourceMetadata[db]}' and this table '${headers.CamelDebeziumSourceMetadata[table]}'")
     .log("    with the key ${headers.CamelDebeziumKey}")
-    .log("    the previous value is ${headers.CamelDebeziumBefore}")
+    .choice()
+        .when(header(DebeziumConstants.HEADER_OPERATION).in("c", "u", "r"))
+            .unmarshal().json()
+            .log("Event received from Debezium : ${body}")
+         .end()
+    .end();
 ----
 
-By default, the component will emit the events in the body and `CamelDebeziumBefore` header as String JSON format, this can be easily converted to JSON using Camel JSON Data Format e.g: `.unmarshal().json()` like the above example.
+By default, the component will emit the events in the body String JSON format in case of `u`, `c` or `r` operations, this can be easily converted to JSON using Camel JSON Data Format e.g: `.unmarshal().json()` like the above example. In case of operation `d`, the body will be `null`.
 
 *Important Note:* This component is a thin wrapper around Debezium Engine as mentioned, therefore before using this component in production, you need to understand how Debezium works and how configurations can reflect the expected behavior, especially in regards to https://debezium.io/documentation/reference/0.9/operations/embedded.html#_handling_failures[handling failures].


### PR DESCRIPTION
Due to the nature of MongoDB oplog, the Debezium Mongodb connector differs a little with the message structure, for example `after` only available with the initial snapshot meanwhile in updates and inserts, there is another field populated called `patch`. This PR shall address this issue  