### PR TITLE
Fix potential race condition in double-checked locking object initial…

### DIFF
--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockExpressionClause.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockExpressionClause.java
@@ -433,11 +433,12 @@ public class MockExpressionClause<T> implements Expression, Predicate {
         if (expr == null) {
             synchronized (this) {
                 if (expr == null) {
-                    expr = getExpressionValue();
-                    if (expr == null) {
-                        expr = getExpressionType().createExpression(context);
+                    Expression newExpression = getExpressionValue();
+                    if (newExpression == null) {
+                        newExpression = getExpressionType().createExpression(context);
                     }
-                    expr.init(context);
+                    newExpression.init(context);
+                    expr = newExpression;
                 }
             }
         }

--- a/core/camel-core-engine/src/main/java/org/apache/camel/builder/ExpressionClause.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/builder/ExpressionClause.java
@@ -946,11 +946,12 @@ public class ExpressionClause<T> implements Expression, Predicate {
         if (expr == null) {
             synchronized (this) {
                 if (expr == null) {
-                    expr = getExpressionValue();
-                    if (expr == null) {
-                        expr = delegate.getExpressionType().createExpression(context);
+                    Expression newExpression = getExpressionValue();
+                    if (newExpression == null) {
+                        newExpression = delegate.getExpressionType().createExpression(context);
                     }
-                    expr.init(context);
+                    newExpression.init(context);
+                    expr = newExpression;
                 }
             }
         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
@@ -695,8 +695,9 @@ public class ExpressionBuilder {
                             if (lan != null) {
                                 pred = lan.createPredicate(expression);
                                 pred.init(context);
-                                expr = lan.createExpression(expression);
-                                expr.init(context);
+                                Expression newExpression = lan.createExpression(expression);
+                                newExpression.init(context);
+                                expr = newExpression;
                             } else {
                                 throw new NoSuchLanguageException(language);
                             }


### PR DESCRIPTION
…ization (as reported by lgtm.com) by making the assignment to the shared variable the last statement of the synchronized block.

See: https://lgtm.com/projects/g/apache/camel/?mode=tree&ruleFocus=1507076816054