### PR TITLE
CAMEL-14194: Message thread name removed from JID

### DIFF
--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppPrivateChatProducer.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppPrivateChatProducer.java
@@ -79,7 +79,7 @@ public class XmppPrivateChatProducer extends DefaultProducer {
             message.setType(Message.Type.normal);
 
             ChatManager chatManager = ChatManager.getInstanceFor(connection);
-            Chat chat = getOrCreateChat(chatManager, participant, thread);
+            Chat chat = getOrCreateChat(chatManager, participant);
 
             endpoint.getBinding().populateXmppMessage(message, exchange);
 
@@ -93,9 +93,9 @@ public class XmppPrivateChatProducer extends DefaultProducer {
         }
     }
 
-    private Chat getOrCreateChat(ChatManager chatManager, final String participant, String thread) throws XmppStringprepException {
+    private Chat getOrCreateChat(ChatManager chatManager, final String participant) throws XmppStringprepException {
         // this starts a new chat or retrieves the pre-existing one in a threadsafe manner
-        return chatManager.chatWith(JidCreate.entityBareFrom(participant + "@" + thread));
+        return chatManager.chatWith(JidCreate.entityBareFrom(participant));
     }
 
     private synchronized void reconnect() throws InterruptedException, IOException, SmackException, XMPPException {


### PR DESCRIPTION
A proposed fix to the issue where invalid JID's are generated for private chat messages.
I could not find any reason for the message thread to be appended to the JID and the thread is set in the message, and have removed the thread.
Tested using Openfire 4.4.3.