### PR TITLE
Resolves CAMEL-14791: fix broken link: and <<>> constructs

### DIFF
--- a/camel-core/src/main/docs/dynamic-router.adoc
+++ b/camel-core/src/main/docs/dynamic-router.adoc
@@ -60,7 +60,7 @@ from("direct:start")
     .dynamicRouter(method(DynamicRouterTest.class, "slip"));
 ----
 
-Which will leverage a <<bean-component,Bean>> to compute the slip
+Which will leverage a xref:bean-component.adoc[Bean] to compute the slip
 _on-the-fly_, which could be implemented as follows:
 
 [source,java]
@@ -139,7 +139,7 @@ Exchange are. Although there was a bug in the method
 call expression, see the warning below.
 
 WARNING:*Using beans to store state*
-Mind that in Camel 2.9.2 or older, when using a <<bean-component,Bean>> the
+Mind that in Camel 2.9.2 or older, when using a xref:bean-component.adoc[Bean] the
 state is not propagated, so you will have to use a
 Processor instead. This is fixed in Camel 2.9.3
 onwards.
@@ -198,12 +198,12 @@ In the above we can use the
 Parameter Binding Annotations
 to bind different parts of the Message to method
 parameters or use an Expression such as using
-<<xpath-language,XPath>> or <<xpath-language,XQuery>>.
+xref:languages:xpath-language.adoc[XPath] or xref:languages:xpath-language.adoc[XQuery].
 
 The method can be invoked in a number of ways as described in the
 Bean Integration such as
 
 * POJO Producing
 * Spring Remoting
-* <<bean-component,Bean>> component
+* xref:bean-component.adoc[Bean] component
 

--- a/camel-core/src/main/docs/eips/bean-eip.adoc
+++ b/camel-core/src/main/docs/eips/bean-eip.adoc
@@ -30,7 +30,7 @@ The Bean EIP supports 5 options which are listed below:
 
 === Bean as endpoint
 
-Camel also supports invoking <<bean-component,Bean>> as an Endpoint. In the
+Camel also supports invoking xref:bean-component.adoc[Bean] as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
@@ -43,7 +43,7 @@ type and storing the output of the method on the Exchange Out body.
 
 === Java DSL bean syntax
 
-Java DSL comes with syntactic sugar for the <<bean-component,Bean>>
+Java DSL comes with syntactic sugar for the xref:bean-component.adoc[Bean]
 component. Instead of specifying the bean explicitly as the endpoint
 (i.e. `to("bean:beanName")`) you can use the following syntax:
 

--- a/camel-core/src/main/docs/eips/dead-letter-channel.adoc
+++ b/camel-core/src/main/docs/eips/dead-letter-channel.adoc
@@ -323,7 +323,7 @@ failed.
 
 These information is kept on the Exchange even if the message
 was successfully processed by a given endpoint, and then later fails for
-example in a local <<bean-component,Bean>> processing instead. So beware
+example in a local xref:bean-component.adoc[Bean] processing instead. So beware
 that this is a hint that helps pinpoint errors.
 
 [source,java]

--- a/camel-core/src/main/docs/eips/toD-eip.adoc
+++ b/camel-core/src/main/docs/eips/toD-eip.adoc
@@ -67,7 +67,7 @@ then the header foo is appended. So for example if the header foo has
 value order, then the endpoint is computed as "mock:order".
 
 You can also use other languages than <<simple-language,Simple>> such
-as <<xpath-language,XPath>> - this requires to prefix with language: as
+as xref:languages:xpath-language.adoc[XPath] - this requires to prefix with language: as
 shown below (simple language is the default language). If you do not
 specify language: then the endpoint is a component name. And in some
 cases there is both a component and language with the same name such as
@@ -89,7 +89,7 @@ from("direct:start")
   .toD("language:xpath:/order/@uri");
 ----
 
-You can also concat multiple <<language-component,Language>>(s) together
+You can also concat multiple xref:language-component[Language](s) together
 using the plus sign `+` such as shown below:
 
 [source,xml]

--- a/camel-core/src/main/docs/modules/ROOT/pages/bean-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/bean-component.adoc
@@ -106,7 +106,7 @@ And the same route using Spring DSL:
 
 == Bean as endpoint
 
-Camel also supports invoking <<bean-component,Bean>> as an Endpoint. In the
+Camel also supports invoking xref:bean-component.adoc[Bean] as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
@@ -119,7 +119,7 @@ type and storing the output of the method on the Exchange Out body.
 
 == Java DSL bean syntax
 
-Java DSL comes with syntactic sugar for the <<bean-component,Bean>>
+Java DSL comes with syntactic sugar for the xref:bean-component.adoc[Bean]
 component. Instead of specifying the bean explicitly as the endpoint
 (i.e. `to("bean:beanName")`) you can use the following syntax:
 
@@ -165,6 +165,6 @@ mechanisms in Camel.
 * Endpoint
 * Getting Started
 
-* <<class-component,Class>> component
+* xref:class-component.adoc[Class] component
 * Bean Binding
 * Bean Integration

--- a/camel-core/src/main/docs/modules/ROOT/pages/binding-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/binding-component.adoc
@@ -5,7 +5,7 @@
 
 In Camel terms a _binding_ is a way of wrapping an
 Endpoint in a contract; such as a
-Data Format, a link:content-enricher.html[Content
+Data Format, a xref:{eip-vc}:eips:content-enricher.adoc[Content
 Enricher] or validation step. Bindings are completely optional and you
 can choose to use them on any camel endpoint.
 

--- a/camel-core/src/main/docs/modules/ROOT/pages/class-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/class-component.adoc
@@ -4,7 +4,7 @@
 *Available as of Camel version 2.4*
 
 The *class:* component binds beans to Camel message exchanges. It works
-in the same way as the <<bean-component,Bean>> component but instead of
+in the same way as the xref:bean-component.adoc[Bean] component but instead of
 looking up beans from a Registry it creates the bean
 based on the class name.
 
@@ -72,7 +72,7 @@ with the following path and query parameters:
 
 == Using
 
-You simply use the *class* component just as the <<bean-component,Bean>>
+You simply use the *class* component just as the xref:bean-component.adoc[Bean]
 component but by specifying the fully qualified classname instead. +
  For example to use the `MyFooBean` you have to do as follows:
 
@@ -127,7 +127,7 @@ Which will lookup a bean from the Registry with the
 id `foo` and invoke the `setCool` method on the created instance of the
 `MyPrefixBean` class.
 
-TIP:See more details at the <<bean-component,Bean>> component as the *class*
+TIP:See more details at the xref:bean-component.adoc[Bean] component as the *class*
 component works in much the same way.
 
 == See Also
@@ -137,6 +137,6 @@ component works in much the same way.
 * Endpoint
 * Getting Started
 
-* <<bean-component,Bean>>
+* xref:bean-component.adoc[Bean]
 * Bean Binding
 * Bean Integration

--- a/camel-core/src/main/docs/modules/ROOT/pages/controlbus-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/controlbus-component.adoc
@@ -22,7 +22,7 @@ by using a Java API from the `CamelContext`, or from the
 here.
 
 From Camel 2.11 onwards we have introduced a new
-<<controlbus-component,ControlBus Component>> that allows you to
+xref:controlbus-component.adoc[ControlBus Component] that allows you to
 send messages to a control bus Endpoint that reacts
 accordingly.
 
@@ -31,7 +31,7 @@ accordingly.
 *Available as of Camel 2.11*
 
 The *controlbus:* component provides easy management of Camel
-applications based on the <<controlbus-component,Control Bus>> EIP
+applications based on the xref:controlbus-component.adoc[Control Bus] EIP
 pattern.
 For example, by sending a message to an Endpoint
 you can control the lifecycle of routes, or gather performance
@@ -53,7 +53,7 @@ use.
 
 |`route` |To control routes using the `routeId` and `action` parameter.
 
-|`language` |Allows you to specify a <<language-component,Language>> to use for
+|`language` |Allows you to specify a xref:language-component.adoc[Language] to use for
 evaluating the message body. If there is any result from the evaluation,
 then the result is put in the message body.
 |===
@@ -154,7 +154,7 @@ String xml = template.requestBody("controlbus:route?action=stats", null, String.
 
 == Using Simple language
 
-You can use the <<simple-language,Simple>> language with the control bus,
+You can use the xref:languages:simple-language.adoc[Simple] language with the control bus,
 for example to stop a specific route, you can send a message to the
 `"controlbus:language:simple"` endpoint containing the following
 message:
@@ -174,8 +174,8 @@ String status = template.requestBody("controlbus:language:simple", "${camelConte
 
 It's easier to use the `route` command to control lifecycle of
 routes. The `language` command allows you to execute a language script
-that has stronger powers such as <<groovy-language,Groovy>> or to some
-extend the <<simple-language,Simple>> language.
+that has stronger powers such as xref:languages:groovy-language.adoc[Groovy] or to some
+extend the xref:languages:simple-language.adoc[Simple] language.
 
 For example to shutdown Camel itself you can do:
 
@@ -188,4 +188,4 @@ We use `async=true` to stop Camel asynchronously as otherwise we
 would be trying to stop Camel while it was in-flight processing the
 message we sent to the control bus component.
 
-TIP: You can also use other languages such as <<groovy-language,Groovy>>, etc.
+TIP: You can also use other languages such as xref:languages:groovy-language.adoc[Groovy], etc.

--- a/camel-core/src/main/docs/modules/ROOT/pages/dataformat-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/dataformat-component.adoc
@@ -3,7 +3,7 @@
 
 *Available as of Camel version 2.12*
 
-The *dataformat:* component allows to use link:data-format.html[Data
+The *dataformat:* component allows to use xref:latest@manual::data-format.adoc[Data
 Format] as a Camel Component.
 
 == URI format
@@ -15,7 +15,7 @@ dataformat:name:(marshal|unmarshal)[?options]
 
 Where *name* is the name of the Data Format. And
 then followed by the operation which must either be `marshal` or
-`unmarshal`. The options is used for configuring the link:data-format.html[Data
+`unmarshal`. The options is used for configuring the xref:latest@manual::data-format.adoc[Data
 Format] in use. See the Data Format documentation
 for which options it support.
 
@@ -61,7 +61,7 @@ with the following path and query parameters:
 
 == Samples
 
-For example to use the <<jaxb-dataformat,JAXB>> link:data-format.html[Data
+For example to use the xref:dataformats:jaxb-dataformat.adoc[JAXB] xref:latest@manual::data-format.adoc[Data
 Format] we can do as follows:
 
 [source,java]

--- a/camel-core/src/main/docs/modules/ROOT/pages/dataset-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/dataset-component.adoc
@@ -4,11 +4,11 @@
 *Available as of Camel version 1.3*
 
 Testing of distributed and asynchronous processing is
-notoriously difficult. The <<mock-component,Mock>>, <<mock-component,Test>>
-and <<dataset-component,DataSet>> endpoints work great with the
+notoriously difficult. The xref:mock-component.adoc[Mock], xref:test-component.adoc[Test]
+and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-link:enterprise-integration-patterns.html[Enterprise Integration
+xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 
@@ -18,7 +18,7 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/compon
 instances] both as a source of messages and as a way to assert that the
 data set is received.
 
-Camel will use the <<log-component,throughput logger>> when sending
+Camel will use the xref:log-component.adoc[throughput logger] when sending
 dataset's.
 
 == URI format

--- a/camel-core/src/main/docs/modules/ROOT/pages/direct-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/direct-component.adoc
@@ -9,11 +9,11 @@ consumers when a producer sends a message exchange. +
 camel context.
 
 TIP: *Asynchronous*
-The <<seda-component,SEDA>> component provides asynchronous invocation of
+The xref:seda-component.adoc[SEDA] component provides asynchronous invocation of
 any consumers when a producer sends a message exchange.
 
 TIP: *Connection to other camel contexts*
-The <<vm-component,VM>> component provides connections between Camel
+The xref:vm-component.adoc[VM] component provides connections between Camel
 contexts as long they run in the same *JVM*.
 
 == URI format
@@ -115,10 +115,10 @@ And the sample using spring DSL:
 </route>
 ----
 
-See also samples from the <<seda-component,SEDA>> component, how they can
+See also samples from the xref:seda-component.adoc[SEDA] component, how they can
 be used together.
 
 == See Also
 
-* <<seda-component,SEDA>>
-* <<vm-component,VM>>
+* xref:seda-component.adoc[SEDA]
+* xref:vm-component.adoc[VM]

--- a/camel-core/src/main/docs/modules/ROOT/pages/direct-vm-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/direct-vm-component.adoc
@@ -8,8 +8,8 @@ any consumers in the JVM when a producer sends a message exchange. +
  This endpoint can be used to connect existing routes in the same camel
 context, as well from other camel contexts in the *same* JVM.
 
-This component differs from the <<direct-component,Direct>> component in
-that <<direct-vm-component,Direct-VM>> supports communication across
+This component differs from the xref:direct-component.adoc[Direct] component in
+that xref:direct-vm-component.adoc[Direct-VM] supports communication across
 CamelContext instances - so you can use this mechanism to communicate
 across web applications (provided that camel-core.jar is on the
 system/boot classpath).
@@ -137,6 +137,6 @@ And the sample using spring DSL:
 
 == See Also
 
-* <<direct-component,Direct>>
-* <<seda-component,SEDA>>
-* <<vm-component,VM>>
+* xref:direct-component.adoc[Direct]
+* xref:seda-component.adoc[SEDA]
+* xref:vm-component.adoc[VM]

--- a/camel-core/src/main/docs/modules/ROOT/pages/file-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/file-component.adoc
@@ -192,7 +192,7 @@ bean completes, and thus the route is completed, the file consumer will
 perform the move operation and move the file to the `.done` sub-folder.
 
 The *move* and the *preMove* options are considered as a directory name
-(though if you use an expression such as <<file-language,File Language>>, or <<simple-language,Simple>> then the result of the expression
+(though if you use an expression such as xref:languages:file-language.adoc[File Language], or xref:languages:simple-language.adoc[Simple] then the result of the expression
 evaluation is the file name to be used - eg if you set
 
 [source]
@@ -200,7 +200,7 @@ evaluation is the file name to be used - eg if you set
 move=../backup/copy-of-${file:name}
 ----
 
-then that's using the <<file-language,File Language>> which we
+then that's using the xref:languages:file-language.adoc[File Language] which we
 use return the file name to be used), which can be either relative or
 absolute. If relative, the directory is created as a sub-folder from
 within the folder where the file was consumed.
@@ -238,10 +238,10 @@ processed and after it's processed, it's moved to the `.done` folder.
 
 The *move* and *preMove* options
 are Expression-based, so we have the full power of
-the <<file-language,File Language>> to do advanced configuration
+the xref:languages:file-language.adoc[File Language] to do advanced configuration
 of the directory and name pattern. +
  Camel will, in fact, internally convert the directory name you enter
-into a <<file-language,File Language>> expression. So when we
+into a xref:languages:file-language.adoc[File Language] expression. So when we
 enter `move=.done` Camel will convert this into:
 `${``file:parent``}/.done/${``file:onlyname`}. This is only done if
 Camel detects that you have not provided a $\{ } in the option value
@@ -264,7 +264,7 @@ choice. For example to move the files in an error folder with a
 timestamp you can use
 `moveFailed=/error/${``file:name.noext``}-${date:now:yyyyMMddHHmmssSSS}.${``file:ext`}.
 
-See more examples at <<file-language,File Language>>
+See more examples at xref:languages:file-language.adoc[File Language]
 
 == Message Headers
 
@@ -278,7 +278,7 @@ The following headers are supported by this component:
 
 |`CamelFileName` |Specifies the name of the file to write (relative to the endpoint
 directory). This name can be a `String`; a `String` with a
-<<file-language,File Language>> or <<simple-language,Simple>>
+xref:languages:file-language.adoc[File Language] or xref:languages:simple-language.adoc[Simple]
 expression; or an Expression object. If it's
 `null` then Camel will auto-generate a filename based on the message
 unique ID.
@@ -487,8 +487,8 @@ from("direct:report").to("file:target/reports/?fileName=report.txt");
 == Filename Expression
 
 Filename can be set either using the *expression* option or as a
-string-based <<file-language,File Language>> expression in the
-`CamelFileName` header. See the <<file-language,File Language>>
+string-based xref:languages:file-language.adoc[File Language] expression in the
+`CamelFileName` header. See the xref:languages:file-language.adoc[File Language]
 for syntax and samples.
 
 == Consuming files from folders where others drop files directly
@@ -770,7 +770,7 @@ today's date as a sub-folder name:
 from("file://inbox?move=backup/${date:now:yyyyMMdd}/${file:name}").to("...");
 ----
 
-See <<file-language,File Language>> for more samples.
+See xref:languages:file-language.adoc[File Language] for more samples.
 
 == Avoiding reading the same file more than once (idempotent consumer)
 
@@ -971,7 +971,7 @@ Registry for a bean with the ID, `mySorter`.
 === Sorting using sortBy
 
 Camel supports pluggable sorting strategies. This strategy it to use the
-<<file-language,File Language>> to configure the sorting. The
+xref:languages:file-language.adoc[File Language] to configure the sorting. The
 `sortBy` option is configured as follows:
 
 [source]
@@ -995,7 +995,7 @@ This will sort by file name, you can reverse the order by prefixing
 sortBy=reverse:file:name
 ----
 
-As we have the full power of <<file-language,File Language>> we
+As we have the full power of xref:languages:file-language.adoc[File Language] we
 can use some of the other parameters, so if we want to sort by file size
 we do:
 
@@ -1039,7 +1039,7 @@ sortBy=file:modified;file:name
 Now there is an issue here, can you spot it? Well the modified timestamp
 of the file is too fine as it will be in milliseconds, but what if we
 want to sort by date only and then subgroup by name? +
- Well as we have the true power of <<file-language,File Language>> we can use its date command that supports patterns. So this
+ Well as we have the true power of xref:languages:file-language.adoc[File Language] we can use its date command that supports patterns. So this
 can be solved as:
 
 [source]
@@ -1130,6 +1130,6 @@ problems.
 
 == See Also
 
-* <<file-language,File Language>>
+* xref:languages:file-language.adoc[File Language]
 * FTP
 * Polling Consumer

--- a/camel-core/src/main/docs/modules/ROOT/pages/language-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/language-component.adoc
@@ -8,14 +8,14 @@ to an endpoint which executes a script by any of the supported
 Languages in Camel. +
  By having a component to execute language scripts, it allows more
 dynamic routing capabilities. For example by using the
-Routing Slip or link:dynamic-router.html[Dynamic
+Routing Slip or xref:{eip-vc}:eips:dynamic-router.adoc[Dynamic
 Router] EIPs you can send messages to `language` endpoints where the
 script is dynamic defined as well.
 
 This component is provided out of the box in `camel-core` and hence no
 additional JARs is needed. You only have to include additional Camel
 components if the language of choice mandates it, such as using
-<<groovy-language,Groovy>> or <<groovy-language,JavaScript>> languages.
+xref:languages:groovy-language.adoc[Groovy] or xref:languages:groovy-language.adoc[JavaScript] languages.
 
 == URI format
 
@@ -26,7 +26,7 @@ language://languageName[:script][?options]
 
 And from Camel 2.11 onwards you can refer to an external resource for
 the script using same notation as supported by the other
-<<language-component,Language>>s in Camel
+xref:language-component.adoc[Language]s in Camel
 
 [source]
 ----
@@ -93,17 +93,17 @@ script configured on the endpoint.
 
 == Examples
 
-For example you can use the <<simple-language,Simple>> language to
+For example you can use the xref:languages:simple-language.adoc[Simple] language to
 Message Translator a message:
 
 In case you want to convert the message body type you can do this as
 well:
 
-You can also use the <<groovy-language,Groovy>> language, such as this
+You can also use the xref:languages:groovy-language.adoc[Groovy] language, such as this
 example where the input message will by multiplied with 2:
 
 You can also provide the script as a header as shown below. Here we use
-<<xpath-language,XPath>> language to extract the text from the `<foo>`
+xref:languages:xpath-language.adoc[XPath] language to extract the text from the `<foo>`
 tag.
 
 [source,java]
@@ -130,5 +130,5 @@ evaluation. +
 updated script is used:
 
 From *Camel 2.11* onwards you can refer to the resource similar to the
-other <<language-component,Language>>s in Camel by prefixing with
+other xref:language-component.adoc[Language]s in Camel by prefixing with
 `"resource:"` as shown below:

--- a/camel-core/src/main/docs/modules/ROOT/pages/log-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/log-component.adoc
@@ -230,7 +230,7 @@ Note that the masking formatter must implement `org.apache.camel.spi.MaskingForm
 
 *Available as of Camel 2.11*
 
-With the options outlined in the <<log-component,#Formatting>> section, you
+With the options outlined in the xref:log-component.adoc[#Formatting] section, you
 can control much of the output of the logger. However, log lines will
 always follow this structure:
 

--- a/camel-core/src/main/docs/modules/ROOT/pages/mock-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/mock-component.adoc
@@ -4,11 +4,11 @@
 *Available as of Camel version 1.0*
 
 Testing of distributed and asynchronous processing is
-notoriously difficult. The <<mock-component,Mock>>, <<mock-component,Test>>
-and <<dataset-component,DataSet>> endpoints work great with the
+notoriously difficult. The xref:mock-component.adoc[Mock], xref:test-component.adoc[Test]
+and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-link:enterprise-integration-patterns.html[Enterprise Integration
+xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 
@@ -28,16 +28,16 @@ Expression to create an order testing function,
 * Messages arrive match some kind of Predicate such
 as that specific headers have certain values, or that parts of the
 messages match some predicate, such as by evaluating an
-<<xpath-language,XPath>> or <<xpath-language,XQuery>>
+xref:languages:xpath-language.adoc[XPath] or xref:languages:xpath-language.adoc[XQuery]
 Expression.
 
 [NOTE]
-There is also the <<test-component,Test endpoint>> which is a
+There is also the xref:test-component.adoc[Test endpoint] which is a
 Mock endpoint, but which uses a second endpoint to provide the list of
 expected message bodies and automatically sets up the Mock endpoint
 assertions. In other words, it's a Mock endpoint that automatically sets
 up its assertions from some sample messages in a File
-or <<jpa-component,database>>, for example.
+or xref:jpa-component.adoc[database], for example.
 
 [CAUTION]
 *Mock endpoints keep received Exchanges in memory indefinitely.* +
@@ -247,7 +247,7 @@ Camel routes.
 
 [NOTE]
 *How it works* The endpoints are still in action. What happens differently
-is that a <<mock-component,Mock>> endpoint is injected and receives the
+is that a xref:mock-component.adoc[Mock] endpoint is injected and receives the
 message first and then delegates the message to the target endpoint. You
 can view this as a kind of intercept and delegate or endpoint listener.
 
@@ -354,7 +354,7 @@ include::{examplesdir}/components/camel-spring/src/test/resources/org/apache/cam
 Then in your unit test you load the new XML file
 (`test-camel-route.xml`) instead of `camel-route.xml`.
 
-To only mock all <<log-component,Log>> endpoints you can define the pattern
+To only mock all xref:log-component.adoc[Log] endpoints you can define the pattern
 in the constructor for the bean:
 
 [source,xml]
@@ -394,7 +394,7 @@ include::{examplesdir}/components/camel-test/src/test/java/org/apache/camel/test
 
 *Available as of Camel 2.10*
 
-The <<mock-component,Mock>> endpoints will by default keep a copy of every
+The xref:mock-component.adoc[Mock] endpoints will by default keep a copy of every
 Exchange that it received. So if you test with a lot
 of messages, then it will consume memory. +
 From Camel 2.10 onwards we have introduced two options `retainFirst` and
@@ -429,7 +429,7 @@ expectations on the 10 retained messages.
 
 *Available as of Camel 2.7*
 
-The <<mock-component,Mock>> endpoint stores the arrival time of the message
+The xref:mock-component.adoc[Mock] endpoint stores the arrival time of the message
 as a property on the Exchange.
 
 [source,java]
@@ -440,7 +440,7 @@ Date time = exchange.getProperty(Exchange.RECEIVED_TIMESTAMP, Date.class);
 You can use this information to know when the message arrived on the
 mock. But it also provides foundation to know the time interval between
 the previous and next message arrived on the mock. You can use this to
-set expectations using the `arrives` DSL on the <<mock-component,Mock>>
+set expectations using the `arrives` DSL on the xref:mock-component.adoc[Mock]
 endpoint.
 
 For example to say that the first message should arrive between 0-2

--- a/camel-core/src/main/docs/modules/ROOT/pages/properties-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/properties-component.adoc
@@ -96,7 +96,7 @@ This works much like you would do if using Spring's
 `<property-placeholder>` tag. However Spring have a limitation which
 prevents 3rd party frameworks to leverage Spring property placeholders
 to the fullest. See more at
-link:how-do-i-use-spring-property-placeholder-with-camel-xml.html[How do
+xref:latest@manual::faq/how-do-i-use-spring-property-placeholder-with-camel-xml.adoc[How do
 I use Spring Property Placeholder with Camel XML].
 
 [TIP]
@@ -111,7 +111,7 @@ The property placeholder is generally in use when doing:
 * lookup of beans in the Registry
 * additional supported in Spring XML (see below in examples)
 * using Blueprint PropertyPlaceholder with Camel
-<<properties-component,Properties>> component
+xref:properties-component.adoc[Properties] component
 * using `@PropertyInject` to inject a property in a POJO
 * *Camel 2.14.1* Using default value if a property does not exists
 * *Camel 2.14.1* Include out of the box functions, to lookup property
@@ -316,7 +316,7 @@ inside the Spring as well as the Blueprint XML.
 For example in OSGi you may want to expose a service which returns the
 properties as a `java.util.Properties` object.
 
-Then you could setup the <<properties-component,Properties>> component as
+Then you could setup the xref:properties-component.adoc[Properties] component as
 follows:
 
 [source,xml]
@@ -415,9 +415,9 @@ ProducerTemplate for example:
 template.sendBody("{{cool.start}}", "Hello World");
 ----
 
-== Example with <<simple-language,Simple>> language
+== Example with xref:languages:simple-language.adoc[Simple] language
 
-The <<simple-language,Simple>> language now also support using property
+The xref:languages:simple-language.adoc[Simple] language now also support using property
 placeholders, for example in the route below:
 
 [source,java]
@@ -430,7 +430,7 @@ from("direct:start")
     .transform().simple("Hi ${body} do you think ${properties:cheese.quote}?");
 ----
 
-You can also specify the location in the <<simple-language,Simple>>
+You can also specify the location in the xref:languages:simple-language.adoc[Simple]
 language for example:
 
 [source,java]
@@ -728,7 +728,7 @@ placeholder notation with `{{` and `}}`.
 == Clashing Spring property placeholders with Camels Simple language
 
 Take notice when using Spring bridging placeholder then the spring `${ }`
-syntax clashes with the <<simple-language,Simple>> in Camel, and therefore
+syntax clashes with the xref:languages:simple-language.adoc[Simple] in Camel, and therefore
 take care. For example:
 
 [source,xml]
@@ -739,7 +739,7 @@ take care. For example:
 ----
 
 clashes with Spring property placeholders, and you should use `$simple{ }`
-to indicate using the <<simple-language,Simple>> language in Camel.
+to indicate using the xref:languages:simple-language.adoc[Simple] language in Camel.
 
 [source,xml]
 ----
@@ -756,7 +756,7 @@ An alternative is to configure the `PropertyPlaceholderConfigurer` with
 *Available as of Camel 2.10*
 
 When Testing with Camel and using the
-<<properties-component,Properties>> component, you may want to be able to
+xref:properties-component.adoc[Properties] component, you may want to be able to
 provide the properties to be used from directly within the unit test
 source code.
 
@@ -836,7 +836,7 @@ private int timeout;
 
 *Available as of Camel 2.14.1*
 
-The <<properties-component,Properties>> component includes the following
+The xref:properties-component.adoc[Properties] component includes the following
 functions out of the box
 
 * `env` - A function to lookup the property from OS environment variables
@@ -904,7 +904,7 @@ export $FOO_SERVICE_PORT=8888
 
 For example if the FOO service a remote HTTP service, then we can refer
 to the service in the Camel endpoint uri, and use
-the <<http-component,HTTP>> component to make the HTTP call:
+the xref:http-component.adoc[HTTP] component to make the HTTP call:
 
 [source,xml]
 ----
@@ -933,7 +933,7 @@ example to call a service on localhost, maybe for unit testing etc
 
 *Available as of Camel 2.14.1*
 
-The <<properties-component,Properties>> component allow to plugin 3rd party
+The xref:properties-component.adoc[Properties] component allow to plugin 3rd party
 functions which can be used during parsing of the property placeholders.
 These functions are then able to do custom logic to resolve the
 placeholders, such as looking up in databases, do custom computations,
@@ -1001,6 +1001,6 @@ pc.addFunction(new MyBeerFunction());
 
 == See Also
 
-* <<properties-component,Properties>> component
+* xref:properties-component.adoc[Properties] component
 * Jasypt for using encrypted values (eg passwords) in
 the properties

--- a/camel-core/src/main/docs/modules/ROOT/pages/rest-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/rest-component.adoc
@@ -248,4 +248,4 @@ containers.
 == See Also
 
 * Rest DSL
-* <<servlet-component,SERVLET>>
+* xref:servlet-component.adoc[SERVLET]

--- a/camel-core/src/main/docs/modules/ROOT/pages/scheduler-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/scheduler-component.adoc
@@ -5,7 +5,7 @@
 
 The *scheduler:* component is used to generate message exchanges when a
 scheduler fires. This component is similar to the
- <<timer-component,Timer>> component, but it offers more functionality in
+ xref:timer-component.adoc[Timer] component, but it offers more functionality in
 terms of scheduling. Also this component uses
 JDK `ScheduledExecutorService`. Where as the timer uses a JDK `Timer`.
 
@@ -161,5 +161,5 @@ exchange.
 
 == See Also
 
-* <<timer-component,Timer>>
-* <<quartz-component,Quartz>>
+* xref:timer-component.adoc[Timer]
+* xref:quartz-component.adoc[Quartz]

--- a/camel-core/src/main/docs/modules/ROOT/pages/seda-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/seda-component.adoc
@@ -12,15 +12,15 @@ and consumers are invoked in a separate thread from the producer.
 Note that queues are only visible within a _single_
 CamelContext. If you want to communicate across
 `CamelContext` instances (for example, communicating between Web
-applications), see the <<vm-component,VM>> component.
+applications), see the xref:vm-component.adoc[VM] component.
 
 This component does not implement any kind of persistence or recovery,
 if the VM terminates while messages are yet to be processed. If you need
 persistence, reliability or distributed SEDA, try using either
-<<jms-component,JMS>> or <<jms-component,ActiveMQ>>.
+xref:jms-component.adoc[JMS] or xref:jms-component.adoc[ActiveMQ].
 
 TIP:*Synchronous*
-The <<direct-component,Direct>> component provides synchronous invocation
+The xref:direct-component.adoc[Direct] component provides synchronous invocation
 of any consumers when a producer sends a message exchange.
 
 == URI format
@@ -139,7 +139,7 @@ ArrayBlockingQueueFactory and PriorityBlockingQueueFactory:
 
 == Use of Request Reply
 
-The <<seda-component,SEDA>> component supports using
+The xref:seda-component.adoc[SEDA] component supports using
 Request Reply, where the caller will wait for
 the Async route to complete. For instance:
 
@@ -158,7 +158,7 @@ copies the response to the original message response.
 
 NOTE: *until 2.2: Works only with 2 endpoints*
 Using Request Reply over SEDA
-or <<vm-component,VM>> only works with 2 endpoints. You *cannot* chain
+or xref:vm-component.adoc[VM] only works with 2 endpoints. You *cannot* chain
 endpoints by sending to A -> B -> C etc. Only between A -> B. The reason
 is the implementation logic is fairly simple. To support 3+ endpoints
 makes the logic much more complex to handle ordering and notification
@@ -193,7 +193,7 @@ from("seda:stageName").thread(5).process(...)
 
 Can wind up with two `BlockQueues`: one from the SEDA endpoint, and one
 from the workqueue of the thread pool, which may not be what you want.
-Instead, you might wish to configure a <<direct-component,Direct>> endpoint
+Instead, you might wish to configure a xref:direct-component.adoc[Direct] endpoint
 with a thread pool, which can process messages both synchronously and
 asynchronously. For example:
 
@@ -247,7 +247,7 @@ int size = seda.getExchanges().size();
 
 == See Also
 
-* <<vm-component,VM>>
-* <<disruptor-component,Disruptor>>
-* <<direct-component,Direct>>
+* xref:vm-component.adoc[VM]
+* xref:disruptor-component.adoc[Disruptor]
+* xref:direct-component.adoc[Direct]
 * Async

--- a/camel-core/src/main/docs/modules/ROOT/pages/stub-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/stub-component.adoc
@@ -6,12 +6,12 @@
 The *stub:* component provides a simple way to stub out any physical
 endpoints while in development or testing, allowing you for example to
 run a route without needing to actually connect to a specific
-<<mail-component,SMTP>> or <<mail-component,Http>> endpoint. Just add *stub:*
+xref:mail-component.adoc[SMTP] or xref:http-component.adoc[Http] endpoint. Just add *stub:*
 in front of any endpoint URI to stub out the endpoint.
 
-Internally the Stub component creates <<vm-component,VM>> endpoints. The
-main difference between <<stub-component,Stub>> and <<stub-component,VM>> is
-that <<vm-component,VM>> will validate the URI and parameters you give it,
+Internally the Stub component creates xref:vm-component.adoc[VM] endpoints. The
+main difference between xref:stub-component.adoc[Stub] and xref:vm-component.adoc[VM] is
+that xref:vm-component.adoc[VM] will validate the URI and parameters you give it,
 so putting vm: in front of a typical URI with query arguments will
 usually fail. Stub won't though, as it basically ignores all query
 parameters to let you quickly stub out one or more endpoints in your

--- a/camel-core/src/main/docs/modules/ROOT/pages/test-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/test-component.adoc
@@ -4,23 +4,23 @@
 *Available as of Camel version 1.3*
 
 Testing of distributed and asynchronous processing is
-notoriously difficult. The <<mock-component,Mock>>, <<mock-component,Test>>
-and <<dataset-component,DataSet>> endpoints work great with the
+notoriously difficult. The xref:mock-component.adoc[Mock], xref:test-component.adoc[Test]
+and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-link:enterprise-integration-patterns.html[Enterprise Integration
+xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 
-The *test* component extends the <<mock-component,Mock>> component to
+The *test* component extends the xref:mock-component.adoc[Mock] component to
 support pulling messages from another endpoint on startup to set the
-expected message bodies on the underlying <<mock-component,Mock>> endpoint.
+expected message bodies on the underlying xref:mock-component.adoc[Mock] endpoint.
 That is, you use the test endpoint in a route and messages arriving on
 it will be implicitly compared to some expected messages extracted from
 some other location.
 
 So you can use, for example, an expected set of message bodies as files.
-This will then set up a properly configured <<mock-component,Mock>>
+This will then set up a properly configured xref:mock-component.adoc[Mock]
 endpoint, which is only valid if the received messages match the number
 of expected messages and their message payloads are equal.
 
@@ -37,7 +37,7 @@ for this component when using *Camel 2.8* or older:
 </dependency>
 ----
 
-From Camel 2.9 onwards the <<test-component,Test>> component is provided
+From Camel 2.9 onwards the xref:test-component.adoc[Test] component is provided
 directly in the camel-core.
 
 == URI format
@@ -116,7 +116,7 @@ http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/compon
 method], your test case will perform the necessary assertions.
 
 To see how you can set other expectations on the test endpoint, see the
-<<mock-component,Mock>> component.
+xref:mock-component.adoc[Mock] component.
 
 == See Also
 

--- a/camel-core/src/main/docs/modules/ROOT/pages/timer-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/timer-component.adoc
@@ -24,12 +24,12 @@ You can append query options to the URI in the following format,
 `exchange.getIn().getBody()` returns `null`.
 
 TIP:*Advanced Scheduler*
-See also the <<quartz-component,Quartz>> component that supports much more
+See also the xref:quartz-component.adoc[Quartz] component that supports much more
 advanced scheduling.
 
 TIP:*Specify time in human friendly format*
 In *Camel 2.3* onwards you can specify the time in
-link:how-do-i-specify-time-period-in-a-human-friendly-syntax.html[human
+xref:latest@manual::faq/how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
 friendly syntax].
 
 
@@ -167,5 +167,5 @@ starting the route. To do that you use the repeatCount option as shown:
 
 == See Also
 
-* <<scheduler-component,Scheduler>>
-* <<quartz-component,Quartz>>
+* xref:scheduler-component.adoc[Scheduler]
+* xref:quartz-component.adoc[Quartz]

--- a/camel-core/src/main/docs/modules/ROOT/pages/validator-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/validator-component.adoc
@@ -8,14 +8,14 @@ using the JAXP Validation API and based on any of the supported XML
 schema languages, which defaults to http://www.w3.org/XML/Schema[XML
 Schema]
 
-Note that the <<jing-component,Jing>> component also supports the following
+Note that the xref:jing-component.adoc[Jing] component also supports the following
 useful schema languages:
 
 * http://relaxng.org/compact-tutorial-20030326.html[RelaxNG Compact
 Syntax]
 * http://relaxng.org/[RelaxNG XML Syntax]
 
-The <<msv-component,MSV>> component also supports
+The xref:msv-component.adoc[MSV] component also supports
 http://relaxng.org/[RelaxNG XML Syntax].
 
 == URI format

--- a/camel-core/src/main/docs/modules/ROOT/pages/vm-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/vm-component.adoc
@@ -9,12 +9,12 @@ messages on a
 http://java.sun.com/j2se/1.5.0/docs/api/java/util/concurrent/BlockingQueue.html[BlockingQueue]
 and invoking consumers in a separate thread pool.
 
-This component differs from the <<seda-component,Seda>> component in that
+This component differs from the xref:seda-component.adoc[Seda] component in that
 VM supports communication across CamelContext instances - so you can use
 this mechanism to communicate across web applications (provided that
 `camel-core.jar` is on the `system/boot` classpath).
 
-VM is an extension to the <<seda-component,Seda>> component.
+VM is an extension to the xref:seda-component.adoc[Seda] component.
 
 == URI format
 
@@ -30,9 +30,9 @@ camel-core.jar)
 You can append query options to the URI in the following format:
 `?option=value&option=value&...`
 
-An exactly identical <<vm-component,VM>> endpoint URI *must* be used for
+An exactly identical xref:vm-component.adoc[VM] endpoint URI *must* be used for
 both the producer and the consumer endpoint. Otherwise, Camel will
-create a second <<vm-component,VM>> endpoint despite that the `queueName`
+create a second xref:vm-component.adoc[VM] endpoint despite that the `queueName`
 portion of the URI is identical. For example:
 
 [source,java]
@@ -122,8 +122,8 @@ with the following path and query parameters:
 // endpoint options: END
 
 
-See the <<seda-component,Seda>> component for options and other important
-usage details as the same rules apply to the <<vm-component,Vm>> component.
+See the xref:seda-component.adoc[Seda] component for options and other important
+usage details as the same rules apply to the xref:vm-component.adoc[Vm] component.
 
 == Samples
 
@@ -145,4 +145,4 @@ from("vm:order.email").bean(MyOrderEmailSender.class);
 
 == See Also
 
-* <<seda-component,Seda>>
+* xref:seda-component.adoc[Seda]

--- a/camel-core/src/main/docs/modules/ROOT/pages/xslt-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/xslt-component.adoc
@@ -48,7 +48,7 @@ for this component:
 </dependency>
 ----
 
-From *Camel 2.9* onwards the <<xslt-component,XSLT>> component is provided
+From *Camel 2.9* onwards the xref:xslt-component.adoc[XSLT] component is provided
 directly in the camel-core.
 
 == Options
@@ -278,7 +278,7 @@ With Spring XML:
 == Dynamic stylesheets
 
 To provide a dynamic stylesheet at runtime you can define a dynamic URI.
-See link:how-to-use-a-dynamic-uri-in-to.html[How to use a dynamic URI in
+See xref:latest@manual::faq/how-to-use-a-dynamic-uri-in-to.adoc[How to use a dynamic URI in
 to()] for more information.
 
 *Available as of Camel 2.9 (removed in 2.11.4, 2.12.3 and 2.13.0)*

--- a/camel-core/src/main/docs/modules/dataformats/pages/gzip-dataformat.adoc
+++ b/camel-core/src/main/docs/modules/dataformats/pages/gzip-dataformat.adoc
@@ -5,7 +5,7 @@
 
 The GZip Data Format is a message compression and
 de-compression format. It uses the same deflate algorithm that is used
-in <<zip-dataformat,Zip DataFormat>>, although some additional
+in xref:dataformats:zip-dataformat.adoc[Zip DataFormat], although some additional
 headers are provided. This format is produced by popular `gzip`/`gunzip`
 tool. Messages marshalled using GZip compression can be unmarshalled
 using GZip decompression just prior to being consumed at the endpoint.

--- a/camel-core/src/main/docs/modules/languages/pages/bean-language.adoc
+++ b/camel-core/src/main/docs/modules/languages/pages/bean-language.adoc
@@ -19,7 +19,7 @@ the message body and using any annotations on the bean methods.
 The Bean Binding rules are used to bind the
 Message Exchange to the method parameters; so you can
 annotate the bean to extract headers or other expressions such as
-<<xpath-language,XPath>> or <<xpath-language,XQuery>> from the message.
+xref:languages:xpath-language.adoc[XPath] or xref:languages:xpath-language.adoc[XQuery] from the message.
 
 == Bean Options
 
@@ -107,7 +107,7 @@ or other expressions.
 
 == Non registry beans
 
-The <<bean-language,Bean Language>> also supports invoking beans
+The xref:bean-language.adoc[Bean Language] also supports invoking beans
 that isn't registered in the Registry. This is
 usable for quickly to invoke a bean from Java DSL where you don't need
 to register the bean in the Registry such as the

--- a/camel-core/src/main/docs/modules/languages/pages/file-language.adoc
+++ b/camel-core/src/main/docs/modules/languages/pages/file-language.adoc
@@ -5,11 +5,11 @@
 
 INFO:*File language is now merged with Simple language*
 From Camel 2.2 onwards, the file language is now merged with
-<<simple-language,Simple>> language which means you can use all the file
+xref:simple-language.adoc[Simple] language which means you can use all the file
 syntax directly within the simple language.
 
 The File Expression Language is an extension to the
-<<simple-language,Simple>> language, adding file related capabilities.
+xref:simple-language.adoc[Simple] language, adding file related capabilities.
 These capabilities are related to common use cases working with file
 path and names. The goal is to allow expressions to be used with the
 File and FTP components for setting
@@ -32,18 +32,18 @@ The File language supports 2 options, which are listed below.
 
 == Syntax
 
-This language is an *extension* to the <<simple-language,Simple>> language
-so the <<simple-language,Simple>> syntax applies also. So the table below
+This language is an *extension* to the xref:simple-language.adoc[Simple] language
+so the xref:simple-language.adoc[Simple] syntax applies also. So the table below
 only lists the additional.  +
- As opposed to <<simple-language,Simple>> language
-<<file-language,File Language>> also supports
-<<constant-language,Constant>> expressions so you can enter a fixed
+ As opposed to xref:simple-language.adoc[Simple] language
+xref:file-language.adoc[File Language] also supports
+xref:constant-language.adoc[Constant] expressions so you can enter a fixed
 filename.
 
 All the file tokens use the same expression name as the method on the
 `java.io.File` object, for instance `file:absolute` refers to the
 `java.io.File.getAbsolute()` method. Notice that not all expressions are
-supported by the current Exchange. For instance the <<ftp-component,FTP>>
+supported by the current Exchange. For instance the xref:ROOT:ftp-component.adoc[FTP]
 component supports some of the options, where as the
 File component supports all of them.
 
@@ -95,9 +95,9 @@ this expression strips only the last part, and keep the others.
 |file:modified |Date |yes |no |yes |no |Refers to the file last modified returned as a Date type
 
 |date:_command:pattern_ |String |yes |yes |yes |yes |for date formatting using the `java.text.SimpleDateFormat` patterns. Is
-an *extension* to the <<simple-language,Simple>> language. Additional
+an *extension* to the xref:simple-language.adoc[Simple] language. Additional
 command is: *file* (consumers only) for the last modified timestamp of
-the file. Notice: all the commands from the <<simple-language,Simple>>
+the file. Notice: all the commands from the xref:simple-language.adoc[Simple]
 language can also be used.
 |===
 
@@ -171,7 +171,7 @@ return as:
 
 == Samples
 
-You can enter a fixed <<constant-language,Constant>> expression such as
+You can enter a fixed xref:constant-language.adoc[Constant] expression such as
 `myfile.txt`:
 
 [source]
@@ -196,7 +196,7 @@ should be a sibling folder then you can append .. as:
 fileName="../backup/${date:now:yyyyMMdd}/${file:name.noext}.bak"
 ----
 
-As this is an extension to the <<simple-language,Simple>> language we have
+As this is an extension to the xref:simple-language.adoc[Simple] language we have
 access to all the goodies from this language also, so in this use case
 we want to use the in.header.type as a parameter in the dynamic
 expression:
@@ -223,14 +223,14 @@ fileName="uniquefile-${bean:myguidgenerator.generateid}.txt"
 ----
 
 And of course all this can be combined in one expression where you can
-use the <<file-language,File Language>>, <<file-language,Simple>>
-and the <<bean-component,Bean>> language in one combined expression. This
+use the xref:file-language.adoc[File Language], xref:simple-language.adoc[Simple]
+and the xref:bean-language.adoc[Bean] language in one combined expression. This
 is pretty powerful for those common file path patterns.
 
 == Using Spring PropertyPlaceholderConfigurer together with the File component
 
-In Camel you can use the <<file-language,File Language>> directly
-from the <<simple-language,Simple>> language which makes a
+In Camel you can use the xref:file-language.adoc[File Language] directly
+from the xref:simple-language.adoc[Simple] language which makes a
 Content Based Router easier to do in
 Spring XML, where we can route based on file extensions as shown below:
 
@@ -253,7 +253,7 @@ Spring XML, where we can route based on file extensions as shown below:
 ----
 
 If you use the `fileName` option on the File endpoint
-to set a dynamic filename using the <<file-language,File Language>> then make sure you  +
+to set a dynamic filename using the xref:file-language.adoc[File Language] then make sure you  +
  use the alternative syntax (available from Camel 2.5 onwards) to avoid
 clashing with Springs `PropertyPlaceholderConfigurer`.
 

--- a/camel-core/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/camel-core/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -8,21 +8,18 @@ created, but has since grown more powerful. It is primarily intended for
 being a really small and simple language for evaluating
 Expressions and Predicates
 without requiring any new dependencies or knowledge of
-<<xpath-language,XPath>>; so it is ideal for testing in camel-core. The
+xref:languages:xpath-language.adoc[XPath]; so it is ideal for testing in camel-core. The
 idea was to cover 95% of the common use cases when you need a little bit
 of expression based script in your Camel routes.
 
 However for much more complex use cases you are generally recommended to
 choose a more expressive and powerful language such as:
 
-* <<spel-language,SpEL>>
-* <<mvel-component,Mvel>>
-* <<groovy-language,Groovy>>
-* JavaScript
-* <<el-language,EL>>
-* <<ognl-language,OGNL>>
-* one of the supported link:scripting-languages.html[Scripting
-Languages]
+* xref:groovy-language.adoc[Groovy]
+* xref:spel-language.adoc[SpEL]
+* xref:mvel-language.adoc[MVEL]
+* xref:ognl-language.adoc[OGNL]
+* xref:el-language.adoc[EL]
 
 The simple language uses `${body`} placeholders for complex expressions
 where the expression contains constant literals. The $\{ } placeholders
@@ -35,13 +32,13 @@ Spring property placeholder together with Camel.
 
 == Simple Language Changes in Camel 2.9 onwards
 
-The <<simple-language,Simple>> language have been improved from Camel 2.9
+The xref:simple-language.adoc[Simple] language have been improved from Camel 2.9
 onwards to use a better syntax parser, which can do index precise error
 messages, so you know exactly what is wrong and where the problem is.
 For example if you have made a typo in one of the operators, then
 previously the parser would not be able to detect this, and cause the
 evaluation to be true. There are a few changes in the syntax which are
-no longer backwards compatible. When using <<simple-language,Simple>>
+no longer backwards compatible. When using xref:simple-language.adoc[Simple]
 language as a Predicate then the literal text
 *must* be enclosed in either single or double quotes. For example:
 `"$\{body} == 'Camel'"`. Notice how we have single quotes around the
@@ -214,9 +211,9 @@ Command accepts offsets such as: *now-24h* or *in.header.xxx+1h* or even *now+1h
 
 |date-with-timezone:_command:timezone:pattern_ |String |Date formatting using `java.text.SimpleDataFormat` timezones and patterns.
 
-|bean:_bean expression_ |Object |Invoking a bean expression using the <<bean-component,Bean>> language.
+|bean:_bean expression_ |Object |Invoking a bean expression using the xref:ROOT:bean-component.adoc[Bean] language.
 Specifying a method name you must use dot as separator. We also support
-the ?method=methodname syntax that is used by the <<bean-component,Bean>>
+the ?method=methodname syntax that is used by the xref:ROOT:bean-component.adoc[Bean]
 component.
 
 |properties:_locations:key_ |String |*Deprecated (use properties-location instead) Camel 2.3:* Lookup a
@@ -280,7 +277,7 @@ fields. From *Camel 2.11.1* onwards we added special support for accessing the
 length field of Java arrays.
 
 
-The <<simple-language,Simple>> and <<simple-language,Bean>> language now
+The xref:simple-language.adoc[Simple] and xref:bean-language.adoc[Bean] language now
 supports a Camel OGNL notation for invoking beans in a chain like
 fashion. Suppose the Message IN body contains a POJO which has a `getAddress()`
 method.
@@ -501,7 +498,7 @@ function, otherwise parsed as literal.
 |\ |*Camel 2.9.3 to 2.10.x* To escape a value, eg \$, to indicate a $ sign.
 Special: Use \n for new line, \t for tab, and \r for carriage return.
 *Notice:* Escaping is *not* supported using the
-<<file-language,File Language>>. *Notice:* From Camel 2.11
+xref:file-language.adoc[File Language]. *Notice:* From Camel 2.11
 onwards the escape character is no longer support, but replaced with the
 following three special escaping.
 
@@ -802,7 +799,7 @@ from("direct:order")
 ----
 
 We can use the `?method=methodname` option that we are familiar with the
-<<bean-component,Bean>> component itself:
+xref:ROOT:bean-component.adoc[Bean] component itself:
 
 [source,java]
 ----
@@ -857,7 +854,7 @@ From Camel 2.9 onwards you can nest functions, such as shown below:
 Suppose you have an enum for customers
 
 And in a Content Based Router we can use
-the <<simple-language,Simple>> language to refer to this enum, to check
+the xref:simple-language.adoc[Simple] language to refer to this enum, to check
 the message which enum it matches.
 
 == Using new lines or tabs in XML DSLs
@@ -894,7 +891,7 @@ whitespace characters.
 
 *Available as of Camel 2.8*
 
-You can now provide a result type to the <<simple-language,Simple>>
+You can now provide a result type to the xref:simple-language.adoc[Simple]
 expression, which means the result of the evaluation will be converted
 to the desired type. This is most useable to define types such as
 booleans, integers, etc.
@@ -976,4 +973,4 @@ You can set a spring bean into an exchange property as shown below:
 
 == Dependencies
 
-The <<simple-language,Simple>> language is part of *camel-core*.
+The xref:simple-language.adoc[Simple] language is part of *camel-core*.

--- a/camel-core/src/main/docs/modules/languages/pages/xpath-language.adoc
+++ b/camel-core/src/main/docs/modules/languages/pages/xpath-language.adoc
@@ -5,9 +5,9 @@
 
 Camel supports http://www.w3.org/TR/xpath[XPath] to allow an
 Expression or Predicate to be
-used in the DSL or link:xml-configuration.html[Xml
+used in the DSL or xref:latest@manual::xml-configuration.adoc[Xml
 Configuration]. For example you could use XPath to create an
-Predicate in a link:message-filter.html[Message
+Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
 Recipient List.
 
@@ -16,7 +16,7 @@ Recipient List.
 If the message body is stream based, which means the input it receives
 is submitted to Camel as a stream. That means you will only be able to
 read the content of the stream *once*. So often when you use
-<<xpath-language,XPath>> as <<xpath-language,Message Filter>> or
+xref:languages:xpath-language.adoc[XPath] as xref:{eip-vc}:eips:filter-eip.adoc[Message Filter] or
 Content Based Router then you need to
 access the data multiple times, and you should use
 Stream Caching or convert the message body to
@@ -125,9 +125,9 @@ exchange:
 |out:header |the header name |Object |Will return the *out* message header.
 
 |function:properties |key for property |String |*Camel 2.5:* To lookup a property using the
-<<properties-component,Properties>> component (property placeholders).
+xref:ROOT:properties-component.adoc[Properties] component (property placeholders).
 
-|function:simple |simple expression |Object |*Camel 2.5:* To evaluate a <<simple-language,Simple>> expression.
+|function:simple |simple expression |Object |*Camel 2.5:* To evaluate a xref:simple-language.adoc[Simple] expression.
 |===
 
 CAUTION: `function:properties` and `function:simple` is not supported
@@ -172,10 +172,10 @@ on the mailinglist] about using your own namespaces with xpath
 
 == Setting result type
 
-The <<xpath-language,XPath>> expression will return a result type using
+The xref:languages:xpath-language.adoc[XPath] expression will return a result type using
 native XML objects such as `org.w3c.dom.NodeList`. But many times you
 want a result type to be a String. To do this you have to instruct the
-<<xpath-language,XPath>> which result type to use.
+xref:languages:xpath-language.adoc[XPath] which result type to use.
 
 In Java DSL:
 
@@ -422,7 +422,7 @@ Any of these options can be used to activate this logging:
 `org.apache.camel.builder.xml.XPathBuilder` logger, or some parent
 logger such as `org.apache.camel` or the root logger
 2.  Enable the `logNamespaces` option as indicated in
-<<xpath-language,Auditing Namespaces>>, in which case the logging will
+xref:xpath-language.adoc[Auditing Namespaces], in which case the logging will
 occur on the INFO level
 
 === Auditing namespaces

--- a/camel-core/src/main/docs/rest-dsl.adoc
+++ b/camel-core/src/main/docs/rest-dsl.adoc
@@ -7,7 +7,7 @@ REST style with verbs such as get, post, delete etc.
 
 === How it works
 
-The Rest DSL is a facade that builds <<rest-component,Rest>> endpoints as
+The Rest DSL is a facade that builds xref:rest-component.adoc[Rest] endpoints as
 consumers for Camel routes. The actual REST transport is leveraged by
 using Camel REST components such
 as <<restlet-component,Restlet>>, <<restlet-component,Spark-rest>>, and
@@ -202,7 +202,7 @@ over <<jms-component,JMS>> where the queue name is dynamic defined
 
 See more details at Message Endpoint about
 the dynamic to, and what syntax it supports. By default it uses
-the <<simple-language,Simple>> language, but it has more power than so.
+the xref:simple-language[Simple] language, but it has more power than so.
 
 === Embedding Camel routes
 


### PR DESCRIPTION
I don't see any errors related to this running yarn checks locally.  There are a lot of broken link errors due to trying to check the edit urls.
