### PR TITLE
CAMEL-13679: fixed Camel-FTP component does not set CamelFtpReplyCode…

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpsOperations.java
@@ -62,12 +62,6 @@ public class FtpsOperations extends FtpOperations {
                     log.debug("FTPClient initializing with execProt={}", execProt);
                     getFtpClient().execPROT(execProt);
                 }
-
-                if (exchange != null) {
-                    // store client reply information after the operation
-                    exchange.getIn().setHeader(FtpConstants.FTP_REPLY_CODE, client.getReplyCode());
-                    exchange.getIn().setHeader(FtpConstants.FTP_REPLY_STRING, client.getReplyString());
-                }
             } catch (SSLException e) {
                 throw new GenericFileOperationFailedException(client.getReplyCode(),
                         client.getReplyString(), e.getMessage(), e);


### PR DESCRIPTION
… in some case(ex 530).

This commit is only part of the fix, the other one (commit 302e43e306708939b076cdfb5ea3bf0223315729) had a worng issue number in the comment:
CAMEL-12570: fixed Camel-FTP component does not set CamelFtpReplyCode in some case(ex 530).