### PR TITLE
Disable tracing fix

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -530,6 +530,11 @@ public abstract class BaseMainSupport extends ServiceSupport {
             autoConfigurationFromProperties(camelContext, autoConfiguredProperties);
         }
 
+        // tracing may be enabled by some other property (i.e. camel.context.tracer.exchange-formatter.show-headers)
+        if (camelContext.isTracing() && !mainConfigurationProperties.isTracing()) {
+            camelContext.setTracing(Boolean.FALSE);
+        }
+
         // log summary of configurations
         if (mainConfigurationProperties.isAutoConfigurationLogSummary() && !autoConfiguredProperties.isEmpty()) {
             LOG.info("Auto-configuration summary:");

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainTest.java
@@ -104,6 +104,18 @@ public class MainTest extends Assert {
         main.stop();
     }
 
+    @Test
+    public void testDisableTracing() throws Exception {
+        Main main = new Main();
+        main.addRoutesBuilder(new MyRouteBuilder());
+        main.start();
+
+        CamelContext camelContext = main.getCamelContext();
+        assertFalse("Tracing should be disabled", camelContext.isTracing());
+
+        main.stop();
+    }
+
     public static class MyRouteBuilder extends RouteBuilder {
         @Override
         public void configure() throws Exception {

--- a/core/camel-main/src/test/resources/application.properties
+++ b/core/camel-main/src/test/resources/application.properties
@@ -19,3 +19,6 @@ hello=World
 camel.component.seda.concurrent-consumers=2
 camel.component.seda.queueSize=500
 camel.component.direct.timeout=1234
+
+camel.main.tracing = false
+camel.context.tracer.exchange-formatter.show-headers = true


### PR DESCRIPTION
Even if tracing is disabled using `camel.main.tracing = false`, it may be re-enabled by some other property (i.e. `camel.context.tracer.exchange-formatter.show-headers`). The problem shows up regardless of the value of the `*.tracer.*` property.