### PR TITLE
CAMEL-14420: Support additional properties on Debezium components

### DIFF
--- a/components/camel-debezium-common/camel-debezium-common-component/src/main/java/org/apache/camel/component/debezium/DebeziumComponent.java
+++ b/components/camel-debezium-common/camel-debezium-common-component/src/main/java/org/apache/camel/component/debezium/DebeziumComponent.java
@@ -23,6 +23,7 @@ import org.apache.camel.component.debezium.configuration.ConfigurationValidation
 import org.apache.camel.component.debezium.configuration.EmbeddedDebeziumConfiguration;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.PropertiesHelper;
 
 /**
  * Base class for all debezium components
@@ -52,6 +53,14 @@ public abstract class DebeziumComponent<C extends EmbeddedDebeziumConfiguration>
 
         DebeziumEndpoint endpoint = initializeDebeziumEndpoint(uri, configuration);
         setProperties(endpoint, parameters);
+
+        // extract the additional properties map
+        if (PropertiesHelper.hasProperties(parameters, "additionalProperties.")) {
+            final Map<String, Object> additionalProperties = endpoint.getConfiguration().getAdditionalProperties();
+
+            // add and overwrite additional properties from endpoint to pre-configured properties
+            additionalProperties.putAll(PropertiesHelper.extractProperties(parameters, "additionalProperties."));
+        }
 
         // validate configurations
         final ConfigurationValidation configurationValidation = configuration.validateConfiguration();

--- a/components/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/DebeziumComponentTest.java
+++ b/components/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/DebeziumComponentTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.debezium;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.component.debezium.configuration.FileConnectorEmbeddedDebeziumConfiguration;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class DebeziumComponentTest extends CamelTestSupport {
+
+    @Test
+    public void testIfSetsAdditionalProperties() throws Exception {
+        final DebeziumTestComponent component = new DebeziumTestComponent(context);
+        final FileConnectorEmbeddedDebeziumConfiguration configuration = new FileConnectorEmbeddedDebeziumConfiguration();
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put("extra.1", 789);
+        params.put("extra.3", "test.extra.3");
+
+        configuration.setOffsetStorageFileName("/test");
+        configuration.setTestFilePath(Paths.get("."));
+        configuration.setTopicConfig("test_conf");
+        configuration.setAdditionalProperties(params);
+
+        component.setConfiguration(configuration);
+
+        final DebeziumTestEndpoint endpoint = (DebeziumTestEndpoint) component.createEndpoint("debezium-dummy:test_name?additionalProperties.extra.1=123&additionalProperties.extra.2=test");
+
+        assertEquals("test_name", endpoint.getConfiguration().getName());
+        assertEquals("test_conf", endpoint.getConfiguration().getTopicConfig());
+        assertEquals("123", endpoint.getConfiguration().getAdditionalProperties().get("extra.1"));
+        assertEquals("test", endpoint.getConfiguration().getAdditionalProperties().get("extra.2"));
+        assertEquals("test.extra.3", endpoint.getConfiguration().getAdditionalProperties().get("extra.3"));
+    }
+}

--- a/components/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfigurationTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.debezium.configuration;
 
+import java.util.Collections;
+
 import io.debezium.config.Configuration;
 import io.debezium.embedded.EmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
@@ -58,6 +60,19 @@ public class EmbeddedDebeziumConfigurationTest {
         configuration.setTestField("test_field");
 
         assertTrue(configuration.validateConfiguration().isValid());
+    }
+
+    @Test
+    public void testIfCreatesAdditionalProperties() {
+        final TestEmbeddedDebeziumConfiguration configuration = new TestEmbeddedDebeziumConfiguration();
+        configuration.setName("test_config");
+        configuration.setAdditionalProperties(Collections.singletonMap("test.additional", "test_additional"));
+        configuration.setTestField("test_field");
+
+        final Configuration dbzEmbeddedConfiguration = configuration.createDebeziumConfiguration();
+
+        assertEquals("test_config", dbzEmbeddedConfiguration.getString("name"));
+        assertEquals("test_additional", dbzEmbeddedConfiguration.getString("test.additional"));
     }
 
 }

--- a/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
+++ b/components/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
@@ -75,12 +75,13 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (43 parameters):
+=== Query Parameters (44 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *additionalProperties* (common) | Sets additional properties for debezium components in case they can't be set directly on the camel configurations (e.g: setting Kafka Connect properties needed by Debezium engine, for example setting KafkaOffsetBackingStore), the properties have to be prefixed with additionalProperties.. E.g: additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=\http://localhost:8811/avro |  | Map
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *internalKeyConverter* (consumer) | The Converter class that should be used to serialize and deserialize key data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String
 | *internalValueConverter* (consumer) | The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String

--- a/components/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
+++ b/components/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
@@ -82,12 +82,13 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (73 parameters):
+=== Query Parameters (74 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *additionalProperties* (common) | Sets additional properties for debezium components in case they can't be set directly on the camel configurations (e.g: setting Kafka Connect properties needed by Debezium engine, for example setting KafkaOffsetBackingStore), the properties have to be prefixed with additionalProperties.. E.g: additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=\http://localhost:8811/avro |  | Map
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *internalKeyConverter* (consumer) | The Converter class that should be used to serialize and deserialize key data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String
 | *internalValueConverter* (consumer) | The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String

--- a/components/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
+++ b/components/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
@@ -73,12 +73,13 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (65 parameters):
+=== Query Parameters (66 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *additionalProperties* (common) | Sets additional properties for debezium components in case they can't be set directly on the camel configurations (e.g: setting Kafka Connect properties needed by Debezium engine, for example setting KafkaOffsetBackingStore), the properties have to be prefixed with additionalProperties.. E.g: additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=\http://localhost:8811/avro |  | Map
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *internalKeyConverter* (consumer) | The Converter class that should be used to serialize and deserialize key data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String
 | *internalValueConverter* (consumer) | The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String

--- a/components/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
+++ b/components/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
@@ -72,12 +72,13 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (47 parameters):
+=== Query Parameters (48 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
+| *additionalProperties* (common) | Sets additional properties for debezium components in case they can't be set directly on the camel configurations (e.g: setting Kafka Connect properties needed by Debezium engine, for example setting KafkaOffsetBackingStore), the properties have to be prefixed with additionalProperties.. E.g: additionalProperties.transactional.id=12345&additionalProperties.schema.registry.url=\http://localhost:8811/avro |  | Map
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *internalKeyConverter* (consumer) | The Converter class that should be used to serialize and deserialize key data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String
 | *internalValueConverter* (consumer) | The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter. | org.apache.kafka.connect.json.JsonConverter | String


### PR DESCRIPTION
Per title. Similar to [camel-kafka](https://github.com/apache/camel/pull/3468), users can set additional properties using prefix `additionalProperties.`. E.g: 
`debezium-mysql:test?offsetStorage=test&additionalProperties.schema.url=localhost:1246`