### PR TITLE
Fix DynamoDB Scan Operation.

### DIFF
--- a/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
+++ b/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/AbstractDdbCommand.java
@@ -88,4 +88,13 @@ public abstract class AbstractDdbCommand {
     protected Boolean determineConsistentRead() {
         return exchange.getIn().getHeader(DdbConstants.CONSISTENT_READ, configuration.isConsistentRead(), Boolean.class);
     }
+
+    @SuppressWarnings("unchecked")
+    protected Map<String, AttributeValue> determineExclusiveStartKey() {
+        return exchange.getIn().getHeader(DdbConstants.START_KEY, Map.class);
+    }
+
+    protected Integer determineLimit() {
+        return exchange.getIn().getHeader(DdbConstants.LIMIT, Integer.class);
+    }
 }

--- a/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
+++ b/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/QueryCommand.java
@@ -69,8 +69,4 @@ public class QueryCommand extends AbstractDdbCommand {
     private Map determineKeyConditions() {
         return exchange.getIn().getHeader(DdbConstants.KEY_CONDITIONS, Map.class);
     }
-
-    private Integer determineLimit() {
-        return exchange.getIn().getHeader(DdbConstants.LIMIT, Integer.class);
-    }
 }

--- a/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
+++ b/components/camel-aws-ddb/src/main/java/org/apache/camel/component/aws/ddb/ScanCommand.java
@@ -35,6 +35,8 @@ public class ScanCommand extends AbstractDdbCommand {
     public void execute() {
         ScanResult result = ddbClient.scan(new ScanRequest()
                 .withTableName(determineTableName())
+                .withLimit(determineLimit())
+                .withExclusiveStartKey(determineExclusiveStartKey())
                 .withScanFilter(determineScanFilter()));
 
         Map tmp = new HashMap<>();


### PR DESCRIPTION
The limit and start key headers were not being used by the component. This has been corrected. They are key features of the operation as documented here https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html.

Also, I would need this fix relatively soon. I can backport it to the 3.0.x branch if needed.