### PR TITLE
added suport for get with body on camel-http4

### DIFF
--- a/components/camel-http4/src/main/docs/http4-component.adoc
+++ b/components/camel-http4/src/main/docs/http4-component.adoc
@@ -108,7 +108,7 @@ with the following path and query parameters:
 |===
 
 
-==== Query Parameters (49 parameters):
+==== Query Parameters (50 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -125,6 +125,7 @@ with the following path and query parameters:
 | *cookieStore* (producer) | To use a custom CookieStore. By default the BasicCookieStore is used which is an in-memory only cookie store. Notice if bridgeEndpoint=true then the cookie store is forced to be a noop cookie store as cookie shouldn't be stored as we are just bridging (eg acting as a proxy). If a cookieHandler is set then the cookie store is also forced to be a noop cookie store as cookie handling is then performed by the cookieHandler. |  | CookieStore
 | *copyHeaders* (producer) | If this option is true then IN exchange headers will be copied to OUT exchange headers according to copy strategy. Setting this to false, allows to only include the headers from the HTTP response (not propagating IN headers). | true | boolean
 | *deleteWithBody* (producer) | Whether the HTTP DELETE should include the message body or not. By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body. | false | boolean
+| *getWithBody* (producer) | Whether the HTTP GET should include the message body or not. By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the message body. | false | boolean
 | *httpMethod* (producer) | Configure the HTTP method to use. The HttpMethod header cannot override this option if set. |  | HttpMethods
 | *ignoreResponseBody* (producer) | If this option is true, The http producer won't read response body and cache the input stream | false | boolean
 | *preserveHostHeader* (producer) | If the option is true, HttpProducer will set the Host header to the value contained in the current exchange Host header, useful in reverse proxy applications where you want the Host header received by the downstream server to reflect the URL called by the upstream client, this allows applications which use the Host header to generate accurate URL's for a proxied service | false | boolean

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
@@ -112,6 +112,9 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     @UriParam(label = "producer", description = "Whether the HTTP DELETE should include the message body or not."
         + " By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
     private boolean deleteWithBody;
+    @UriParam(label = "producer", description = "Whether the HTTP GET should include the message body or not."
+        + " By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
+    private boolean getWithBody;
 
     @UriParam(label = "advanced", defaultValue = "200", description = "The maximum number of connections.")
     private int maxTotalConnections;
@@ -307,6 +310,9 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     public boolean isDeleteWithBody() {
         return deleteWithBody;
     }
+    public boolean isGetWithBody() {
+        return getWithBody;
+    }
 
     /**
      * Whether the HTTP DELETE should include the message body or not.
@@ -316,6 +322,15 @@ public class HttpEndpoint extends HttpCommonEndpoint {
      */
     public void setDeleteWithBody(boolean deleteWithBody) {
         this.deleteWithBody = deleteWithBody;
+    }
+    /**
+     * Whether the HTTP GET should include the message body or not.
+     * <p/>
+     * By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the
+     * message body.
+     */
+    public void setGetWithBody(boolean getWithBody) {
+        this.getWithBody = getWithBody;
     }
 
     public CookieStore getCookieStore() {

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpGetWithBodyMethod.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpGetWithBodyMethod.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http4;
+
+import java.net.URI;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+public class HttpGetWithBodyMethod extends HttpEntityEnclosingRequestBase {
+
+    public static final String METHOD_NAME = "GET";
+
+    public HttpGetWithBodyMethod(String uri, HttpEntity entity) {
+        setURI(URI.create(uri));
+        setEntity(entity);
+    }
+
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
@@ -460,6 +460,10 @@ public class HttpProducer extends DefaultProducer {
         if (getEndpoint().isDeleteWithBody() && "DELETE".equals(method.getMethod())) {
             method = new HttpDeleteWithBodyMethod(url, requestEntity);
         }
+        // special for HTTP GET if the message body should be included
+        if (getEndpoint().isGetWithBody() && "GET".equals(method.getMethod())) {
+            method = new HttpGetWithBodyMethod(url, requestEntity);
+        }
 
         LOG.trace("Using URL: {} with method: {}", url, method);
 


### PR DESCRIPTION
Added support for GET with body content on camel-http4.  This is triggered with the 'getWithBody=true' uri parameter.

**note: built and tested with maven compiler plugin 3.6.0 because of a dependency issue with plexus-util-1.1 when using v3.8.0 (NoClassDefFound error on org/codehaus/plexus/compiler/util/scan/InclusionScanException).