### PR TITLE
Fix for XML DSL example: Setting Serialization Include Option for Jackson Marshal

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/json.adoc
+++ b/docs/user-manual/modules/ROOT/pages/json.adoc
@@ -284,7 +284,7 @@ Or from XML DSL you configure this as
 [source,java]
 ------------------------------------------------------------
     <dataFormats>
-      <json id="json" library="Jackson" include="NOT_NULL"/>
+      <json id="json" library="Jackson" include="NON_NULL"/>
     </dataFormats>
 ------------------------------------------------------------
 


### PR DESCRIPTION
The include option in the example should have the value "NON_NULL" instead of "NO**T**_NULL:

<json id="json" library="Jackson" include="NON_NULL" />