### PR TITLE
CAMEL-11492: offer an introduction to user manual page

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/index.adoc
+++ b/docs/user-manual/modules/ROOT/pages/index.adoc
@@ -1,3 +1,17 @@
+Apache Camel (TM) is a versatile open-source integration framework based on
+known xref:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns].
+
+Camel empowers you to define routing and mediation rules in a variety of
+domain-specific languages, including a Java-based xref:dsl.adoc[Fluent
+API], xref:spring.adoc[Spring] or
+xref:using-osgi-blueprint-with-camel.adoc[Blueprint]
+xref:xml-configuration.adoc[XML Configuration] files.
+This means you get smart completion of
+routing rules in your IDE, whether in a Java or XML editor.
+
+For a deeper and better understanding of Apache Camel, an xref:faq/what-is-camel.adoc[Introduction] is provided.
+
 = Summary
 
 * <<Overview>>
@@ -7,7 +21,6 @@
 
 == Overview
 
-* xref:faq/what-is-camel.adoc[Introduction]
 * xref:getting-started.adoc[Getting Started]
 * xref:book-getting-started.adoc[Longer Getting Started Guide]
 * xref:faq.adoc[FAQ]


### PR DESCRIPTION
To the user manual page, a brief introduction is provided about `Apache Camel` and the link to the `Introduction` is provided as well along with the paragraph. 

Hence, from the `Overview` section, the link to `Introduction` is removed as it can be easily accessed before the list of chapters itself.