### PR TITLE
[CAMEL-13462] - Override blob name using header implementation.

### DIFF
--- a/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobHeadersConstants.java
+++ b/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobHeadersConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.blob;
+
+public interface BlobHeadersConstants {
+
+    String OVERRIDE_BLOB_NAME = "overrideBlobName";
+
+}

--- a/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobHeadersConstants.java
+++ b/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobHeadersConstants.java
@@ -18,6 +18,6 @@ package org.apache.camel.component.azure.blob;
 
 public interface BlobHeadersConstants {
 
-    String OVERRIDE_BLOB_NAME = "overrideBlobName";
+    String OVERRIDE_BLOB_NAME = "CamelOverrideBlobName";
 
 }

--- a/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceComponent.java
+++ b/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceComponent.java
@@ -63,22 +63,16 @@ public class BlobServiceComponent extends DefaultComponent {
         configuration.setAccountName(parts[0]);
         configuration.setContainerName(parts[1]);
 
-        String blobName = (String) parameters.get(OVERRIDE_BLOB_NAME);
-
-        if (StringUtils.isEmpty(blobName)) {
-            if (parts.length > 2) {
-                // Blob names can contain forward slashes
-                StringBuilder sb = new StringBuilder();
-                for (int i = 2; i < parts.length; i++) {
-                    sb.append(parts[i]);
-                    if (i + 1 < parts.length) {
-                        sb.append('/');
-                    }
+        if (parts.length > 2) {
+            // Blob names can contain forward slashes
+            StringBuilder sb = new StringBuilder();
+            for (int i = 2; i < parts.length; i++) {
+                sb.append(parts[i]);
+                if (i + 1 < parts.length) {
+                    sb.append('/');
                 }
-                configuration.setBlobName(sb.toString());
             }
-        } else {
-            configuration.setBlobName(blobName);
+            configuration.setBlobName(sb.toString());
         }
 
         BlobServiceEndpoint endpoint = new BlobServiceEndpoint(uri, this, configuration);

--- a/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceComponent.java
+++ b/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceComponent.java
@@ -27,9 +27,6 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
-import org.apache.commons.lang3.StringUtils;
-
-import static org.apache.camel.component.azure.blob.BlobHeadersConstants.OVERRIDE_BLOB_NAME;
 
 @Component("azure-blob")
 public class BlobServiceComponent extends DefaultComponent {

--- a/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceProducer.java
+++ b/components/camel-azure/src/main/java/org/apache/camel/component/azure/blob/BlobServiceProducer.java
@@ -46,7 +46,6 @@ import org.apache.camel.component.azure.common.ExchangeUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -505,9 +504,8 @@ public class BlobServiceProducer extends DefaultProducer {
     private void overrideBlobName(Exchange exchange) {
         String blobName = exchange.getIn().getHeader(OVERRIDE_BLOB_NAME, String.class);
 
-        if (StringUtils.isNotEmpty(blobName)) {
+        if (ObjectHelper.isNotEmpty(blobName)) {
             getEndpoint().getConfiguration().setBlobName(blobName);
         }
     }
-
 }

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceAppendConsumerTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceAppendConsumerTest.java
@@ -23,9 +23,7 @@ import java.io.FileInputStream;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -41,11 +39,7 @@ public class BlobServiceAppendConsumerTest extends CamelTestSupport {
     @Test
     @Ignore
     public void testGetAppendBlob() throws Exception {
-        templateStart.send("direct:start", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody("Append Blob");
-            }
-        });
+        templateStart.send("direct:start", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody("Append Blob"));
         
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceBlockConsumerTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceBlockConsumerTest.java
@@ -23,9 +23,7 @@ import java.io.FileInputStream;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -41,11 +39,7 @@ public class BlobServiceBlockConsumerTest extends CamelTestSupport {
     @Test
     @Ignore
     public void testGetBlockBlob() throws Exception {
-        templateStart.send("direct:start", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody("Block Blob");
-            }
-        });
+        templateStart.send("direct:start", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody("Block Blob"));
         
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceComponentConfigurationClientTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceComponentConfigurationClientTest.java
@@ -24,8 +24,6 @@ import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.core.Base64;
 import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
@@ -181,11 +179,8 @@ public class BlobServiceComponentConfigurationClientTest extends CamelTestSuppor
     }
     
     private static void createConsumer(Endpoint endpoint) throws Exception {
-        endpoint.createConsumer(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                // noop
-            }
+        endpoint.createConsumer(exchange -> {
+            // noop
         });
     }
     

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceComponentConfigurationTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceComponentConfigurationTest.java
@@ -25,8 +25,6 @@ import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.core.Base64;
 import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
@@ -195,13 +193,10 @@ public class BlobServiceComponentConfigurationTest extends CamelTestSupport {
             (BlobServiceEndpoint)context.getEndpoint("azure-blob://camelazure/component1/blob/sub?credentials=#creds");
         assertEquals("blob/sub", endpoint.getConfiguration().getBlobName());
     }
-    
+
     private static void createConsumer(Endpoint endpoint) throws Exception {
-        endpoint.createConsumer(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                // noop
-            }
+        endpoint.createConsumer(exchange -> {
+            // noop
         });
     }
     

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceProducerOverrideBlobNameTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceProducerOverrideBlobNameTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.blob;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.camel.component.azure.blob.BlobHeadersConstants.OVERRIDE_BLOB_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class BlobServiceProducerOverrideBlobNameTest {
+
+    private Exchange exchange;
+    private BlobServiceProducer producer;
+
+    @Before
+    public void setUp() {
+        CamelContext context = new DefaultCamelContext();
+        BlobServiceEndpoint endpoint = (BlobServiceEndpoint) context.getEndpoint("azure-blob://camelazure/container/blob?credentialsAccountKey=aKey&credentialsAccountName=name");
+        exchange = new DefaultExchange(context);
+        producer = new BlobServiceProducer(endpoint);
+    }
+
+    @Test
+    public void testOverrideBlobName() throws Exception {
+
+        String blobName = "blobName";
+        exchange.getIn().setHeader(OVERRIDE_BLOB_NAME, blobName);
+
+        producer.process(exchange);
+
+        assertEquals(blobName, producer.getEndpoint().getConfiguration().getBlobName());
+    }
+
+    @Test
+    public void testSetBlobNameFromEndpoint() throws Exception {
+
+        String blobName = "blob";
+        exchange.getIn().setHeader(OVERRIDE_BLOB_NAME, blobName);
+
+        producer.process(exchange);
+
+        assertEquals(blobName, producer.getEndpoint().getConfiguration().getBlobName());
+    }
+
+}

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceProducerSpringTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/blob/BlobServiceProducerSpringTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
@@ -45,11 +44,7 @@ public class BlobServiceProducerSpringTest extends CamelSpringTestSupport {
     public void testUpdateBlockBlob() throws Exception {
         result.expectedMessageCount(1);
         
-        template.send("direct:updateBlockBlob", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody("Block Blob");
-            }
-        });
+        template.send("direct:updateBlockBlob", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody("Block Blob"));
         
         assertMockEndpointsSatisfied();
         
@@ -61,11 +56,7 @@ public class BlobServiceProducerSpringTest extends CamelSpringTestSupport {
     public void testUploadBlobBlocks() throws Exception {
         result.expectedMessageCount(1);
         final BlobBlock st = new BlobBlock(new ByteArrayInputStream("Block Blob List".getBytes()));
-        template.send("direct:uploadBlobBlocks", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody(st);
-            }
-        });
+        template.send("direct:uploadBlobBlocks", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody(st));
         
         assertMockEndpointsSatisfied();
         
@@ -77,11 +68,7 @@ public class BlobServiceProducerSpringTest extends CamelSpringTestSupport {
     public void testGetBlockBlob() throws Exception {
         result.expectedMessageCount(1);
         OutputStream os = new ByteArrayOutputStream();
-        template.send("direct:getBlockBlob", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody(os);
-            }
-        });
+        template.send("direct:getBlockBlob", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody(os));
         
         assertMockEndpointsSatisfied();
         
@@ -93,11 +80,7 @@ public class BlobServiceProducerSpringTest extends CamelSpringTestSupport {
     public void testUpdateAppendBlob() throws Exception {
         result.expectedMessageCount(1);
         
-        template.send("direct:updateAppendBlob", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody("Append Blob");
-            }
-        });
+        template.send("direct:updateAppendBlob", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody("Append Blob"));
         
         assertMockEndpointsSatisfied();
         
@@ -110,11 +93,7 @@ public class BlobServiceProducerSpringTest extends CamelSpringTestSupport {
         result.expectedMessageCount(1);
         final byte[] data = new byte[512];
         Arrays.fill(data, (byte)1);
-        template.send("direct:updatePageBlob", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setBody(new ByteArrayInputStream(data));
-            }
-        });
+        template.send("direct:updatePageBlob", ExchangePattern.InOnly, exchange -> exchange.getIn().setBody(new ByteArrayInputStream(data)));
         
         assertMockEndpointsSatisfied();
         

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/common/AzureServiceCommonTestUtil.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/common/AzureServiceCommonTestUtil.java
@@ -66,8 +66,7 @@ public final class AzureServiceCommonTestUtil {
 
     public static CloudBlockBlob createBlockBlobClient(String accountName, String accountKey) throws Exception {
         URI uri = new URI("https://camelazure.blob.core.windows.net/container1/blobBlock");
-        CloudBlockBlob client = new CloudBlockBlob(uri, newAccountKeyCredentials(accountName, accountKey));
-        return client;
+        return new CloudBlockBlob(uri, newAccountKeyCredentials(accountName, accountKey));
     }
 
     public static CloudBlockBlob createBlockBlobClient() throws Exception {
@@ -86,8 +85,7 @@ public final class AzureServiceCommonTestUtil {
 
     public static CloudQueue createQueueClient(String accountName, String accountKey) throws Exception {
         URI uri = new URI("https://camelazure.queue.core.windows.net/testqueue/");
-        CloudQueue client = new CloudQueue(uri, newAccountKeyCredentials(accountName, accountKey));
-        return client;
+        return new CloudQueue(uri, newAccountKeyCredentials(accountName, accountKey));
     }
 
     public static CloudQueue createQueueClient() throws Exception {

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/common/MissingCredentialsTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/common/MissingCredentialsTest.java
@@ -27,7 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.apache.camel.component.azure.blob.BlobServiceComponent.MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE;
+import static org.apache.camel.component.azure.blob.BlobServiceComponent.MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE;
 import static org.apache.camel.component.azure.common.AzureServiceCommonTestUtil.ACCOUNT_NAME;
 import static org.apache.camel.component.azure.common.AzureServiceCommonTestUtil.BLOB_NAME;
 import static org.apache.camel.component.azure.common.AzureServiceCommonTestUtil.CONTAINER_NAME;
@@ -93,7 +93,7 @@ public class MissingCredentialsTest extends CamelTestSupport {
     // Missing Credentials Blob Tests
     @Test
     public void createBlobEndpointWithoutCredentials() {
-        createEndpointWithoutCredentials(missingCredentialsBlobUriEndoint, MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE);
+        createEndpointWithoutCredentials(missingCredentialsBlobUriEndoint, MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -105,12 +105,12 @@ public class MissingCredentialsTest extends CamelTestSupport {
 
     @Test
     public void createBlobEndpointWithoutCredentialsAccountName() {
-        createEndpointWithoutCredentials(missingCredentialsAccountNameBlobUriEndoint, MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE);
+        createEndpointWithoutCredentials(missingCredentialsAccountNameBlobUriEndoint, MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void createBlobEndpointWithoutCredentialsAccountKey() {
-        createEndpointWithoutCredentials(missingCredentialsAccountKeyBlobUriEndoint, MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE);
+        createEndpointWithoutCredentials(missingCredentialsAccountKeyBlobUriEndoint, MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE);
     }
 
     // Missing Credentials Queue Tests
@@ -147,7 +147,7 @@ public class MissingCredentialsTest extends CamelTestSupport {
     @Test
     public void testBlobClientWithoutAnonymousCredentials() throws Exception {
         exceptionRule.expect(ResolveEndpointFailedException.class);
-        exceptionRule.expectMessage(MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE);
+        exceptionRule.expectMessage(MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE);
         CloudBlockBlob client =
                 new CloudBlockBlob(URI.create("https://camelazure.blob.core.windows.net/container/blob"),
                         StorageCredentialsAnonymous.ANONYMOUS);
@@ -158,7 +158,7 @@ public class MissingCredentialsTest extends CamelTestSupport {
     @Test
     public void testBlobClientWithoutCredentials() throws Exception {
         exceptionRule.expect(ResolveEndpointFailedException.class);
-        exceptionRule.expectMessage(MISSING_BLOB_CREDNTIALS_EXCEPTION_MESSAGE);
+        exceptionRule.expectMessage(MISSING_BLOB_CREDENTIALS_EXCEPTION_MESSAGE);
         CloudBlockBlob client =
                 new CloudBlockBlob(URI.create("https://camelazure.blob.core.windows.net/container/blob"));
         context.getRegistry().bind("azureBlobClient", client);

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/queue/QueueServiceComponentClientConfigurationTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/queue/QueueServiceComponentClientConfigurationTest.java
@@ -23,8 +23,6 @@ import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.core.Base64;
 import com.microsoft.azure.storage.queue.CloudQueue;
 import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
@@ -129,11 +127,8 @@ public class QueueServiceComponentClientConfigurationTest extends CamelTestSuppo
     
     
     private static void createConsumer(Endpoint endpoint) throws Exception {
-        endpoint.createConsumer(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                // noop
-            }
+        endpoint.createConsumer(exchange -> {
+            // noop
         });
     }
     

--- a/components/camel-azure/src/test/java/org/apache/camel/component/azure/queue/QueueServiceComponentConfigurationTest.java
+++ b/components/camel-azure/src/test/java/org/apache/camel/component/azure/queue/QueueServiceComponentConfigurationTest.java
@@ -23,8 +23,6 @@ import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.core.Base64;
 import com.microsoft.azure.storage.queue.CloudQueue;
 import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
 
@@ -129,11 +127,8 @@ public class QueueServiceComponentConfigurationTest extends CamelTestSupport {
     
     
     private static void createConsumer(Endpoint endpoint) throws Exception {
-        endpoint.createConsumer(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                // noop
-            }
+        endpoint.createConsumer(exchange -> {
+            // noop
         });
     }
     


### PR DESCRIPTION
[JIRA TASK](https://issues.apache.org/jira/browse/CAMEL-13462)

Using custom header to override blob name in the producer.
Use lambda expressions in tests where it's possible.