### PR TITLE
Remove all redundant space from each properties-components documents

### DIFF
--- a/core/camel-base/src/main/docs/properties-component.adoc
+++ b/core/camel-base/src/main/docs/properties-component.adoc
@@ -668,7 +668,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -684,7 +683,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>
@@ -692,8 +690,6 @@ is a `log:foo` and `log:bar` value.
     </route>
   </camelContext>
 ----
-
- 
 
 The service function is for looking up a service which is defined using
 OS environment variables using the service naming idiom, to refer to a

--- a/docs/components/modules/ROOT/pages/properties-component.adoc
+++ b/docs/components/modules/ROOT/pages/properties-component.adoc
@@ -1,6 +1,5 @@
 [[properties-component]]
 = Properties Component
-:page-source: core/camel-base/src/main/docs/properties-component.adoc
 
 *Since Camel 2.3*
 
@@ -669,7 +668,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -685,7 +683,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>
@@ -693,8 +690,6 @@ is a `log:foo` and `log:bar` value.
     </route>
   </camelContext>
 ----
-
- 
 
 The service function is for looking up a service which is defined using
 OS environment variables using the service naming idiom, to refer to a

--- a/docs/components/modules/ROOT/pages/properties-component.adoc
+++ b/docs/components/modules/ROOT/pages/properties-component.adoc
@@ -1,5 +1,6 @@
 [[properties-component]]
 = Properties Component
+:page-source: core/camel-base/src/main/docs/properties-component.adoc
 
 *Since Camel 2.3*
 

--- a/docs/user-manual/modules/ROOT/pages/properties-component.adoc
+++ b/docs/user-manual/modules/ROOT/pages/properties-component.adoc
@@ -1,6 +1,5 @@
 [[properties-component]]
 = Properties Component
-:page-source: core/camel-base/src/main/docs/properties-component.adoc
 
 *Since Camel 2.3*
 
@@ -669,7 +668,6 @@ can easily be used as shown below:
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME}`}"/>
@@ -685,7 +683,6 @@ is a `log:foo` and `log:bar` value.
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <route>
       <from uri="direct:start"/>
       <to uri="{`{env:SOMENAME:log:foo}`}"/>
@@ -693,8 +690,6 @@ is a `log:foo` and `log:bar` value.
     </route>
   </camelContext>
 ----
-
- 
 
 The service function is for looking up a service which is defined using
 OS environment variables using the service naming idiom, to refer to a

--- a/docs/user-manual/modules/ROOT/pages/properties-component.adoc
+++ b/docs/user-manual/modules/ROOT/pages/properties-component.adoc
@@ -1,5 +1,6 @@
 [[properties-component]]
 = Properties Component
+:page-source: core/camel-base/src/main/docs/properties-component.adoc
 
 *Since Camel 2.3*
 


### PR DESCRIPTION
* The `properties-component.adoc` had a few redundant spaces in the code snippets. Hence, I removed the redundant spaces from the `core/camel-base`, `docs/user-manual`, `docs/components` so that the code snippets have a similar structure format. 