### PR TITLE
Move camel-core-osgi-activator tests to Karaf itests

### DIFF
--- a/core/camel-core-osgi-activator/pom.xml
+++ b/core/camel-core-osgi-activator/pom.xml
@@ -57,73 +57,6 @@
       <artifactId>camel-core-osgi</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- test -->
-
-    <!-- PAX Exam -->
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-spi</artifactId>
-      <version>${pax-exam-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-container-karaf</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.url</groupId>
-      <artifactId>pax-url-aether</artifactId>
-      <version>2.4.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.tinybundles</groupId>
-      <artifactId>tinybundles</artifactId>
-      <version>2.1.1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Karaf & Command Shell -->
-    <dependency>
-      <groupId>org.apache.karaf</groupId>
-      <artifactId>apache-karaf</artifactId>
-      <version>${karaf4-version}</version>
-      <type>zip</type>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.karaf.features</groupId>
-          <artifactId>framework</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- Karaf Features -->
-    <dependency>
-      <groupId>org.apache.camel.karaf</groupId>
-      <artifactId>apache-camel</artifactId>
-      <version>${project.version}</version>
-      <classifier>features</classifier>
-      <type>xml</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -136,44 +69,6 @@
             <goals>
               <goal>generate-depends-file</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-                <descriptors>
-                    <descriptor>src/assembly/test-bundles.xml</descriptor>
-                </descriptors>
-              <finalName>test</finalName>
-              <attach>false</attach>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Execute in the integration-test phase so that the packaged JAR 
-        can be used -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/*IT.java</include>
-              </includes>
-              <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tests/camel-itest-karaf/pom.xml
+++ b/tests/camel-itest-karaf/pom.xml
@@ -84,6 +84,19 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>apache-karaf</artifactId>
+            <version>${karaf4-version}</version>
+            <type>zip</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.karaf.features</groupId>
+                    <artifactId>framework</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
             <scope>test</scope>
@@ -125,11 +138,52 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- test and logging -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- PAX Exam -->
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-spi</artifactId>
+            <version>${pax-exam-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-karaf</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-aether</artifactId>
+            <version>2.4.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.tinybundles</groupId>
+            <artifactId>tinybundles</artifactId>
+            <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -195,6 +249,46 @@
                         <camelKarafFeatureVersion>${project.version}</camelKarafFeatureVersion>
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/test-bundles.xml</descriptor>
+                            </descriptors>
+                            <finalName>test</finalName>
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Execute in the integration-test phase so that the packaged JAR 
+            can be used -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                            <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/main/BundleIT.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/main/BundleIT.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.core.osgi.main.it;
+package org.apache.camel.itest.karaf.main;
 
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/main/PaxExamOptions.java
+++ b/tests/camel-itest-karaf/src/test/java/org/apache/camel/itest/karaf/main/PaxExamOptions.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.core.osgi.main.it;
+package org.apache.camel.itest.karaf.main;
 
 import java.io.File;
 


### PR DESCRIPTION
Since OSGI activator depends on Karaf features it can only be built
after it, and since Karaf features include OSGI activator it fails as
the activator is not present in the Maven reactor at that point -- it
will be built right after it. This moves the tests, the only part that
depends on the Karaf features to the Karaf integration tests to prevent
this situation.