### PR TITLE
Fix camel-rabbitmq integration test

### DIFF
--- a/components/camel-rabbitmq/pom.xml
+++ b/components/camel-rabbitmq/pom.xml
@@ -105,6 +105,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -446,7 +446,9 @@ For example declaring a method in Spring
 ----
 @Bean(name = "bindArgs")
 public Map<String, Object> bindArgsBuilder() {
-    return Collections.singletonMap("foo", "bar");
+    return new HashMap<String, Object>() {{
+        put("binding.foo", "bar");
+    }};
 }
 ----
 


### PR DESCRIPTION
While working on CAMEL-14260, found that test.
Changes:
1. Bindning was not configured.
2. Test was always passed, beacause all 3 messages were allways recevied. I added Thread.Sleep to verify that there is no other messages.
3. Fixed docs - added prefix "binding."
4. Type `Collections.singletonMap` cannot be used because of `PropertiesHelper.extractProperties`. Or sources of component have to be modified.