### PR TITLE
Fix PackageComponentMojo when generates json files

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageComponentMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageComponentMojo.java
@@ -131,9 +131,10 @@ public class PackageComponentMojo extends AbstractGeneratorMojo {
     }
 
     private static void enrichComponentJsonFiles(Log log, MavenProject project, File buildDir, Set<String> components) throws MojoExecutionException {
-        final Map<String, File> files = PackageHelper.findJsonFiles(buildDir, p -> p.isDirectory() || p.getName().endsWith(".json"));
+        Set<File> files = new HashSet<>();
+        PackageHelper.findJsonFiles(buildDir, files, p -> p.isDirectory() || p.getName().endsWith(".json"));
 
-        for (File file : files.values()) {
+        for (File file : files) {
             // clip the .json suffix
             String name = file.getName().substring(0, file.getName().length() - 5);
             if (components.contains(name)) {


### PR DESCRIPTION
Changed it to `Set` in order to keep all json files with the same name (but with different path) for a component. I think this was the original behavior, to expect a Set instead of Map