### PR TITLE
[CAMEL-14150] Camel-exec: option to hide sensitive information in log

### DIFF
--- a/components/camel-exec/src/main/docs/exec-component.adoc
+++ b/components/camel-exec/src/main/docs/exec-component.adoc
@@ -64,7 +64,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (10 parameters):
+=== Query Parameters (11 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -73,6 +73,7 @@ with the following path and query parameters:
 | *args* (producer) | The arguments may be one or many whitespace-separated tokens. |  | String
 | *binding* (producer) | A reference to a org.apache.commons.exec.ExecBinding in the Registry. |  | ExecBinding
 | *commandExecutor* (producer) | A reference to a org.apache.commons.exec.ExecCommandExecutor in the Registry that customizes the command execution. The default command executor utilizes the commons-exec library, which adds a shutdown hook for every executed command. |  | ExecCommandExecutor
+| *commandLogLevel* (producer) | Logging level to be used for commands during execution. The default value is DEBUG. Possible values are TRACE, DEBUG, INFO, WARN, ERROR or OFF. (Values of ExecCommandLogLevelType enum) | DEBUG | LoggingLevel
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
 | *outFile* (producer) | The name of a file, created by the executable, that should be considered as its output. If no outFile is set, the standard output (stdout) of the executable will be used instead. |  | String
 | *timeout* (producer) | The timeout, in milliseconds, after which the executable should be terminated. If execution has not completed within the timeout, the component will send a termination request. |  | long
@@ -151,6 +152,9 @@ the executable. If no stderr is written, the value is `null`.
 |`ExecBinding.EXEC_USE_STDERR_ON_EMPTY_STDOUT` |`boolean` |`in` |Indicates that when `stdout` is empty, this component will populate the
 Camel Message Body with `stderr`. This behavior is disabled (`false`) by
 default.
+
+|`ExecBinding.EXEC_COMMANDS_LOG_LEVEL` |`String` |`in` |Logging level to be used for commands during execution. The default value is DEBUG.
+Possible values are TRACE, DEBUG, INFO, WARN, ERROR or OFF (Values of LoggingLevel enum)
 |=======================================================================
 
 == Message body

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecBinding.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecBinding.java
@@ -91,6 +91,12 @@ public interface ExecBinding {
     String EXEC_USE_STDERR_ON_EMPTY_STDOUT = "CamelExecUseStderrOnEmptyStdout";
 
     /**
+     * The value of this header define logging level to be used for commands during execution. The default value is INFO.
+     * Possible values are TRACE, DEBUG, INFO, WARN, ERROR or OFF. (Values of LoggingLevel enum)
+     */
+    String EXEC_COMMAND_LOG_LEVEL = "CamelExecCommandLogLevel";
+
+    /**
      * Creates a {@link ExecCommand} from the headers in the
      * <code>exchange</code> and the settings of the <code>endpoint</code>.
      * 

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecCommand.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecCommand.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.camel.LoggingLevel;
 
 import static org.apache.camel.util.ObjectHelper.notNull;
 
@@ -62,10 +63,15 @@ public class ExecCommand implements Serializable {
      */
     private final InputStream input;
 
+    /**
+     * Log level for commands during execution
+     */
+    private final LoggingLevel commandLogLevel;
+
     private final boolean useStderrOnEmptyStdout;
 
     public ExecCommand(String executable, List<String> args, String workingDir, Long timeout,
-                       InputStream input, File outFile, boolean useStderrOnEmptyStdout) {
+                       InputStream input, File outFile, boolean useStderrOnEmptyStdout, LoggingLevel commandLogLevel) {
         notNull(executable, "command executable");
         this.executable = executable;
         this.args = unmodifiableOrEmptyList(args);
@@ -74,6 +80,7 @@ public class ExecCommand implements Serializable {
         this.input = input;
         this.outFile = outFile;
         this.useStderrOnEmptyStdout = useStderrOnEmptyStdout;
+        this.commandLogLevel = commandLogLevel;
     }
 
     public List<String> getArgs() {
@@ -104,12 +111,16 @@ public class ExecCommand implements Serializable {
         return useStderrOnEmptyStdout;
     }
 
+    public LoggingLevel getCommandLogLevel() {
+        return commandLogLevel;
+    }
+
     @Override
     public String toString() {
         String dirToPrint = workingDir == null ? "null" : workingDir;
         String outFileToPrint = outFile == null ? "null" : outFile.getPath();
         return "ExecCommand [args=" + args + ", executable=" + executable + ", timeout=" + timeout + ", outFile="
-                + outFileToPrint + ", workingDir=" + dirToPrint + ", useStderrOnEmptyStdout=" + useStderrOnEmptyStdout + "]";
+                + outFileToPrint + ", workingDir=" + dirToPrint + ", commandLogLevel=" + commandLogLevel + ", useStderrOnEmptyStdout=" + useStderrOnEmptyStdout + "]";
     }
 
     private <T> List<T> unmodifiableOrEmptyList(List<T> list) {

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecEndpoint.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecEndpoint.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.exec;
 
 import org.apache.camel.Consumer;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.component.exec.impl.DefaultExecBinding;
@@ -55,6 +56,8 @@ public class ExecEndpoint extends DefaultEndpoint {
     private ExecBinding binding;
     @UriParam
     private boolean useStderrOnEmptyStdout;
+    @UriParam(defaultValue = "DEBUG")
+    private LoggingLevel commandLogLevel = LoggingLevel.DEBUG;
 
     public ExecEndpoint(String uri, ExecComponent component) {
         super(uri, component);
@@ -168,5 +171,17 @@ public class ExecEndpoint extends DefaultEndpoint {
      */
     public void setUseStderrOnEmptyStdout(boolean useStderrOnEmptyStdout) {
         this.useStderrOnEmptyStdout = useStderrOnEmptyStdout;
+    }
+
+    public LoggingLevel getCommandLogLevel() {
+        return commandLogLevel;
+    }
+
+    /**
+     * Logging level to be used for commands during execution. The default value is DEBUG.
+     * Possible values are TRACE, DEBUG, INFO, WARN, ERROR or OFF. (Values of ExecCommandLogLevelType enum)
+     */
+    public void setCommandLogLevel(LoggingLevel commandLogLevel) {
+        this.commandLogLevel = commandLogLevel;
     }
 }

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecProducer.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/ExecProducer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.exec;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.exec.impl.DefaultExecCommandExecutor;
+import org.apache.camel.spi.CamelLogger;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -32,12 +33,15 @@ public class ExecProducer extends DefaultProducer {
 
     private final Logger log;
 
+    private final CamelLogger logger;
+
     private final ExecEndpoint endpoint;
 
     public ExecProducer(ExecEndpoint endpoint) {
         super(endpoint);
         this.endpoint = endpoint;
         this.log = LoggerFactory.getLogger(ExecProducer.class);
+        this.logger = new CamelLogger(log);
     }
 
     @Override
@@ -50,11 +54,13 @@ public class ExecProducer extends DefaultProducer {
             executor = new DefaultExecCommandExecutor();
         }
 
-        log.info("Executing {}", execCommand);
+
+        logger.log(String.format("Executing %s", execCommand), execCommand.getCommandLogLevel());
+
         ExecResult result = executor.execute(execCommand);
 
         ObjectHelper.notNull(result, "The command executor must return a not-null result");
-        log.info("The command {} had exit value {}", execCommand, result.getExitValue());
+        logger.log(String.format("The command %s had exit value %s", execCommand, result.getExitValue()), execCommand.getCommandLogLevel());
         if (result.getExitValue() != 0) {
             log.error("The command {} returned exit value {}", execCommand, result.getExitValue());
         }

--- a/components/camel-exec/src/main/java/org/apache/camel/component/exec/impl/DefaultExecBinding.java
+++ b/components/camel-exec/src/main/java/org/apache/camel/component/exec/impl/DefaultExecBinding.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.Message;
 import org.apache.camel.component.exec.ExecBinding;
 import org.apache.camel.component.exec.ExecCommand;
@@ -53,6 +54,7 @@ public class DefaultExecBinding implements ExecBinding {
         long timeout = getAndRemoveHeader(exchange.getIn(), EXEC_COMMAND_TIMEOUT, endpoint.getTimeout(), Long.class);
         String outFilePath = getAndRemoveHeader(exchange.getIn(), EXEC_COMMAND_OUT_FILE, endpoint.getOutFile(), String.class);
         boolean useStderrOnEmptyStdout = getAndRemoveHeader(exchange.getIn(), EXEC_USE_STDERR_ON_EMPTY_STDOUT, endpoint.isUseStderrOnEmptyStdout(), Boolean.class);
+        LoggingLevel commandLogLevel = getAndRemoveHeader(exchange.getIn(), EXEC_COMMAND_LOG_LEVEL, endpoint.getCommandLogLevel(), LoggingLevel.class);
         InputStream input = exchange.getIn().getBody(InputStream.class);
 
         // If the args is a list of strings already..
@@ -73,7 +75,7 @@ public class DefaultExecBinding implements ExecBinding {
         }
 
         File outFile = outFilePath == null ? null : new File(outFilePath);
-        return new ExecCommand(cmd, argsList, dir, timeout, input, outFile, useStderrOnEmptyStdout);
+        return new ExecCommand(cmd, argsList, dir, timeout, input, outFile, useStderrOnEmptyStdout, commandLogLevel);
     }
 
     private boolean isListOfStrings(Object o) {


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14150

Adds configuration parameter (logCommandsAtLevelDebug) to set legging level DEBUG for logging of executed commands (for the scenario, when commands contains some sensitive information). Default value is false, so there is no change of behavior if parameter is not defined.