### PR TITLE
Correct "not equals" symbol

### DIFF
--- a/core/camel-base/src/main/docs/simple-language.adoc
+++ b/core/camel-base/src/main/docs/simple-language.adoc
@@ -395,7 +395,7 @@ The following operators are supported:
 
 |<= |less than or equals
 
-|!=~ |not equals
+|!= |not equals
 
 |!=~ |not equals ignore case (will ignore case when comparing String values)
 


### PR DESCRIPTION
Differentiate between "not equals" and "not equals ignore case" symbol.