### PR TITLE
CAMEL-14172: when loggingSizeLimit is -1 it should do what the docs say it does

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpoint.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpoint.java
@@ -321,7 +321,7 @@ public class CxfEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
 
         if (isLoggingFeatureEnabled()) {
             LoggingFeature loggingFeature = new LoggingFeature();
-            if (getLoggingSizeLimit() > 0) {
+            if (getLoggingSizeLimit() >= -1) {
                 loggingFeature.setLimit(getLoggingSizeLimit());
             }
             sfb.getFeatures().add(loggingFeature);
@@ -510,7 +510,7 @@ public class CxfEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
 
         if (isLoggingFeatureEnabled()) {
             LoggingFeature loggingFeature = new LoggingFeature();
-            if (getLoggingSizeLimit() > 0) {
+            if (getLoggingSizeLimit() >= -1) {
                 loggingFeature.setLimit(getLoggingSizeLimit());
 
             }


### PR DESCRIPTION
I was able to manually verify this fix works against 2.25.0-SNAPSHOT but couldn't figure out how to write a unit test. Happy to do that if given some hints on how to (successfully) get at log output in a unit test or access the underlying CXF LoggingFeature from a CxfEndpoint. 