### PR TITLE
include relevant snippets from configuration file in configuring-camel.adoc

### DIFF
--- a/docs/user-manual/modules/ROOT/examples/components/camel-jms/src/test/resources/org/apache/camel/component/jms/jmsRouteUsingSpring.xml
+++ b/docs/user-manual/modules/ROOT/examples/components/camel-jms/src/test/resources/org/apache/camel/component/jms/jmsRouteUsingSpring.xml
@@ -24,7 +24,7 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
 
-  <!-- START SNIPPET: example -->
+  <!-- tag::example[] -->
   <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
       <jmxAgent id="agent" disabled="true"/>
   </camelContext>
@@ -36,6 +36,6 @@
       </bean>
     </property>
   </bean>
-  <!-- END SNIPPET: example -->
+  <!-- end::example[] -->
 
 </beans>

--- a/docs/user-manual/modules/ROOT/pages/configuring-camel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/configuring-camel.adoc
@@ -51,7 +51,10 @@ injection.
 
 You can configure a component via Spring using the following mechanism:
 
-include::{examplesdir}/components/camel-jms/src/test/resources/org/apache/camel/component/jms/jmsRouteUsingSpring.xml[]
+[source,xml]
+----
+include::{examplesdir}/components/camel-jms/src/test/resources/org/apache/camel/component/jms/jmsRouteUsingSpring.xml[tags=example]
+----
 
 Which allows you to configure a component using some name (activemq in the
 above example), then you can refer to the component using


### PR DESCRIPTION
The include was missing a tags, this PR fixes it.

Current version online: https://camel.apache.org/manual/latest/configuring-camel.html

Before: 

![image](https://user-images.githubusercontent.com/3957921/71489121-53ea0200-2824-11ea-8f53-9eef745da6d0.png)

After: 

![image](https://user-images.githubusercontent.com/3957921/71489098-3d43ab00-2824-11ea-980c-b2421235a158.png)
