### PR TITLE
CAMEL-14726: Upgrade MongoDB client to 4.0.0

### DIFF
--- a/components/camel-mongodb-gridfs/pom.xml
+++ b/components/camel-mongodb-gridfs/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo-java-driver-version}</version>
+            <version>${mongo3-java-driver-version}</version>
         </dependency>
 
         <!-- test -->

--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -50,7 +50,7 @@
         <!-- MongoDB driver dependency -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
+            <artifactId>mongodb-driver-sync</artifactId>
             <version>${mongo-java-driver-version}</version>
         </dependency>
 

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbEndpoint.java
@@ -26,7 +26,6 @@ import java.util.stream.StreamSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
-import com.mongodb.WriteResult;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -330,7 +329,7 @@ public class MongoDbEndpoint extends DefaultEndpoint {
     }
 
     /**
-     * Name of {@link com.mongodb.Mongo} to use.
+     * Name of {@link com.mongodb.client.MongoClient} to use.
      */
     public void setConnectionBean(String connectionBean) {
         this.connectionBean = connectionBean;
@@ -601,7 +600,7 @@ public class MongoDbEndpoint extends DefaultEndpoint {
 
     /**
      * In write operations, it determines whether instead of returning
-     * {@link WriteResult} as the body of the OUT message, we transfer the IN
+     * WriteResult as the body of the OUT message, we transfer the IN
      * message to the OUT and attach the WriteResult as a header.
      *
      * @param writeResultAsHeader flag to indicate if this option is enabled

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
@@ -323,7 +323,7 @@ public class MongoDbProducer extends DefaultProducer {
             if (query == null) {
                 query = new Document();
             }
-            return calculateCollection(exchange).count(query);
+            return calculateCollection(exchange).countDocuments(query);
         };
     }
 

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/meta/MongoDBMetaExtension.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/meta/MongoDBMetaExtension.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.mongodb.MongoClientURI;
+import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.model.Filters;
@@ -57,10 +57,10 @@ public class MongoDBMetaExtension extends AbstractMetaDataExtension {
         LOGGER.debug("Fetching mongodb meta information with params: {}", textParameters);
 
         ConnectionParamsConfiguration mongoConf = new ConnectionParamsConfiguration(textParameters);
-        MongoClientURI connectionURI = new MongoClientURI(mongoConf.getMongoClientURI());
+        ConnectionString connectionString = new ConnectionString(mongoConf.getMongoClientURI());
 
         JsonNode collectionInfoRoot;
-        try (MongoClient mongoConnection = MongoClients.create(connectionURI.getURI())) {
+        try (MongoClient mongoConnection = MongoClients.create(connectionString)) {
             Document collectionInfo = mongoConnection.getDatabase(textParameters.get("database"))
                     .listCollections()
                     .filter(Filters.eq("name", textParameters.get("collection")))

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/verifier/MongoComponentVerifierExtension.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/verifier/MongoComponentVerifierExtension.java
@@ -17,13 +17,15 @@
 package org.apache.camel.component.mongodb.verifier;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientURI;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
@@ -62,17 +64,20 @@ public class MongoComponentVerifierExtension extends DefaultComponentVerifierExt
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         ConnectionParamsConfiguration mongoConf = new ConnectionParamsConfiguration(cast(parameters));
-        MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
-        // Avoid retry and long timeout
-        optionsBuilder.connectTimeout(CONNECTION_TIMEOUT);
-        optionsBuilder.serverSelectionTimeout(CONNECTION_TIMEOUT);
-        optionsBuilder.maxWaitTime(CONNECTION_TIMEOUT);
-        MongoClientURI connectionURI = new MongoClientURI(mongoConf.getMongoClientURI(), optionsBuilder);
 
-        LOG.info("Testing connection against {}", connectionURI);
-        try (MongoClient mongoClient = MongoClients.create(connectionURI.getURI())) {
+        MongoClientSettings.Builder optionsBuilder = MongoClientSettings.builder();
+        optionsBuilder.applyToSocketSettings(socketBuilder -> socketBuilder.connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS));
+        optionsBuilder.applyToConnectionPoolSettings(connectionPoolBuilder -> connectionPoolBuilder.maxWaitTime(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS));
+        optionsBuilder.applyToClusterSettings(clusterBuilder -> clusterBuilder.serverSelectionTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS));
+
+        ConnectionString connectionString = new ConnectionString(mongoConf.getMongoClientURI());
+        optionsBuilder.applyConnectionString(connectionString);
+
+        LOG.info("Testing connection against {}", connectionString);
+        try (MongoClient mongoClient = MongoClients.create(connectionString)) {
             // Just ping the server
-            mongoClient.getDatabase(connectionURI.getDatabase()).runCommand(Document.parse("{ ping: 1 }"));
+            MongoDatabase database = mongoClient.getDatabase(mongoConf.getAdminDB());
+            database.runCommand(Document.parse("{ ping: 1 }"));
             LOG.info("Testing connection successful!");
         } catch (MongoSecurityException e) {
             ResultErrorBuilder errorBuilder = ResultErrorBuilder.withCodeAndDescription(

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbIndexTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbIndexTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
-import com.mongodb.WriteResult;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -174,7 +173,7 @@ public class MongoDbIndexTest extends AbstractMongoDbTest {
         Map<String, Object> headers = new HashMap<>();
 
         Object result = template.requestBodyAndHeaders("direct:dynamicityDisabled", body, headers);
-        assertEquals(WriteResult.class, result.getClass(), "Response isn't of type WriteResult");
+        assertEquals(Document.class, result.getClass(), "Response isn't of type WriteResult");
 
         MongoCollection<Document> collection = db.getCollection("otherCollection", Document.class);
         MongoCursor<Document> indexInfos = collection.listIndexes().iterator();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -483,7 +483,8 @@
         <mock-javamail-version>1.9</mock-javamail-version>
         <mockwebserver-version>0.1.7</mockwebserver-version>
         <mockito-version>3.3.3</mockito-version>
-        <mongo-java-driver-version>3.12.2</mongo-java-driver-version>
+        <mongo3-java-driver-version>3.12.2</mongo3-java-driver-version>
+        <mongo-java-driver-version>4.0.0</mongo-java-driver-version>
         <mongo-hadoop-version>1.5.0</mongo-hadoop-version>
         <msv-version>2013.6.1</msv-version>
         <mustache-java-version>0.9.6</mustache-java-version>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1775,13 +1775,15 @@
   <feature name='camel-mongodb' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature version='${project.version}'>camel-jackson</feature>
-    <bundle dependency='true'>mvn:org.mongodb/mongo-java-driver/${mongo-java-driver-version}</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-mongodb/${project.version}</bundle>
   </feature>
   <feature name='camel-mongodb-gridfs' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature version='${project.version}'>camel-jackson</feature>
-    <bundle dependency='true'>mvn:org.mongodb/mongo-java-driver/${mongo-java-driver-version}</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/mongo-java-driver/${mongo3-java-driver-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-mongodb-gridfs/${project.version}</bundle>
   </feature>
   <feature name='camel-msv' version='${project.version}' start-level='50'>


### PR DESCRIPTION
I was thinking of creating a separate mongo4 component for this but the changes required to the existing component turned out to be fairly minimal. Hence I amended it. Hope that's ok.

The `mongo-gridfs` component is trickier to upgrade, so I left it untouched for now.