### PR TITLE
[ENTESB-12590] Camel netty4 requestTimeout doesn't work as expected

### DIFF
--- a/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/handlers/ClientChannelHandler.java
+++ b/components/camel-netty4/src/main/java/org/apache/camel/component/netty4/handlers/ClientChannelHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.netty4.handlers;
 
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.camel.AsyncCallback;
@@ -149,11 +148,6 @@ public class ClientChannelHandler extends SimpleChannelInboundHandler<Object> {
             LOG.trace("Message received: {}", msg);
         }
 
-        ChannelHandler handler = ctx.pipeline().get("timeout");
-        if (handler != null) {
-            LOG.trace("Removing timeout channel as we received message");
-            ctx.pipeline().remove(handler);
-        }
 
         NettyCamelState state = getState(ctx, msg);
         Exchange exchange = state != null ? state.getExchange() : null;

--- a/components/camel-netty4/src/test/java/org/apache/camel/component/netty4/NettyRequestTimeoutTest.java
+++ b/components/camel-netty4/src/test/java/org/apache/camel/component/netty4/NettyRequestTimeoutTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.netty4;
 
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -38,6 +39,20 @@ public class NettyRequestTimeoutTest extends BaseNettyTest {
     public void testRequestTimeout() throws Exception {
         try {
             template.requestBody("netty4:tcp://localhost:{{port}}?textline=true&sync=true&requestTimeout=100", "Hello Camel", String.class);
+            fail("Should have thrown exception");
+        } catch (CamelExecutionException e) {
+            ReadTimeoutException cause = assertIsInstanceOf(ReadTimeoutException.class, e.getCause());
+            assertNotNull(cause);
+        }
+    }
+
+    @Test
+    public void testKeepingTimeoutHeader() throws Exception {
+        Endpoint endpoint = this.resolveMandatoryEndpoint("netty4:tcp://localhost:{{port}}?textline=true&sync=true&requestTimeout=100");
+        try {
+            String out = template.requestBody(endpoint, "Hello", String.class);
+            assertEquals("Bye World", out);
+            template.requestBody(endpoint, "Hello Camel", String.class);
             fail("Should have thrown exception");
         } catch (CamelExecutionException e) {
             ReadTimeoutException cause = assertIsInstanceOf(ReadTimeoutException.class, e.getCause());


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14373

Master issue: https://issues.apache.org/jira/browse/CAMEL-14363
Master PR: https://github.com/apache/camel/pull/3460

Backported 1c8fd20ba01c4beebc7e8b4a87b00e09d4298361
