### PR TITLE
Minor cleanup for camel-test-spring documentation 

### DIFF
--- a/components/camel-test-spring/src/main/docs/test-spring.adoc
+++ b/components/camel-test-spring/src/main/docs/test-spring.adoc
@@ -261,6 +261,7 @@ JMX is disabled a|JMX is disabled
 Indicates if certain route builder classes should be excluded from discovery.  Initializes a `org.apache.camel.spi.PackageScanClassResolver` to exclude a set of given classes from being resolved. Typically this is used at test time to exclude certain routes, which might otherwise be just noisy, from being discovered and initialized. a|
 Not enabled and no routes are excluded a|No routes are excluded
 
+|org.apache.camel.test.spring.LazyLoadTypeConverters (Deprecated) a|Class a|
 Indicates if the CamelContexts that are bootstrapped during the test through the use of Spring Test loaded application contexts should use lazy loading of type converters. a|
 Type converters are not lazy loaded a|
 Type converters are not lazy loaded

--- a/components/camel-test-spring/src/main/docs/test-spring.adoc
+++ b/components/camel-test-spring/src/main/docs/test-spring.adoc
@@ -261,11 +261,6 @@ JMX is disabled a|JMX is disabled
 Indicates if certain route builder classes should be excluded from discovery.  Initializes a `org.apache.camel.spi.PackageScanClassResolver` to exclude a set of given classes from being resolved. Typically this is used at test time to exclude certain routes, which might otherwise be just noisy, from being discovered and initialized. a|
 Not enabled and no routes are excluded a|No routes are excluded
 
-|org.apache.camel.test.spring.LazyLoadTypeConverters (Deprecated) a|Class a|
-Indicates if the CamelContexts that are bootstrapped during the test through the use of Spring Test loaded application contexts should use lazy loading of type converters. a|
-Type converters are not lazy loaded a|
-Type converters are not lazy loaded
-
 |org.apache.camel.test.spring.MockEndpoints a|Class a|
 Triggers the auto-mocking of endpoints whose URIs match the provided filter.  The default filter is `"*"` which matches all endpoints.  See `org.apache.camel.impl.InterceptSendToMockEndpointStrategy` for more details on the registration of the mock endpoints. a|
 Not enabled a|All endpoints are sniffed and recorded in a mock endpoint.


### PR DESCRIPTION
Completely removed a partially deleted row for class org.apache.camel.test.spring.LazyLoadTypeConverters.

LazyLoadTypeConverters has been deprecated and removed from at least version 2.20.2