### PR TITLE
camel-smpp: Remove commons-codec dependency.

### DIFF
--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -45,10 +45,6 @@
             <artifactId>jsmpp</artifactId>
             <version>${jsmpp-version}</version>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConnectionFactory.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConnectionFactory.java
@@ -53,6 +53,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Base64;
 import java.util.Map;
 
 import javax.net.SocketFactory;
@@ -61,7 +62,6 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.util.IOHelper;
-import org.apache.commons.codec.binary.Base64;
 import org.jsmpp.session.connection.Connection;
 import org.jsmpp.session.connection.ConnectionFactory;
 import org.jsmpp.session.connection.socket.SocketConnection;
@@ -126,7 +126,7 @@ public final class SmppConnectionFactory implements ConnectionFactory {
             
             if (username != null && password != null) {
                 String usernamePassword = username + ":" + password;
-                byte[] code = Base64.encodeBase64(usernamePassword.getBytes());
+                byte[] code = Base64.getEncoder().encode(usernamePassword.getBytes());
                 out.write("Proxy-Authorization: Basic ".getBytes());
                 out.write(code);
                 out.write("\r\n".getBytes());

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -2259,7 +2259,6 @@
   <feature name='camel-smpp' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:org.jsmpp/jsmpp/${jsmpp-version}</bundle>
-    <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-smpp/${project.version}</bundle>
   </feature>
   <feature name='camel-snakeyaml' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Use java.util.Base64 instead.