### PR TITLE
Camel-Salesforce: Fixed incorrect JsonProperty name.

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/SObjectCompositeResult.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/SObjectCompositeResult.java
@@ -42,13 +42,12 @@ public final class SObjectCompositeResult implements Serializable {
     private final String referenceId;
 
     @JsonCreator
-    public SObjectCompositeResult(@JsonProperty("body")
-    final Object body, @JsonProperty("headers")
-    final Map<String, String> headers, @JsonProperty("httpStatusCode")
-    final int httpStatusCode, @JsonProperty("referenceID")
-    final String referenceId) {
+    public SObjectCompositeResult(@JsonProperty("body") final Object body,
+            @JsonProperty("httpHeaders") final Map<String, String> httpHeaders,
+            @JsonProperty("httpStatusCode") final int httpStatusCode,
+            @JsonProperty("referenceID") final String referenceId) {
         this.body = body;
-        httpHeaders = headers;
+        this.httpHeaders = httpHeaders;
         this.httpStatusCode = httpStatusCode;
         this.referenceId = referenceId;
     }


### PR DESCRIPTION
The `@JsonProperty("headers")` was the problem. Should be `@JsonProperty("httpHeaders")`. Oddly, it still worked, probably due to a Jackson matching algorithm. Other than that, cleaned up formatting a little.

Here's an example of what it's unmarshalling from:
```
{
  "compositeResponse": [
    {
      "body": {
        "id": "0037A00000OF7cZQAT",
        "success": true,
        "errors": []
      },
      "httpHeaders": {
        "Location": "/services/data/v38.0/sobjects/Contact/0037A00000OF7cZQAT"
      },
      "httpStatusCode": 201,
      "referenceId": "P1"
    }
  ]
}
```