### PR TITLE
[CAMEL-14374] Camel-irc validation of endpoint's url fails for url

### DIFF
--- a/components/camel-irc/src/main/docs/irc-component.adoc
+++ b/components/camel-irc/src/main/docs/irc-component.adoc
@@ -24,17 +24,6 @@ for this component:
 </dependency>
 ------------------------------------------------------------
 
-== URI format
-
-[source,java]
----------------------------------------------------------------------
-irc:nick@host[:port]/#room[?options]
-irc:nick@host[:port]?channels=#channel1,#channel2,#channel3[?options]
----------------------------------------------------------------------
-
-You can append query options to the URI in the following format,
-`?option=value&option=value&...`
-
 == Options
 
 
@@ -79,14 +68,16 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (27 parameters):
+=== Query Parameters (29 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
 | *autoRejoin* (common) | Whether to auto re-join when being kicked | true | boolean
+| *channels* (common) | Comma separated list of IRC channels. |  | String
 | *commandTimeout* (common) | Delay in milliseconds before sending commands after the connection is established. | 5000 | long
+| *keys* (common) | Comma separated list of keys for channels. |  | String
 | *namesOnJoin* (common) | Sends NAMES command to channel after joining it. onReply has to be true in order to process the result which will have the header value irc.num = '353'. | false | boolean
 | *nickname* (common) | The nickname used in chat. |  | String
 | *persistent* (common) | *Deprecated* Use persistent messages. | true | boolean

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcComponent.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcComponent.java
@@ -76,7 +76,7 @@ public class IrcComponent extends DefaultComponent implements SSLContextParamete
 
             if (log.isDebugEnabled()) {
                 log.debug("Creating SSL Connection to {} destination(s): {} nick: {} user: {}",
-                    new Object[]{configuration.getHostname(), configuration.getListOfChannels(), configuration.getNickname(), configuration.getUsername()});
+                    new Object[]{configuration.getHostname(), configuration.getSpaceSeparatedChannelNames(), configuration.getNickname(), configuration.getUsername()});
             }
 
             SSLContextParameters sslParams = configuration.getSslContextParameters();
@@ -98,7 +98,7 @@ public class IrcComponent extends DefaultComponent implements SSLContextParamete
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Creating Connection to {} destination(s): {} nick: {} user: {}",
-                        new Object[]{configuration.getHostname(), configuration.getListOfChannels(), configuration.getNickname(), configuration.getUsername()});
+                        new Object[]{configuration.getHostname(), configuration.getSpaceSeparatedChannelNames(), configuration.getNickname(), configuration.getUsername()});
             }
 
             conn = new IRCConnection(configuration.getHostname(), configuration.getPorts(), configuration.getPassword(),

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
@@ -44,7 +44,7 @@ public class IrcConfiguration implements Cloneable {
     private static final Logger LOG = LoggerFactory.getLogger(IrcConfiguration.class);
 
     private boolean usingSSL;
-    private List<IrcChannel> channels = new ArrayList<>();
+    private List<IrcChannel> channelList = new ArrayList<>();
 
     @UriPath @Metadata(required = true)
     private String hostname;
@@ -53,9 +53,13 @@ public class IrcConfiguration implements Cloneable {
     private int[] ports = {6667, 6668, 6669};
     @UriParam(label = "security", secret = true)
     private String password;
-    @UriParam
+    @UriParam(label = "common")
     private String nickname;
-    @UriParam
+    @UriParam(label = "common")
+    private String channels;
+    @UriParam(label = "common")
+    private String keys;
+    @UriParam(label = "common")
     private String realname;
     @UriParam(label = "security", secret = true)
     private String username;
@@ -86,7 +90,7 @@ public class IrcConfiguration implements Cloneable {
     private boolean onPrivmsg = true;
     @UriParam(defaultValue = "true")
     private boolean autoRejoin = true;
-    @UriParam
+    @UriParam(label = "common")
     private boolean namesOnJoin;
     @UriParam(label = "security")
     private SSLContextParameters sslContextParameters;
@@ -98,11 +102,11 @@ public class IrcConfiguration implements Cloneable {
     public IrcConfiguration() {
     }
 
-    public IrcConfiguration(String hostname, String nickname, String displayname, List<IrcChannel> channels) {
+    public IrcConfiguration(String hostname, String nickname, String displayname, String channels) {
         this(hostname, null, null, nickname, displayname, channels);
     }
 
-    public IrcConfiguration(String hostname, String username, String password, String nickname, String displayname, List<IrcChannel> channels) {
+    public IrcConfiguration(String hostname, String username, String password, String nickname, String displayname, String channels) {
         this.channels = channels;
         this.hostname = hostname;
         this.username = username;
@@ -126,9 +130,9 @@ public class IrcConfiguration implements Cloneable {
     /*
      * Return space separated list of channel names without pwd
      */
-    public String getListOfChannels() {
+    public String getSpaceSeparatedChannelNames() {
         StringBuilder retval = new StringBuilder();
-        for (IrcChannel channel : channels) {
+        for (IrcChannel channel : channelList) {
             retval.append(retval.length() == 0 ? "" : " ").append(channel.getName());
         }
         return retval.toString();
@@ -184,22 +188,12 @@ public class IrcConfiguration implements Cloneable {
         }
     }
 
-    public void setChannel(String channel) {
-        channels.add(createChannel(channel));
-    }
-
-    public void setChannel(List<String> channels) {
-        for (String ci : channels) {
-            this.channels.add(createChannel(ci));
-        }
-    }
-
-    public List<IrcChannel> getChannels() {
-        return channels;
+    public List<IrcChannel> getChannelList() {
+        return channelList;
     }
     
     public IrcChannel findChannel(String name) {
-        for (IrcChannel channel : channels) {
+        for (IrcChannel channel : channelList) {
             if (channel.getName().equals(name)) {
                 return channel;
             }
@@ -272,6 +266,54 @@ public class IrcConfiguration implements Cloneable {
 
     public String getUsername() {
         return username;
+    }
+
+    /**
+     * Comma separated list of IRC channels.
+     */
+    public String getChannels() {
+        return channels;
+    }
+
+    public void setChannels(String channels) {
+        this.channels = channels;
+        createChannels();
+    }
+
+    /**
+     * Comma separated list of keys for channels.
+     */
+    public String getKeys() {
+        return keys;
+    }
+
+    public void setKeys(String keys) {
+        this.keys = keys;
+        createChannels();
+    }
+
+    private void createChannels() {
+        channelList.clear();
+
+        if(channels == null) {
+            return;
+        }
+
+        String[] chs = channels.split(",");
+        String[] ks = keys != null ? keys.split(",") : null;
+
+        int count = chs.length;
+        for (int i = 0; i < count; i++) {
+            String channel = chs[i].trim();
+            String key = ks != null && ks.length > i ? ks[i].trim() : null;
+            if (channel.startsWith("#") && !channel.startsWith("##")) {
+                channel = channel.substring(1);
+            }
+            if (key != null && !key.isEmpty()) {
+                channel += "!" + key;
+            }
+            channelList.add(createChannel(channel));
+        }
     }
 
     /**
@@ -498,123 +540,11 @@ public class IrcConfiguration implements Cloneable {
         return new IrcChannel(pair[0], pair.length > 1 ? pair[1] : null);
     }
 
-    @Deprecated
     public static String sanitize(String uri) {
-        // may be removed in camel-3.0.0 
-        // make sure it's an URL first
-        int colon = uri.indexOf(':');
-        if (colon != -1 && uri.indexOf("://") != colon) {
-            uri = uri.substring(0, colon) + "://" + uri.substring(colon + 1);
-        }
-
-        try {
-            URI u = new URI(UnsafeUriCharactersEncoder.encode(uri));
-            String[] userInfo = u.getUserInfo() != null ? u.getUserInfo().split(":") : null;
-            String username = userInfo != null ? userInfo[0] : null;
-            String password = userInfo != null && userInfo.length > 1 ? userInfo[1] : null;
-
-            String path = URLDecoder.decode(u.getPath() != null ? u.getPath() : "", "UTF-8");
-            if (path.startsWith("/")) {
-                path = path.substring(1);
-            }
-            if (path.startsWith("#") && !path.startsWith("##")) {
-                path = path.substring(1);
-            }
-
-            Map<String, Object> parameters = URISupport.parseParameters(u);
-            String user = (String)parameters.get("username");
-            String nick = (String)parameters.get("nickname");
-            // not specified in authority
-            if (user != null) {
-                if (username == null) {
-                    username = user;
-                } else if (!username.equals(user)) {
-                    LOG.warn("Username specified twice in endpoint URI with different values. "
-                        + "The userInfo value ('{}') will be used, paramter ('{}') ignored", username, user);
-                }
-                parameters.remove("username");
-            }
-            if (nick != null) {
-                if (username == null) {
-                    username = nick;
-                }
-                if (username.equals(nick)) {
-                    parameters.remove("nickname");      // redundant
-                }
-            }
-            if (username == null) {
-                throw new RuntimeCamelException("IrcEndpoint URI with no user/nick specified is invalid");
-            }
-
-            String pwd = (String)parameters.get("password");
-            if (pwd != null) {
-                password = pwd;
-                parameters.remove("password");
-            }
-            
-            // Remove unneeded '#' channel prefixes per convention
-            // and replace ',' separators and merge channel and key using convention "channel!key"
-            List<String> cl = new ArrayList<>();
-            String channels = (String)parameters.get("channels");
-            String keys =  (String)parameters.get("keys");
-            keys = keys == null ? keys : keys + " ";    // if @keys ends with a ',' it will miss the last empty key after split(",")
-            if (channels != null) {
-                String[] chs = channels.split(",");
-                String[] ks = keys != null ? keys.split(",") : null;
-                parameters.remove("channels");
-                int count = chs.length;
-                if (ks != null) {
-                    parameters.remove("keys");
-                    if (!path.isEmpty()) {
-                        LOG.warn("Specifying a channel '{}' in the URI path is ambiguous"
-                            + " when @channels and @keys are provided and will be ignored", path);
-                        path = "";
-                    }
-                    if (ks.length != chs.length) {
-                        count = count < ks.length ? count : ks.length;
-                        LOG.warn("Different count of @channels and @keys. Only the first {} are used.", count);
-                    }
-                }
-                for (int i = 0; i < count; i++) {
-                    String channel = chs[i].trim();
-                    String key = ks != null ? ks[i].trim() : null;
-                    if (channel.startsWith("#") && !channel.startsWith("##")) {
-                        channel = channel.substring(1);
-                    }
-                    if (key != null && !key.isEmpty()) {
-                        channel += "!" + key;
-                    }
-                    cl.add(channel);
-                }
-            } else {
-                if (path.isEmpty()) {
-                    LOG.warn("No channel specified for the irc endpoint");
-                }
-                cl.add(path);
-            }
-            parameters.put("channel", cl);
-
-            StringBuilder sb = new StringBuilder();
-            sb.append(u.getScheme());
-            sb.append("://");
-            sb.append(username);
-            sb.append(password == null ? "" : ":" + password);
-            sb.append("@");
-            sb.append(u.getHost());
-            sb.append(u.getPort() == -1 ? "" : ":" + u.getPort());
-            // ignore the path we have it as a @channel now
-            String query = formatQuery(parameters);
-            if (!query.isEmpty()) {
-                sb.append("?");
-                sb.append(query);
-            }
-            // make things a bit more predictable
-            return sb.toString();
-        } catch (Exception e) {
-            throw new RuntimeCamelException(e);
-        }
+        //symbol # has to be encoded. otherwise value after '#' won't be propagated into parameters
+        return uri.replaceAll("#", "%23");
     }
-    
+
     private static String formatQuery(Map<String, Object> params) {
         if (params == null || params.size() == 0) {
             return "";

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConsumer.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConsumer.java
@@ -42,7 +42,7 @@ public class IrcConsumer extends DefaultConsumer {
     @Override
     protected void doStop() throws Exception {
         if (connection != null) {
-            for (IrcChannel channel : endpoint.getConfiguration().getChannels()) {
+            for (IrcChannel channel : endpoint.getConfiguration().getChannelList()) {
                 log.debug("Parting: {}", channel);
                 connection.doPart(channel.getName());
             }

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcEndpoint.java
@@ -36,7 +36,7 @@ import org.schwering.irc.lib.IRCUser;
     firstVersion = "1.1.0", 
     scheme = "irc", 
     title = "IRC", 
-    syntax = "irc:hostname:port", 
+    syntax = "irc:hostname:port",
     alternativeSyntax = "irc:username:password@hostname:port", 
     label = "chat")
 public class IrcEndpoint extends DefaultEndpoint {
@@ -185,7 +185,7 @@ public class IrcEndpoint extends DefaultEndpoint {
     }
 
     public void joinChannels() {
-        for (IrcChannel channel : configuration.getChannels()) {
+        for (IrcChannel channel : configuration.getChannelList()) {
             joinChannel(channel);
         }
     }

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcProducer.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcProducer.java
@@ -57,7 +57,7 @@ public class IrcProducer extends DefaultProducer {
                 log.debug("Sending to: {} message: {}", sendTo, msg);
                 connection.doPrivmsg(sendTo, msg);
             } else {
-                for (IrcChannel channel : endpoint.getConfiguration().getChannels()) {
+                for (IrcChannel channel : endpoint.getConfiguration().getChannelList()) {
                     log.debug("Sending to: {} message: {}", channel, msg);
                     connection.doPrivmsg(channel.getName(), msg);
                 }
@@ -83,7 +83,7 @@ public class IrcProducer extends DefaultProducer {
     @Override
     protected void doStop() throws Exception {
         if (connection != null) {
-            for (IrcChannel channel : endpoint.getConfiguration().getChannels()) {
+            for (IrcChannel channel : endpoint.getConfiguration().getChannelList()) {
                 log.debug("Parting: {}", channel);
                 connection.doPart(channel.getName());
             }

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/CodehausIrcChat.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/CodehausIrcChat.java
@@ -92,9 +92,7 @@ public final class CodehausIrcChat {
     }
 
     public static void main(String[] args) throws InterruptedException {
-        List<IrcChannel> channels = new ArrayList<>();
-        channels.add(new IrcChannel("camel-test", null));
-        final IrcConfiguration config = new IrcConfiguration("irc.codehaus.org", "camel-rc", "Camel IRC Component", channels);
+        final IrcConfiguration config = new IrcConfiguration("irc.codehaus.org", "camel-rc", "Camel IRC Component", "camel-test");
 
         final IRCConnection conn = new IRCConnection(config.getHostname(), config.getPorts(), config.getPassword(), config.getNickname(), config.getUsername(), config.getRealname());
 
@@ -118,7 +116,7 @@ public final class CodehausIrcChat {
 
         // log.info("Joining Channel: " + config.getTarget());
 
-        for (IrcChannel channel : config.getChannels()) {
+        for (IrcChannel channel : config.getChannelList()) {
             conn.doJoin(channel.getName());
         }
 

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcConfigurationTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcConfigurationTest.java
@@ -26,100 +26,6 @@ import org.junit.Test;
 public class IrcConfigurationTest extends CamelTestSupport {
 
     @Test
-    public void testInvalidUriConversion() throws Exception {
-        // Note: valid URIs won't throw on new URI(endpoint.getEndpointUri())
-        
-        String deprecate;
-        String sanitized;
-        Endpoint endpoint;
-        IrcComponent component = context.getComponent("irc", IrcComponent.class);
-
-        // Test conversion of the URI path to @channel parameter (drop the '#')
-        deprecate = "irc://camelbot@irc.freenode.net:1234/#camel";
-        sanitized = "irc://camelbot@irc.freenode.net:1234?channel=camel";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test conversion of the URI path to @channel parameter (encode the double '##')
-        deprecate = "irc://camelbot@irc.freenode.net/##camel";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=%23%23camel";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test drop path and both path and @channels are specified
-        deprecate = "irc://camelbot@irc.freenode.net/#karaf?channels=#camel,#cxf";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel&channel=cxf";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, no keys
-        deprecate = "irc://camelbot@irc.freenode.net?channels=#camel,#cxf";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel&channel=cxf";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, with keys
-        deprecate = "irc://camelbot@irc.freenode.net?channels=#camel,#cxf&keys=foo,bar";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel!foo&channel=cxf!bar";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, with keys (last key is empty)
-        deprecate = "irc://camelbot@irc.freenode.net?channels=#camel,#cxf&keys=foo,";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel!foo&channel=cxf";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, deprecated @username
-        deprecate = "irc://irc.freenode.net?keys=,foo&channels=#camel,#cxf&username=camelbot";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel&channel=cxf!foo";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, deprecated @username and @password
-        deprecate = "irc://irc.freenode.net?keys=,foo&channels=#camel,#cxf&username=camelbot&password=secret";
-        sanitized = "irc://camelbot:secret@irc.freenode.net?channel=camel&channel=cxf!foo";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test multiple channels, drop @nickname same as @username
-        deprecate = "irc://irc.freenode.net?channels=#camel,#cxf&nickname=camelbot";
-        sanitized = "irc://camelbot@irc.freenode.net?channel=camel&channel=cxf";
-        endpoint = component.createEndpoint(deprecate); 
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-
-        // Test with encoding of @realname
-        deprecate = "irc://user@irc.freenode.net?keys=foo,&channels=#camel,#cxf&realname=Camel Bot&username=user&nickname=camelbot";
-        sanitized = "irc://user@irc.freenode.net?realname=Camel%20Bot&nickname=camelbot&channel=camel!foo&channel=cxf";
-        endpoint = component.createEndpoint(deprecate);
-        assertEquals(sanitized, endpoint.getEndpointUri());
-        assertNotNull(new URI(endpoint.getEndpointUri()));
-    }
-
-    @Test
-    public void testConfigureFormat1() throws Exception {
-        IrcComponent component = context.getComponent("irc", IrcComponent.class);
-
-        // irc:nick@host[:port]/#room[?options]
-        IrcEndpoint endpoint = (IrcEndpoint) component.createEndpoint("irc://camelbot@irc.freenode.net/#camel");
-        IrcConfiguration conf = endpoint.getConfiguration();
-        assertEquals("camelbot", conf.getNickname());
-        assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
-        assertEquals(1, channels.size());
-        assertEquals("#camel", channels.get(0).getName());
-    }
-
-    @Test
     public void testConfigureFormat2() throws Exception {
         IrcComponent component = context.getComponent("irc", IrcComponent.class);
 
@@ -129,7 +35,7 @@ public class IrcConfigurationTest extends CamelTestSupport {
         IrcConfiguration conf = endpoint.getConfiguration();
         assertEquals("camelbot", conf.getNickname());
         assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
+        List<IrcChannel> channels = conf.getChannelList();
         assertEquals(1, channels.size());
         assertEquals("#camel", channels.get(0).getName());
     }
@@ -144,7 +50,7 @@ public class IrcConfigurationTest extends CamelTestSupport {
         IrcConfiguration conf = endpoint.getConfiguration();
         assertEquals("camelbot", conf.getNickname());
         assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
+        List<IrcChannel> channels = conf.getChannelList();
         assertEquals(1, channels.size());
         assertEquals("#camel", channels.get(0).getName());
     }
@@ -159,7 +65,7 @@ public class IrcConfigurationTest extends CamelTestSupport {
         IrcConfiguration conf = endpoint.getConfiguration();
         assertEquals("camelbot", conf.getNickname());
         assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
+        List<IrcChannel> channels = conf.getChannelList();
         assertEquals(2, channels.size());
         assertNotNull(conf.findChannel("#camel"));
         assertNotNull(conf.findChannel("#smx"));
@@ -177,7 +83,7 @@ public class IrcConfigurationTest extends CamelTestSupport {
         IrcConfiguration conf = endpoint.getConfiguration();
         assertEquals("camelbot", conf.getNickname());
         assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
+        List<IrcChannel> channels = conf.getChannelList();
         assertEquals(2, channels.size());
         assertNotNull(conf.findChannel("#camel"));
         assertEquals("foo", conf.findChannel("#camel").getKey());
@@ -195,7 +101,7 @@ public class IrcConfigurationTest extends CamelTestSupport {
         IrcConfiguration conf = endpoint.getConfiguration();
         assertEquals("camelbot", conf.getNickname());
         assertEquals("irc.freenode.net", conf.getHostname());
-        List<IrcChannel> channels = conf.getChannels();
+        List<IrcChannel> channels = conf.getChannelList();
         assertEquals(2, channels.size());
         assertNotNull(conf.findChannel("#camel"));
         assertNotNull(conf.findChannel("#smx"));

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcConsumerTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcConsumerTest.java
@@ -50,7 +50,7 @@ public class IrcConsumerTest {
         channels.add(new IrcChannel("#chan1", null));
         channels.add(new IrcChannel("#chan2", "chan2key"));
 
-        when(configuration.getChannels()).thenReturn(channels);
+        when(configuration.getChannelList()).thenReturn(channels);
         when(endpoint.getConfiguration()).thenReturn(configuration);
 
         consumer = new IrcConsumer(endpoint, processor, connection);

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcEndpointTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcEndpointTest.java
@@ -46,7 +46,7 @@ public class IrcEndpointTest {
         channels.add(new IrcChannel("#chan1", null));
         channels.add(new IrcChannel("#chan2", "chan2key"));
 
-        when(configuration.getChannels()).thenReturn(channels);
+        when(configuration.getChannelList()).thenReturn(channels);
         when(configuration.findChannel("#chan1")).thenReturn(channels.get(0));
         when(configuration.findChannel("#chan2")).thenReturn(channels.get(1));
         when(component.getIRCConnection(configuration)).thenReturn(connection);

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcProducerTest.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/IrcProducerTest.java
@@ -54,7 +54,7 @@ public class IrcProducerTest {
         channels.add(new IrcChannel("#chan1", null));
         channels.add(new IrcChannel("#chan2", "chan2key"));
 
-        when(configuration.getChannels()).thenReturn(channels);
+        when(configuration.getChannelList()).thenReturn(channels);
         when(endpoint.getConfiguration()).thenReturn(configuration);
 
         producer = new IrcProducer(endpoint, connection);

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/IrcEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/IrcEndpointBuilderFactory.java
@@ -66,6 +66,17 @@ public interface IrcEndpointBuilderFactory {
             return this;
         }
         /**
+         * Comma separated list of IRC channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointConsumerBuilder channels(String channels) {
+            doSetProperty("channels", channels);
+            return this;
+        }
+        /**
          * Delay in milliseconds before sending commands after the connection is
          * established.
          * 
@@ -89,6 +100,17 @@ public interface IrcEndpointBuilderFactory {
          */
         default IrcEndpointConsumerBuilder commandTimeout(String commandTimeout) {
             doSetProperty("commandTimeout", commandTimeout);
+            return this;
+        }
+        /**
+         * Comma separated list of keys for channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointConsumerBuilder keys(String keys) {
+            doSetProperty("keys", keys);
             return this;
         }
         /**
@@ -698,6 +720,17 @@ public interface IrcEndpointBuilderFactory {
             return this;
         }
         /**
+         * Comma separated list of IRC channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointProducerBuilder channels(String channels) {
+            doSetProperty("channels", channels);
+            return this;
+        }
+        /**
          * Delay in milliseconds before sending commands after the connection is
          * established.
          * 
@@ -721,6 +754,17 @@ public interface IrcEndpointBuilderFactory {
          */
         default IrcEndpointProducerBuilder commandTimeout(String commandTimeout) {
             doSetProperty("commandTimeout", commandTimeout);
+            return this;
+        }
+        /**
+         * Comma separated list of keys for channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointProducerBuilder keys(String keys) {
+            doSetProperty("keys", keys);
             return this;
         }
         /**
@@ -1277,6 +1321,17 @@ public interface IrcEndpointBuilderFactory {
             return this;
         }
         /**
+         * Comma separated list of IRC channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointBuilder channels(String channels) {
+            doSetProperty("channels", channels);
+            return this;
+        }
+        /**
          * Delay in milliseconds before sending commands after the connection is
          * established.
          * 
@@ -1300,6 +1355,17 @@ public interface IrcEndpointBuilderFactory {
          */
         default IrcEndpointBuilder commandTimeout(String commandTimeout) {
             doSetProperty("commandTimeout", commandTimeout);
+            return this;
+        }
+        /**
+         * Comma separated list of keys for channels.
+         * 
+         * The option is a: <code>java.lang.String</code> type.
+         * 
+         * Group: common
+         */
+        default IrcEndpointBuilder keys(String keys) {
+            doSetProperty("keys", keys);
             return this;
         }
         /**

--- a/docs/components/modules/ROOT/pages/irc-component.adoc
+++ b/docs/components/modules/ROOT/pages/irc-component.adoc
@@ -25,17 +25,6 @@ for this component:
 </dependency>
 ------------------------------------------------------------
 
-== URI format
-
-[source,java]
----------------------------------------------------------------------
-irc:nick@host[:port]/#room[?options]
-irc:nick@host[:port]?channels=#channel1,#channel2,#channel3[?options]
----------------------------------------------------------------------
-
-You can append query options to the URI in the following format,
-`?option=value&option=value&...`
-
 == Options
 
 
@@ -80,14 +69,16 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (27 parameters):
+=== Query Parameters (29 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
 | *autoRejoin* (common) | Whether to auto re-join when being kicked | true | boolean
+| *channels* (common) | Comma separated list of IRC channels. |  | String
 | *commandTimeout* (common) | Delay in milliseconds before sending commands after the connection is established. | 5000 | long
+| *keys* (common) | Comma separated list of keys for channels. |  | String
 | *namesOnJoin* (common) | Sends NAMES command to channel after joining it. onReply has to be true in order to process the result which will have the header value irc.num = '353'. | false | boolean
 | *nickname* (common) | The nickname used in chat. |  | String
 | *persistent* (common) | *Deprecated* Use persistent messages. | true | boolean

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
@@ -20,6 +20,15 @@ The option `cache` has been deprecated in favour of the new `scope` option that 
 
 NOTE: Setting this to Prototype will let Camel create/lookup a new bean instance, per use; which acts as prototype scoped. However beware that if you lookup the bean, then the registry that holds the bean, would return a bean accordingly to its configuration, which can be singleton or prototype scoped. For example if you use Spring, or CDI, which has their own settings for setting bean scopes.
 
+=== camel-irc
+
+The `camel-irc` component has changed its endpoint syntax and removed option #room as a part of the url path. Allowed syntax is:
+
+[source,text]
+----
+irc:nick@host[:port]?[options]
+----
+
 === camel-nats
 
 The `camel-nats` component has changed its endpoint syntax from `nats:servers` to `nats:topic`.


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14374

Method sanitaze(), which contained a lot of logic about handling the uri, was removed.
Compo model was used instead.

This change led to remove one of the uri syntaxes (irc:nick@host[:port]/#room[?options])
Doc was updated and note to the upgrade guide was added.