### PR TITLE
Http4+get with body

### DIFF
--- a/components/camel-http4/src/main/docs/http4-component.adoc
+++ b/components/camel-http4/src/main/docs/http4-component.adoc
@@ -53,7 +53,7 @@ route, use the xref:jetty-component.adoc[Jetty] instead.
 
 
 // component options: START
-The HTTP4 component supports 20 options, which are listed below.
+The HTTP4 component supports 18 options, which are listed below.
 
 
 
@@ -70,8 +70,6 @@ The HTTP4 component supports 20 options, which are listed below.
 | *connectionsPerRoute* (advanced) | The maximum number of connections per route. | 20 | int
 | *connectionTimeToLive* (advanced) | The time for connection to live, the time unit is millisecond, the default value is always keep alive. |  | long
 | *cookieStore* (producer) | To use a custom org.apache.http.client.CookieStore. By default the org.apache.http.impl.client.BasicCookieStore is used which is an in-memory only cookie store. Notice if bridgeEndpoint=true then the cookie store is forced to be a noop cookie store as cookie shouldn't be stored as we are just bridging (eg acting as a proxy). |  | CookieStore
-| *deleteWithBody* (producer) | Whether the HTTP DELETE should include the message body or not. By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
-| *getWithBody* (producer) | Whether the HTTP GET should include the message body or not. By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
 | *connectionRequest Timeout* (timeout) | The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int
 | *connectTimeout* (timeout) | Determines the timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int
 | *socketTimeout* (timeout) | Defines the socket timeout (SO_TIMEOUT) in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int
@@ -111,7 +109,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (49 parameters):
+=== Query Parameters (50 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -127,7 +125,8 @@ with the following path and query parameters:
 | *connectionClose* (producer) | Specifies whether a Connection Close header must be added to HTTP Request. By default connectionClose is false. | false | boolean
 | *cookieStore* (producer) | To use a custom CookieStore. By default the BasicCookieStore is used which is an in-memory only cookie store. Notice if bridgeEndpoint=true then the cookie store is forced to be a noop cookie store as cookie shouldn't be stored as we are just bridging (eg acting as a proxy). If a cookieHandler is set then the cookie store is also forced to be a noop cookie store as cookie handling is then performed by the cookieHandler. |  | CookieStore
 | *copyHeaders* (producer) | If this option is true then IN exchange headers will be copied to OUT exchange headers according to copy strategy. Setting this to false, allows to only include the headers from the HTTP response (not propagating IN headers). | true | boolean
-| *deleteWithBody* (producer) | Whether the HTTP DELETE should include the message body or not. By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body. | false | boolean
+| *deleteWithBody* (producer) | Whether the HTTP DELETE should include the message body or not. By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
+| *getWithBody* (producer) | Whether the HTTP GET should include the message body or not. By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
 | *httpMethod* (producer) | Configure the HTTP method to use. The HttpMethod header cannot override this option if set. |  | HttpMethods
 | *ignoreResponseBody* (producer) | If this option is true, The http producer won't read response body and cache the input stream | false | boolean
 | *preserveHostHeader* (producer) | If the option is true, HttpProducer will set the Host header to the value contained in the current exchange Host header, useful in reverse proxy applications where you want the Host header received by the downstream server to reflect the URL called by the upstream client, this allows applications which use the Host header to generate accurate URL's for a proxied service | false | boolean

--- a/components/camel-http4/src/main/docs/http4-component.adoc
+++ b/components/camel-http4/src/main/docs/http4-component.adoc
@@ -53,7 +53,7 @@ route, use the xref:jetty-component.adoc[Jetty] instead.
 
 
 // component options: START
-The HTTP4 component supports 18 options, which are listed below.
+The HTTP4 component supports 20 options, which are listed below.
 
 
 
@@ -70,6 +70,8 @@ The HTTP4 component supports 18 options, which are listed below.
 | *connectionsPerRoute* (advanced) | The maximum number of connections per route. | 20 | int
 | *connectionTimeToLive* (advanced) | The time for connection to live, the time unit is millisecond, the default value is always keep alive. |  | long
 | *cookieStore* (producer) | To use a custom org.apache.http.client.CookieStore. By default the org.apache.http.impl.client.BasicCookieStore is used which is an in-memory only cookie store. Notice if bridgeEndpoint=true then the cookie store is forced to be a noop cookie store as cookie shouldn't be stored as we are just bridging (eg acting as a proxy). |  | CookieStore
+| *deleteWithBody* (producer) | Whether the HTTP DELETE should include the message body or not. By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
+| *getWithBody* (producer) | Whether the HTTP GET should include the message body or not. By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the message body. | false | boolean
 | *connectionRequest Timeout* (timeout) | The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int
 | *connectTimeout* (timeout) | Determines the timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int
 | *socketTimeout* (timeout) | Defines the socket timeout (SO_TIMEOUT) in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default). Default: code -1 | -1 | int

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
@@ -110,10 +110,10 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     @UriParam(label = "producer", description = "If this option is true, camel-http4 sends preemptive basic authentication to the server.")
     private boolean authenticationPreemptive;
     @UriParam(label = "producer", description = "Whether the HTTP DELETE should include the message body or not."
-        + " By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
+        + " By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the message body.")
     private boolean deleteWithBody;
     @UriParam(label = "producer", description = "Whether the HTTP GET should include the message body or not."
-        + " By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
+        + " By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the message body.")
     private boolean getWithBody;
 
     @UriParam(label = "advanced", defaultValue = "200", description = "The maximum number of connections.")

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
@@ -109,13 +109,12 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     private boolean clearExpiredCookies = true;
     @UriParam(label = "producer", description = "If this option is true, camel-http4 sends preemptive basic authentication to the server.")
     private boolean authenticationPreemptive;
-    @UriParam(label = "producer", description = "Whether the HTTP DELETE should include the message body or not."
-        + " By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the message body.")
-    private boolean deleteWithBody;
     @UriParam(label = "producer", description = "Whether the HTTP GET should include the message body or not."
         + " By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the message body.")
     private boolean getWithBody;
-
+    @UriParam(label = "producer", description = "Whether the HTTP DELETE should include the message body or not."
+        + " By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
+    private boolean deleteWithBody;
     @UriParam(label = "advanced", defaultValue = "200", description = "The maximum number of connections.")
     private int maxTotalConnections;
     @UriParam(label = "advanced", defaultValue = "20", description = "The maximum number of connections per route.")
@@ -310,23 +309,25 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     public boolean isDeleteWithBody() {
         return deleteWithBody;
     }
-    public boolean isGetWithBody() {
-        return getWithBody;
-    }
 
     /**
      * Whether the HTTP DELETE should include the message body or not.
      * <p/>
-     * By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the
+     * By default HTTP DELETE do not include any HTTP body. However in some rare cases users may need to be able to include the
      * message body.
      */
     public void setDeleteWithBody(boolean deleteWithBody) {
         this.deleteWithBody = deleteWithBody;
     }
+
+    public boolean isGetWithBody() {
+        return getWithBody;
+    }
+
     /**
      * Whether the HTTP GET should include the message body or not.
      * <p/>
-     * By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the
+     * By default HTTP GET do not include any HTTP body. However in some rare cases users may need to be able to include the
      * message body.
      */
     public void setGetWithBody(boolean getWithBody) {

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpEndpoint.java
@@ -112,6 +112,9 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     @UriParam(label = "producer", description = "Whether the HTTP DELETE should include the message body or not."
         + " By default HTTP DELETE do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
     private boolean deleteWithBody;
+    @UriParam(label = "producer", description = "Whether the HTTP GET should include the message body or not."
+        + " By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the message body.")
+    private boolean getWithBody;
 
     @UriParam(label = "advanced", defaultValue = "200", description = "The maximum number of connections.")
     private int maxTotalConnections;
@@ -307,6 +310,9 @@ public class HttpEndpoint extends HttpCommonEndpoint {
     public boolean isDeleteWithBody() {
         return deleteWithBody;
     }
+    public boolean isGetWithBody() {
+        return getWithBody;
+    }
 
     /**
      * Whether the HTTP DELETE should include the message body or not.
@@ -316,6 +322,15 @@ public class HttpEndpoint extends HttpCommonEndpoint {
      */
     public void setDeleteWithBody(boolean deleteWithBody) {
         this.deleteWithBody = deleteWithBody;
+    }
+    /**
+     * Whether the HTTP GET should include the message body or not.
+     * <p/>
+     * By default HTTP GET do not include any HTTP message. However in some rare cases users may need to be able to include the
+     * message body.
+     */
+    public void setGetWithBody(boolean getWithBody) {
+        this.getWithBody = getWithBody;
     }
 
     public CookieStore getCookieStore() {

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpGetWithBodyMethod.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpGetWithBodyMethod.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http4;
+
+import java.net.URI;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+public class HttpGetWithBodyMethod extends HttpEntityEnclosingRequestBase {
+
+    public static final String METHOD_NAME = "GET";
+
+    public HttpGetWithBodyMethod(String uri, HttpEntity entity) {
+        setURI(URI.create(uri));
+        setEntity(entity);
+    }
+
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
@@ -452,22 +452,24 @@ public class HttpProducer extends DefaultProducer {
         }
 
         // create http holder objects for the request
-        HttpEntity requestEntity = createRequestEntity(exchange);
-        HttpMethods methodToUse = HttpMethodHelper.createMethod(exchange, getEndpoint(), requestEntity != null);
+        HttpMethods methodToUse = HttpMethodHelper.createMethod(exchange, getEndpoint());
         HttpRequestBase method = methodToUse.createMethod(url);
 
-        // special for HTTP DELETE if the message body should be included
+        // special for HTTP DELETE/GET if the message body should be included
         if (getEndpoint().isDeleteWithBody() && "DELETE".equals(method.getMethod())) {
+            HttpEntity requestEntity = createRequestEntity(exchange);
             method = new HttpDeleteWithBodyMethod(url, requestEntity);
-        }
-        // special for HTTP GET if the message body should be included
-        if (getEndpoint().isGetWithBody() && "GET".equals(method.getMethod())) {
+        } else if (getEndpoint().isGetWithBody() && "GET".equals(method.getMethod())) {
+            HttpEntity requestEntity = createRequestEntity(exchange);
             method = new HttpGetWithBodyMethod(url, requestEntity);
         }
+
 
         LOG.trace("Using URL: {} with method: {}", url, method);
 
         if (methodToUse.isEntityEnclosing()) {
+            // only create entity for http payload if the HTTP method carries payload (such as POST)
+            HttpEntity requestEntity = createRequestEntity(exchange);
             ((HttpEntityEnclosingRequestBase) method).setEntity(requestEntity);
             if (requestEntity != null && requestEntity.getContentType() == null) {
                 LOG.debug("No Content-Type provided for URL: {} with exchange: {}", url, exchange);

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/HttpProducer.java
@@ -460,6 +460,10 @@ public class HttpProducer extends DefaultProducer {
         if (getEndpoint().isDeleteWithBody() && "DELETE".equals(method.getMethod())) {
             method = new HttpDeleteWithBodyMethod(url, requestEntity);
         }
+        // special for HTTP GET if the message body should be included
+        if (getEndpoint().isGetWithBody() && "GET".equals(method.getMethod())) {
+            method = new HttpGetWithBodyMethod(url, requestEntity);
+        }
 
         LOG.trace("Using URL: {} with method: {}", url, method);
 

--- a/components/camel-http4/src/main/java/org/apache/camel/component/http4/helper/HttpMethodHelper.java
+++ b/components/camel-http4/src/main/java/org/apache/camel/component/http4/helper/HttpMethodHelper.java
@@ -33,12 +33,8 @@ public final class HttpMethodHelper {
 
     /**
      * Creates the HttpMethod to use to call the remote server, often either its GET or POST.
-     *
-     * @param exchange the exchange
-     * @return the created method
-     * @throws URISyntaxException 
      */
-    public static HttpMethods createMethod(Exchange exchange, HttpEndpoint endpoint, boolean hasPayload) throws URISyntaxException {
+    public static HttpMethods createMethod(Exchange exchange, HttpEndpoint endpoint) throws URISyntaxException {
         // is a query string provided in the endpoint URI or in a header (header
         // overrules endpoint)
         String queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
@@ -76,7 +72,7 @@ public final class HttpMethodHelper {
                 answer = HttpMethods.GET;
             } else {
                 // fallback to POST if we have payload, otherwise GET
-                answer = hasPayload ? HttpMethods.POST : HttpMethods.GET;
+                answer = exchange.getMessage().getBody() != null ? HttpMethods.POST : HttpMethods.GET;
             }
         }
 

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
@@ -82,7 +82,22 @@ public class HttpMethodsTest extends BaseHttpTest {
 
         assertExchange(exchange);
     }
-    
+   
+    @Test
+    public void httpGetWithBody() throws Exception {
+
+        Exchange exchange = template.request("http://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/get?getWithBody=true", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_METHOD, "GET");
+                exchange.getIn().setBody("rocks camel?");
+            }
+        });
+
+        assertExchange(exchange);
+
+        // the http server will not provide body on HTTP GET so we cannot test the server side
+    } 
+
     @Test
     public void httpGetWithUriParam() throws Exception {
 

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
@@ -86,7 +86,7 @@ public class HttpMethodsTest extends BaseHttpTest {
     @Test
     public void httpGetWithBody() throws Exception {
 
-        Exchange exchange = template.request("http://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/get?getWithBody=true", new Processor() {
+        Exchange exchange = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/get?getWithBody=true", new Processor() {
             public void process(Exchange exchange) throws Exception {
                 exchange.getIn().setHeader(Exchange.HTTP_METHOD, "GET");
                 exchange.getIn().setBody("rocks camel?");

--- a/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
+++ b/components/camel-http4/src/test/java/org/apache/camel/component/http4/HttpMethodsTest.java
@@ -82,22 +82,7 @@ public class HttpMethodsTest extends BaseHttpTest {
 
         assertExchange(exchange);
     }
-   
-    @Test
-    public void httpGetWithBody() throws Exception {
-
-        Exchange exchange = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/get?getWithBody=true", new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(Exchange.HTTP_METHOD, "GET");
-                exchange.getIn().setBody("rocks camel?");
-            }
-        });
-
-        assertExchange(exchange);
-
-        // the http server will not provide body on HTTP GET so we cannot test the server side
-    } 
-
+    
     @Test
     public void httpGetWithUriParam() throws Exception {
 
@@ -235,6 +220,21 @@ public class HttpMethodsTest extends BaseHttpTest {
         assertExchange(exchange);
 
         // the http4 server will not provide body on HTTP DELETE so we cannot test the server side
+    }
+
+    @Test
+    public void httpGetWithBody() throws Exception {
+
+        Exchange exchange = template.request("http4://" + localServer.getInetAddress().getHostName() + ":" + localServer.getLocalPort() + "/get?getWithBody=true", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Exchange.HTTP_METHOD, "GET");
+                exchange.getIn().setBody("rocks camel?");
+            }
+        });
+
+        assertExchange(exchange);
+
+        // the http server will not provide body on HTTP GET so we cannot test the server side
     }
 
     @Test

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -343,8 +343,7 @@
       <plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-package-maven-plugin</artifactId>
-        <!--<version>${project.version}</version>-->
-        <version>2.24.0</version>
+        <version>${project.version}</version>
         <configuration>
             <!-- set to true to make build fail fast if missing documentation in docs files -->
             <failFast>false</failFast>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -343,7 +343,8 @@
       <plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-package-maven-plugin</artifactId>
-        <version>${project.version}</version>
+        <!--<version>${project.version}</version>-->
+        <version>2.24.0</version>
         <configuration>
             <!-- set to true to make build fail fast if missing documentation in docs files -->
             <failFast>false</failFast>


### PR DESCRIPTION
Added support for GET with body content on camel-http4. This is triggered with the 'getWithBody=true' uri parameter.