### PR TITLE
escape placeholders in text that would otherwise be treated as AsciiDoc attributes

### DIFF
--- a/components/camel-azure/src/main/docs/azure-blob-component.adoc
+++ b/components/camel-azure/src/main/docs/azure-blob-component.adoc
@@ -277,4 +277,4 @@ Maven users will need to add the following dependency to their `pom.xml`.
 </dependency>
 ----
 
-where `${camel-version}` must be replaced by the actual version of Camel.
+where `+++${camel-version}+++` must be replaced by the actual version of Camel.

--- a/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
+++ b/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
@@ -209,7 +209,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` for read (in the case of a initial sync).

--- a/components/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
+++ b/components/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
@@ -276,7 +276,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/components/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
+++ b/components/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
@@ -249,7 +249,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/components/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
+++ b/components/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
@@ -210,7 +210,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/components/modules/ROOT/pages/azure-blob-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-blob-component.adoc
@@ -278,4 +278,4 @@ Maven users will need to add the following dependency to their `pom.xml`.
 </dependency>
 ----
 
-where `${camel-version}` must be replaced by the actual version of Camel.
+where `+++${camel-version}+++` must be replaced by the actual version of Camel.

--- a/docs/components/modules/ROOT/pages/debezium-mongodb-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-mongodb-component.adoc
@@ -210,7 +210,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` for read (in the case of a initial sync).

--- a/docs/components/modules/ROOT/pages/debezium-mysql-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-mysql-component.adoc
@@ -277,7 +277,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/components/modules/ROOT/pages/debezium-postgres-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-postgres-component.adoc
@@ -250,7 +250,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.

--- a/docs/components/modules/ROOT/pages/debezium-sqlserver-component.adoc
+++ b/docs/components/modules/ROOT/pages/debezium-sqlserver-component.adoc
@@ -211,7 +211,7 @@ The following headers are available when consuming change events from Debezium.
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
 | Header constant                           | Header value                                   | Type        | Description
-| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "{server-name}.{database-name}.{table-name}".
+| DebeziumConstants.HEADER_IDENTIFIER       | "CamelDebeziumIdentifier"                      | String      | The identifier of the connector, normally is this format "+++{server-name}.{database-name}.{table-name}+++".
 | DebeziumConstants.HEADER_KEY              | "CamelDebeziumKey"                             | Struct      | The key of the event, normally is the table Primary Key.
 | DebeziumConstants.HEADER_SOURCE_METADATA  | "CamelDebeziumSourceMetadata"                  | Map         | The metadata about the source event, for example `table` name, database `name`, log position, etc, please refer to the Debezium documentation for more info.
 | DebeziumConstants.HEADER_OPERATION        | "CamelDebeziumOperation"                       | String      | If presents, the type of event operation. Values for the connector are `c` for create (or insert), `u` for update, `d` for delete or `r` in case of a snapshot event.


### PR DESCRIPTION
I didn't change the original files in PR #3449, this fixes it. I also ran regenerate to update also the Antora folder.