### PR TITLE
CAMEL-14285: Create bundle based karaf tests for camel-osgi-activator.

### DIFF
--- a/components/camel-osgi-activator/pom.xml
+++ b/components/camel-osgi-activator/pom.xml
@@ -55,7 +55,137 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-osgi</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <!-- test -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-timer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-log</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- PAX Exam -->
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-spi</artifactId>
+            <version>${pax-exam-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-karaf</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-aether</artifactId>
+            <version>2.4.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.tinybundles</groupId>
+            <artifactId>tinybundles</artifactId>
+            <version>2.1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Karaf & Command Shell -->
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>apache-karaf</artifactId>
+            <version>${karaf4-version}</version>
+            <type>zip</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.karaf.features</groupId>
+                    <artifactId>framework</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Karaf Features -->
+        <dependency>
+            <groupId>org.apache.camel.karaf</groupId>
+            <artifactId>apache-camel</artifactId>
+            <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/test-bundles.xml</descriptor>
+                            </descriptors>
+                            <finalName>test</finalName>
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Execute in the integration-test phase so that the packaged 
+                JAR can be used -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                            <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/components/camel-osgi-activator/src/assembly/test-bundles.xml
+++ b/components/camel-osgi-activator/src/assembly/test-bundles.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>bundles</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory/>
+      <outputFileNameMapping>${artifact.artifactId}.jar</outputFileNameMapping>
+      <includes>
+        <include>org.apache.camel:camel-core-engine</include>
+        <include>org.apache.camel:camel-api</include>
+        <include>org.apache.camel:camel-base</include>
+        <include>org.apache.camel:camel-jaxp</include>
+        <include>org.apache.camel:camel-management-api</include>
+        <include>org.apache.camel:camel-support</include>
+        <include>org.apache.camel:camel-util</include>
+        <include>org.apache.camel:camel-util-json</include>
+        <include>org.apache.camel:spi-annotations</include>
+        <include>org.apache.camel:camel-timer</include>
+        <include>org.apache.camel:camel-log</include>
+        <include>org.apache.camel:camel-core-osgi</include>
+        <include>org.apache.camel:camel-osgi-activator</include>
+      </includes>
+      <scope>test</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/components/camel-osgi-activator/src/test/java/org/apache/camel/component/osgi/activator/CamelOsgiActivatorIT.java
+++ b/components/camel-osgi-activator/src/test/java/org/apache/camel/component/osgi/activator/CamelOsgiActivatorIT.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.osgi.activator;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.tinybundles.core.TinyBundles;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelOsgiActivatorIT {
+    @Inject
+    private BundleContext bc;
+
+    @Configuration
+    public Option[] configuration() throws IOException, URISyntaxException, ClassNotFoundException {
+        return options(
+                PaxExamOptions.KARAF.option(),
+                PaxExamOptions.CAMEL_CORE_OSGI.option(),
+                streamBundle(
+                        TinyBundles.bundle()
+                            .read(
+                                Files.newInputStream(
+                                    Paths.get("target/test-bundles")
+                                        .resolve("camel-osgi-activator.jar")))
+                            .build()),
+                junitBundles());
+    }
+    
+    @Test
+    public void testBundleLoaded() throws Exception {
+        boolean hasOsgi = false;
+        boolean hasCamelCoreOsgiActivator = false;
+        for (Bundle b : bc.getBundles()) {
+            if ("org.apache.camel.camel-core-osgi".equals(b.getSymbolicName())) {
+                hasOsgi = true;
+                assertEquals("Camel Core OSGi not activated", Bundle.ACTIVE, b.getState());
+            }
+            
+            if ("org.apache.camel.camel-osgi-activator".equals(b.getSymbolicName())) {
+                hasCamelCoreOsgiActivator = true;
+                assertEquals("Camel OSGi Activator not activated", Bundle.ACTIVE, b.getState());
+            }
+        }
+        assertTrue("Camel Core OSGi bundle not found", hasOsgi);
+        assertTrue("Camel OSGi Activator bundle not found", hasCamelCoreOsgiActivator);
+    }
+
+    @Test
+    public void testRouteLoadAndRemoved() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        ServiceRegistration<RouteBuilder> testServiceRegistration = bc.registerService(RouteBuilder.class,
+                new RouteBuilder() {
+
+                    @Override
+                    public void configure() throws Exception {
+                        from("timer:test?fixedRate=true&period=300").process(exchange -> {
+                            latch.countDown();
+                        });
+                    }
+                }, null);
+
+        latch.await(10, TimeUnit.SECONDS);
+
+        CamelContext camelContext = bc.getService(bc.getServiceReference(CamelContext.class));
+
+        assertEquals("There should be one route in the context.", 1, camelContext.getRoutes().size());
+
+        testServiceRegistration.unregister();
+
+        assertEquals("There should be no routes in the context.", 0, camelContext.getRoutes().size());
+
+    }
+
+}

--- a/components/camel-osgi-activator/src/test/java/org/apache/camel/component/osgi/activator/PaxExamOptions.java
+++ b/components/camel-osgi-activator/src/test/java/org/apache/camel/component/osgi/activator/PaxExamOptions.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.osgi.activator;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.options.DefaultCompositeOption;
+import org.ops4j.pax.tinybundles.core.TinyBundles;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+
+public enum PaxExamOptions {
+    
+    KARAF(
+            karafDistributionConfiguration()
+                .frameworkUrl(
+                    maven()
+                        .groupId("org.apache.karaf")
+                        .artifactId("apache-karaf")
+                        .versionAsInProject()
+                        .type("zip"))
+                .name("Apache Karaf")
+                .useDeployFolder(false)
+                .unpackDirectory(new File("target/paxexam/unpack/")),
+            keepRuntimeFolder(),
+            // Don't bother with local console output as it just ends up cluttering the logs
+            configureConsole().ignoreLocalConsole(),
+            // Force the log level to INFO so we have more details during the test. It defaults to WARN.
+            logLevel(LogLevelOption.LogLevel.INFO)
+        ),
+        CAMEL_CORE_OSGI(
+                createStreamBundleOption("camel-core-engine.jar"),
+                createStreamBundleOption("camel-api.jar"),
+                createStreamBundleOption("camel-base.jar"),
+                createStreamBundleOption("camel-jaxp.jar"),
+                createStreamBundleOption("camel-management-api.jar"),
+                createStreamBundleOption("camel-support.jar"),
+                createStreamBundleOption("camel-util.jar"),
+                createStreamBundleOption("camel-util-json.jar"),
+                createStreamBundleOption("spi-annotations.jar"),
+                createStreamBundleOption("camel-timer.jar"),
+                createStreamBundleOption("camel-log.jar"),
+                createStreamBundleOption("camel-core-osgi.jar")        
+        );
+
+    private final Option[] options;
+
+    PaxExamOptions(Option... options) {
+        this.options = options;
+    }
+
+    public Option option() {
+        return new DefaultCompositeOption(options);
+    }
+    
+    public static Option createStreamBundleOption(String fileName) {
+        InputStream bundleInputStream = null;
+        try {
+            bundleInputStream = Files.newInputStream(
+                    Paths.get("target/test-bundles")
+                        .resolve(fileName));
+            
+        } catch (IOException e) {
+            throw new RuntimeException("Error resolving Bundle", e);
+        }
+        
+        return streamBundle(
+                    TinyBundles.bundle()
+                        .read(bundleInputStream)
+                        .build());
+    }
+}


### PR DESCRIPTION
Also not sure if it makes sense to remove the tests from camel-itest-karaf.  They are similar with the exception that camel-itest-karaf uses feature installs rather than bundle installs.