### PR TITLE
DefaultHttpRegistry thread safety

### DIFF
--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/DefaultHttpRegistry.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/DefaultHttpRegistry.java
@@ -32,6 +32,7 @@ public class DefaultHttpRegistry implements HttpRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpRegistry.class);
 
     private static Map<String, HttpRegistry> registries = new HashMap<>();
+    private final Object lock = new Object();
     
     private final Set<HttpConsumer> consumers;
     private final Set<CamelServlet> providers;
@@ -62,23 +63,27 @@ public class DefaultHttpRegistry implements HttpRegistry {
     
     @Override
     public void register(HttpConsumer consumer) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Registering consumer for path {} providers present: {}", consumer.getPath(), providers.size());
-        }
-        consumers.add(consumer);
-        for (CamelServlet provider : providers) {
-            provider.connect(consumer);
+        synchronized (lock) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Registering consumer for path {} providers present: {}", consumer.getPath(), providers.size());
+            }
+            consumers.add(consumer);
+            for (CamelServlet provider : providers) {
+                provider.connect(consumer);
+            }
         }
     }
     
     @Override
     public void unregister(HttpConsumer consumer) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Unregistering consumer for path {}", consumer.getPath());
-        }
-        consumers.remove(consumer);
-        for (CamelServlet provider : providers) {
-            provider.disconnect(consumer);
+        synchronized (lock) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Unregistering consumer for path {}", consumer.getPath());
+            }
+            consumers.remove(consumer);
+            for (CamelServlet provider : providers) {
+                provider.disconnect(consumer);
+            }
         }
     }
     
@@ -95,38 +100,46 @@ public class DefaultHttpRegistry implements HttpRegistry {
     
     @Override
     public void register(CamelServlet provider) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Registering CamelServlet with name {} consumers present: {}", provider.getServletName(), consumers.size());
-        }
-        providers.add(provider);
-        for (HttpConsumer consumer : consumers) {
-            provider.connect(consumer);
+        synchronized (lock) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Registering CamelServlet with name {} consumers present: {}", provider.getServletName(), consumers.size());
+            }
+            providers.add(provider);
+            for (HttpConsumer consumer : consumers) {
+                provider.connect(consumer);
+            }
         }
     }
 
     @Override
     public void unregister(CamelServlet provider) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Unregistering CamelServlet with name {}", provider.getServletName());
+        synchronized (lock) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Unregistering CamelServlet with name {}", provider.getServletName());
+            }
+            providers.remove(provider);
         }
-        providers.remove(provider);
     }
 
     @Override
     public CamelServlet getCamelServlet(String servletName) {
-        for (CamelServlet provider : providers) {
-            if (provider.getServletName().equals(servletName)) {
-                return provider;
+        synchronized (lock) {
+            for (CamelServlet provider : providers) {
+                if (provider.getServletName().equals(servletName)) {
+                    return provider;
+                }
             }
+            return null;
         }
-        return null;
     }
 
     public void setServlets(List<Servlet> servlets) {
-        providers.clear();
-        for (Servlet servlet : servlets) {
-            if (servlet instanceof CamelServlet) {
-                providers.add((CamelServlet) servlet);
+        synchronized (lock) {
+            providers.clear();
+            for (Servlet servlet : servlets) {
+                if (servlet instanceof CamelServlet) {
+                    providers.add((CamelServlet) servlet);
+                }
             }
         }
     }


### PR DESCRIPTION
added synchronized blocks so that registry is now thread-safe
[CAMEL-14639](https://issues.apache.org/jira/browse/CAMEL-14639)