### PR TITLE
CAMEL-14127: (2.x port) avoid file by file target replacement when fileExist=Append (#3309)

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/camel-core/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -262,10 +262,11 @@ public class FileOperations implements GenericFileOperations<File> {
             String charset = endpoint.getCharset();
 
             // we can optimize and use file based if no charset must be used, and the input body is a file
+            // however optimization cannot be applied when content should be appended to target file
             File source = null;
             boolean fileBased = false;
-            if (charset == null) {
-                // if no charset, then we can try using file directly (optimized)
+            if (charset == null && endpoint.getFileExist() != GenericFileExist.Append) {
+                // if no charset and not in appending mode, then we can try using file directly (optimized)
                 Object body = exchange.getIn().getBody();
                 if (body instanceof WrappedFile) {
                     body = ((WrappedFile<?>) body).getFile();

--- a/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendTest.java
+++ b/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendTest.java
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 package org.apache.camel.component.file;
+
+import java.io.File;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -47,6 +50,26 @@ public class FileProducerFileExistAppendTest extends ContextTestSupport {
         context.startAllRoutes();
 
         assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testAppendFileByFile() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+
+        // Create some test files
+        template.sendBodyAndHeader("file://target/file", "Row 1\n", Exchange.FILE_NAME, "test1.txt");
+        template.sendBodyAndHeader("file://target/file", "Row 2\n", Exchange.FILE_NAME, "test2.txt");
+
+        // Append test files to the target one
+        template.sendBodyAndHeader("file://target/file?fileExist=Append", new File("target/file/test1.txt"), Exchange.FILE_NAME, "out.txt");
+        template.sendBodyAndHeader("file://target/file?fileExist=Append", new File("target/file/test2.txt"), Exchange.FILE_NAME, "out.txt");
+
+        mock.expectedFileExists("target/file/out.txt", "Row 1\nRow 2\n");
+
+        context.startAllRoutes();
+
+        assertMockEndpointsSatisfied();
+
     }
 
     @Override


### PR DESCRIPTION
When file producer applies file based optimization it ignores
fileExist=Append mode and always replaces target file.
This change avoids file based optimization when fileExist=Append.