### PR TITLE
Reformat the structure for the documentation on Java DSL

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -45,20 +45,20 @@ In the example above we have a single route, which pickup files,
 
 [source,java]
 ---------------------------------------
-        from("file:src/data?noop=true")
+from("file:src/data?noop=true")
 ---------------------------------------
 
-Then we use the Content Based Router (eg
+Then we use the `Content Based Router` (eg
 the choice) to route the message depending if the person is from London
 or not.
 
 [source,java]
 -------------------------------------------------------
-            .choice()
-                .when(xpath("/person/city = 'London'"))
-                    .to("file:target/messages/uk")
-                .otherwise()
-                    .to("file:target/messages/others");
+.choice()
+    .when(xpath("/person/city = 'London'"))
+        .to("file:target/messages/uk")
+    .otherwise()
+        .to("file:target/messages/others");
 -------------------------------------------------------
 
 [[JavaDSL-Routes]]

--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -48,7 +48,7 @@ In the example above we have a single route, which pickup files,
 from("file:src/data?noop=true")
 ---------------------------------------
 
-Then we use the `Content Based Router` (eg
+Then we use the `Content Based Router` (For example :- 
 the choice) to route the message depending if the person is from London
 or not.
 

--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -48,8 +48,8 @@ In the example above we have a single route, which pickup files,
 from("file:src/data?noop=true")
 ---------------------------------------
 
-Then we use the `Content Based Router` (For example :- 
-the choice) to route the message depending if the person is from London
+Then we use the `Content Based Router` (for example: 
+ the choice) to route the message depending if the person is from London
 or not.
 
 [source,java]

--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -48,7 +48,7 @@ In the example above we have a single route, which pickup files,
 from("file:src/data?noop=true")
 ---------------------------------------
 
-Then we use the `Content Based Router` (for example: 
+Then we use the `Content Based Router` (for ex: 
  the choice) to route the message depending if the person is from London
 or not.
 


### PR DESCRIPTION
* Observed that the code snippets were given spaces to match the indentation of the previous code block. However, before each code snippets, it was provided with a paragraph that specifies where the code snippet is to be placed within the main code block.

* Hence, to improve readability and to increase the ease in reading documentation, I have removed the spaces within the code snippets and highlighted the methods to which the particular code snippets belong to in the paragraph.