### PR TITLE
camel-core tests: fix producer, consumer cache failing tests on slow VM 

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerCacheTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerCacheTest.java
@@ -16,11 +16,15 @@
  */
 package org.apache.camel.impl;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Endpoint;
 import org.apache.camel.PollingConsumer;
 import org.apache.camel.impl.engine.DefaultConsumerCache;
 import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class DefaultConsumerCacheTest extends ContextTestSupport {
 
@@ -41,7 +45,7 @@ public class DefaultConsumerCacheTest extends ContextTestSupport {
 
         // the eviction is async so force cleanup
         cache.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> cache.size() == 1000);
         assertEquals("Size should be 1000", 1000, cache.size());
         cache.stop();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateTest.java
@@ -345,7 +345,7 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 500);
         assertEquals("Size should be 500", 500, template.getCurrentCacheSize());
         template.stop();
 
@@ -368,7 +368,7 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 500);
         assertEquals("Size should be 500", 500, template.getCurrentCacheSize());
         template.stop();
 
@@ -394,5 +394,4 @@ public class DefaultConsumerTemplateTest extends ContextTestSupport {
 
         assertFalse("File should have been deleted " + file, file.exists());
     }
-
 }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateWithCustomCacheMaxSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultConsumerTemplateWithCustomCacheMaxSizeTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.camel.impl;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class DefaultConsumerTemplateWithCustomCacheMaxSizeTest extends ContextTestSupport {
 
@@ -47,7 +51,7 @@ public class DefaultConsumerTemplateWithCustomCacheMaxSizeTest extends ContextTe
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 200);
         assertEquals("Size should be 200", 200, template.getCurrentCacheSize());
         template.stop();
 
@@ -76,5 +80,4 @@ public class DefaultConsumerTemplateWithCustomCacheMaxSizeTest extends ContextTe
             assertEquals("Property CamelMaximumCachePoolSize must be a positive number, was: 0", e.getCause().getMessage());
         }
     }
-
 }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerCacheTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerCacheTest.java
@@ -191,7 +191,6 @@ public class DefaultProducerCacheTest extends ContextTestSupport {
         public boolean isSingleton() {
             return isSingleton;
         }
-
     }
 
     private final class MyProducer extends DefaultProducer {
@@ -215,5 +214,4 @@ public class DefaultProducerCacheTest extends ContextTestSupport {
             shutdownCounter.incrementAndGet();
         }
     }
-
 }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Endpoint;
@@ -31,6 +32,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
 import org.junit.Test;
 
+import static org.awaitility.Awaitility.await;
 /**
  * Unit test for DefaultProducerTemplate
  */
@@ -291,7 +293,7 @@ public class DefaultProducerTemplateTest extends ContextTestSupport {
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 500);
         assertEquals("Size should be 500", 500, template.getCurrentCacheSize());
         template.stop();
 
@@ -314,12 +316,11 @@ public class DefaultProducerTemplateTest extends ContextTestSupport {
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 500);
         assertEquals("Size should be 500", 500, template.getCurrentCacheSize());
         template.stop();
 
         // should be 0
         assertEquals("Size should be 0", 0, template.getCurrentCacheSize());
     }
-
 }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateWithCustomCacheMaxSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateWithCustomCacheMaxSizeTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.camel.impl;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ContextTestSupport;
@@ -22,6 +23,8 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class DefaultProducerTemplateWithCustomCacheMaxSizeTest extends ContextTestSupport {
 
@@ -47,10 +50,9 @@ public class DefaultProducerTemplateWithCustomCacheMaxSizeTest extends ContextTe
 
         // the eviction is async so force cleanup
         template.cleanUp();
-
+        await().atMost(1, TimeUnit.SECONDS).until(() -> template.getCurrentCacheSize() == 200);
         assertEquals("Size should be 200", 200, template.getCurrentCacheSize());
         template.stop();
-
         // should be 0
         assertEquals("Size should be 0", 0, template.getCurrentCacheSize());
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
@@ -76,7 +76,7 @@ public class AggregateClosedCorrelationKeyTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "D", "id", 2);
         template.sendBodyAndHeader("direct:start", "E", "id", 3);
         template.sendBodyAndHeader("direct:start", "F", "id", 3);
-
+        Thread.sleep(200);
         // 2 of them should now be closed
         int closed = 0;
 


### PR DESCRIPTION
Producer/Consumer tests might fail in various envs especially with slow WMs. I added few timeouts that fixed the issue.