### PR TITLE
CAMEL-13841: (Backport to 2.x) Allow manual Pulsar message acknowledgments

### DIFF
--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -126,3 +126,23 @@ The component supports 3 options, which are listed below.
 | *camel.component.pulsar.resolve-property-placeholders* | Whether the component should resolve property placeholders on itself when starting. Only properties which are of String type can use property placeholders. | true | Boolean
 |===
 // spring-boot-auto-configure options: END
+
+// message-headers options: START
+=== Message headers set by the Pulsar consumer
+
+
+[width="100%",cols="10%,10%,80%",options="header",]
+|===
+| Header | Type | Description
+| `properties` | `Map<String,String>` | The properties from the Pulsar message or the empty Map if unset on the Pulsar message
+| `producer_name` | `String` | The name of the producer that created the message
+| `sequence_id` | `long` | Sequence identifier of the Pulsar message
+| `publish_time` | `long` | Time the Pulsar message was published to the topic
+| `message_id` | `MessageId` | Unique identifier of the message
+| `event_time` | `long` | The event time associated with the message or 0 if unset on the Pulsar message
+| `key` | `String` | The key of the Pulsar message in String form or the empty string if unset on the Pulsar message
+| `key_bytes` | `byte[]` | The bytes in the key. If the key has been base64 encoded, it is decoded before being returned. Otherwise, if the key is a plain string, the UTF-8 encoded bytes of the string.
+| `topic_name` | `String` | The topic to which the message was published
+| `manual_acknowledgement` | `PulsarManualAcknowledgement` | If allowManualAcknowledgement is set, this will contain the object for manually acknowledging the Pulsar message; otherwise it is unset
+|===
+// message-headers options: END

--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -29,7 +29,7 @@ pulsar:[persistent|non-persistent]://tenant/namespace/topic
 
 
 // component options: START
-The Apache Pulsar component supports 3 options, which are listed below.
+The Apache Pulsar component supports 5 options, which are listed below.
 
 
 
@@ -38,6 +38,8 @@ The Apache Pulsar component supports 3 options, which are listed below.
 | Name | Description | Default | Type
 | *autoConfiguration* (common) | The pulsar autoconfiguration |  | AutoConfiguration
 | *pulsarClient* (common) | The pulsar client |  | PulsarClient
+| *allowManual Acknowledgement* (consumer) | Whether to allow manual message acknowledgements. If this option is enabled, then messages are not immediately acknowledged after being consumed. Instead, an instance of PulsarMessageReceipt is stored as a header on the org.apache.camel.Exchange. Messages can then be acknowledged using PulsarMessageReceipt at any time before the ackTimeout occurs. | false | boolean
+| *pulsarMessageReceipt Factory* (consumer) | Provide a factory to create an alternate implementation of PulsarMessageReceipt. |  | PulsarMessageReceipt Factory
 | *resolveProperty Placeholders* (advanced) | Whether the component should resolve property placeholders on itself when starting. Only properties which are of String type can use property placeholders. | true | boolean
 |===
 // component options: END
@@ -65,12 +67,15 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (20 parameters):
+=== Query Parameters (23 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *ackGroupTimeMillis* (consumer) | Group the consumer acknowledgments for the specified time in milliseconds - defaults to 100 | 100 | long
+| *ackTimeoutMillis* (consumer) | Timeout for unacknowledged messages in milliseconds - defaults to 10000 | 10000 | long
+| *allowManualAcknowledgement* (consumer) | Whether to allow manual message acknowledgements. If this option is enabled, then messages are not immediately acknowledged after being consumed. Instead, an instance of PulsarMessageReceipt is stored as a header on the org.apache.camel.Exchange. Messages can then be acknowledged using PulsarMessageReceipt at any time before the ackTimeout occurs. | false | boolean
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *consumerName* (consumer) | Name of the consumer when subscription is EXCLUSIVE | sole-consumer | String
 | *consumerNamePrefix* (consumer) | Prefix to add to consumer names when a SHARED or FAILOVER subscription is used | cons | String

--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -128,6 +128,17 @@ The component supports 3 options, which are listed below.
 // spring-boot-auto-configure options: END
 
 // message-headers options: START
+=== Message headers evaluated by the Pulsar producer
+
+
+[width="100%",cols="10%,10%,80%",options="header",]
+|===
+| Header | Type | Description
+| `CamelPulsarProducerMessageKey` | `String` | Sets the key on the message for the Pulsar routing policy
+| `CamelPulsarProducerMessageProperties` | `Map<String,String>` | The properties to set on the Pulsar message
+| `CamelPulsarProducerEventTime` | `long` | Sets the event time on the message
+|===
+
 === Message headers set by the Pulsar consumer
 
 
@@ -144,16 +155,5 @@ The component supports 3 options, which are listed below.
 | `key_bytes` | `byte[]` | The bytes in the key. If the key has been base64 encoded, it is decoded before being returned. Otherwise, if the key is a plain string, the UTF-8 encoded bytes of the string.
 | `topic_name` | `String` | The topic to which the message was published
 | `manual_acknowledgement` | `PulsarManualAcknowledgement` | If allowManualAcknowledgement is set, this will contain the object for manually acknowledging the Pulsar message; otherwise it is unset
-|===
-
-=== Message headers evaluated by the Pulsar producer
-
-
-[width="100%",cols="10%,10%,80%",options="header",]
-|===
-| Header | Type | Description
-| `CamelPulsarProducerMessageKey` | `String` | Sets the key on the message for the Pulsar routing policy
-| `CamelPulsarProducerMessageProperties` | `Map<String,String>` | The properties to set on the Pulsar message
-| `CamelPulsarProducerEventTime` | `long` | Sets the event time on the message
 |===
 // message-headers options: END

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceipt.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceipt.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceipt.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceipt.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+public class DefaultPulsarMessageReceipt implements PulsarMessageReceipt {
+
+    private final Consumer consumer;
+
+    private final MessageId messageId;
+
+    public DefaultPulsarMessageReceipt(Consumer consumer, MessageId messageId) {
+        this.consumer = consumer;
+        this.messageId = messageId;
+    }
+
+    @Override
+    public void acknowledge() throws PulsarClientException {
+        consumer.acknowledge(messageId);
+    }
+
+    @Override
+    public void acknowledgeCumulative() throws PulsarClientException {
+        consumer.acknowledgeCumulative(messageId);
+    }
+
+    @Override
+    public CompletableFuture<Void> acknowledgeAsync() {
+        return consumer.acknowledgeAsync(messageId);
+    }
+
+    @Override
+    public CompletableFuture<Void> acknowledgeCumulativeAsync() {
+        return consumer.acknowledgeCumulativeAsync(messageId);
+    }
+
+    @Override
+    public void negativeAcknowledge() {
+        throw new UnsupportedOperationException("Negative acknowledge is not supported in this version of the Pulsar client.");
+    }
+
+    public Consumer getConsumer() {
+        return consumer;
+    }
+
+    public MessageId getMessageId() {
+        return messageId;
+    }
+}

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceiptFactory.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceiptFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceiptFactory.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/DefaultPulsarMessageReceiptFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,18 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.pulsar.utils.message;
+package org.apache.camel.component.pulsar;
 
-public interface PulsarMessageHeaders {
+import org.apache.camel.Exchange;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 
-    String PROPERTIES = "properties";
-    String PRODUCER_NAME = "producer_name";
-    String SEQUENCE_ID = "sequence_id";
-    String PUBLISH_TIME = "publish_time";
-    String MESSAGE_ID = "message_id";
-    String EVENT_TIME = "event_time";
-    String KEY = "key";
-    String KEY_BYTES = "key_bytes";
-    String TOPIC_NAME = "topic_name";
-    String MESSAGE_RECEIPT = "message_receipt";
+public class DefaultPulsarMessageReceiptFactory implements PulsarMessageReceiptFactory {
+
+    @Override
+    public PulsarMessageReceipt newInstance(Exchange exchange, Message message, Consumer consumer) {
+        return new DefaultPulsarMessageReceipt(consumer, message.getMessageId());
+    }
+
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarComponent.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarComponent.java
@@ -32,6 +32,10 @@ public class PulsarComponent extends DefaultComponent {
     private AutoConfiguration autoConfiguration;
     @Metadata
     private PulsarClient pulsarClient;
+    @Metadata(label = "consumer", defaultValue = "false")
+    private boolean allowManualAcknowledgement;
+    @Metadata(label = "consumer,advanced")
+    private PulsarMessageReceiptFactory pulsarMessageReceiptFactory = new DefaultPulsarMessageReceiptFactory();
 
     public PulsarComponent() {
         this(null);
@@ -44,6 +48,8 @@ public class PulsarComponent extends DefaultComponent {
     @Override
     protected Endpoint createEndpoint(final String uri, final String path, final Map<String, Object> parameters) throws Exception {
         final PulsarConfiguration configuration = new PulsarConfiguration();
+
+        configuration.setAllowManualAcknowledgement(isAllowManualAcknowledgement());
 
         setProperties(configuration, parameters);
         if (autoConfiguration != null) {
@@ -77,5 +83,31 @@ public class PulsarComponent extends DefaultComponent {
      */
     public void setPulsarClient(PulsarClient pulsarClient) {
         this.pulsarClient = pulsarClient;
+    }
+
+    public boolean isAllowManualAcknowledgement() {
+        return allowManualAcknowledgement;
+    }
+
+    /**
+     * Whether to allow manual message acknowledgements.
+     * <p/>
+     * If this option is enabled, then messages are not immediately acknowledged after being consumed.
+     * Instead, an instance of {@link PulsarMessageReceipt} is stored as a header on the {@link org.apache.camel.Exchange}.
+     * Messages can then be acknowledged using {@link PulsarMessageReceipt} at any time before the ackTimeout occurs.
+     */
+    public void setAllowManualAcknowledgement(boolean allowManualAcknowledgement) {
+        this.allowManualAcknowledgement = allowManualAcknowledgement;
+    }
+
+    public PulsarMessageReceiptFactory getPulsarMessageReceiptFactory() {
+        return pulsarMessageReceiptFactory;
+    }
+
+    /**
+     * Provide a factory to create an alternate implementation of {@link PulsarMessageReceipt}.
+     */
+    public void setPulsarMessageReceiptFactory(PulsarMessageReceiptFactory pulsarMessageReceiptFactory) {
+        this.pulsarMessageReceiptFactory = pulsarMessageReceiptFactory;
     }
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarEndpoint.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarEndpoint.java
@@ -89,4 +89,9 @@ public class PulsarEndpoint extends DefaultEndpoint {
         return topicUri;
     }
 
+    @Override
+    public PulsarComponent getComponent() {
+        return (PulsarComponent) super.getComponent();
+    }
+
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
@@ -17,18 +17,53 @@
 package org.apache.camel.component.pulsar;
 
 import java.util.concurrent.CompletableFuture;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.pulsar.configuration.PulsarConfiguration;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 
+/**
+ * Acknowledge the receipt of a message using the Pulsar consumer.
+ * <p>
+ * Available on the {@link Exchange} if {@link PulsarConfiguration#isAllowManualAcknowledgement()} is true.
+ * An alternative to the default may be provided by implementing {@link PulsarMessageReceiptFactory}.
+ */
 public interface PulsarMessageReceipt {
 
+    /**
+     * Acknowledge receipt of this message synchronously.
+     *
+     * @see org.apache.pulsar.client.api.Consumer#acknowledge(MessageId)
+     */
     void acknowledge() throws PulsarClientException;
 
+    /**
+     * Acknowledge receipt of all of the messages in the stream up to and including this message synchronously.
+     *
+     * @see org.apache.pulsar.client.api.Consumer#acknowledgeCumulative(MessageId)
+     */
     void acknowledgeCumulative() throws PulsarClientException;
 
+    /**
+     * Acknowledge receipt of this message asynchronously.
+     *
+     * @see org.apache.pulsar.client.api.Consumer#acknowledgeAsync(MessageId)
+     */
     CompletableFuture<Void> acknowledgeAsync();
 
+    /**
+     * Acknowledge receipt of all of the messages in the stream up to and including this message asynchronously.
+     *
+     * @see org.apache.pulsar.client.api.Consumer#acknowledgeCumulativeAsync(MessageId)
+     */
     CompletableFuture<Void> acknowledgeCumulativeAsync();
 
+    /**
+     * Acknowledge the failure to process this message.
+     *
+     * @see org.apache.pulsar.client.api.Consumer#negativeAcknowledge(MessageId)
+     * Note: Available in Puslar 2.4.0. Implementations with earlier versions should return an {@link java.lang.UnsupportedOperationException}.
+     */
     void negativeAcknowledge();
 
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceipt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,18 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.pulsar.utils.message;
+package org.apache.camel.component.pulsar;
 
-public interface PulsarMessageHeaders {
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.PulsarClientException;
 
-    String PROPERTIES = "properties";
-    String PRODUCER_NAME = "producer_name";
-    String SEQUENCE_ID = "sequence_id";
-    String PUBLISH_TIME = "publish_time";
-    String MESSAGE_ID = "message_id";
-    String EVENT_TIME = "event_time";
-    String KEY = "key";
-    String KEY_BYTES = "key_bytes";
-    String TOPIC_NAME = "topic_name";
-    String MESSAGE_RECEIPT = "message_receipt";
+public interface PulsarMessageReceipt {
+
+    void acknowledge() throws PulsarClientException;
+
+    void acknowledgeCumulative() throws PulsarClientException;
+
+    CompletableFuture<Void> acknowledgeAsync();
+
+    CompletableFuture<Void> acknowledgeCumulativeAsync();
+
+    void negativeAcknowledge();
+
 }
+

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
@@ -20,8 +20,17 @@ import org.apache.camel.Exchange;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 
+/**
+ * Factory to create a new {@link PulsarMessageReceipt} to store on the {@link Exchange}.
+ * <p>
+ * Implement this interface if an alternate implementation of {@link PulsarMessageReceipt} is required
+ * as newer Pulsar clients may have acknowledgement functionality not yet supported by {@link DefaultPulsarMessageReceipt}.
+ */
 public interface PulsarMessageReceiptFactory {
 
+    /**
+     * Creates a new instance of {@link PulsarMessageReceipt}.
+     */
     PulsarMessageReceipt newInstance(Exchange exchange, Message message, Consumer consumer);
 
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarMessageReceiptFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.pulsar.utils.message;
+package org.apache.camel.component.pulsar;
 
-public interface PulsarMessageHeaders {
+import org.apache.camel.Exchange;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 
-    String PROPERTIES = "properties";
-    String PRODUCER_NAME = "producer_name";
-    String SEQUENCE_ID = "sequence_id";
-    String PUBLISH_TIME = "publish_time";
-    String MESSAGE_ID = "message_id";
-    String EVENT_TIME = "event_time";
-    String KEY = "key";
-    String KEY_BYTES = "key_bytes";
-    String TOPIC_NAME = "topic_name";
-    String MESSAGE_RECEIPT = "message_receipt";
+public interface PulsarMessageReceiptFactory {
+
+    PulsarMessageReceipt newInstance(Exchange exchange, Message message, Consumer consumer);
+
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
@@ -42,6 +42,12 @@ public class PulsarConfiguration {
     private String producerName;
     @UriParam(label = "consumer", defaultValue = "cons")
     private String consumerNamePrefix = "cons";
+    @UriParam(label = "consumer", defaultValue = "false")
+    private boolean allowManualAcknowledgement;
+    @UriParam(label = "consumer", defaultValue = "10000")
+    private long ackTimeoutMillis = 10000;
+    @UriParam(label = "consumer", defaultValue = "100")
+    private long ackGroupTimeMillis = 100;
     @UriParam(label = "producer", description = "Send timeout in milliseconds", defaultValue = "30000")
     private int sendTimeoutMs = 30000;
     @UriParam(label = "producer", description = "Whether to block the producing thread if pending messages queue is full or to throw a ProducerQueueIsFullError", defaultValue = "false")
@@ -139,6 +145,43 @@ public class PulsarConfiguration {
      */
     public void setConsumerNamePrefix(String consumerNamePrefix) {
         this.consumerNamePrefix = consumerNamePrefix;
+    }
+
+    public boolean isAllowManualAcknowledgement() {
+        return allowManualAcknowledgement;
+    }
+
+    /**
+     * Whether to allow manual message acknowledgements.
+     * <p/>
+     * If this option is enabled, then messages are not immediately acknowledged after being consumed.
+     * Instead, an instance of {@link PulsarMessageReceipt} is stored as a header on the {@link org.apache.camel.Exchange}.
+     * Messages can then be acknowledged using {@link PulsarMessageReceipt} at any time before the ackTimeout occurs.
+     */
+    public void setAllowManualAcknowledgement(boolean allowManualAcknowledgement) {
+        this.allowManualAcknowledgement = allowManualAcknowledgement;
+    }
+
+    public long getAckTimeoutMillis() {
+        return ackTimeoutMillis;
+    }
+
+    /**
+     * Timeout for unacknowledged messages in milliseconds - defaults to 10000
+     */
+    public void setAckTimeoutMillis(long ackTimeoutMillis) {
+        this.ackTimeoutMillis = ackTimeoutMillis;
+    }
+
+    public long getAckGroupTimeMillis() {
+        return ackGroupTimeMillis;
+    }
+
+    /**
+     * Group the consumer acknowledgments for the specified time in milliseconds - defaults to 100
+     */
+    public void setAckGroupTimeMillis(long ackGroupTimeMillis) {
+        this.ackGroupTimeMillis = ackGroupTimeMillis;
     }
 
     /**

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/CommonCreationStrategyImpl.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/CommonCreationStrategyImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.pulsar.utils.consumers;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.camel.component.pulsar.PulsarConsumer;
 import org.apache.camel.component.pulsar.PulsarEndpoint;
 import org.apache.camel.component.pulsar.PulsarMessageListener;
@@ -32,6 +33,8 @@ public final class CommonCreationStrategyImpl {
 
         return pulsarEndpoint.getPulsarClient().newConsumer().topic(pulsarEndpoint.getTopicUri()).subscriptionName(endpointConfiguration.getSubscriptionName())
             .receiverQueueSize(endpointConfiguration.getConsumerQueueSize()).consumerName(name)
+            .ackTimeout(endpointConfiguration.getAckTimeoutMillis(), TimeUnit.MILLISECONDS)
+            .acknowledgmentGroupTime(endpointConfiguration.getAckGroupTimeMillis(), TimeUnit.MILLISECONDS)
             .messageListener(new PulsarMessageListener(pulsarEndpoint, pulsarConsumer.getExceptionHandler(), pulsarConsumer.getProcessor()));
     }
 }

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarComponentTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarComponentTest.java
@@ -62,6 +62,7 @@ public class PulsarComponentTest extends CamelTestSupport {
         assertNull(endpoint.getPulsarConfiguration().getProducerName());
         assertEquals("subs", endpoint.getPulsarConfiguration().getSubscriptionName());
         assertEquals(SubscriptionType.EXCLUSIVE, endpoint.getPulsarConfiguration().getSubscriptionType());
+        assertFalse(endpoint.getPulsarConfiguration().isAllowManualAcknowledgement());
     }
 
     @Test
@@ -74,4 +75,17 @@ public class PulsarComponentTest extends CamelTestSupport {
 
         verify(autoConfiguration).ensureNameSpaceAndTenant(Matchers.anyString());
     }
+
+    @Test
+    public void testPulsarEndpointAllowManualAcknowledgementDefaultTrue() throws Exception {
+        PulsarComponent component = new PulsarComponent(context);
+        component.setAllowManualAcknowledgement(true);
+
+        // allowManualAcknowledgement is absent as a query parameter.
+        PulsarEndpoint endpoint = (PulsarEndpoint)component.createEndpoint("pulsar://persistent/test/foobar/BatchCreated");
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint.getPulsarConfiguration().isAllowManualAcknowledgement());
+    }
+
 }

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerAcknowledgementTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.pulsar.utils.AutoConfiguration;
+import org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PulsarConsumerAcknowledgementTest extends PulsarTestSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarConsumerAcknowledgementTest.class);
+
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic";
+    private static final String PRODUCER = "camel-producer-1";
+
+    @EndpointInject(uri = "pulsar:" + TOPIC_URI
+            + "?numberOfConsumers=1&subscriptionType=Exclusive"
+            + "&subscriptionName=camel-subscription&consumerQueueSize=1&consumerName=camel-consumer"
+            + "&allowManualAcknowledgement=true"
+            + "&ackTimeoutMillis=1000"
+    )
+    private Endpoint from;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint to;
+
+    Producer<String> producer;
+
+    @Before
+    public void setup() throws Exception {
+        context.removeRoute("myRoute");
+        producer = givenPulsarClient().newProducer(Schema.STRING)
+                .producerName(PRODUCER)
+                .topic(TOPIC_URI)
+                .create();
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+
+        registerPulsarBeans(jndi);
+
+        return jndi;
+    }
+
+    private void registerPulsarBeans(final JndiRegistry jndi) throws PulsarClientException {
+        PulsarClient pulsarClient = givenPulsarClient();
+        AutoConfiguration autoConfiguration = new AutoConfiguration(null, null);
+
+        jndi.bind("pulsarClient", pulsarClient);
+        PulsarComponent comp = new PulsarComponent(context);
+        comp.setAutoConfiguration(autoConfiguration);
+        comp.setPulsarClient(pulsarClient);
+        jndi.bind("pulsar", comp);
+    }
+
+    private PulsarClient givenPulsarClient() throws PulsarClientException {
+        return new ClientBuilderImpl()
+                .serviceUrl(getPulsarBrokerUrl())
+                .ioThreads(1)
+                .listenerThreads(1)
+                .build();
+    }
+
+    @Test
+    public void testAcknowledge() throws Exception {
+        to.expectsNoDuplicates(body());
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(from).routeId("myRoute").to(to).process(exchange -> {
+                    LOGGER.info("Processing message {}", exchange.getIn().getBody());
+
+                    PulsarMessageReceipt receipt = (PulsarMessageReceipt) exchange.getIn()
+                            .getHeader(PulsarMessageHeaders.MESSAGE_RECEIPT);
+                    receipt.acknowledge();
+                });
+            }
+        });
+
+        producer.send("Hello World!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+
+    @Test
+    public void testAcknowledgeAsync() throws Exception {
+        to.expectsNoDuplicates(body());
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(from).routeId("myRoute").to(to).process(exchange -> {
+                    LOGGER.info("Processing message {}", exchange.getIn().getBody());
+
+                    PulsarMessageReceipt receipt = (PulsarMessageReceipt) exchange.getIn()
+                            .getHeader(PulsarMessageHeaders.MESSAGE_RECEIPT);
+                    try {
+                        CompletableFuture<Void> f = receipt.acknowledgeAsync();
+                        f.get();
+                    } catch (Exception e) {
+                        LOGGER.error(e.getMessage());
+                    }
+                });
+            }
+        });
+
+        producer.send("Hello World!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+
+    @Test
+    public void testAcknowledgeCumulative() throws Exception {
+        to.expectsNoDuplicates(body());
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(from).routeId("myRoute").to(to).process(exchange -> {
+                    LOGGER.info("Processing message {}", exchange.getIn().getBody());
+
+                    PulsarMessageReceipt receipt = (PulsarMessageReceipt) exchange.getIn()
+                            .getHeader(PulsarMessageHeaders.MESSAGE_RECEIPT);
+                    // Ack the second message. The first will also be acked.
+                    if (exchange.getIn().getBody().equals("Hello World Again!")) {
+                        receipt.acknowledgeCumulative();
+                    }
+                });
+            }
+        });
+
+        producer.send("Hello World!");
+        producer.send("Hello World Again!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+
+    @Test
+    public void testAcknowledgeCumulativeAsync() throws Exception {
+        to.expectsNoDuplicates(body());
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(from).routeId("myRoute").to(to).process(exchange -> {
+                    LOGGER.info("Processing message {}", exchange.getIn().getBody());
+
+                    PulsarMessageReceipt receipt = (PulsarMessageReceipt) exchange.getIn()
+                            .getHeader(PulsarMessageHeaders.MESSAGE_RECEIPT);
+                    // Ack the second message. The first will also be acked.
+                    if (exchange.getIn().getBody().equals("Hello World Again!")) {
+                        try {
+                            CompletableFuture<Void> f = receipt.acknowledgeCumulativeAsync();
+                            f.get();
+                        } catch (Exception e) {
+                            LOGGER.error(e.getMessage());
+                        }
+                    }
+                });
+            }
+        });
+
+        producer.send("Hello World!");
+        producer.send("Hello World Again!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+}

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerAcknowledgementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -53,7 +53,7 @@ public class PulsarConsumerAcknowledgementTest extends PulsarTestSupport {
     @EndpointInject(uri = "mock:result")
     private MockEndpoint to;
 
-    Producer<String> producer;
+    private Producer<String> producer;
 
     @Before
     public void setup() throws Exception {

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerNoAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerNoAcknowledgementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerNoAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerNoAcknowledgementTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.pulsar.utils.AutoConfiguration;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.junit.Test;
+
+public class PulsarConsumerNoAcknowledgementTest extends PulsarTestSupport {
+
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic";
+    private static final String PRODUCER = "camel-producer-1";
+
+    @EndpointInject(uri = "pulsar:" + TOPIC_URI
+            + "?numberOfConsumers=1&subscriptionType=Exclusive"
+            + "&subscriptionName=camel-subscription&consumerQueueSize=1&consumerName=camel-consumer"
+            + "&ackTimeoutMillis=1000"
+    )
+    private Endpoint from;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint to;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                // Nothing in the route will ack the message.
+                from(from).to(to);
+            }
+        };
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+
+        registerPulsarBeans(jndi);
+
+        return jndi;
+    }
+
+    private void registerPulsarBeans(final JndiRegistry jndi) throws PulsarClientException {
+        PulsarClient pulsarClient = givenPulsarClient();
+        AutoConfiguration autoConfiguration = new AutoConfiguration(null, null);
+
+        jndi.bind("pulsarClient", pulsarClient);
+        PulsarComponent comp = new PulsarComponent(context);
+        comp.setAutoConfiguration(autoConfiguration);
+        comp.setPulsarClient(pulsarClient);
+        comp.setAllowManualAcknowledgement(true); // Set to true here instead of the endpoint query parameter.
+        jndi.bind("pulsar", comp);
+    }
+
+    private PulsarClient givenPulsarClient() throws PulsarClientException {
+        return new ClientBuilderImpl()
+                .serviceUrl(getPulsarBrokerUrl())
+                .ioThreads(1)
+                .listenerThreads(1)
+                .build();
+    }
+
+    @Test
+    public void testAMessageIsConsumedMultipleTimes() throws Exception {
+        to.expectedMinimumMessageCount(2);
+
+        Producer<String> producer = givenPulsarClient().newProducer(Schema.STRING)
+                .producerName(PRODUCER)
+                .topic(TOPIC_URI)
+                .create();
+
+        producer.send("Hello World!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+    }
+
+}

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarCustomMessageReceiptTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarCustomMessageReceiptTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.pulsar.utils.AutoConfiguration;
+import org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PulsarCustomMessageReceiptTest extends PulsarTestSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarCustomMessageReceiptTest.class);
+
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic";
+    private static final String PRODUCER = "camel-producer-1";
+
+    public PulsarMessageReceiptFactory mockPulsarMessageReceiptFactory = mock(PulsarMessageReceiptFactory.class);
+
+    public PulsarMessageReceipt mockPulsarMessageReceipt = mock(PulsarMessageReceipt.class);
+
+    @EndpointInject(uri = "pulsar:" + TOPIC_URI
+            + "?numberOfConsumers=1&subscriptionType=Exclusive"
+            + "&subscriptionName=camel-subscription&consumerQueueSize=1&consumerName=camel-consumer"
+            + "&allowManualAcknowledgement=true"
+            + "&ackTimeoutMillis=1000"
+    )
+    private Endpoint from;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint to;
+
+    Producer<String> producer;
+
+    @Before
+    public void setup() throws Exception {
+        producer = givenPulsarClient().newProducer(Schema.STRING)
+                .producerName(PRODUCER)
+                .topic(TOPIC_URI)
+                .create();
+    }
+
+    @Override
+    protected JndiRegistry createRegistry() throws Exception {
+        JndiRegistry jndi = super.createRegistry();
+
+        registerPulsarBeans(jndi);
+
+        return jndi;
+    }
+
+    private void registerPulsarBeans(final JndiRegistry jndi) throws PulsarClientException {
+        PulsarClient pulsarClient = givenPulsarClient();
+        AutoConfiguration autoConfiguration = new AutoConfiguration(null, null);
+
+        jndi.bind("pulsarClient", pulsarClient);
+        PulsarComponent comp = new PulsarComponent(context);
+        comp.setAutoConfiguration(autoConfiguration);
+        comp.setPulsarClient(pulsarClient);
+        // Test adding a custom PulsarMessageReceiptFactory
+        comp.setPulsarMessageReceiptFactory(mockPulsarMessageReceiptFactory);
+        jndi.bind("pulsar", comp);
+    }
+
+    private PulsarClient givenPulsarClient() throws PulsarClientException {
+        return new ClientBuilderImpl()
+                .serviceUrl(getPulsarBrokerUrl())
+                .ioThreads(1)
+                .listenerThreads(1)
+                .build();
+    }
+
+    @Test
+    public void testAcknowledgeWithCustomMessageReceipt() throws Exception {
+        to.expectedMinimumMessageCount(2);
+
+        when(mockPulsarMessageReceiptFactory.newInstance(any(), any(), any())).thenReturn(mockPulsarMessageReceipt);
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(from).routeId("myRoute").to(to).process(exchange -> {
+                    LOGGER.info("Processing message {}", exchange.getIn().getBody());
+
+                    PulsarMessageReceipt receipt = (PulsarMessageReceipt) exchange.getIn()
+                            .getHeader(PulsarMessageHeaders.MESSAGE_RECEIPT);
+                    receipt.acknowledge();
+                });
+            }
+        });
+
+        producer.send("Hello World!");
+
+        MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, to);
+
+        // The mock does not actually acknowledge using the pulsar consumer, so the message will be re-consumed
+        // after the ackTimeout.
+        verify(mockPulsarMessageReceipt, atLeast(2)).acknowledge();
+        verifyNoMoreInteractions(mockPulsarMessageReceipt);
+    }
+    
+}

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarCustomMessageReceiptTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarCustomMessageReceiptTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -15,13 +15,6 @@
  * limitations under the License.
  */
 package org.apache.camel.component.pulsar;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.camel.Endpoint;
@@ -41,6 +34,13 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 public class PulsarCustomMessageReceiptTest extends PulsarTestSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarCustomMessageReceiptTest.class);
@@ -48,9 +48,9 @@ public class PulsarCustomMessageReceiptTest extends PulsarTestSupport {
     private static final String TOPIC_URI = "persistent://public/default/camel-topic";
     private static final String PRODUCER = "camel-producer-1";
 
-    public PulsarMessageReceiptFactory mockPulsarMessageReceiptFactory = mock(PulsarMessageReceiptFactory.class);
+    private PulsarMessageReceiptFactory mockPulsarMessageReceiptFactory = mock(PulsarMessageReceiptFactory.class);
 
-    public PulsarMessageReceipt mockPulsarMessageReceipt = mock(PulsarMessageReceipt.class);
+    private PulsarMessageReceipt mockPulsarMessageReceipt = mock(PulsarMessageReceipt.class);
 
     @EndpointInject(uri = "pulsar:" + TOPIC_URI
             + "?numberOfConsumers=1&subscriptionType=Exclusive"
@@ -63,7 +63,7 @@ public class PulsarCustomMessageReceiptTest extends PulsarTestSupport {
     @EndpointInject(uri = "mock:result")
     private MockEndpoint to;
 
-    Producer<String> producer;
+    private Producer<String> producer;
 
     @Before
     public void setup() throws Exception {

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarNegativeAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarNegativeAcknowledgementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,18 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.pulsar.utils.message;
+package org.apache.camel.component.pulsar;
 
-public interface PulsarMessageHeaders {
+import static org.mockito.Mockito.mock;
 
-    String PROPERTIES = "properties";
-    String PRODUCER_NAME = "producer_name";
-    String SEQUENCE_ID = "sequence_id";
-    String PUBLISH_TIME = "publish_time";
-    String MESSAGE_ID = "message_id";
-    String EVENT_TIME = "event_time";
-    String KEY = "key";
-    String KEY_BYTES = "key_bytes";
-    String TOPIC_NAME = "topic_name";
-    String MESSAGE_RECEIPT = "message_receipt";
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.junit.Test;
+
+public class PulsarNegativeAcknowledgementTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testNegativeAcknowledgement() {
+        PulsarMessageReceipt receipt = new DefaultPulsarMessageReceipt(mock(Consumer.class), mock(MessageId.class));
+        receipt.negativeAcknowledge();
+    }
+
 }

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarNegativeAcknowledgementTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarNegativeAcknowledgementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.pulsar;
 
-import static org.mockito.Mockito.mock;
-
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
 
 public class PulsarNegativeAcknowledgementTest {
 

--- a/platforms/spring-boot/components-starter/camel-pulsar-starter/src/main/java/org/apache/camel/component/pulsar/springboot/PulsarComponentConfiguration.java
+++ b/platforms/spring-boot/components-starter/camel-pulsar-starter/src/main/java/org/apache/camel/component/pulsar/springboot/PulsarComponentConfiguration.java
@@ -46,6 +46,21 @@ public class PulsarComponentConfiguration
      */
     private String pulsarClient;
     /**
+     * Whether to allow manual message acknowledgements. If this option is
+     * enabled, then messages are not immediately acknowledged after being
+     * consumed. Instead, an instance of PulsarMessageReceipt is stored as a
+     * header on the org.apache.camel.Exchange. Messages can then be
+     * acknowledged using PulsarMessageReceipt at any time before the ackTimeout
+     * occurs.
+     */
+    private Boolean allowManualAcknowledgement = false;
+    /**
+     * Provide a factory to create an alternate implementation of
+     * PulsarMessageReceipt. The option is a
+     * org.apache.camel.component.pulsar.PulsarMessageReceiptFactory type.
+     */
+    private String pulsarMessageReceiptFactory;
+    /**
      * Whether the component should resolve property placeholders on itself when
      * starting. Only properties which are of String type can use property
      * placeholders.
@@ -67,6 +82,23 @@ public class PulsarComponentConfiguration
 
     public void setPulsarClient(String pulsarClient) {
         this.pulsarClient = pulsarClient;
+    }
+
+    public Boolean getAllowManualAcknowledgement() {
+        return allowManualAcknowledgement;
+    }
+
+    public void setAllowManualAcknowledgement(Boolean allowManualAcknowledgement) {
+        this.allowManualAcknowledgement = allowManualAcknowledgement;
+    }
+
+    public String getPulsarMessageReceiptFactory() {
+        return pulsarMessageReceiptFactory;
+    }
+
+    public void setPulsarMessageReceiptFactory(
+            String pulsarMessageReceiptFactory) {
+        this.pulsarMessageReceiptFactory = pulsarMessageReceiptFactory;
     }
 
     public Boolean getResolvePropertyPlaceholders() {


### PR DESCRIPTION
Back-port to 2.x of: [#3094](https://github.com/apache/camel/pull/3094)