### PR TITLE
CAMEL-14333: Camel Jgroups Component doesn't export org.apache.camel.…

### DIFF
--- a/components/camel-jgroups/pom.xml
+++ b/components/camel-jgroups/pom.xml
@@ -32,7 +32,7 @@
     <description>Camel JGroups support</description>
 
     <properties>
-        <camel.osgi.export.pkg>org.apache.camel.component.jgroups</camel.osgi.export.pkg>
+        <camel.osgi.export.pkg>org.apache.camel.component.jgroups,org.apache.camel.component.jgroups.cluster</camel.osgi.export.pkg>
         <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=jgroups</camel.osgi.export.service>
     </properties>
 


### PR DESCRIPTION
…component.jgroups.cluster