### PR TITLE
resolves CAMEL-14771: unambiguous property name and some more source info

### DIFF
--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
@@ -47,6 +47,10 @@ public final class JsonMapper {
             return generateModel(json);
         } catch (IOException e) {
             throw new RuntimeException("Error reading json file: " + file, e);
+        } catch (IllegalArgumentException iae) {
+            throw new IllegalArgumentException("IAE on file " + file, iae);
+        } catch (RuntimeException re) {
+            throw new RuntimeException("Bad json in file: " + file, re);
         }
     }
 
@@ -67,7 +71,7 @@ public final class JsonMapper {
         } else if (obj.containsKey("model")) {
             return generateEipModel(obj);
         } else {
-            throw new IllegalArgumentException("Unsupported JSON");
+            throw new IllegalArgumentException("Unsupported JSON: " + obj);
         }
     }
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareCatalogMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareCatalogMojo.java
@@ -161,7 +161,7 @@ public class PrepareCatalogMojo extends AbstractMojo {
      * The camel-core-languages directory
      */
     @Parameter(defaultValue = "${project.build.directory}/../../../core/camel-core-languages")
-    protected File languagesDir;
+    protected File coreLanguagesDir;
 
     /**
      * The camel-xml-jaxp directory
@@ -223,11 +223,11 @@ public class PrepareCatalogMojo extends AbstractMojo {
             allJsonFiles = new TreeSet<>();
             allPropertiesFiles = new TreeSet<>();
 
-            Stream.concat(list(componentsDir.toPath()), Stream.of(coreDir.toPath(), baseDir.toPath(), languagesDir.toPath(), jaxpDir.toPath(), springDir.toPath()))
+            Stream.concat(list(componentsDir.toPath()), Stream.of(coreDir.toPath(), baseDir.toPath(), coreLanguagesDir.toPath(), jaxpDir.toPath(), springDir.toPath()))
                     .filter(dir -> !"target".equals(dir.getFileName().toString())).map(this::getComponentPath).filter(dir -> Files.isDirectory(dir.resolve("src")))
                     .map(p -> p.resolve("target/classes")).flatMap(PackageHelper::walk).forEach(p -> {
                         String f = p.getFileName().toString();
-                        if (f.endsWith(PackageHelper.JSON_SUFIX)) {
+                        if (f.endsWith(PackageHelper.JSON_SUFIX) && !f.endsWith("-metadata.json")) {
                             allJsonFiles.add(p);
                         } else if (f.equals("component.properties") || f.equals("dataformat.properties") || f.equals("language.properties") || f.equals("other.properties")) {
                             allPropertiesFiles.add(p);
@@ -651,7 +651,7 @@ public class PrepareCatalogMojo extends AbstractMojo {
 
         // find all camel maven modules
         Stream.concat(list(componentsDir.toPath()).filter(dir -> !"target".equals(dir.getFileName().toString())).map(this::getComponentPath),
-                Stream.of(coreDir.toPath(), baseDir.toPath(), languagesDir.toPath(), jaxpDir.toPath()))
+                Stream.of(coreDir.toPath(), baseDir.toPath(), coreLanguagesDir.toPath(), jaxpDir.toPath()))
                 .forEach(dir -> {
                     List<Path> l = PackageHelper.walk(dir.resolve("src/main/docs")).filter(f -> f.getFileName().toString().endsWith(".adoc")).collect(Collectors.toList());
                     if (l.isEmpty()) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareUserGuideMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareUserGuideMojo.java
@@ -273,9 +273,13 @@ public class PrepareUserGuideMojo extends AbstractMojo {
         try {
             List<LanguageModel> models = new ArrayList<>();
             for (File file : languageFiles) {
-                String json = PackageHelper.loadText(file);
-                LanguageModel model = JsonMapper.generateLanguageModel(json);
-                models.add(model);
+                try {
+                    String json = PackageHelper.loadText(file);
+                    LanguageModel model = JsonMapper.generateLanguageModel(json);
+                    models.add(model);
+                } catch (java.lang.RuntimeException e) {
+                    throw new RuntimeException("Error on file: " + file, e);
+                }
             }
 
             // sort the models


### PR DESCRIPTION
NEEDS REVIEW AND CONSIDERATION!

I've included:
- PrepareCatalogMojo.java change property name so it may be configured (needed for use in 2.x branch). This also filters out some json files that should not be processed but are located in the 2.x branch.
- a few catch-rethrow exceptions to add the file name of the problematic resource.  I needed these to figure out what was going wrong on the 2.x branch.

Is this a good idea?

Here's the configuration for the 2.x platforms/camel-catalog/pom.xml:
```
      <!-- generate and include all components in the catalog -->
      <plugin>
        <groupId>org.apache.camel</groupId>
        <artifactId>camel-package-maven-plugin</artifactId>
        <version>3.2.0-SNAPSHOT</version>
        <executions>
          <execution>
            <!-- prepare the catalog before the user guide / readme -->
            <goals>
                            <goal>prepare-catalog</goal>
                            <goal>prepare-user-guide</goal>
                            <goal>update-doc-component-list</goal>
                            <goal>prepare-parent-pom</goal>
                            <goal>prepare-release-pom</goal>
            </goals>
	    <configuration>
	      <coreLanguagesDir>${project.build.directory}/../../../camel-core</coreLanguagesDir>
	    </configuration>
            <phase>process-resources</phase>
          </execution>
        </executions>
      </plugin>
```