### PR TITLE
Properties component/modify

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/index.adoc
+++ b/docs/user-manual/modules/ROOT/pages/index.adoc
@@ -1,3 +1,17 @@
+Apache Camel (TM) is a versatile open-source integration framework based on
+known xref:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns].
+
+Camel empowers you to define routing and mediation rules in a variety of
+domain-specific languages, including a Java-based xref:dsl.adoc[Fluent
+API], xref:spring.adoc[Spring] or
+xref:using-osgi-blueprint-with-camel.adoc[Blueprint]
+xref:xml-configuration.adoc[XML Configuration] files.
+This means you get smart completion of
+routing rules in your IDE, whether in a Java or XML editor.
+
+For a deeper and better understanding of Apache Camel, an xref:faq/what-is-camel.adoc[Introduction] is provided.
+
 = Summary
 
 * <<Overview>>
@@ -7,7 +21,6 @@
 
 == Overview
 
-* xref:faq/what-is-camel.adoc[Introduction]
 * xref:getting-started.adoc[Getting Started]
 * xref:book-getting-started.adoc[Longer Getting Started Guide]
 * xref:faq.adoc[FAQ]

--- a/docs/user-manual/modules/ROOT/pages/properties-component.adoc
+++ b/docs/user-manual/modules/ROOT/pages/properties-component.adoc
@@ -669,7 +669,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -685,7 +684,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>


### PR DESCRIPTION
* Within the documentation of properties component, while reading through it I observed that are redundant spaces in a few and not in others when they had similar code structure. Hence, I have removed those redundant spaces and modified it with a minor change.