### PR TITLE
CAMEL-14544

### DIFF
--- a/components/camel-hazelcast/pom.xml
+++ b/components/camel-hazelcast/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <camel.osgi.import.before.defaults>
-            com.hazelcast.*;version="[3.2,4)"
+            com.hazelcast.*;version="[4,5)"
         </camel.osgi.import.before.defaults>
     </properties>
 

--- a/components/camel-hazelcast/pom.xml
+++ b/components/camel-hazelcast/pom.xml
@@ -48,11 +48,6 @@
             <artifactId>hazelcast</artifactId>
             <version>${hazelcast-version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast-version}</version>
-        </dependency>
 
 
         <dependency>

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastConstants.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastConstants.java
@@ -309,6 +309,7 @@ public final class HazelcastConstants {
     // listener actions
     public static final String REMOVED = "removed";
     public static final String EVICTED = "evicted";
+    public static final String EXPIRED = "expired";
     public static final String UPDATED = "updated";
     public static final String ADDED = "added";
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.hazelcast.atomicnumber;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.cp.IAtomicLong;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
@@ -34,7 +34,7 @@ public class HazelcastAtomicnumberProducer extends HazelcastDefaultProducer {
 
     public HazelcastAtomicnumberProducer(HazelcastInstance hazelcastInstance, HazelcastDefaultEndpoint endpoint, String cacheName) {
         super(endpoint);
-        this.atomicnumber = hazelcastInstance.getAtomicLong(cacheName);
+        this.atomicnumber = hazelcastInstance.getCPSubsystem().getAtomicLong(cacheName);
     }
 
     @Override

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/instance/HazelcastInstanceConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/instance/HazelcastInstanceConsumer.java
@@ -18,10 +18,9 @@ package org.apache.camel.component.hazelcast.instance;
 
 import java.net.InetSocketAddress;
 
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
@@ -47,11 +46,6 @@ public class HazelcastInstanceConsumer extends DefaultConsumer {
         @Override
         public void memberRemoved(MembershipEvent event) {
             this.sendExchange(event, HazelcastConstants.REMOVED);
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent event) {
-            this.sendExchange(event, HazelcastConstants.UPDATED);
         }
 
         private void sendExchange(MembershipEvent event, String action) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListConsumer.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.list;
 
+import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
 import org.apache.camel.Consumer;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
@@ -19,8 +19,8 @@ package org.apache.camel.component.hazelcast.list;
 import java.util.Collection;
 import java.util.Map;
 
+import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
 import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelEntryListener.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelEntryListener.java
@@ -18,7 +18,7 @@ package org.apache.camel.component.hazelcast.listener;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.MapEvent;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 
@@ -59,5 +59,10 @@ public class CamelEntryListener extends CamelListener implements EntryListener<O
     @Override
     public void entryUpdated(EntryEvent<Object, Object> event) {
         this.sendExchange(HazelcastConstants.UPDATED, event.getKey(), event.getValue());
+    }
+
+    @Override
+    public void entryExpired(EntryEvent<Object, Object> event) {
+        this.sendExchange(HazelcastConstants.EXPIRED, event.getKey(), event.getValue());
     }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelItemListener.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelItemListener.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.listener;
 
-import com.hazelcast.core.ItemEvent;
-import com.hazelcast.core.ItemListener;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelMapListener.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelMapListener.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.listener;
 
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.MapEvent;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelMessageListener.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/listener/CamelMessageListener.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.listener;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.camel.component.hazelcast.HazelcastConstants;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapConsumer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.map.IMap;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapConsumer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.multimap;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.MultiMap;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.hazelcast.multimap;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.MultiMap;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicy.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicy.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.Route;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueConsumer.java
@@ -19,8 +19,8 @@ package org.apache.camel.component.hazelcast.queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapConsumer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.replicatedmap;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapProducer.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.hazelcast.replicatedmap;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
@@ -19,8 +19,9 @@ package org.apache.camel.component.hazelcast.seda;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.BaseQueue;
+import com.hazelcast.collection.BaseQueue;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionOptions;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.AsyncProcessor;
 import org.apache.camel.Consumer;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetConsumer.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.set;
 
+import com.hazelcast.collection.ISet;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ISet;
 import org.apache.camel.Consumer;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
@@ -18,8 +18,8 @@ package org.apache.camel.component.hazelcast.set;
 
 import java.util.Collection;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.collection.ISet;
+import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/set/HazelcastSetProducer.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.hazelcast.set;
 import java.util.Collection;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ISet;
+import com.hazelcast.collection.ISet;
 import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicConsumer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.topic;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
+import com.hazelcast.topic.ITopic;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicProducer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast.topic;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
+import com.hazelcast.topic.ITopic;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.hazelcast.HazelcastComponentHelper;
 import org.apache.camel.component.hazelcast.HazelcastConstants;

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepository.java
@@ -25,10 +25,10 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.map.IMap;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalMap;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.OptimisticLockingAggregationRepository;
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * {@link RecoverableAggregationRepository} and {@link OptimisticLockingAggregationRepository}.
  * Defaults to thread-safe (non-optimistic) locking and recoverable strategy.
  * Hazelcast settings are given to an end-user and can be controlled with repositoryName and persistentRespositoryName,
- * both are {@link com.hazelcast.core.IMap} &lt;String, Exchange&gt;. However HazelcastAggregationRepository
+ * both are {@link com.hazelcast.map.IMap} &lt;String, Exchange&gt;. However HazelcastAggregationRepository
  * can run it's own Hazelcast instance, but obviously no benefits of Hazelcast clustering are gained this way.
  * If the {@link HazelcastAggregationRepository} uses it's own local {@link HazelcastInstance} it will DESTROY this
  * instance on {@link #doStop()}. You should control {@link HazelcastInstance} lifecycle yourself whenever you instantiate
@@ -208,7 +208,7 @@ public class HazelcastAggregationRepository extends ServiceSupport
             throw new UnsupportedOperationException();
         }
         LOG.trace("Adding an Exchange with ID {} for key {} in a thread-safe manner.", exchange.getExchangeId(), key);
-        Lock l = hzInstance.getLock(mapName);
+        Lock l = hzInstance.getCPSubsystem().getLock(mapName);
         try {
             l.lock();
             DefaultExchangeHolder newHolder = DefaultExchangeHolder.marshal(exchange, true, allowSerializedHeaders);

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepository.java
@@ -17,7 +17,7 @@
 package org.apache.camel.processor.idempotent.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.camel.support.service.ServiceSupport;
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerForSpringTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerForSpringTest.java
@@ -46,7 +46,7 @@ public class HazelcastAtomicnumberProducerForSpringTest extends HazelcastCamelSp
 
     @Override
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance,times(7)).getCPSubsystem();
+        verify(hazelcastInstance, times(7)).getCPSubsystem();
         verify(cpSubsystem, atLeastOnce()).getAtomicLong("foo");
     }
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerForSpringTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerForSpringTest.java
@@ -20,31 +20,34 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.cp.IAtomicLong;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class HazelcastAtomicnumberProducerForSpringTest extends HazelcastCamelSpringTestSupport {
 
     @Mock
     private IAtomicLong atomicNumber;
 
+    @Mock
+    private CPSubsystem cpSubsystem;
+
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        when(hazelcastInstance.getAtomicLong("foo")).thenReturn(atomicNumber);
+        when(hazelcastInstance.getCPSubsystem()).thenReturn(cpSubsystem);
+        when(cpSubsystem.getAtomicLong("foo")).thenReturn(atomicNumber);
     }
 
     @Override
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance, atLeastOnce()).getAtomicLong("foo");
+        verify(hazelcastInstance,times(7)).getCPSubsystem();
+        verify(cpSubsystem, atLeastOnce()).getAtomicLong("foo");
     }
 
     @After

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
@@ -20,7 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.cp.IAtomicLong;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;
@@ -34,14 +35,19 @@ public class HazelcastAtomicnumberProducerTest extends HazelcastCamelTestSupport
     @Mock
     private IAtomicLong atomicNumber;
 
+    @Mock
+    private CPSubsystem cpSubsystem;
+
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        when(hazelcastInstance.getAtomicLong("foo")).thenReturn(atomicNumber);
+        when(hazelcastInstance.getCPSubsystem()).thenReturn(cpSubsystem);
+        when(cpSubsystem.getAtomicLong("foo")).thenReturn(atomicNumber);
     }
 
     @Override
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance, atLeastOnce()).getAtomicLong("foo");
+        verify(hazelcastInstance,times(10)).getCPSubsystem();
+        verify(cpSubsystem, atLeastOnce()).getAtomicLong("foo");
     }
 
     @After

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastAtomicnumberProducerTest.java
@@ -46,7 +46,7 @@ public class HazelcastAtomicnumberProducerTest extends HazelcastCamelTestSupport
 
     @Override
     protected void verifyHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        verify(hazelcastInstance,times(10)).getCPSubsystem();
+        verify(hazelcastInstance, times(10)).getCPSubsystem();
         verify(cpSubsystem, atLeastOnce()).getAtomicLong("foo");
     }
 

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastInstanceConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastInstanceConsumerTest.java
@@ -18,14 +18,15 @@ package org.apache.camel.component.hazelcast;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.Cluster;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
+import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
-import com.hazelcast.core.Member;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -54,7 +55,7 @@ public class HazelcastInstanceConsumerTest extends HazelcastCamelTestSupport {
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.getCluster()).thenReturn(cluster);
         argument = ArgumentCaptor.forClass(MembershipListener.class);
-        when(cluster.addMembershipListener(any())).thenReturn("foo");
+        when(cluster.addMembershipListener(any())).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListConsumerTest.java
@@ -17,13 +17,14 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.collection.IList;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
-import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
-import com.hazelcast.core.ItemListener;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class HazelcastListConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.<String>getList("foo")).thenReturn(list);
-        when(list.addItemListener(any(), eq(true))).thenReturn("foo");
+        when(list.addItemListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
@@ -19,8 +19,8 @@ package org.apache.camel.component.hazelcast;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapConsumerTest.java
@@ -17,12 +17,13 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.hazelcast.listener.MapEntryListener;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -47,7 +48,7 @@ public class HazelcastMapConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.getMap("foo")).thenReturn(map);
-        when(map.addEntryListener(any(), eq(true))).thenReturn("foo");
+        when(map.addEntryListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerForSpringTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerForSpringTest.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.map.IMap;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
 import org.apache.camel.component.hazelcast.testutil.Dummy;
 import org.junit.After;
 import org.junit.Test;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMapProducerTest.java
@@ -26,8 +26,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.map.IMap;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.hazelcast.testutil.Dummy;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapConsumerTest.java
@@ -17,13 +17,14 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.MultiMap;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class HazelcastMultimapConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.getMultiMap("mm")).thenReturn(map);
-        when(map.addEntryListener(any(), eq(true))).thenReturn("foo");
+        when(map.addEntryListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerForSpringTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerForSpringTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.MultiMap;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastMultimapProducerTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.MultiMap;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
@@ -19,8 +19,8 @@ package org.apache.camel.component.hazelcast;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerTest.java
@@ -20,10 +20,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.collection.ItemEvent;
 import com.hazelcast.collection.ItemListener;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ItemEventType;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerTest.java
@@ -17,13 +17,14 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
-import com.hazelcast.core.ItemEvent;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.core.ItemEventType;
-import com.hazelcast.core.ItemListener;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class HazelcastQueueConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.<String>getQueue("foo")).thenReturn(queue);
-        when(queue.addItemListener(any(), eq(true))).thenReturn("foo");
+        when(queue.addItemListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
@@ -23,8 +23,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueProducerTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
+import com.hazelcast.collection.IQueue;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicConsumerTest.java
@@ -17,12 +17,13 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class HazelcastReliableTopicConsumerTest extends HazelcastCamelTestSuppor
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.<String>getReliableTopic("foo")).thenReturn(reliableTopic);
-        when(reliableTopic.addMessageListener(any())).thenReturn("foo");
+        when(reliableTopic.addMessageListener(any())).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReliableTopicProducerTest.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
+import com.hazelcast.topic.ITopic;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
@@ -17,13 +17,14 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class HazelcastReplicatedmapConsumerTest extends HazelcastCamelTestSuppor
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.getReplicatedMap("rm")).thenReturn(map);
-        when(map.addEntryListener(any(), eq(true))).thenReturn("foo");
+        when(map.addEntryListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerForSpringTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerForSpringTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapProducerTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaRecoverableConsumerTest.java
@@ -18,8 +18,8 @@ package org.apache.camel.component.hazelcast;
 
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.IQueue;
-import com.hazelcast.core.TransactionalQueue;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.transaction.TransactionalQueue;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetConsumerTest.java
@@ -17,13 +17,14 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.collection.ISet;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ISet;
-import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
-import com.hazelcast.core.ItemListener;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class HazelcastSetConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.<String>getSet("foo")).thenReturn(set);
-        when(set.addItemListener(any(), eq(true))).thenReturn("foo");
+        when(set.addItemListener(any(), eq(true))).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
@@ -19,8 +19,8 @@ package org.apache.camel.component.hazelcast;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import com.hazelcast.collection.ISet;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ISet;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicConsumerTest.java
@@ -17,12 +17,13 @@
 package org.apache.camel.component.hazelcast;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class HazelcastTopicConsumerTest extends HazelcastCamelTestSupport {
     @Override
     protected void trainHazelcastInstance(HazelcastInstance hazelcastInstance) {
         when(hazelcastInstance.<String>getTopic("foo")).thenReturn(topic);
-        when(topic.addMessageListener(any())).thenReturn("foo");
+        when(topic.addMessageListener(any())).thenReturn(UUID.randomUUID());
     }
 
     @Override

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastTopicProducerTest.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
+import com.hazelcast.topic.ITopic;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.processor.idempotent.hazelcast;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;

--- a/components/camel-hazelcast/src/test/resources/hazelcast-custom.xml
+++ b/components/camel-hazelcast/src/test/resources/hazelcast-custom.xml
@@ -17,14 +17,15 @@
     limitations under the License.
 
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
-					 xmlns="http://www.hazelcast.com/schema/config"
-					 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		   xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-	<group>
+	<!--  DEPRECATED SINCE: 4.0 group>
 		<name>dev</name>
 		<password>dev-pass</password>
-	</group>
+	</group-->
 	
 	<!-- Disable the version check -->
 	<properties>

--- a/components/camel-hazelcast/src/test/resources/hazelcast-default.xml
+++ b/components/camel-hazelcast/src/test/resources/hazelcast-default.xml
@@ -17,15 +17,16 @@
     limitations under the License.
 
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
-					 xmlns="http://www.hazelcast.com/schema/config"
-					 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		   xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-	<group>
+	<!--  DEPRECATED SINCE: 4.0group>
 		<name>dev</name>
 		<password>dev-pass</password>
-	</group>
-	
+	</group-->
+
 	<!-- Disable the version check -->
 	<properties>
 	  <property name="hazelcast.phone.home.enabled">false</property>
@@ -86,13 +87,20 @@
 			Valid values are: NONE (no eviction), LRU (Least Recently Used), LFU
 			(Least Frequently Used). NONE is the default.
 		-->
-		<eviction-policy>LRU</eviction-policy>
+		<eviction eviction-policy="LRU" max-size-policy="PER_NODE" size="20"/>
+		<!--
+            Maximum number of seconds for each entry to stay idle in the map. Entries that are
+            idle(not touched) for more than <max-idle-seconds> will get
+            automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+        -->
+		<max-idle-seconds>0</max-idle-seconds>
 		<!--
 			Maximum size of the map. When max size is reached, map is evicted
 			based on the policy defined. Any integer between 0 and
 			Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
 		-->
-		<max-size>5</max-size>
+		<!--  DEPRECATED SINCE: 4.0 <max-size>5</max-size-->
 		<!--
 			When max. size is reached, specified percentage of the map will be
 			evicted. Any integer between 0 and 100. If 25 is set for example, 25%

--- a/components/camel-hazelcast/src/test/resources/hazelcast-named.xml
+++ b/components/camel-hazelcast/src/test/resources/hazelcast-named.xml
@@ -17,16 +17,17 @@
     limitations under the License.
 
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
-					 xmlns="http://www.hazelcast.com/schema/config"
-					 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		   xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
 	<instance-name>camel-hz</instance-name>
 
-	<group>
+	<!--  DEPRECATED SINCE: 4.0 group>
 		<name>dev</name>
 		<password>dev-pass</password>
-	</group>
+	</group-->
 	
 	<!-- Disable the version check -->
 	<properties>
@@ -35,7 +36,7 @@
 	</properties>
 
 	<network>
-		<port auto-increment="true">9876</port>
+		<port auto-increment="true" port-count="100">9876</port>
 		<join>
 			<multicast enabled="false"/>
 			<tcp-ip enabled="false"/>

--- a/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/policy/CacheManagerFromRegistryTest.java
+++ b/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/policy/CacheManagerFromRegistryTest.java
@@ -22,7 +22,7 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.After;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -277,7 +277,7 @@
         <hapi-fhir-version>4.1.0</hapi-fhir-version>
         <hawtbuf-version>1.11</hawtbuf-version>
         <hawtdispatch-version>1.22</hawtdispatch-version>
-        <hazelcast-version>3.12.6</hazelcast-version>
+        <hazelcast-version>4.0</hazelcast-version>
         <hbase-version>1.2.6</hbase-version>
         <hdrhistrogram-version>2.1.11</hdrhistrogram-version>
         <hibernate-validator-version>6.1.2.Final</hibernate-validator-version>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1203,7 +1203,6 @@
     <feature>transaction</feature>
     <bundle dependency='true'>mvn:com.eclipsesource.minimal-json/minimal-json/${minimal-json-version}</bundle>
     <bundle dependency='true'>mvn:com.hazelcast/hazelcast/${hazelcast-version}</bundle>
-    <bundle dependency='true'>mvn:com.hazelcast/hazelcast-client/${hazelcast-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-hazelcast/${project.version}</bundle>
   </feature>
   <feature name='camel-hdfs' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Hazelcast Upgrade 4.0 

Executed tests in camel-hazelcast component

[INFO]
[INFO] --- maven-surefire-plugin:3.0.0-M4:test (default-test) @ camel-hazelcast ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.camel.component.hazelcast.HazelcastAtomicnumberProducerForSpringTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.67 s - in org.apache.camel.component.hazelcast.HazelcastAtomicnumberProducerForSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastAtomicnumberProducerTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.85 s - in org.apache.camel.component.hazelcast.HazelcastAtomicnumberProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastComponentInstanceReferenceNameSpringTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.691 s - in org.apache.camel.component.hazelcast.HazelcastComponentInstanceReferenceNameSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastComponentInstanceReferenceSpringTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.338 s - in org.apache.camel.component.hazelcast.HazelcastComponentInstanceReferenceSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastConfigurationTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 60.761 s - in org.apache.camel.component.hazelcast.HazelcastConfigurationTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastErrorMessagesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.534 s - in org.apache.camel.component.hazelcast.HazelcastErrorMessagesTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastInstanceConsumerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.678 s - in org.apache.camel.component.hazelcast.HazelcastInstanceConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastListConsumerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.42 s - in org.apache.camel.component.hazelcast.HazelcastListConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastListProducerTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.822 s - in org.apache.camel.component.hazelcast.HazelcastListProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMapConsumerTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.707 s - in org.apache.camel.component.hazelcast.HazelcastMapConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMapProducerForSpringTest
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.814 s - in org.apache.camel.component.hazelcast.HazelcastMapProducerForSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMapProducerTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.746 s - in org.apache.camel.component.hazelcast.HazelcastMapProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMultimapConsumerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.608 s - in org.apache.camel.component.hazelcast.HazelcastMultimapConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMultimapProducerForSpringTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.774 s - in org.apache.camel.component.hazelcast.HazelcastMultimapProducerForSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastMultimapProducerTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.082 s - in org.apache.camel.component.hazelcast.HazelcastMultimapProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastQueueConsumerPollTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.953 s - in org.apache.camel.component.hazelcast.HazelcastQueueConsumerPollTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastQueueConsumerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.501 s - in org.apache.camel.component.hazelcast.HazelcastQueueConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastQueueProducerTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.609 s - in org.apache.camel.component.hazelcast.HazelcastQueueProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastReliableTopicConsumerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.18 s - in org.apache.camel.component.hazelcast.HazelcastReliableTopicConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastReliableTopicProducerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.722 s - in org.apache.camel.component.hazelcast.HazelcastReliableTopicProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastReplicatedmapConsumerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.467 s - in org.apache.camel.component.hazelcast.HazelcastReplicatedmapConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastReplicatedmapProducerForSpringTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.02 s - in org.apache.camel.component.hazelcast.HazelcastReplicatedmapProducerForSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastReplicatedmapProducerTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.422 s - in org.apache.camel.component.hazelcast.HazelcastReplicatedmapProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastRingbufferProducerForSpringTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.473 s - in org.apache.camel.component.hazelcast.HazelcastRingbufferProducerForSpringTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastRingbufferProducerTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.912 s - in org.apache.camel.component.hazelcast.HazelcastRingbufferProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaConcurrentConsumersTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.896 s - in org.apache.camel.component.hazelcast.HazelcastSedaConcurrentConsumersTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaConfigurationTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.018 s - in org.apache.camel.component.hazelcast.HazelcastSedaConfigurationTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaFIFOTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.822 s - in org.apache.camel.component.hazelcast.HazelcastSedaFIFOTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaInOnlyTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.901 s - in org.apache.camel.component.hazelcast.HazelcastSedaInOnlyTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaInOutTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.832 s - in org.apache.camel.component.hazelcast.HazelcastSedaInOutTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaInOutTransactedTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.531 s - in org.apache.camel.component.hazelcast.HazelcastSedaInOutTransactedTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaRecoverableConsumerNewTransactionTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.645 s - in org.apache.camel.component.hazelcast.HazelcastSedaRecoverableConsumerNewTransactionTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaRecoverableConsumerRollbackTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.639 s - in org.apache.camel.component.hazelcast.HazelcastSedaRecoverableConsumerRollbackTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaSpringSupportTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.847 s - in org.apache.camel.component.hazelcast.HazelcastSedaSpringSupportTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSedaTransferExchangeTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.829 s - in org.apache.camel.component.hazelcast.HazelcastSedaTransferExchangeTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSetConsumerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.321 s - in org.apache.camel.component.hazelcast.HazelcastSetConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastSetProducerTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.313 s - in org.apache.camel.component.hazelcast.HazelcastSetProducerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastTopicConsumerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.18 s - in org.apache.camel.component.hazelcast.HazelcastTopicConsumerTest
[INFO] Running org.apache.camel.component.hazelcast.HazelcastTopicProducerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.7 s - in org.apache.camel.component.hazelcast.HazelcastTopicProducerTest
[INFO] Running org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryConstructorsTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.346 s - in org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryConstructorsTest
[INFO] Running org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryOperationsTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.713 s - in org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryOperationsTest
[INFO] Running org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryRecoverableRoutesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.921 s - in org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryRecoverableRoutesTest
[INFO] Running org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryRoutesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.946 s - in org.apache.camel.processor.aggregate.hazelcast.HazelcastAggregationRepositoryRoutesTest
[INFO] Running org.apache.camel.processor.idempotent.hazelcast.HazelcastIdempotentRepositoryTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.933 s - in org.apache.camel.processor.idempotent.hazelcast.HazelcastIdempotentRepositoryTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 204, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- camel-bundle-plugin:3.2.0-SNAPSHOT:manifest (bundle-manifest) @ camel-hazelcast ---
[INFO] No previous run data found, generating manifest.
[INFO]
[INFO] --- maven-jar-plugin:3.2.0:jar (default-jar) @ camel-hazelcast ---
[INFO] Building jar: C:\Users\madha\IdeaProjects\camel\components\camel-hazelcast\target\camel-hazelcast-3.2.0-SNAPSHOT.jar
[INFO]
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ camel-hazelcast ---
[INFO] Installing C:\Users\madha\IdeaProjects\camel\components\camel-hazelcast\target\camel-hazelcast-3.2.0-SNAPSHOT.jar to C:\Users\madha\.m2\repository\org\apache\camel\camel-hazelcast\3.2.0-SNAPSHOT\camel-hazelcast-3.2.0-SNAPSHOT.jar
[INFO] Installing C:\Users\madha\IdeaProjects\camel\components\camel-hazelcast\.flattened-pom.xml to C:\Users\madha\.m2\repository\org\apache\camel\camel-hazelcast\3.2.0-SNAPSHOT\camel-hazelcast-3.2.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:15 min
[INFO] Finished at: 2020-03-12T00:48:21+01:00
[INFO] ------------------------------------------------------------------------