### PR TITLE
CAMEL-14250: Allow custom configurations into Kafka component

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -78,12 +78,13 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (95 parameters):
+=== Query Parameters (96 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *additionalProperties* (common) | Sets additional properties for either kafka consumer or kafka producer in case they can't be set directly on the camel configurations (e.g: new Kafka properties that are not reflected yet in Camel configurations), the properties have to be prefixed with additionalProperties.. E.g: additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=\http://localhost:8811/avro |  | Map
 | *brokers* (common) | URL of the Kafka brokers to use. The format is host1:port1,host2:port2, and the list can be a subset of brokers or a VIP pointing to a subset of brokers. This option is known as bootstrap.servers in the Kafka documentation. |  | String
 | *clientId* (common) | The client id is a user-specified string sent in each request to help trace calls. It should logically identify the application making the request. |  | String
 | *headerFilterStrategy* (common) | To use a custom HeaderFilterStrategy to filter header to and from Camel message. |  | HeaderFilterStrategy

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
@@ -26,6 +26,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.PropertiesHelper;
 
 @Component("kafka")
 public class KafkaComponent extends DefaultComponent implements SSLContextParametersAware {
@@ -76,6 +77,11 @@ public class KafkaComponent extends DefaultComponent implements SSLContextParame
 
         if (endpoint.getConfiguration().getSslContextParameters() == null) {
             endpoint.getConfiguration().setSslContextParameters(retrieveGlobalSslContextParameters());
+        }
+
+        // extract the additional properties map
+        if (PropertiesHelper.hasProperties(params, "additionalProperties.")) {
+            endpoint.getConfiguration().setAdditionalProperties(PropertiesHelper.extractProperties(params, "additionalProperties."));
         }
 
         return endpoint;

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.kafka;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -81,7 +82,10 @@ public class KafkaComponent extends DefaultComponent implements SSLContextParame
 
         // extract the additional properties map
         if (PropertiesHelper.hasProperties(params, "additionalProperties.")) {
-            endpoint.getConfiguration().setAdditionalProperties(PropertiesHelper.extractProperties(params, "additionalProperties."));
+            final Map<String, Object> additionalProperties = endpoint.getConfiguration().getAdditionalProperties();
+
+            // add and overwrite additional properties from endpoint to pre-configured properties
+            additionalProperties.putAll(PropertiesHelper.extractProperties(params, "additionalProperties."));
         }
 
         return endpoint;

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kafka;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -317,7 +318,7 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
 
     // Additional properties
     @UriParam(label = "common", prefix = "additionalProperties.", multiValue = true)
-    private Map<String, Object> additionalProperties;
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     public KafkaConfiguration() {
     }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaComponentTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaComponentTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.kafka;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -62,8 +63,19 @@ public class KafkaComponentTest extends CamelTestSupport {
     }
 
     @Test
-    public void testCreateAdditionalProperties() {
-        String uri = "kafka:mytopic?brokers=broker1:12345,broker2:12566&partitioner=com.class.Party&additionalProperties.extra.1=123&additionalProperties.extra.2=test";
+    public void testCreateAdditionalPropertiesOnEndpointAndComponent() {
+        final KafkaComponent kafkaComponent = context.getComponent("kafka", KafkaComponent.class);
+
+        // also we set the configs on the component level
+        final KafkaConfiguration kafkaConfiguration = new KafkaConfiguration();
+        final Map<String, Object> params = new HashMap<>();
+
+        params.put("extra.1", 789);
+        params.put("extra.3", "test.extra.3");
+        kafkaConfiguration.setAdditionalProperties(params);
+        kafkaComponent.setConfiguration(kafkaConfiguration);
+
+        final String uri = "kafka:mytopic?brokers=broker1:12345,broker2:12566&partitioner=com.class.Party&additionalProperties.extra.1=123&additionalProperties.extra.2=test";
 
         KafkaEndpoint endpoint = context.getEndpoint(uri, KafkaEndpoint.class);
         assertEquals("broker1:12345,broker2:12566", endpoint.getConfiguration().getBrokers());
@@ -71,16 +83,19 @@ public class KafkaComponentTest extends CamelTestSupport {
         assertEquals("com.class.Party", endpoint.getConfiguration().getPartitioner());
         assertEquals("123", endpoint.getConfiguration().getAdditionalProperties().get("extra.1"));
         assertEquals("test", endpoint.getConfiguration().getAdditionalProperties().get("extra.2"));
+        assertEquals("test.extra.3", endpoint.getConfiguration().getAdditionalProperties().get("extra.3"));
 
         // test properties on producer keys
         final Properties producerProperties = endpoint.getConfiguration().createProducerProperties();
         assertEquals("123", producerProperties.getProperty("extra.1"));
         assertEquals("test", producerProperties.getProperty("extra.2"));
+        assertEquals("test.extra.3", producerProperties.getProperty("extra.3"));
 
         // test properties on consumer keys
         final Properties consumerProperties = endpoint.getConfiguration().createConsumerProperties();
         assertEquals("123", consumerProperties.getProperty("extra.1"));
         assertEquals("test", consumerProperties.getProperty("extra.2"));
+        assertEquals("test.extra.3", producerProperties.getProperty("extra.3"));
     }
 
     @Test

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaComponentTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaComponentTest.java
@@ -62,6 +62,28 @@ public class KafkaComponentTest extends CamelTestSupport {
     }
 
     @Test
+    public void testCreateAdditionalProperties() {
+        String uri = "kafka:mytopic?brokers=broker1:12345,broker2:12566&partitioner=com.class.Party&additionalProperties.extra.1=123&additionalProperties.extra.2=test";
+
+        KafkaEndpoint endpoint = context.getEndpoint(uri, KafkaEndpoint.class);
+        assertEquals("broker1:12345,broker2:12566", endpoint.getConfiguration().getBrokers());
+        assertEquals("mytopic", endpoint.getConfiguration().getTopic());
+        assertEquals("com.class.Party", endpoint.getConfiguration().getPartitioner());
+        assertEquals("123", endpoint.getConfiguration().getAdditionalProperties().get("extra.1"));
+        assertEquals("test", endpoint.getConfiguration().getAdditionalProperties().get("extra.2"));
+
+        // test properties on producer keys
+        final Properties producerProperties = endpoint.getConfiguration().createProducerProperties();
+        assertEquals("123", producerProperties.getProperty("extra.1"));
+        assertEquals("test", producerProperties.getProperty("extra.2"));
+
+        // test properties on consumer keys
+        final Properties consumerProperties = endpoint.getConfiguration().createConsumerProperties();
+        assertEquals("123", consumerProperties.getProperty("extra.1"));
+        assertEquals("test", consumerProperties.getProperty("extra.2"));
+    }
+
+    @Test
     public void testAllProducerConfigProperty() throws Exception {
         Map<String, Object> params = new HashMap<>();
         setProducerProperty(params);

--- a/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/KafkaEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/dsl/KafkaEndpointBuilderFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.builder.endpoint.dsl;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Generated;
 import org.apache.camel.ExchangePattern;
@@ -44,6 +45,43 @@ public interface KafkaEndpointBuilderFactory {
                 EndpointConsumerBuilder {
         default AdvancedKafkaEndpointConsumerBuilder advanced() {
             return (AdvancedKafkaEndpointConsumerBuilder) this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option is a: <code>java.util.Map&lt;java.lang.String,
+         * java.lang.Object&gt;</code> type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointConsumerBuilder additionalProperties(
+                Map<String, Object> additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option will be converted to a
+         * <code>java.util.Map&lt;java.lang.String, java.lang.Object&gt;</code>
+         * type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointConsumerBuilder additionalProperties(
+                String additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
         }
         /**
          * URL of the Kafka brokers to use. The format is
@@ -1431,6 +1469,43 @@ public interface KafkaEndpointBuilderFactory {
                 EndpointProducerBuilder {
         default AdvancedKafkaEndpointProducerBuilder advanced() {
             return (AdvancedKafkaEndpointProducerBuilder) this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option is a: <code>java.util.Map&lt;java.lang.String,
+         * java.lang.Object&gt;</code> type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointProducerBuilder additionalProperties(
+                Map<String, Object> additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option will be converted to a
+         * <code>java.util.Map&lt;java.lang.String, java.lang.Object&gt;</code>
+         * type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointProducerBuilder additionalProperties(
+                String additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
         }
         /**
          * URL of the Kafka brokers to use. The format is
@@ -2982,6 +3057,43 @@ public interface KafkaEndpointBuilderFactory {
                 KafkaEndpointConsumerBuilder, KafkaEndpointProducerBuilder {
         default AdvancedKafkaEndpointBuilder advanced() {
             return (AdvancedKafkaEndpointBuilder) this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option is a: <code>java.util.Map&lt;java.lang.String,
+         * java.lang.Object&gt;</code> type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointBuilder additionalProperties(
+                Map<String, Object> additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
+        }
+        /**
+         * Sets additional properties for either kafka consumer or kafka
+         * producer in case they can't be set directly on the camel
+         * configurations (e.g: new Kafka properties that are not reflected yet
+         * in Camel configurations), the properties have to be prefixed with
+         * additionalProperties.. E.g:
+         * additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=http://localhost:8811/avro.
+         * 
+         * The option will be converted to a
+         * <code>java.util.Map&lt;java.lang.String, java.lang.Object&gt;</code>
+         * type.
+         * 
+         * Group: common
+         */
+        default KafkaEndpointBuilder additionalProperties(
+                String additionalProperties) {
+            doSetProperty("additionalProperties", additionalProperties);
+            return this;
         }
         /**
          * URL of the Kafka brokers to use. The format is


### PR DESCRIPTION
My first PR after my holidays and to kick my brain on again :). 

Per [CAMEL-14250](https://issues.apache.org/jira/browse/CAMEL-14250), this will add new optional called `additionalProperties.` to Kafka component to allow properties that are not covered by `KafkaConfigurations`