### PR TITLE
CAMEL-14303: Refactor Rest Component Common code into helper.

### DIFF
--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
@@ -42,6 +42,7 @@ import org.apache.camel.spi.RestConsumerFactory;
 import org.apache.camel.spi.RestProducerFactory;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.PropertyBindingSupport;
+import org.apache.camel.support.RestComponentHelper;
 import org.apache.camel.support.RestProducerFactoryHelper;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.FileUtil;
@@ -373,23 +374,10 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
 
         // if no explicit hostname set then resolve the hostname
         if (ObjectHelper.isEmpty(host)) {
-            if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.allLocalIp) {
-                host = "0.0.0.0";
-            } else if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.localHostName) {
-                host = HostUtils.getLocalHostName();
-            } else if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.localIp) {
-                host = HostUtils.getLocalIp();
-            }
+            host = RestComponentHelper.resolveRestHostName(host, config);
         }
 
-        Map<String, Object> map = new HashMap<>();
-        // build query string, and append any endpoint configuration properties
-        if (config.getComponent() == null || config.getComponent().equals("netty-http")) {
-            // setup endpoint options
-            if (config.getEndpointProperties() != null && !config.getEndpointProperties().isEmpty()) {
-                map.putAll(config.getEndpointProperties());
-            }
-        }
+        Map<String, Object> map = RestComponentHelper.initRestEndpointProperties("netty-http", config);
 
         // allow HTTP Options as we want to handle CORS in rest-dsl
         boolean cors = config.isEnableCORS();
@@ -398,21 +386,7 @@ public class NettyHttpComponent extends NettyComponent implements HeaderFilterSt
             map.put("matchOnUriPrefix", "true");
         }
 
-        String query = URISupport.createQueryString(map);
-
-        String url = "netty-http:%s://%s:%s/%s?httpMethodRestrict=%s";
-        
-        // must use upper case for restrict
-        String restrict = verb.toUpperCase(Locale.US);
-        if (cors) {
-            restrict += ",OPTIONS";
-        }
-        // get the endpoint
-        url = String.format(url, scheme, host, port, path, restrict);
-
-        if (!query.isEmpty()) {
-            url = url + "&" + query;
-        }
+        String url = RestComponentHelper.createRestConsumerUrl("netty-http", verb, scheme, host, port, path, cors, map);
 
         NettyHttpEndpoint endpoint = camelContext.getEndpoint(url, NettyHttpEndpoint.class);
         setProperties(camelContext, endpoint, parameters);

--- a/core/camel-support/src/main/java/org/apache/camel/support/RestComponentHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RestComponentHelper.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.camel.spi.RestConfiguration;
+import org.apache.camel.util.HostUtils;
+import org.apache.camel.util.URISupport;
+
+public final class RestComponentHelper {
+    private RestComponentHelper() {
+    }
+    
+    public static Map<String, Object> addHttpRestrictParam(Map<String, Object> queryMap, String verb, Boolean cors) {
+        String restrict = verb.toUpperCase(Locale.US);
+        if (cors) {
+            restrict += ",OPTIONS";
+        }
+        queryMap.put("httpMethodRestrict", restrict);
+        return queryMap;
+    }
+    
+    public static Map<String, Object> initRestEndpointProperties(String componentName, RestConfiguration config) {
+        Map<String, Object> map = new HashMap<>();
+        // build query string, and append any endpoint configuration properties
+        if (config.getComponent() == null || config.getComponent().equals(componentName)) {
+            // setup endpoint options
+            if (config.getEndpointProperties() != null && !config.getEndpointProperties().isEmpty()) {
+                map.putAll(config.getEndpointProperties());
+            }
+        }
+        return map;
+    }
+    
+    public static String resolveRestHostName(String host, RestConfiguration config) throws UnknownHostException {
+        if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.allLocalIp) {
+            host = "0.0.0.0";
+        } else if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.localHostName) {
+            host = HostUtils.getLocalHostName();
+        } else if (config.getHostNameResolver() == RestConfiguration.RestHostNameResolver.localIp) {
+            host = HostUtils.getLocalIp();
+        }
+        return host;
+    }
+    
+    public static String createRestConsumerUrl(String componentName, String verb, String path, Boolean cors, Map<String, Object> queryMap) throws URISyntaxException {
+        String query = generateComponentQueryString(verb, cors, queryMap);
+        return applyFormatAndQuery("%s:/%s?", query, componentName, path);
+    }
+    
+    public static String createRestConsumerUrl(String componentName, String verb, String scheme, String host, int port, String path, Boolean cors, Map<String, Object> queryMap) throws URISyntaxException {
+        
+        String query = generateComponentQueryString(verb, cors, queryMap);
+        
+        return applyFormatAndQuery("%s:%s://%s:%s/%s?", query, componentName, scheme, host, port, path);
+    }
+
+    private static String generateComponentQueryString(String verb, Boolean cors, Map<String, Object> queryMap)
+            throws URISyntaxException {
+        addHttpRestrictParam(queryMap, verb, cors);
+        
+        String query = URISupport.createQueryString(queryMap);
+        return query;
+    }
+    
+    private static String applyFormatAndQuery(String format, String query, Object... formatOptions) {
+     // get the endpoint
+        String url = String.format(format, formatOptions);
+
+        if (!query.isEmpty()) {
+            url = url + query;
+        }
+        return url;
+    }
+}


### PR DESCRIPTION
Given the duplication on the consumer creation for the REST DSL components I wanted to propose some refactoring to make it more maintainable with the matchOnUriPrefix change.  Can apply to the other components, add tests and appropriate api documentation but I wanted to solicit feedback on the refactor before adding any polish.