### PR TITLE
[CAMEL-13213] Cannot use rest-swagger component with swagger.json pro…

### DIFF
--- a/components/camel-rest-swagger/pom.xml
+++ b/components/camel-rest-swagger/pom.xml
@@ -71,6 +71,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -118,12 +123,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jaxb</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-http</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-rest-swagger/src/main/docs/rest-swagger-component.adoc
+++ b/components/camel-rest-swagger/src/main/docs/rest-swagger-component.adoc
@@ -126,7 +126,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (8 parameters):
+=== Query Parameters (9 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -140,6 +140,7 @@ with the following path and query parameters:
 | *produces* (producer) | What payload type this component is producing. For example application/json according to the RFC7231. This equates to the value of Content-Type HTTP header. If set overrides any value present in the Swagger specification. Overrides all other configuration. |  | String
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
+| *sslContextParameters* (security) | To configure security using SSLContextParameters. |  | SSLContextParameters
 |===
 // endpoint options: END
 // spring-boot-auto-configure options: START

--- a/components/camel-rest-swagger/src/test/java/org/apache/camel/component/rest/swagger/RestSwaggerEndpointTest.java
+++ b/components/camel-rest-swagger/src/test/java/org/apache/camel/component/rest/swagger/RestSwaggerEndpointTest.java
@@ -338,7 +338,7 @@ public class RestSwaggerEndpointTest {
         when(camelContext.getClassResolver()).thenReturn(new DefaultClassResolver());
 
         assertThat(
-            RestSwaggerEndpoint.loadSpecificationFrom(camelContext, RestSwaggerComponent.DEFAULT_SPECIFICATION_URI))
+            RestSwaggerEndpoint.loadSpecificationFrom(camelContext, RestSwaggerComponent.DEFAULT_SPECIFICATION_URI, null))
                 .isNotNull();
     }
 
@@ -363,7 +363,7 @@ public class RestSwaggerEndpointTest {
         final CamelContext camelContext = mock(CamelContext.class);
         when(camelContext.getClassResolver()).thenReturn(new DefaultClassResolver());
 
-        RestSwaggerEndpoint.loadSpecificationFrom(camelContext, URI.create("non-existant.json"));
+        RestSwaggerEndpoint.loadSpecificationFrom(camelContext, URI.create("non-existant.json"), null);
     }
 
     @Test

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -2080,6 +2080,7 @@
   </feature> -->
   <feature name='camel-rest-swagger' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
+    <feature version='${project.version}'>camel-http</feature>
     <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml-version}</bundle>
     <bundle dependency='true'>mvn:javax.validation/validation-api/${validation-1-api-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>


### PR DESCRIPTION
…vided over HTTPS protocol

Issue: https://issues.apache.org/jira/browse/CAMEL-13213

There was on static call for swagger.json, which didn't care about ssl. I was trying to follow suggested direction from issue "What we should do is to load the resource via the chose camel http component and do a HTTP GET call. Then you setup SSL on it (as you would need to do to use https for the actual HTTP rest calls)." 
So I've:
- added dependency to camel-http
- added sslContextParameters definition to endpoint
- replaced "ResourceHelper.resolveMandatoryResourceAsInputStream" with camel-http call, which uses sslContextParameters
- added JUnit test to cover this case

@davsclaus what do you think?