### PR TITLE
CAMEL-14482: Fix broken Javadocs on Camel Components

### DIFF
--- a/components/camel-bean/src/main/docs/bean-component.adoc
+++ b/components/camel-bean/src/main/docs/bean-component.adoc
@@ -96,7 +96,7 @@ Endpoint to the bean endpoint as output. So consider
 using a *direct:* or *queue:* endpoint as the input.
 
 You can use the `createProxy()` methods on
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/bean/ProxyHelper.html[ProxyHelper]
+https://www.javadoc.io/doc/org.apache.camel/camel-bean/current/org/apache/camel/component/bean/ProxyHelper.html[ProxyHelper]
 to create a proxy that will generate exchanges and send them to any
 endpoint:
 

--- a/components/camel-cxf/src/main/docs/cxfrs-component.adoc
+++ b/components/camel-cxf/src/main/docs/cxfrs-component.adoc
@@ -433,15 +433,15 @@ provides
 http://cxf.apache.org/docs/jax-rs-client-api.html#JAX-RSClientAPI-CXFWebClientAPI[a
 http centric client API]. You can also invoke this API from
 `camel-cxfrs` producer. You need to specify the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchange.html#HTTP_PATH[HTTP_PATH]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html#HTTP_PATH[HTTP_PATH]
 and
-the http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchange.html#HTTP_METHOD[HTTP_METHOD] and
+the https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html#HTTP_METHOD[HTTP_METHOD] and
 let the producer use the http centric client API by using the URI option
 *httpClientAPI* or by setting the message header
-http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_USING_HTTP_API[CxfConstants.CAMEL_CXF_RS_USING_HTTP_API].
+https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_USING_HTTP_API[CxfConstants.CAMEL_CXF_RS_USING_HTTP_API].
 You can turn the response object to the type class specified with the
 message
-header http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_RESPONSE_CLASS[CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS].
+header https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_RESPONSE_CLASS[CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS].
 [source,java]
 ----
 Exchange exchange = template.send("direct://http", new Processor() {
@@ -470,7 +470,7 @@ cxfrs URI for the CXFRS http centric client.
 Exchange exchange = template.send("cxfrs://http://localhost:9003/testQuery?httpClientAPI=true&q1=12&q2=13"
 ----
 To support the Dynamical routing, you can override the URI's query
-parameters by using the http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_QUERY_MAP[CxfConstants.CAMEL_CXF_RS_QUERY_MAP]
+parameters by using the https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_QUERY_MAP[CxfConstants.CAMEL_CXF_RS_QUERY_MAP]
 header to set the parameter map for it.
 [source,java]
 ----

--- a/components/camel-dataset/src/main/docs/dataset-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-component.adoc
@@ -18,7 +18,7 @@ together with the powerful Bean Integration.
 
 The DataSet component provides a mechanism to easily perform load & soak
 testing of your system. It works by allowing you to create
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/dataset/DataSet.html[DataSet
+https://www.javadoc.io/doc/org.apache.camel/camel-dataset/current/org/apache/camel/component/dataset/DataSet.html[DataSet
 instances] both as a source of messages and as a way to assert that the
 data set is received.
 
@@ -33,7 +33,7 @@ dataset:name[?options]
 ----
 
 Where *name* is used to find the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/dataset/DataSet.html[DataSet
+https://www.javadoc.io/doc/org.apache.camel/camel-dataset/current/org/apache/camel/component/dataset/DataSet.html[DataSet
 instance] in the Registry
 
 Camel ships with a support implementation of

--- a/components/camel-dataset/src/main/docs/dataset-test-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-test-component.adoc
@@ -115,7 +115,7 @@ from("seda:someEndpoint").
 ----
 
 If your test then invokes the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied(org.apache.camel.CamelContext)[MockEndpoint.assertIsSatisfied(camelContext)
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied-org.apache.camel.CamelContext-[MockEndpoint.assertIsSatisfied(camelContext)
 method], your test case will perform the necessary assertions.
 
 To see how you can set other expectations on the test endpoint, see the

--- a/components/camel-jpa/src/main/docs/jpa-component.adoc
+++ b/components/camel-jpa/src/main/docs/jpa-component.adoc
@@ -65,11 +65,11 @@ URI. This will result in the entity being processed each poll.
 If you would rather perform some update on the entity to mark it as
 processed (such as to exclude it from a future query) then you can
 annotate a method with
-http://camel.apache.org/maven/current/camel-jpa/apidocs/org/apache/camel/component/jpa/Consumed.html[@Consumed]
+https://www.javadoc.io/doc/org.apache.camel/camel-jpa/current/org/apache/camel/component/jpa/Consumed.html[@Consumed]
 which will be invoked on your entity bean when the entity bean when it
 has been processed (and when routing is done).
 
-You can use http://camel.apache.org/maven/current/camel-jpa/apidocs/org/apache/camel/component/jpa/PreConsumed.html[@PreConsumed]
+You can use https://www.javadoc.io/doc/org.apache.camel/camel-jpa/current/org/apache/camel/component/jpa/PreConsumed.html[@PreConsumed]
 which will be invoked on your entity bean before it has been processed
 (before routing).
 

--- a/components/camel-jsch/src/main/docs/scp-component.adoc
+++ b/components/camel-jsch/src/main/docs/scp-component.adoc
@@ -128,6 +128,6 @@ with the following path and query parameters:
 == Limitations
 
 Currently camel-jsch only supports a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 (i.e. copy files to another host). 
 

--- a/components/camel-log/src/main/docs/log-component.adoc
+++ b/components/camel-log/src/main/docs/log-component.adoc
@@ -269,7 +269,7 @@ Splunk.
 
 Whenever you require absolute customization, you can create a class that
 implements the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/ExchangeFormatter.html[`ExchangeFormatter`]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/ExchangeFormatter.html[`ExchangeFormatter`]
 interface. Within the `format(Exchange)` method you have access to the
 full Exchange, so you can select and extract the precise information you
 need, format it in a custom manner and return it. The return value will

--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -162,7 +162,7 @@ resultEndpoint.assertIsSatisfied();
 ----
 
 You typically always call the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied()[`assertIsSatisfied()`]
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/latest/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied--[`assertIsSatisfied()`]
 method to test that the expectations were met after running a test.
 
 Camel will by default wait 10 seconds when the `assertIsSatisfied()` is
@@ -193,34 +193,34 @@ resultEndpoint.assertIsSatisfied();
 == Setting expectations
 
 You can see from the Javadoc of
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html[MockEndpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html[MockEndpoint]
 the various helper methods you can use to set expectations. The main
 methods are as follows:
 
 [width="100%",cols="1m,1",options="header",]
 |===
 |Method |Description
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedMessageCount(int)[expectedMessageCount(int)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedMessageCount-int-[expectedMessageCount(int)]
 |To define the expected message count on the endpoint.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedMinimumMessageCount(int)[expectedMinimumMessageCount(int)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedMinimumMessageCount-int-[expectedMinimumMessageCount(int)]
 |To define the minimum number of expected messages on the endpoint.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedBodiesReceived(java.lang.Object...)[expectedBodiesReceived(...)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedBodiesReceived-java.lang.Object...-[expectedBodiesReceived(...)]
 |To define the expected bodies that should be received (in order).
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedHeaderReceived(java.lang.String,%20java.lang.String)[expectedHeaderReceived(...)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedHeaderReceived-java.lang.String-java.lang.Object-[expectedHeaderReceived(...)]
 |To define the expected header that should be received
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsAscending(org.apache.camel.Expression)[expectsAscending(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsAscending-org.apache.camel.Expression-[expectsAscending(Expression)]
 |To add an expectation that messages are received in order, using the
 given Expression to compare messages.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsDescending(org.apache.camel.Expression)[expectsDescending(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsDescending-org.apache.camel.Expression-[expectsDescending(Expression)]
 |To add an expectation that messages are received in order, using the
 given Expression to compare messages.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsNoDuplicates(org.apache.camel.Expression)[expectsNoDuplicates(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsNoDuplicates-org.apache.camel.Expression-[expectsNoDuplicates(Expression)]
 |To add an expectation that no duplicate messages are received; using an
 Expression to calculate a unique identifier for
 each message. This could be something like the `JMSMessageID` if using

--- a/components/camel-stomp/src/main/docs/stomp-component.adoc
+++ b/components/camel-stomp/src/main/docs/stomp-component.adoc
@@ -134,7 +134,7 @@ from("stomp:queue:test").transform(body().convertToString()).to("mock:result")
 
 Camel supports the Message Endpoint pattern
 using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html[Endpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. Endpoints are usually created by a
 Component and Endpoints are usually referred to in
 the DSL via their URIs.
@@ -142,20 +142,20 @@ the DSL via their URIs.
 From an Endpoint you can use the following methods
 
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createProducer()[createProducer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createProducer--[createProducer()]
 will create a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 for sending message exchanges to the endpoint
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createConsumer(org.apache.camel.Processor)[createConsumer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createConsumer-org.apache.camel.Processor-[createConsumer()]
 implements the Event Driven Consumer
 pattern for consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 when creating a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Consumer.html[Consumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Consumer.html[Consumer]
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createPollingConsumer()[createPollingConsumer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createPollingConsumer--[createPollingConsumer()]
 implements the Polling Consumer pattern for
 consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/PollingConsumer.html[PollingConsumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/PollingConsumer.html[PollingConsumer]
 

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -248,7 +248,7 @@ value from the message and bind it to a method parameter.
 The default XPath annotation has SOAP and XML namespaces available. If
 you want to use your own namespace URIs in an XPath expression you can
 use your own copy of the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/language/XPath.html[XPath
+https://www.javadoc.io/doc/org.apache.camel/camel-xpath/current/org/apache/camel/language/xpath/XPath.html[XPath
 annotation] to create whatever namespace prefixes you want to use.
 
 i.e. cut and paste upper code to your own project in a different package

--- a/docs/components/modules/ROOT/pages/bean-component.adoc
+++ b/docs/components/modules/ROOT/pages/bean-component.adoc
@@ -97,7 +97,7 @@ Endpoint to the bean endpoint as output. So consider
 using a *direct:* or *queue:* endpoint as the input.
 
 You can use the `createProxy()` methods on
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/bean/ProxyHelper.html[ProxyHelper]
+https://www.javadoc.io/doc/org.apache.camel/camel-bean/current/org/apache/camel/component/bean/ProxyHelper.html[ProxyHelper]
 to create a proxy that will generate exchanges and send them to any
 endpoint:
 

--- a/docs/components/modules/ROOT/pages/cxfrs-component.adoc
+++ b/docs/components/modules/ROOT/pages/cxfrs-component.adoc
@@ -434,15 +434,15 @@ provides
 http://cxf.apache.org/docs/jax-rs-client-api.html#JAX-RSClientAPI-CXFWebClientAPI[a
 http centric client API]. You can also invoke this API from
 `camel-cxfrs` producer. You need to specify the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchange.html#HTTP_PATH[HTTP_PATH]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html#HTTP_PATH[HTTP_PATH]
 and
-the http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Exchange.html#HTTP_METHOD[HTTP_METHOD] and
+the https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html#HTTP_METHOD[HTTP_METHOD] and
 let the producer use the http centric client API by using the URI option
 *httpClientAPI* or by setting the message header
-http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_USING_HTTP_API[CxfConstants.CAMEL_CXF_RS_USING_HTTP_API].
+https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_USING_HTTP_API[CxfConstants.CAMEL_CXF_RS_USING_HTTP_API].
 You can turn the response object to the type class specified with the
 message
-header http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_RESPONSE_CLASS[CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS].
+header https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_RESPONSE_CLASS[CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS].
 [source,java]
 ----
 Exchange exchange = template.send("direct://http", new Processor() {
@@ -471,7 +471,7 @@ cxfrs URI for the CXFRS http centric client.
 Exchange exchange = template.send("cxfrs://http://localhost:9003/testQuery?httpClientAPI=true&q1=12&q2=13"
 ----
 To support the Dynamical routing, you can override the URI's query
-parameters by using the http://camel.apache.org/maven/current/camel-cxf/apidocs/org/apache/camel/component/cxf/CxfConstants.html#CAMEL_CXF_RS_QUERY_MAP[CxfConstants.CAMEL_CXF_RS_QUERY_MAP]
+parameters by using the https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_QUERY_MAP[CxfConstants.CAMEL_CXF_RS_QUERY_MAP]
 header to set the parameter map for it.
 [source,java]
 ----

--- a/docs/components/modules/ROOT/pages/dataset-component.adoc
+++ b/docs/components/modules/ROOT/pages/dataset-component.adoc
@@ -19,7 +19,7 @@ together with the powerful Bean Integration.
 
 The DataSet component provides a mechanism to easily perform load & soak
 testing of your system. It works by allowing you to create
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/dataset/DataSet.html[DataSet
+https://www.javadoc.io/doc/org.apache.camel/camel-dataset/current/org/apache/camel/component/dataset/DataSet.html[DataSet
 instances] both as a source of messages and as a way to assert that the
 data set is received.
 
@@ -34,7 +34,7 @@ dataset:name[?options]
 ----
 
 Where *name* is used to find the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/dataset/DataSet.html[DataSet
+https://www.javadoc.io/doc/org.apache.camel/camel-dataset/current/org/apache/camel/component/dataset/DataSet.html[DataSet
 instance] in the Registry
 
 Camel ships with a support implementation of

--- a/docs/components/modules/ROOT/pages/dataset-test-component.adoc
+++ b/docs/components/modules/ROOT/pages/dataset-test-component.adoc
@@ -116,7 +116,7 @@ from("seda:someEndpoint").
 ----
 
 If your test then invokes the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied(org.apache.camel.CamelContext)[MockEndpoint.assertIsSatisfied(camelContext)
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied-org.apache.camel.CamelContext-[MockEndpoint.assertIsSatisfied(camelContext)
 method], your test case will perform the necessary assertions.
 
 To see how you can set other expectations on the test endpoint, see the

--- a/docs/components/modules/ROOT/pages/jpa-component.adoc
+++ b/docs/components/modules/ROOT/pages/jpa-component.adoc
@@ -66,11 +66,11 @@ URI. This will result in the entity being processed each poll.
 If you would rather perform some update on the entity to mark it as
 processed (such as to exclude it from a future query) then you can
 annotate a method with
-http://camel.apache.org/maven/current/camel-jpa/apidocs/org/apache/camel/component/jpa/Consumed.html[@Consumed]
+https://www.javadoc.io/doc/org.apache.camel/camel-jpa/current/org/apache/camel/component/jpa/Consumed.html[@Consumed]
 which will be invoked on your entity bean when the entity bean when it
 has been processed (and when routing is done).
 
-You can use http://camel.apache.org/maven/current/camel-jpa/apidocs/org/apache/camel/component/jpa/PreConsumed.html[@PreConsumed]
+You can use https://www.javadoc.io/doc/org.apache.camel/camel-jpa/current/org/apache/camel/component/jpa/PreConsumed.html[@PreConsumed]
 which will be invoked on your entity bean before it has been processed
 (before routing).
 

--- a/docs/components/modules/ROOT/pages/log-component.adoc
+++ b/docs/components/modules/ROOT/pages/log-component.adoc
@@ -270,7 +270,7 @@ Splunk.
 
 Whenever you require absolute customization, you can create a class that
 implements the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/spi/ExchangeFormatter.html[`ExchangeFormatter`]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/spi/ExchangeFormatter.html[`ExchangeFormatter`]
 interface. Within the `format(Exchange)` method you have access to the
 full Exchange, so you can select and extract the precise information you
 need, format it in a custom manner and return it. The return value will

--- a/docs/components/modules/ROOT/pages/mock-component.adoc
+++ b/docs/components/modules/ROOT/pages/mock-component.adoc
@@ -163,7 +163,7 @@ resultEndpoint.assertIsSatisfied();
 ----
 
 You typically always call the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied()[`assertIsSatisfied()`]
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/latest/org/apache/camel/component/mock/MockEndpoint.html#assertIsSatisfied--[`assertIsSatisfied()`]
 method to test that the expectations were met after running a test.
 
 Camel will by default wait 10 seconds when the `assertIsSatisfied()` is
@@ -194,34 +194,34 @@ resultEndpoint.assertIsSatisfied();
 == Setting expectations
 
 You can see from the Javadoc of
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html[MockEndpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html[MockEndpoint]
 the various helper methods you can use to set expectations. The main
 methods are as follows:
 
 [width="100%",cols="1m,1",options="header",]
 |===
 |Method |Description
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedMessageCount(int)[expectedMessageCount(int)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedMessageCount-int-[expectedMessageCount(int)]
 |To define the expected message count on the endpoint.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedMinimumMessageCount(int)[expectedMinimumMessageCount(int)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedMinimumMessageCount-int-[expectedMinimumMessageCount(int)]
 |To define the minimum number of expected messages on the endpoint.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedBodiesReceived(java.lang.Object...)[expectedBodiesReceived(...)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedBodiesReceived-java.lang.Object...-[expectedBodiesReceived(...)]
 |To define the expected bodies that should be received (in order).
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectedHeaderReceived(java.lang.String,%20java.lang.String)[expectedHeaderReceived(...)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectedHeaderReceived-java.lang.String-java.lang.Object-[expectedHeaderReceived(...)]
 |To define the expected header that should be received
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsAscending(org.apache.camel.Expression)[expectsAscending(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsAscending-org.apache.camel.Expression-[expectsAscending(Expression)]
 |To add an expectation that messages are received in order, using the
 given Expression to compare messages.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsDescending(org.apache.camel.Expression)[expectsDescending(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsDescending-org.apache.camel.Expression-[expectsDescending(Expression)]
 |To add an expectation that messages are received in order, using the
 given Expression to compare messages.
 
-|http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#expectsNoDuplicates(org.apache.camel.Expression)[expectsNoDuplicates(Expression)]
+|https://www.javadoc.io/doc/org.apache.camel/camel-mock/current/org/apache/camel/component/mock/MockEndpoint.html#expectsNoDuplicates-org.apache.camel.Expression-[expectsNoDuplicates(Expression)]
 |To add an expectation that no duplicate messages are received; using an
 Expression to calculate a unique identifier for
 each message. This could be something like the `JMSMessageID` if using

--- a/docs/components/modules/ROOT/pages/scp-component.adoc
+++ b/docs/components/modules/ROOT/pages/scp-component.adoc
@@ -129,6 +129,6 @@ with the following path and query parameters:
 == Limitations
 
 Currently camel-jsch only supports a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 (i.e. copy files to another host). 
 

--- a/docs/components/modules/ROOT/pages/stomp-component.adoc
+++ b/docs/components/modules/ROOT/pages/stomp-component.adoc
@@ -135,7 +135,7 @@ from("stomp:queue:test").transform(body().convertToString()).to("mock:result")
 
 Camel supports the Message Endpoint pattern
 using the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html[Endpoint]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. Endpoints are usually created by a
 Component and Endpoints are usually referred to in
 the DSL via their URIs.
@@ -143,20 +143,20 @@ the DSL via their URIs.
 From an Endpoint you can use the following methods
 
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createProducer()[createProducer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createProducer--[createProducer()]
 will create a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Producer.html[Producer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Producer.html[Producer]
 for sending message exchanges to the endpoint
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createConsumer(org.apache.camel.Processor)[createConsumer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createConsumer-org.apache.camel.Processor-[createConsumer()]
 implements the Event Driven Consumer
 pattern for consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Processor.html[Processor]
 when creating a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Consumer.html[Consumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Consumer.html[Consumer]
 *
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Endpoint.html#createPollingConsumer()[createPollingConsumer()]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html#createPollingConsumer--[createPollingConsumer()]
 implements the Polling Consumer pattern for
 consuming message exchanges from the endpoint via a
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/PollingConsumer.html[PollingConsumer]
+https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/PollingConsumer.html[PollingConsumer]
 

--- a/docs/components/modules/ROOT/pages/xpath-language.adoc
+++ b/docs/components/modules/ROOT/pages/xpath-language.adoc
@@ -249,7 +249,7 @@ value from the message and bind it to a method parameter.
 The default XPath annotation has SOAP and XML namespaces available. If
 you want to use your own namespace URIs in an XPath expression you can
 use your own copy of the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/language/XPath.html[XPath
+https://www.javadoc.io/doc/org.apache.camel/camel-xpath/current/org/apache/camel/language/xpath/XPath.html[XPath
 annotation] to create whatever namespace prefixes you want to use.
 
 i.e. cut and paste upper code to your own project in a different package


### PR DESCRIPTION
Follow up on [PR#3561](https://github.com/apache/camel/pull/3561)
Based on the advise from @oscerd the PR has been updated.

Steps followed
1. Links fixed in `<component-root>/src/main/docs/<doc-file>.adoc`
2. Rebuild the project with `mvn clean install -Pfastinstall`
3. Output files (*.adoc) produced by the build process has been committed as well.

No changes observed on dynamic Javadoc content tables produced as a part of build process