### PR TITLE
CAMEL-14428: add `-XX:+ExitOnOutOfMemoryError` to surefire

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4286,6 +4286,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin-version}</version>
                 <configuration>
+                    <argLine>-XX:+ExitOnOutOfMemoryError</argLine>
                     <!--forkMode>pertest</forkMode -->
                     <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
                     <childDelegation>false</childDelegation>


### PR DESCRIPTION
This configures `-XX:+ExitOnOutOfMemoryError` for JVM spun by Maven
Surefire plugin. So now when JVM launched by Surefire signals
`OutOfMemoryError` it will abruptly exit the JVM, skipping any failing
test rerun and it will not generate the JUnit XML/TXT report.

Instead `target/surefire-reports/*.dumpstream` needs to be consulted to
find errors like:

```
# Created at 2020-01-23T16:30:48.519
Corrupted STDOUT by directly writing to native stream in forked JVM 1. Stream 'Terminating due to java.lang.OutOfMemoryError: Java heap space'.
```

So the downside of this is that troubleshooting test issues when
`OutOfMemoryError` occurs is more difficult; the plugin stops executing
and fails the module build with:

```
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```

Newer version of Surefire include additional `[ERROR]` lines that help
with pinpointing the issue somewhat, though, I assume, it will come as a
surprise for someone not expecting this.

Having JVM exit and not retry the test in a situation where we're
starved for memory enables us to fail fast and not consume any more
shared resources.

Note that on the Jenkins the build is run with `-fae`, meaning that
Maven will fail only after it is unable to proceed due to required
modules not being able to build. With that a OOM in a module built in
the middle of the build will not prevent the build from proceeding to
build other module (that do not depend on it).