### PR TITLE
Make ByteArrayOutputStream to String conversion simpler and more effi…

### DIFF
--- a/components/camel-any23/src/main/java/org/apache/camel/dataformat/any23/Any23DataFormat.java
+++ b/components/camel-any23/src/main/java/org/apache/camel/dataformat/any23/Any23DataFormat.java
@@ -112,7 +112,7 @@ public class Any23DataFormat extends ServiceSupport implements DataFormat, DataF
         if (outputFormat == Any23OutputFormat.RDF4JMODEL) {
             respon = ((RDF4JModelWriter)handler).getModel();
         } else {
-            respon = new String(out.toByteArray());
+            respon = out.toString();
         }
         return respon;
 

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2Utils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2Utils.java
@@ -105,7 +105,7 @@ public final class AS2Utils {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 PrintStream ps = new PrintStream(baos, true, "utf-8")) {
             printRequest(ps, request);
-            String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+            String content = baos.toString(StandardCharsets.UTF_8.name());
             return content;
         }
     }
@@ -114,7 +114,7 @@ public final class AS2Utils {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 PrintStream ps = new PrintStream(baos, true, "utf-8")) {
             printMessage(ps, message);
-            String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+            String content = baos.toString(StandardCharsets.UTF_8.name());
             return content;
         }
     }

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/EntityUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/EntityUtils.java
@@ -274,7 +274,7 @@ public final class EntityUtils {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              PrintStream ps = new PrintStream(baos, true, "utf-8")) {
             printEntity(ps, entity);
-            String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+            String content = baos.toString(StandardCharsets.UTF_8.name());
             return content;
         }
     }

--- a/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneIndexer.java
+++ b/components/camel-lucene/src/main/java/org/apache/camel/component/lucene/LuceneIndexer.java
@@ -134,7 +134,7 @@ public class LuceneIndexer {
                 try (InputStream is = new FileInputStream(file)) {
                     ByteArrayOutputStream bos = new ByteArrayOutputStream();
                     IOHelper.copy(IOHelper.buffered(is), bos);
-                    contents = new String(bos.toByteArray());
+                    contents = bos.toString();
                 }
                 openIndexWriter();
                 add("path", file.getPath(), false);

--- a/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshHelper.java
+++ b/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshHelper.java
@@ -193,7 +193,7 @@ public final class SshHelper {
 
         while (!channel.isClosed()) {
 
-            String response = new String(output.toByteArray(), "UTF-8");
+            String response = output.toString("UTF-8");
             if (response.trim().endsWith(endpoint.getShellPrompt())) {
                 output.reset();
                 return SshShellOutputStringHelper.betweenBeforeLast(response, System.lineSeparator(), System.lineSeparator());

--- a/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/processor/XmlSignerProcessor.java
+++ b/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/processor/XmlSignerProcessor.java
@@ -620,7 +620,7 @@ public class XmlSignerProcessor extends XmlSignatureProcessor {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         IOHelper.copyAndCloseInput(is, bos);
         try {
-            String text = new String(bos.toByteArray(), encoding);
+            String text = bos.toString(encoding);
             return XmlSignatureHelper.newDocumentBuilder(true).newDocument().createTextNode(text);
         } catch (UnsupportedEncodingException e) {
             throw new XmlSignatureException(String.format("The message encoding %s is not supported.", encoding), e);


### PR DESCRIPTION
…cient (avoid copying the underling byte array) by using ByteArrayOutputStream#toString.

Similar to https://github.com/spring-projects/spring-framework/pull/24785

The copy of the byte array is also created on Java 11.