### PR TITLE
CAMEL-14506 came-ftp - streamDownload and stepwise could cause deadlock

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
@@ -425,6 +425,10 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
 
     @SuppressWarnings("unchecked")
     private boolean retrieveFileToStreamInBody(String name, Exchange exchange) throws GenericFileOperationFailedException {
+        if (endpoint.getConfiguration().isStepwise() && endpoint.getConfiguration().isStreamDownload()) {
+            //stepwise and streamDownload are not supported together
+            throw new IllegalArgumentException("The option stepwise is not supported for stream downloading");
+        }
         boolean result;
         try {
             GenericFile<FTPFile> target = (GenericFile<FTPFile>)exchange.getProperty(FileComponent.FILE_EXCHANGE_FILE);

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingPartialReadTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingPartialReadTest.java
@@ -68,7 +68,7 @@ public class FtpSimpleConsumeStreamingPartialReadTest extends FtpServerTestSuppo
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("ftp://localhost:" + getPort() + "/tmp/mytemp?username=admin&password=admin&delay=10s&disconnect=true&streamDownload=true" + "&move=done&moveFailed=failed")
+                from("ftp://localhost:" + getPort() + "/tmp/mytemp?username=admin&password=admin&delay=10s&disconnect=true&streamDownload=true" + "&move=done&moveFailed=failed&stepwise=false")
                     .routeId("foo").noAutoStartup().process(new Processor() {
 
                         @Override

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingStepwiseTrueTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingStepwiseTrueTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote;
+
+import org.apache.camel.component.mock.MockEndpoint;
+
+public class FtpSimpleConsumeStreamingStepwiseTrueTest extends FtpSimpleConsumeStreamingStepwiseFalseTest {
+
+    @Override
+    boolean isStepwise() {
+        return true;
+    }
+
+    @Override
+    MockEndpoint getMockEndpoint() {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(0);
+        return mock;
+    }
+
+    @Override
+    void assertMore(MockEndpoint mock) {
+    }
+}

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingWithMultipleFilesTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpSimpleConsumeStreamingWithMultipleFilesTest.java
@@ -63,7 +63,7 @@ public class FtpSimpleConsumeStreamingWithMultipleFilesTest extends FtpServerTes
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("ftp://localhost:" + getPort() + "/tmp/mytemp?username=admin&password=admin&delay=10s&disconnect=true&streamDownload=true").routeId("foo").noAutoStartup()
+                from("ftp://localhost:" + getPort() + "/tmp/mytemp?username=admin&password=admin&delay=10s&disconnect=true&streamDownload=true&stepwise=false").routeId("foo").noAutoStartup()
                     .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpStreamingMoveTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/FtpStreamingMoveTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FtpStreamingMoveTest extends FtpServerTestSupport {
 
     private String getFtpUrl() {
-        return "ftp://admin@localhost:" + getPort() + "/mymove?password=admin&delay=1000&streamDownload=true&move=done";
+        return "ftp://admin@localhost:" + getPort() + "/mymove?password=admin&delay=1000&streamDownload=true&move=done&stepwise=false";
     }
 
     @Override

--- a/docs/components/modules/ROOT/pages/ftp-component.adoc
+++ b/docs/components/modules/ROOT/pages/ftp-component.adoc
@@ -472,6 +472,8 @@ stepwise, while others can only download if they do not.
 
 You can use the `stepwise` option to control the behavior.
 
+*Important*: Stepwise=true is not supported for stream download.
+
 Note that stepwise changing of directory will in most cases only work
 when the user is confined to it's home directory and when the home
 directory is reported as `"/"`.

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
@@ -32,6 +32,10 @@ The option `cache` has been deprecated in favour of the new `scope` option that 
 Setting this to Prototype will let Camel create/lookup a new bean instance, per use; which acts as prototype scoped. However beware that if you lookup the bean, then the registry that holds the bean, would return a bean accordingly to its configuration, which can be singleton or prototype scoped. For example if you use Spring, or CDI, which has their own settings for setting bean scopes.
 ====
 
+=== camel-ftp
+
+ The stepwise functionality (stepwise=true) is not supported for stream download (treamDownload=true).
+
 === camel-irc
 
 The `camel-irc` component has changed its endpoint syntax and removed option #room as a part of the url path. Allowed syntax is:


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14506

Stepwise and stream download are not supported together. 
Combination of these two parameters in ftp component is strictly forbidden (could cause freeze). IllegalArgumentException is now thrown when this options are used together.

A new test covering this change is introduced: FtpSimpleConsumeStreamingStepwiseTrueTest

Doc is updated.