### PR TITLE
Support subscriptionInitialPosition in camel-pulsar (CAMEL-14416)

### DIFF
--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -95,6 +95,7 @@ with the following path and query parameters:
 | *subscriptionName* (consumer) | Name of the subscription to use | subs | String
 | *subscriptionType* (consumer) | Type of the subscription EXCLUSIVESHAREDFAILOVER, defaults to EXCLUSIVE | EXCLUSIVE | SubscriptionType
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored. |  | ExceptionHandler
+| *subscriptionInitialPosition* (consumer) | Controls the position of the cursor within the topic when a new subscription is created. Defaults to LATEST message. | LATEST | SubscriptionInitialPosition
 | *exchangePattern* (consumer) | Sets the exchange pattern when the consumer creates an exchange. |  | ExchangePattern
 | *batchingEnabled* (producer) | Control whether automatic batching of messages is enabled for the producer. Default is true. | true | boolean
 | *batchingMaxMessages* (producer) | Set the maximum number of messages permitted in a batch. Default 1,000. | 1000 | int

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/configuration/PulsarConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.pulsar.configuration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.component.pulsar.PulsarMessageReceipt;
+import org.apache.camel.component.pulsar.utils.consumers.SubscriptionInitialPosition;
 import org.apache.camel.component.pulsar.utils.consumers.SubscriptionType;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
@@ -26,6 +27,7 @@ import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 
+import static org.apache.camel.component.pulsar.utils.consumers.SubscriptionInitialPosition.LATEST;
 import static org.apache.camel.component.pulsar.utils.consumers.SubscriptionType.EXCLUSIVE;
 
 @UriParams
@@ -51,6 +53,8 @@ public class PulsarConfiguration {
     private long ackTimeoutMillis = 10000;
     @UriParam(label = "consumer", defaultValue = "100")
     private long ackGroupTimeMillis = 100;
+    @UriParam(label = "consumer", defaultValue = "LATEST")
+    private SubscriptionInitialPosition subscriptionInitialPosition = LATEST;
     @UriParam(label = "producer", description = "Send timeout in milliseconds", defaultValue = "30000")
     private int sendTimeoutMs = 30000;
     @UriParam(label = "producer", description = "Whether to block the producing thread if pending messages queue is full or to throw a ProducerQueueIsFullError", defaultValue = "false")
@@ -283,6 +287,17 @@ public class PulsarConfiguration {
 
     public boolean isBatchingEnabled() {
         return batchingEnabled;
+    }
+
+    /**
+     * Control the initial position in the topic of a newly created subscription. Default is latest message.
+     */
+    public void setSubscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition) {
+        this.subscriptionInitialPosition = subscriptionInitialPosition;
+    }
+
+    public SubscriptionInitialPosition getSubscriptionInitialPosition() {
+        return subscriptionInitialPosition;
     }
 
     /**

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/CommonCreationStrategyImpl.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/CommonCreationStrategyImpl.java
@@ -34,6 +34,7 @@ public final class CommonCreationStrategyImpl {
 
         return pulsarEndpoint.getPulsarClient().newConsumer().topic(pulsarEndpoint.getUri()).subscriptionName(endpointConfiguration.getSubscriptionName())
             .receiverQueueSize(endpointConfiguration.getConsumerQueueSize()).consumerName(name).ackTimeout(endpointConfiguration.getAckTimeoutMillis(), TimeUnit.MILLISECONDS)
+            .subscriptionInitialPosition(endpointConfiguration.getSubscriptionInitialPosition().toPulsarSubscriptionInitialPosition())
             .acknowledgmentGroupTime(endpointConfiguration.getAckGroupTimeMillis(), TimeUnit.MILLISECONDS)
             .messageListener(new PulsarMessageListener(pulsarEndpoint, pulsarConsumer.getExceptionHandler(), pulsarConsumer.getProcessor()));
     }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/SubscriptionInitialPosition.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/consumers/SubscriptionInitialPosition.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pulsar.utils.consumers;
+
+public enum SubscriptionInitialPosition {
+    EARLIEST(org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest),
+    LATEST(org.apache.pulsar.client.api.SubscriptionInitialPosition.Latest);
+
+    private org.apache.pulsar.client.api.SubscriptionInitialPosition pulsarInitialPosition;
+
+    SubscriptionInitialPosition(org.apache.pulsar.client.api.SubscriptionInitialPosition pulsarInitialPosition) {
+        this.pulsarInitialPosition = pulsarInitialPosition;
+    }
+
+    public org.apache.pulsar.client.api.SubscriptionInitialPosition toPulsarSubscriptionInitialPosition() {
+        return pulsarInitialPosition;
+    }
+}


### PR DESCRIPTION
Allows Pulsar consumers to start from the earliest message in the topic (vs the default latest) when creating a new subscription.

See http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/SubscriptionInitialPosition.html.