### PR TITLE
[CAMEL-14482] Fix broken javadoc links

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/architecture.adoc
+++ b/docs/user-manual/modules/ROOT/pages/architecture.adoc
@@ -4,12 +4,12 @@
 Camel uses a Java based xref:dsl.adoc[Routing Domain Specific Language (DSL)] 
 or an XML Configuration to configure
 routing and mediation rules which are added to a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
 to implement the various
 xref:enterprise-integration-patterns.adoc[Enterprise Integration Patterns].
 
 At a high level Camel consists of a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
 which contains a collection of Component instances.
 A Component is essentially a factory of
 Endpoint instances. You can explicitly configure
@@ -21,9 +21,9 @@ An Endpoint acts rather like a URI or URL in a web
 application or a Destination in a JMS system; you can communicate with
 an endpoint; either sending messages to it or consuming messages from
 it. You can then create a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 or
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Consumer.html[Consumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Consumer.html[Consumer]
 on an Endpoint to exchange messages with it.
 
 The DSL makes heavy use of pluggable

--- a/docs/user-manual/modules/ROOT/pages/async.adoc
+++ b/docs/user-manual/modules/ROOT/pages/async.adoc
@@ -172,7 +172,7 @@ Async API and how to use it with Camel.
 == The Async Client API
 
 Camel provides the Async Client API in the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/ProducerTemplate.html[ProducerTemplate]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/ProducerTemplate.html[ProducerTemplate]
 where we have added about 10 new methods to Camel 2.0. We have listed
 the most important in the table below:
 

--- a/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
+++ b/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
@@ -75,18 +75,18 @@ bookmarks to pages that you frequently reference can also save time.
 [[BookGettingStarted-OnlineJavadocdocumentation]]
 == Online Javadoc documentation
 
-The Apache Camel website provides
-http://camel.apache.org/maven/current/camel-core/apidocs/index.html[Javadoc
-documentation]. It is important to note that the Javadoc documentation
+The Apache Camel Javadoc documentation can be accessed from 
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/index.html
+[javadoc.io]. It is important to note that the Javadoc documentation
 is spread over several _independent_ Javadoc hierarchies rather than
 being all contained in a single Javadoc hierarchy. In particular, there
 is one Javadoc hierarchy for the _core_ APIs of Camel, and a separate
 Javadoc hierarchy for each component technology supported by Camel. For
 example, if you will be using Camel with ActiveMQ and FTP then you need
 to look at the Javadoc hierarchies for the
-http://camel.apache.org/maven/current/camel-core/apidocs/index.html[core
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/index.html[core
 API] and
-http://camel.apache.org/maven/current/camel-spring/apidocs/index.html[Spring
+https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/index.html[Spring
 API].
 
 [[BookGettingStarted-ConceptsandterminologyfundamentaltoCamel]]

--- a/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/browsable-endpoint.adoc
@@ -1,7 +1,7 @@
 [[BrowsableEndpoint-BrowsableEndpoint]]
 = BrowsableEndpoint
 
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/BrowsableEndpoint.html[BrowsableEndpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/BrowsableEndpoint.html[BrowsableEndpoint]
 is an extension interface an Endpoint may implement
 to support the browsing of the Message exchanges
 which are pending or have been sent on it.

--- a/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
@@ -2,7 +2,7 @@
 = CamelContext
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
 represents a single Camel routing rulebase. You use the CamelContext in
 a similar way to the Spring
 http://static.springsource.org/spring/docs/3.0.x/javadoc-api/org/springframework/context/ApplicationContext.html[ApplicationContext].

--- a/docs/user-manual/modules/ROOT/pages/dead-letter-channel.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dead-letter-channel.adoc
@@ -5,7 +5,7 @@ Camel supports the
 http://www.enterpriseintegrationpatterns.com/DeadLetterChannel.html[Dead
 Letter Channel] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/DeadLetterChannel.html[DeadLetterChannel]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/DeadLetterChannel.html[DeadLetterChannel]
 processor which is an xref:error-handler.adoc[Error Handler].
 
 image::eip/DeadLetterChannelSolution.gif[image]
@@ -47,7 +47,7 @@ wish to use some kind of redelivery policy to decide how many times to
 try redeliver a message and how long to wait before redelivery attempts.
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
 defines how the message is to be redelivered. You can customize things
 like
 
@@ -276,7 +276,7 @@ reduce that to 1 second.
 == Redelivery header
 
 When a message is redelivered the
-http://camel.apache.org/maven/camel-core/apidocs/org/apache/camel/processor/DeadLetterChannel.html[DeadLetterChannel]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/DeadLetterChannel.html[DeadLetterChannel]
 will append a customizable header to the message to indicate how many
 times its been redelivered.  
 Before Camel 2.6: The header is *CamelRedeliveryCounter*, which is also
@@ -448,7 +448,7 @@ The following example shows how to configure the Dead Letter Channel
 configuration using the xref:dsl.adoc[DSL]
 
 You can also configure the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
 as this example shows
 
 [[deadLetterChannel-HowcanImodifytheExchangebeforeredelivery]]

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -3,25 +3,25 @@
 
 Camel supports the Message Endpoint pattern
 using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html[Endpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. Endpoints are usually created by a
 Component and Endpoints are usually referred to in
 the DSL via their URIs.
 
 From an Endpoint you can use the following methods
 
-* http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createProducer()[createProducer()]
+* https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createProducer--[createProducer()]
 will create a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 for sending message exchanges to the endpoint
-* http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createConsumer(org.apache.camel.Processor)[createConsumer()]
+* https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createConsumer-org.apache.camel.Processor-[createConsumer()]
 implements the Event Driven Consumer
 pattern for consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 when creating a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Consumer.html[Consumer]
-* http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createPollingConsumer()[createPollingConsumer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Consumer.html[Consumer]
+* https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createPollingConsumer--[createPollingConsumer()]
 implements the Polling Consumer pattern for
 consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/PollingConsumer.html[PollingConsumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/PollingConsumer.html[PollingConsumer]
 

--- a/docs/user-manual/modules/ROOT/pages/error-handler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/error-handler.adoc
@@ -2,7 +2,7 @@
 = Error Handler
 
 Camel supports pluggable
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/ErrorHandler.html[ErrorHandler]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/ErrorHandler.html[ErrorHandler]
 strategies to deal with errors processing an
 Event Driven Consumer. An alternative
 is to specify the error handling directly in the DSL

--- a/docs/user-manual/modules/ROOT/pages/eventDrivenConsumer-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/eventDrivenConsumer-eip.adoc
@@ -13,7 +13,7 @@ threading and concurrency for you in a declarative manner.
 image::eip/EventDrivenConsumerSolution.gif[image]
 
 The Event Driven Consumer is implemented by consumers implementing the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 interface which is invoked by the xref:message-endpoint.adoc[Message Endpoint]
 when a xref:message.adoc[Message] is available for processing.
 
@@ -21,7 +21,7 @@ when a xref:message.adoc[Message] is available for processing.
 == Example
 
 The following demonstrates a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 defined in the Camel xref:registry.adoc[Registry] which is
 invoked when an event occurs from a xref:components::jms-component.adoc[JMS] queue.
 

--- a/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
@@ -159,7 +159,7 @@ select the *`onException(IOException.class)`* clause.
 [[ExceptionClause-ConfiguringRedeliveryPolicyredeliveroptions]]
 == Configuring RedeliveryPolicy (redeliver options)
 
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
 requires to use the xref:dead-letter-channel.adoc[Dead Letter Channel]
 as the xref:error-handler.adoc[Error Handler]. Dead Letter Channel
 supports attempting to redeliver the message exchange a number of times
@@ -180,7 +180,7 @@ not be redelivered; however if some other exception occurs, e.g.,
 settings from the xref:dead-letter-channel.adoc[Dead Letter Channel].
 
 However if you want to customize any methods on the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
 object, you can do this via the fluent API. So lets retry in case
 of *`org.apache.camel.ValidationException`* up till two times.
 
@@ -203,7 +203,7 @@ onException(ValidationException.class)
 ----
 
 You can customize any of the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/RedeliveryPolicy.html[RedeliveryPolicy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
 so we can for instance set a different delay of *`5000`* millis:
 
 [source,xml]
@@ -769,7 +769,7 @@ Where the bean *`myRetryHandler`* is computing if we should retry or not:
 *Available in Camel 1.4*
 
 The default
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/processor/exceptionpolicy/ExceptionPolicyStrategy.html[ExceptionPolicyStrategy]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/ExceptionPolicyStrategy.html[ExceptionPolicyStrategy]
 in Camel should be sufficient in nearly all use-cases (see section
 xref:exception-clause.adoc#ExceptionClause-HowDoesCamelSelectWhichClauseShouldHandleaGivenThrownException[How does Camel select which clause should handle a given thrown Exception]).
 However, if you need to use your own this can be configured as the

--- a/docs/user-manual/modules/ROOT/pages/expression.adoc
+++ b/docs/user-manual/modules/ROOT/pages/expression.adoc
@@ -7,7 +7,7 @@ Integration Patterns] in the DSL or
 XML Configuration like the
 Recipient List. +
  To support dynamic rules Camel supports pluggable
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Expression.html[Expression]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Expression.html[Expression]
 strategies using a variety of different Languages.
 
 [[Expression-API]]
@@ -15,9 +15,9 @@ strategies using a variety of different Languages.
 
 If you are outside of the DSL and want to create your own
 expressions you can either implement the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Expression.html[Expression
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Expression.html[Expression
 interface], reuse one of the other builders or try the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/builder/ExpressionBuilder.html[ExpressionBuilder
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/builder/ExpressionBuilder.html[ExpressionBuilder
 class].
 
 [[Expression-Expression]]

--- a/docs/user-manual/modules/ROOT/pages/faq/how-does-the-camel-api-compare-to.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/how-does-the-camel-api-compare-to.adoc
@@ -2,9 +2,9 @@
 = How does the Camel API compare to from CXF, HTTP, JBI, JMS, JavaMail, etc.
 
 We have tried to make the Camel
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchange.html[Exchange]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html[Exchange]
 and
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Message.html[Message]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Message.html[Message]
 map very closely to JBI in particular but also
 xref:components::cxf-component.adoc[CXF], xref:components::http-component.adoc[HTTP], xref:components::jms-component.adoc[JMS],
 xref:components::mail-component.adoc[Mail], xref:components::xmpp-component.adoc[XMPP] and most other integration

--- a/docs/user-manual/modules/ROOT/pages/faq/running-camel-standalone.adoc
+++ b/docs/user-manual/modules/ROOT/pages/faq/running-camel-standalone.adoc
@@ -5,7 +5,7 @@ Yes, Camel can run standalone or in any container. Running Standalone is
 as simple just to create a xref:camelcontext.adoc[CamelContext], add
 routes and start it. If you don't want to write your own Java main, you
 could use the one from xref:components::spring.adoc[camel-spring]
-(http://camel.apache.org/maven/current/camel-spring/apidocs/) also used
+(https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/index.html) also used
 by the xref:camel-maven-plugin.adoc[Camel Maven Plugin].
 
 The starting guide is a good place to start: +

--- a/docs/user-manual/modules/ROOT/pages/injector.adoc
+++ b/docs/user-manual/modules/ROOT/pages/injector.adoc
@@ -2,7 +2,7 @@
 = Injector
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/Injector.html[Injector]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/Injector.html[Injector]
 is a pluggable strategy to any IoC container such as
 Spring to be able to create and
 dependency-inject objects of a certain type.

--- a/docs/user-manual/modules/ROOT/pages/jmx.adoc
+++ b/docs/user-manual/modules/ROOT/pages/jmx.adoc
@@ -10,16 +10,16 @@ obtain insights into how Camel routes perform down to the individual
 processor level.
 
 The supported types of management objects are
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/management/mbean/ManagedEndpoint.html[endpoint],
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/management/mbean/ManagedRoute.html[route],
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/management/mbean/ManagedService.html[service],
+https://www.javadoc.io/doc/org.apache.camel/camel-management/current/org/apache/camel/management/mbean/ManagedEndpoint.html[endpoint],
+https://www.javadoc.io/doc/org.apache.camel/camel-management/current/org/apache/camel/management/mbean/ManagedRoute.html[route],
+https://www.javadoc.io/doc/org.apache.camel/camel-management/current/org/apache/camel/management/mbean/ManagedService.html[service],
 and
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/management/mbean/ManagedProcessor.html[processor].
+https://www.javadoc.io/doc/org.apache.camel/camel-management/current/org/apache/camel/management/mbean/ManagedProcessor.html[processor].
 Some of these management objects also expose lifecycle operations in
 addition to performance counter attributes.
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/management/DefaultManagementObjectNameStrategy.html[`DefaultManagementObjectNameStrategy`]
+https://www.javadoc.io/doc/org.apache.camel/camel-management/current/org/apache/camel/management/DefaultManagementObjectNameStrategy.html[`DefaultManagementObjectNameStrategy`]
 is the default naming strategy which builds object names used for MBean
 registration. By default, `org.apache.camel` is the domain name for all
 object names created by `CamelNamingStrategy`. The domain name of the

--- a/docs/user-manual/modules/ROOT/pages/jndi.adoc
+++ b/docs/user-manual/modules/ROOT/pages/jndi.adoc
@@ -4,7 +4,7 @@
 Camel will use JNDI as the default xref:registry.adoc[Registry]
 implementation if you do not use xref:components::spring.adoc[Spring]. This means
 that using a DefaultCamelContext will try and create a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/JndiRegistry.html[JndiRegistry]
+https://www.javadoc.io/doc/org.apache.camel/camel-core-engine/current/org/apache/camel/impl/JndiRegistry.html[JndiRegistry]
 which uses the JNDI InitialContext as the registry.
 
 This means you need to configure some JNDI provider to be able to use

--- a/docs/user-manual/modules/ROOT/pages/lifecycle.adoc
+++ b/docs/user-manual/modules/ROOT/pages/lifecycle.adoc
@@ -2,7 +2,7 @@
 = Camel Lifecycle
 
 Camel uses a simple _lifecycle_ interface called
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Service.html[Service]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Service.html[Service]
 which has a single start() and stop() method.
 
 Various classes implement Service such as

--- a/docs/user-manual/modules/ROOT/pages/message-endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message-endpoint.adoc
@@ -5,7 +5,7 @@ Camel supports the
 http://www.enterpriseintegrationpatterns.com/MessageEndpoint.html[Message
 Endpoint] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html[Endpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface.
 
 image::eip/MessageEndpointSolution.gif[image]
@@ -13,12 +13,12 @@ image::eip/MessageEndpointSolution.gif[image]
 When using the xref:dsl.adoc[DSL] to create xref:routes.adoc[Routes] you
 typically refer to Message Endpoints by their xref:uris.adoc[URIs]
 rather than directly using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html[Endpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. Its then a responsibility of the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
 to create and activate the necessary Endpoint instances using the
 available
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Component.html[Component]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Component.html[Component]
 implementations.
 
 [[messageEndpoint-Example]]

--- a/docs/user-manual/modules/ROOT/pages/message.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message.adoc
@@ -4,7 +4,7 @@
 Camel supports the
 http://www.enterpriseintegrationpatterns.com/Message.html[Message] from
 the xref:enterprise-integration-patterns.adoc[EIP patterns] using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Message.html[Message]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Message.html[Message]
 interface.
 
 image::eip/MessageSolution.gif[image]

--- a/docs/user-manual/modules/ROOT/pages/predicate.adoc
+++ b/docs/user-manual/modules/ROOT/pages/predicate.adoc
@@ -2,7 +2,7 @@
 = Predicates
 
 Camel supports a pluggable interface called
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Predicate.html[Predicate]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Predicate.html[Predicate]
 which can be used to integrate a dynamic predicate into
 xref:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] such as when using the xref:filter-eip.adoc[Message Filter]
@@ -93,7 +93,7 @@ Currently this feature is only available in the Java-based DSLs, but not
 in the Spring nor Blueprint DSLs.
 
 Using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/builder/PredicateBuilder.html[`PredicateBuilder`]
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/builder/PredicateBuilder.html[`PredicateBuilder`]
 class, you can combine predicates *from different Expression Languages*
 based on logical operators and comparison operators:
 

--- a/docs/user-manual/modules/ROOT/pages/process-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/process-eip.adoc
@@ -2,7 +2,7 @@
 = Process EIP
 :page-source: core/camel-core-engine/src/main/docs/eips/process-eip.adoc
 
-The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a xref:message-translator.adoc[Message Translator]
+The https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor] interface is used to implement consumers of message exchanges or to implement a xref:message-translator.adoc[Message Translator]
 
 == Options
 
@@ -89,13 +89,13 @@ refactor it into a separate class.
 == Turning your processor into a full Component
 
 There is a base class called
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/ProcessorEndpoint.html[ProcessorEndpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/ProcessorEndpoint.html[ProcessorEndpoint]
 which supports the full xref:endpoint.adoc[Endpoint] semantics given a
 Processor instance.
 
 So you just need to create a https://github.com/apache/camel/tree/master/components[Component] class by
 deriving from
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent]
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/DefaultComponent.html[DefaultComponent]
 which returns instances of ProcessorEndpoint. For more details see
 xref:writing-components.adoc[Writing Components]
 

--- a/docs/user-manual/modules/ROOT/pages/processor.adoc
+++ b/docs/user-manual/modules/ROOT/pages/processor.adoc
@@ -2,7 +2,7 @@
 = Processor
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 interface is used to implement consumers of message exchanges or to
 implement a xref:message-translator.adoc[Message Translator].
 
@@ -81,13 +81,13 @@ refactor it into a separate class.
 == Turning your processor into a full Component
 
 There is a base class called
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/ProcessorEndpoint.html[ProcessorEndpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/ProcessorEndpoint.html[ProcessorEndpoint]
 which supports the full xref:endpoint.adoc[Endpoint] semantics given a
 Processor instance.
 
 So you just need to create a xref:component.adoc[Component] class by
 deriving from
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent]
+https://www.javadoc.io/doc/org.apache.camel/camel-support/current/org/apache/camel/support/DefaultComponent.html[DefaultComponent]
 which returns instances of ProcessorEndpoint. For more details see
 xref:writing-components.adoc[Writing Components]
 

--- a/docs/user-manual/modules/ROOT/pages/rollback-eip.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rollback-eip.adoc
@@ -22,7 +22,7 @@ backing system (the transaction manager). In such cases you should
 resort to the backing system how to configure the redelivery.
 
 You should use the
-http://camel.apache.org/maven/current/camel-spring/apidocs/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder]
+https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder]
 to setup the routes since you will need to setup the spring context with
 the TransactionTemplates that will define the transaction manager
 configuration and policies.
@@ -91,7 +91,7 @@ to your spring xml:
 --------------------------------------------------------
 
 Then in your
-http://camel.apache.org/maven/current/camel-spring/apidocs/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder],
+https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder],
 you just need to create new SpringTransactionPolicy objects for each of
 the templates.
 

--- a/docs/user-manual/modules/ROOT/pages/spring.adoc
+++ b/docs/user-manual/modules/ROOT/pages/spring.adoc
@@ -275,7 +275,7 @@ Available as of *Camel 2.17.1*
 --------------------------------------------------------------------------------------------------------------
 
 CamelContextAware
-If you want to be injected with the xref:camelcontext.adoc[CamelContext] in your POJO just implement the http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContextAware.html[CamelContextAware interface]; then when Spring creates your POJO the CamelContext will be injected into your POJO. Also see the Bean Integration for further injections.
+If you want to be injected with the xref:camelcontext.adoc[CamelContext] in your POJO just implement the https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContextAware.html[CamelContextAware interface]; then when Spring creates your POJO the CamelContext will be injected into your POJO. Also see the Bean Integration for further injections.
 
 == Integration Testing
 

--- a/docs/user-manual/modules/ROOT/pages/transactional-client.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transactional-client.adoc
@@ -20,7 +20,7 @@ backing system (the transaction manager). In such cases you should
 resort to the backing system how to configure the redelivery.
 
 You should use the
-http://camel.apache.org/maven/current/camel-spring/apidocs/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder]
+https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder]
 to setup the routes since you will need to setup the spring context with
 the TransactionTemplates that will define the transaction manager
 configuration and policies.
@@ -79,7 +79,7 @@ to your spring xml:
 ----
 
 Then in your
-http://camel.apache.org/maven/current/camel-spring/apidocs/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder],
+https://www.javadoc.io/doc/org.apache.camel/camel-spring/current/org/apache/camel/spring/SpringRouteBuilder.html[SpringRouteBuilder],
 you just need to create new SpringTransactionPolicy objects for each of
 the templates.
 

--- a/docs/user-manual/modules/ROOT/pages/type-converter.adoc
+++ b/docs/user-manual/modules/ROOT/pages/type-converter.adoc
@@ -14,10 +14,10 @@ convert to and from the following common types:
 * ...
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Message.html[Message
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Message.html[Message
 interface] defines a helper method to allow conversions to be done via
 the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Message.html#getBody(java.lang.Class)[getBody(Class)]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Message.html#getBody-java.lang.Class-[getBody(Class)]
 method.
 
 So in an endpoint you can convert a body to another type via:
@@ -32,9 +32,9 @@ Document document = message.getBody(Document.class);
 == How Type Conversion works
 
 The type conversion strategy is defined by the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/TypeConverter.html[TypeConverter]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/TypeConverter.html[TypeConverter]
 interface that can be customized on a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/CamelContext.html[CamelContext].
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext].
 
 Camel provides a default type converter registy.
 From Camel 3 onwards there type converter registry implementation uses source code generation via the `camel-apt` compiler plugin to generate source code, that allows Camel at runtime to load and invoke these type converters via quick java method invocations. The older implementation in Camel 2 uses a annotation based discover to load and register type converters and invokes the type converters via Java method call reflections.
@@ -44,7 +44,7 @@ From Camel 3 onwards there type converter registry implementation uses source co
 == TypeConverterRegistry
 
 Exposed the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/TypeConverterRegistry.html[TypeConverterRegistry]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/TypeConverterRegistry.html[TypeConverterRegistry]
 from xref:camelcontext.adoc[CamelContext] so end users more easily will
 be able to add type converters at runtime. This is also usable in
 situations where the default discovering of type converters fails on
@@ -219,7 +219,7 @@ public static InputStream toInputStream(File file) throws IOException {
 *Available in Camel 2.0*
 
 The
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.html[AnnotationTypeConverterLoader]
+https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.html[AnnotationTypeConverterLoader]
 has been enhanced to also look for methods defined with a
 `@FallbackConverter` annotation, and register it as a fallback type
 converter.


### PR DESCRIPTION
Broken javadoc links will be pointed towards appropriate entries on `javadoc.io`.
This commit fixes all ASCIIDoc files under `docs/user-manual/`
This is **not** a blind find-replace commit. It takes care of API Changes in Camel 3.x, where camel-core was split into several sub modules.

There are 11 files under `docs/components/` that need similar fixes. I'll keep pushing them one by one.