### PR TITLE
Changing the hyper link to actual camel page

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/index.adoc
+++ b/docs/user-manual/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@
 
 == Overview
 
-* https://github.com/apache/camel/blob/master/README.md[Introduction]
+* https://camel.apache.org/manual/latest/faq/what-is-camel.html[Introduction]
 * xref:getting-started.adoc[Getting Started]
 * xref:book-getting-started.adoc[Longer Getting Started Guide]
 * xref:faq.adoc[FAQ]


### PR DESCRIPTION
Changing the hyper link reference from Git page to actual camel page