### PR TITLE
groupId for camel-jetty-starter was incorrect

### DIFF
--- a/components/camel-jetty/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty/src/main/docs/jetty-component.adoc
@@ -173,7 +173,7 @@ When using Spring Boot make sure to use the following Maven dependency to have s
 [source,xml]
 ----
 <dependency>
-  <groupId>org.apache.camel.springboot</groupId>
+  <groupId>org.apache.camel</groupId>
   <artifactId>camel-jetty-starter</artifactId>
   <version>x.x.x</version>
   <!-- use the same version as your Camel core version -->


### PR DESCRIPTION
The camel-jetty-starter artifact is present in groupId org.apache.camel for all versions (including 3.0.0) and in org.apache.camel.springboot only for version 3.0.0. For every version groupId org.apache.camel works, but only for 3.0.0 org.apache.camel.springboot works. In my opinion, the documentation should indicate which dependency to use for which version. This issue is similar to https://github.com/apache/camel/pull/3437 and I suspect there are more similar cases.