### PR TITLE
CAMEL-14221: Stomp Component has no option to set version

### DIFF
--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompConfiguration.java
@@ -35,6 +35,8 @@ public class StompConfiguration implements Cloneable {
     private String host;
     @UriParam(label = "security")
     private SSLContextParameters sslContextParameters;
+    @UriParam
+    private String version;
 
     /**
      * Returns a copy of this configuration
@@ -101,6 +103,17 @@ public class StompConfiguration implements Cloneable {
      */
     public void setSslContextParameters(SSLContextParameters sslContextParameters) {
         this.sslContextParameters = sslContextParameters;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * The STOMP Version
+     */
+    public void setVersion(String version) {
+	this.version = version;
     }
 
 }

--- a/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
+++ b/components/camel-stomp/src/main/java/org/apache/camel/component/stomp/StompEndpoint.java
@@ -98,6 +98,9 @@ public class StompEndpoint extends DefaultEndpoint implements AsyncEndpoint, Hea
         if (configuration.getSslContextParameters() != null) {
             stomp.setSslContext(configuration.getSslContextParameters().createSSLContext(getCamelContext()));
         }
+	if (configuration.getVersion() != null && !configuration.getVersion().isEmpty()) {
+	    stomp.setVersion(configuration.getVersion());
+	}
         stomp.connectCallback(promise);
         if (configuration.getHost() != null && !configuration.getHost().isEmpty()) {
             stomp.setHost(configuration.getHost());


### PR DESCRIPTION
The STOMP version is hardcoded in the org.fusesource.stomp.client.Stomp class. Though the org.fusesource.stomp.client.Stomp class has setter method for version, the Camel-Stomp Component has not exposed that option to be set by the users.