### PR TITLE
CAMEL-11750 Cherry picked into 2.16 -branch.

### DIFF
--- a/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
+++ b/camel-core/src/main/java/org/apache/camel/util/concurrent/SubmitOrderedCompletionService.java
@@ -63,7 +63,22 @@ public class SubmitOrderedCompletionService<V> implements CompletionService<V> {
 
         public long getDelay(TimeUnit unit) {
             // if the answer is 0 then this task is ready to be taken
-            return id - index.get();
+            long answer = id - index.get();
+            if (answer <= 0) {
+                return answer;
+            }
+            // okay this task is not ready yet, and we don't really know when it would be
+            // so we have to return a delay value of one time unit
+            if (TimeUnit.NANOSECONDS == unit) {
+                // okay this is too fast so use a little more delay to avoid CPU burning cycles
+                // To avoid aligh with java 11 impl of
+                // "java.util.concurrent.locks.AbstractQueuedSynchronizer.SPIN_FOR_TIMEOUT_THRESHOLD", otherwise
+                // no sleep with very high CPU usage
+                answer = 1001L;
+            } else {
+                answer = unit.convert(1, unit);
+            }
+            return answer;
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
This is cherry picked from fix for CAMEL-11750 as [shown](https://github.com/leofromgroza/camel-long-term-route) to be a bug in 2.18 branch and later.

I found this also exists in 2.16 branch when running with jre 8 or later.

I recreated the bug [here](https://github.com/Magua/camel/tree/recreate-CAMEL-11750-java8/examples/camel-example-spring-boot). Tests show that on jre 8 or later this maxes out one thread (core) while waiting for aggregation to finish.

I'm happy to provide pr for 2.17 branch as well if this gets approved.