### PR TITLE
Updated reference to javadoc.io CamelContext

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
@@ -2,7 +2,7 @@
 = CamelContext
 
 The
-https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/latest/org/apache/camel/CamelContext.html[CamelContext]
 represents a single Camel routing rulebase. You use the CamelContext in
 a similar way to the Spring
 http://static.springsource.org/spring/docs/3.0.x/javadoc-api/org/springframework/context/ApplicationContext.html[ApplicationContext].


### PR DESCRIPTION
Changed CamelContext hyperlink from https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html (error - PAGE NOT FOUND) to https://www.javadoc.io/doc/org.apache.camel/camel-api/latest/org/apache/camel/CamelContext.html