### PR TITLE
Remove dead link to javadoc of ExchangePattern

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
@@ -11,7 +11,7 @@ Integration Patterns] the common examples are
 * Event Message (or one way)
 
 In Camel we have an
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/ExchangePattern.html[ExchangePattern]
+`org.apache.camel.ExchangePattern`
 enumeration which can be configured on the *exchangePattern* property on
 the Message Exchange indicating if a message
 exchange is a one way Event Message (InOnly) or


### PR DESCRIPTION
use the fully qualified name so that users can find the enumeration easily as the information is no more available from the link that is removed.