### PR TITLE
Fix broken links to Javadoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/configuring-camel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/configuring-camel.adoc
@@ -7,9 +7,9 @@
 You might first want to read xref:writing-components.adoc[Writing
 Components] for a background in how to implement a new component.
 Typically it means you write an implementation of the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Component.html[Component]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Component.html[Component]
 interface, usually deriving from
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent].
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/DefaultComponent.html[DefaultComponent].
 
 You can then register your component explicitly via:
 
@@ -40,7 +40,7 @@ Then if you refer to an endpoint as `foo://somethingOrOther` Camel
 will auto-discover your component and register it.
 
 The `FooComponent` can then be auto-injected with resources using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/Injector.html[Injector],
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/Injector.html[Injector],
 such as to support xref:components::spring.adoc[Spring] based auto-wiring, or to
 support `@Resource` (EJB3 style) injection or Guice style `@Inject`
 injection.


### PR DESCRIPTION
Old Javadoc location at `http://camel.apache.org/maven/*` appears to be broken.
Can we point to `javadoc.io` instead?
Linked adjusted for 3.x changes - Splitting classess from `camel-core` into `camel-api` and `camel-support`.