### PR TITLE
escape placeholders in text that would otherwise be treated as AsciiDoc attributes

### DIFF
--- a/docs/components/modules/ROOT/pages/azure-blob-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-blob-component.adoc
@@ -278,4 +278,4 @@ Maven users will need to add the following dependency to their `pom.xml`.
 </dependency>
 ----
 
-where `${camel-version}` must be replaced by the actual version of Camel.
+where `+++${camel-version}+++` must be replaced by the actual version of Camel.

--- a/docs/components/modules/ROOT/pages/debezium-mongodb-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-mongodb-component.adoc
@@ -210,7 +210,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` for read (in the case of a initial sync).

--- a/docs/components/modules/ROOT/pages/debezium-mysql-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-mysql-component.adoc
@@ -277,7 +277,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/components/modules/ROOT/pages/debezium-postgres-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-postgres-component.adoc
@@ -250,7 +250,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/components/modules/ROOT/pages/debezium-sqlserver-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-sqlserver-component.adoc
@@ -211,7 +211,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -400,7 +400,7 @@ The zip and gzip dataformat has been renamed to zipdeflater and gzipdeflater as 
 
 === Simple language
 
-The functionality to change the simple language tokens for start/end functions has been removed. The default tokens with `${xxx}` and `$simple{xxx}` is now hardcoded (optimized). The functionality to change these tokens was never really in use and would only confuse Camel users if a new syntax are in use.
+The functionality to change the simple language tokens for start/end functions has been removed. The default tokens with `+++${xxx}+++` and `+++${xxx}+++` is now hardcoded (optimized). The functionality to change these tokens was never really in use and would only confuse Camel users if a new syntax are in use.
 
 === Moved APIs
 


### PR DESCRIPTION
This fixes the warnings created when rendering the contents via Antora.

While this PR fixes them for the camel git repo, the same problems occur in camel-k and camel-quarkus and should be fixed there as well.

```
asciidoctor: WARNING: skipping reference to missing attribute: camel-version
asciidoctor: WARNING: skipping reference to missing attribute: server-name
asciidoctor: WARNING: skipping reference to missing attribute: database-name
asciidoctor: WARNING: skipping reference to missing attribute: table-name
asciidoctor: WARNING: skipping reference to missing attribute: server-name
asciidoctor: WARNING: skipping reference to missing attribute: database-name
asciidoctor: WARNING: skipping reference to missing attribute: table-name
asciidoctor: WARNING: skipping reference to missing attribute: server-name
asciidoctor: WARNING: skipping reference to missing attribute: database-name
asciidoctor: WARNING: skipping reference to missing attribute: table-name
asciidoctor: WARNING: skipping reference to missing attribute: server-name
asciidoctor: WARNING: skipping reference to missing attribute: database-name
asciidoctor: WARNING: skipping reference to missing attribute: table-name
asciidoctor: WARNING: skipping reference to missing attribute: xxx
asciidoctor: WARNING: skipping reference to missing attribute: xxx
```

