### PR TITLE
[CAMEL-14363] Camel netty requestTimeout doesn't work as expected

### DIFF
--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/handlers/ClientChannelHandler.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/handlers/ClientChannelHandler.java
@@ -149,12 +149,6 @@ public class ClientChannelHandler extends SimpleChannelInboundHandler<Object> {
             LOG.trace("Message received: {}", msg);
         }
 
-        ChannelHandler handler = ctx.pipeline().get("timeout");
-        if (handler != null) {
-            LOG.trace("Removing timeout channel as we received message");
-            ctx.pipeline().remove(handler);
-        }
-
         NettyCamelState state = getState(ctx, msg);
         Exchange exchange = state != null ? state.getExchange() : null;
         if (exchange == null) {

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyRequestTimeoutTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyRequestTimeoutTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.netty;
 
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -41,6 +42,21 @@ public class NettyRequestTimeoutTest extends BaseNettyTest {
             assertNotNull(cause);
         }
     }
+
+    @Test
+    public void testKeepingTimeoutHeader() throws Exception {
+        Endpoint endpoint = this.resolveMandatoryEndpoint("netty:tcp://localhost:{{port}}?textline=true&sync=true&requestTimeout=100");
+        try {
+            String out = template.requestBody(endpoint, "Hello", String.class);
+            assertEquals("Bye World", out);
+            template.requestBody(endpoint, "Hello Camel", String.class);
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            ReadTimeoutException cause = assertIsInstanceOf(ReadTimeoutException.class, e.getCause());
+            assertNotNull(cause);
+        }
+    }
+
 
     @Test
     public void testRequestTimeoutViaHeader() throws Exception {


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14363

Removed removal of requestTimeout after first successfully received message + JUnit test.