### PR TITLE
Put the example of skipHeaderRecord csv unmarshal

### DIFF
--- a/components/camel-csv/src/main/docs/csv-dataformat.adoc
+++ b/components/camel-csv/src/main/docs/csv-dataformat.adoc
@@ -305,7 +305,22 @@ should illustrate this customization.
 </bean>
 -----------------------------------------------------------------------------------------------------------------------------
 
-== Using skipFirstLine option while unmarshaling
+== Using skipFirstLine or skipHeaderRecord option while unmarshaling
+
+*For Camel >= 2.16.5 
+The instruction for CSV Data format to skip headers or first line is the following. 
+Usign the Spring/XML DSL:
+
+[source,xml]
+---------------------------------------------------
+<route>
+  <from uri="direct:start" />
+  <unmarshal>
+    <csv skipHeaderRecord="true" />
+  </unmarshal>
+  <to uri="bean:myCsvHandler?method=doHandleCsv" />
+</route>
+---------------------------------------------------
 
 *Since Camel 2.10 and deleted for Camel 2.15*
 


### PR DESCRIPTION
Documentation did explains how to skip the first line on header for versions until 2.15, but did not when version is 2.16.5. Method is different. 

I added an example and a message to avoid test with an outdated method.