### PR TITLE
Docs modified for properties component (minor fix)

### DIFF
--- a/docs/components/modules/ROOT/pages/properties-component.adoc
+++ b/docs/components/modules/ROOT/pages/properties-component.adoc
@@ -669,7 +669,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -685,7 +684,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>
@@ -693,8 +691,6 @@ is a `log:foo` and `log:bar` value.
     </route>
   </camelContext>
 ----
-
- 
 
 The service function is for looking up a service which is defined using
 OS environment variables using the service naming idiom, to refer to a

--- a/docs/user-manual/modules/ROOT/pages/properties-component.adoc
+++ b/docs/user-manual/modules/ROOT/pages/properties-component.adoc
@@ -669,7 +669,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -685,7 +684,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>
@@ -693,8 +691,6 @@ is a `log:foo` and `log:bar` value.
     </route>
   </camelContext>
 ----
-
- 
 
 The service function is for looking up a service which is defined using
 OS environment variables using the service naming idiom, to refer to a


### PR DESCRIPTION
* Within the documentation of properties component, while reading through it I observed that there are redundant spaces in a few and not in others when they had similar code structure. Hence, I have removed those redundant spaces and modified it.