### PR TITLE
receiveBody methods are extracted

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultConsumerTemplate.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultConsumerTemplate.java
@@ -109,14 +109,7 @@ public class DefaultConsumerTemplate extends ServiceSupport implements ConsumerT
 
     @Override
     public Object receiveBody(String endpointUri) {
-        Object answer;
-        Exchange exchange = receive(endpointUri);
-        try {
-            answer = extractResultBody(exchange);
-        } finally {
-            doneUoW(exchange);
-        }
-        return answer;
+        return receiveBody(receive(endpointUri));
     }
 
     @Override
@@ -126,14 +119,7 @@ public class DefaultConsumerTemplate extends ServiceSupport implements ConsumerT
 
     @Override
     public Object receiveBody(String endpointUri, long timeout) {
-        Object answer;
-        Exchange exchange = receive(endpointUri, timeout);
-        try {
-            answer = extractResultBody(exchange);
-        } finally {
-            doneUoW(exchange);
-        }
-        return answer;
+        return receiveBody(receive(endpointUri, timeout));
     }
 
     @Override
@@ -143,8 +129,11 @@ public class DefaultConsumerTemplate extends ServiceSupport implements ConsumerT
 
     @Override
     public Object receiveBodyNoWait(String endpointUri) {
+        return receiveBody(receiveNoWait(endpointUri));
+    }
+
+    private Object receiveBody(Exchange exchange) {
         Object answer;
-        Exchange exchange = receiveNoWait(endpointUri);
         try {
             answer = extractResultBody(exchange);
         } finally {
@@ -152,6 +141,7 @@ public class DefaultConsumerTemplate extends ServiceSupport implements ConsumerT
         }
         return answer;
     }
+
 
     @Override
     public Object receiveBodyNoWait(Endpoint endpoint) {


### PR DESCRIPTION
`receiveBody()` methods are duplicated.
This PR extracts a private method from the `receiveBody()` methods and simplifies codes.