### PR TITLE
Fix race conditions in double-checked locking object initializations.

### DIFF
--- a/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/AbstractUniVocityDataFormat.java
+++ b/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/AbstractUniVocityDataFormat.java
@@ -83,8 +83,8 @@ public abstract class AbstractUniVocityDataFormat<F extends Format, CWS extends 
         if (writerSettings == null) {
             synchronized (writerSettingsToken) {
                 if (writerSettings == null) {
-                    writerSettings = createAndConfigureWriterSettings();
                     marshaller = new Marshaller<>(headers, headers == null);
+                    writerSettings = createAndConfigureWriterSettings();
                 }
             }
         }
@@ -105,13 +105,13 @@ public abstract class AbstractUniVocityDataFormat<F extends Format, CWS extends 
         if (parserSettings == null) {
             synchronized (parserSettingsToken) {
                 if (parserSettings == null) {
+                    unmarshaller = new Unmarshaller<>(lazyLoad, asMap);
                     parserSettings = new ThreadLocal<CPS>() {
                         @Override
                         protected CPS initialValue() {
                             return createAndConfigureParserSettings();
                         }
                     };
-                    unmarshaller = new Unmarshaller<>(lazyLoad, asMap);
                 }
             }
         }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/ServicePool.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/ServicePool.java
@@ -230,8 +230,9 @@ public class ServicePool<S extends Service> extends ServiceSupport implements No
             if (s == null) {
                 synchronized (this) {
                     if (s == null) {
-                        s = producer.apply(endpoint);
-                        endpoint.getCamelContext().addService(s, true, true);
+                        S tempS = producer.apply(endpoint);
+                        endpoint.getCamelContext().addService(tempS, true, true);
+                        s = tempS;
                     }
                 }
             }


### PR DESCRIPTION
As reported by https://lgtm.com/projects/g/apache/camel/alerts/?mode=tree&ruleFocus=1507076816054