### PR TITLE
CAMEL-14424: HTTP responses over 4 MB fail

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
@@ -651,7 +651,7 @@ for details on how to generate the DTO.
 
 
 // component options: START
-The Salesforce component supports 33 options, which are listed below.
+The Salesforce component supports 34 options, which are listed below.
 
 
 
@@ -676,6 +676,7 @@ The Salesforce component supports 33 options, which are listed below.
 | *useGlobalSslContextParameters* (security) | Enable usage of global SSL context parameters | false | boolean
 | *httpClientIdleTimeout* (common) | Timeout used by the HttpClient when waiting for response from the Salesforce server. | 10000 | long
 | *httpClientConnectionTimeout* (common) | Connection timeout used by the HttpClient when connecting to the Salesforce server. | 60000 | long
+| *httpMaxContentLength* (common) | Max content length of an HTTP response. |  | Integer
 | *httpProxyHost* (proxy) | Hostname of the HTTP proxy server to use. |  | String
 | *httpProxyPort* (proxy) | Port number of the HTTP proxy server to use. |  | Integer
 | *httpProxyUsername* (security) | Username to use to authenticate against the HTTP proxy server. |  | String

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -79,6 +79,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
     public static final String HTTP_PROXY_REALM = "httpProxyRealm";
     public static final String HTTP_CONNECTION_TIMEOUT = "httpConnectionTimeout";
     public static final String HTTP_IDLE_TIMEOUT = "httpIdleTimeout";
+    public static final String HTTP_MAX_CONTENT_LENGTH = "httpMaxContentLength";
 
     static final int CONNECTION_TIMEOUT = 60000;
     static final int IDLE_TIMEOUT = 10000;
@@ -145,6 +146,9 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
 
     @Metadata(description = "Connection timeout used by the HttpClient when connecting to the Salesforce server.", label = "common", defaultValue = "" + CONNECTION_TIMEOUT)
     private long httpClientConnectionTimeout = CONNECTION_TIMEOUT;
+
+    @Metadata(description = "Max content length of an HTTP response.", label = "common")
+    private Integer httpMaxContentLength;
 
     @Metadata(description = "Used to set any properties that can be configured on the underlying HTTP client. Have a"
                             + " look at properties of SalesforceHttpClient and the Jetty HttpClient for all available options.", label = "common,advanced")
@@ -545,6 +549,14 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         this.httpClientConnectionTimeout = httpClientConnectionTimeout;
     }
 
+    public Integer getHttpMaxContentLength() {
+        return httpMaxContentLength;
+    }
+
+    public void setHttpMaxContentLength(Integer httpMaxContentLength) {
+        this.httpMaxContentLength = httpMaxContentLength;
+    }
+
     public String getHttpProxyHost() {
         return httpProxyHost;
     }
@@ -729,6 +741,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
 
         final Long httpConnectionTimeout = typeConverter.convertTo(Long.class, httpClientProperties.get(HTTP_CONNECTION_TIMEOUT));
         final Long httpIdleTimeout = typeConverter.convertTo(Long.class, httpClientProperties.get(HTTP_IDLE_TIMEOUT));
+        final Integer maxContentLength = typeConverter.convertTo(Integer.class, httpClientProperties.get(HTTP_MAX_CONTENT_LENGTH));
 
         final String httpProxyHost = typeConverter.convertTo(String.class, httpClientProperties.get(HTTP_PROXY_HOST));
         final Integer httpProxyPort = typeConverter.convertTo(Integer.class, httpClientProperties.get(HTTP_PROXY_PORT));
@@ -750,6 +763,9 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         }
         if (httpConnectionTimeout != null) {
             httpClient.setConnectTimeout(httpConnectionTimeout);
+        }
+        if (maxContentLength != null) {
+            httpClient.setMaxContentLength(maxContentLength);
         }
 
         // set HTTP proxy settings
@@ -797,6 +813,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         putValueIfGivenTo(httpClientProperties, HTTP_PROXY_PASSWORD, salesforce::getHttpProxyPassword);
         putValueIfGivenTo(httpClientProperties, HTTP_PROXY_REALM, salesforce::getHttpProxyRealm);
         putValueIfGivenTo(httpClientProperties, HTTP_PROXY_AUTH_URI, salesforce::getHttpProxyAuthUri);
+        putValueIfGivenTo(httpClientProperties, HTTP_MAX_CONTENT_LENGTH, salesforce::getHttpMaxContentLength);
 
         if (ObjectHelper.isNotEmpty(salesforce.getHttpProxyHost())) {
             // let's not put `false` values in client properties if no proxy is


### PR DESCRIPTION
This commit allows the user to overwrite the default http client max content length of 4 MB.