### PR TITLE
Strip both forms of prefixes from namedReplyTo

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/DefaultDestinationCreationStrategy.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/DefaultDestinationCreationStrategy.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.sjms.jms;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Session;
+import org.apache.camel.util.URISupport;
 
 /**
  * Default implementation of DestinationCreationStrategy, delegates to Session.createTopic
@@ -28,23 +29,19 @@ import javax.jms.Session;
  * @see javax.jms.Session
  */
 public class DefaultDestinationCreationStrategy implements DestinationCreationStrategy {
-    private static final String TOPIC_PREFIX = "topic://";
-    private static final String QUEUE_PREFIX = "queue://";
 
     @Override
     public Destination createDestination(final Session session, String name, final boolean topic) throws JMSException {
         Destination destination;
-        if (topic) {
-            if (name.startsWith(TOPIC_PREFIX)) {
-                name = name.substring(TOPIC_PREFIX.length());
-            }
-            destination = session.createTopic(name);
-        } else {
-            if (name.startsWith(QUEUE_PREFIX)) {
-                name = name.substring(QUEUE_PREFIX.length());
-            }
-            destination = session.createQueue(name);
-        }
+      if (topic) {
+        name = URISupport.stripPrefix(name, "topic://");
+        name = URISupport.stripPrefix(name, "topic:");
+        destination = session.createTopic(name);
+      } else {
+        name = URISupport.stripPrefix(name, "queue://");
+        name = URISupport.stripPrefix(name, "queue:");
+        destination = session.createQueue(name);
+      }
         return destination;
     }
 


### PR DESCRIPTION
This PR fixes a bug that was introduced in [CAMEL-12869]

`DefaultDestinationCreationStrategy.createDestination` was not correctly recognizing and removing the prefix of a `namedReplyTo` address.

Other ways to do this but found this to work well for my situation. 

First PR for camel 😃 