### PR TITLE
remove the redundant space from docs and include whitespace after ; for content-richer based code-snippets

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/TransformTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/TransformTest.java
@@ -49,14 +49,12 @@ public class TransformTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                // tag::example[]
-                from("direct:start").process(new Processor() {
+                /*tag::example[]*/from("direct:start").process(new Processor() {
                     public void process(Exchange exchange) {
                         Message in = exchange.getIn();
                         in.setBody(in.getBody(String.class) + " World!");
                     }
-                }).to("mock:result");
-                // end::example[]
+                }).to("mock:result"); /*end::example[]*/
             }
         };
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/TransformViaDSLTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/TransformViaDSLTest.java
@@ -46,9 +46,7 @@ public class TransformViaDSLTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                // tag::example[]
-                from("direct:start").setBody(body().append(" World!")).to("mock:result");
-                // end::example[]
+                /*tag::example[]*/from("direct:start").setBody(body().append(" World!")).to("mock:result"); /*end::example[]*/
             }
         };
     }


### PR DESCRIPTION
* I observed that for the **Content Enricher** docs within the EIP, two of the code snippets are linked to a part of the code within the **TransformTest.java** and **TransformViaDSLTest.java** using the tag. However, the tags are used in such a manner that the indentation space is also taken into account and is seen in the documentation. This doesn't fit with the structure of the entire documentation.

* Hence, I came up with a solution that if we used inline comments it would avoid the unnecessary initial indentation and the format of code snippets would remain structured for the documentation.

![Content Enricher](https://user-images.githubusercontent.com/44139348/77405919-dc535100-6dd9-11ea-813a-3d64d4681ff5.png)

