### PR TITLE
Doc update

### DIFF
--- a/components/camel-jira/src/main/docs/jira-component.adoc
+++ b/components/camel-jira/src/main/docs/jira-component.adoc
@@ -253,14 +253,14 @@ Required:
 * `IssueKey`: The issue key identifier.
 * body of the exchange is the description.
 
-== AttachFile
+== Attach
 
 Only one file should attach per invocation.
 
 Required:
 
 * `IssueKey`: The issue key identifier.
-* body of the exchange should be of type `GenericFile`
+* body of the exchange should be of type `File`
 
 == DeleteIssue
 


### PR DESCRIPTION
AttachFile isn't in the list of enums at org.apache.camel.component.jira.JiraType and it wants a File, not a GenericFile.