### PR TITLE
Delete IOHelper#newStringFromBytes?

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/util/IOHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/util/IOHelperTest.java
@@ -50,18 +50,6 @@ public class IOHelperTest extends Assert {
     }
 
     @Test
-    public void testNewStringFromBytes() {
-        String s = IOHelper.newStringFromBytes("Hello".getBytes());
-        assertEquals("Hello", s);
-    }
-
-    @Test
-    public void testNewStringFromBytesWithStart() {
-        String s = IOHelper.newStringFromBytes("Hello".getBytes(), 2, 3);
-        assertEquals("llo", s);
-    }
-
-    @Test
     public void testCopyAndCloseInput() throws Exception {
         InputStream is = new ByteArrayInputStream("Hello".getBytes());
         OutputStream os = new ByteArrayOutputStream();

--- a/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
@@ -40,7 +40,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.function.Supplier;
 
@@ -65,22 +64,6 @@ public final class IOHelper {
 
     private IOHelper() {
         // Utility Class
-    }
-
-    /**
-     * Use this function instead of new String(byte[]) to avoid surprises from
-     * non-standard default encodings.
-     */
-    public static String newStringFromBytes(byte[] bytes) {
-        return new String(bytes, StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Use this function instead of new String(byte[], int, int) to avoid
-     * surprises from non-standard default encodings.
-     */
-    public static String newStringFromBytes(byte[] bytes, int start, int length) {
-        return new String(bytes, start, length, StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
`git grep` does not show any usage in `camel-core`.

Maybe it should it be deprecated instead?

(I will update the pull request with an entry to the update guide if this pull request is accepted.)

