### PR TITLE
groupId for camel-servlet-starter was incorrect

### DIFF
--- a/components/camel-servlet/src/main/docs/servlet-component.adoc
+++ b/components/camel-servlet/src/main/docs/servlet-component.adoc
@@ -131,7 +131,7 @@ When using Spring Boot make sure to use the following Maven dependency to have s
 [source,xml]
 ----
 <dependency>
-  <groupId>org.apache.camel.springboot</groupId>
+  <groupId>org.apache.camel</groupId>
   <artifactId>camel-servlet-starter</artifactId>
   <version>x.x.x</version>
   <!-- use the same version as your Camel core version -->


### PR DESCRIPTION
The camel-servlet-starter artifact is present in groupId org.apache.camel and in org.apache.camel.springboot. However in org.apache.camel.springboot only release 3.0.0 is present. In org.apache.camel all versions including 3.0.0 are present. For the documentation to provide a consistent dependency for all releases, groupId org.apache.camel seems a better fit. Another solution would be to mention two distinct dependencies in the documentation, depending on the version; maybe for the future versions you want to make org.apache.camel.springboot the groupId and keep org.apache.camel for the old ones.