### PR TITLE
CAMEL-14761 JPAMessageIdRepository.contains() release db connection fix

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
@@ -145,12 +145,24 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
                 if (isJoinTransaction()) {
                     entityManager.joinTransaction();
                 }
-
-                List<?> list = query(entityManager, messageId);
-                if (list.isEmpty()) {
-                    return Boolean.FALSE;
-                } else {
-                    return Boolean.TRUE;
+                try {
+                    List<?> list = query(entityManager, messageId);
+                    if (list.isEmpty()) {
+                        return Boolean.FALSE;
+                    } else {
+                        return Boolean.TRUE;
+                    }
+                } catch (Exception ex) {
+                    LOG.error("Something went wrong trying to check message in repository {}", ex);
+                    throw new PersistenceException(ex);
+                } finally {
+                    try {
+                        if (entityManager.isOpen()) {
+                            entityManager.close();
+                        }
+                    } catch (Exception e) {
+                        // ignore
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fix for: [CAMEL-14761](https://issues.apache.org/jira/browse/CAMEL-14761)

Issue: When using the JpaMessageIdRepository for an idempotent repo (or inProgressRepo) for file processing it holds onto connections on contains() method.  Other methods add(), remove(), etc. were fixed in CAMEL-11630.

PR: code fixed in the same way as it was fixed for methods add(), remove(), etc. in: [CAMEL-11630](https://issues.apache.org/jira/browse/CAMEL-11630), [PR](https://github.com/apache/camel/pull/1883)