### PR TITLE
[CAMEL-14818] fixes documentation for Camel Package Maven plugin

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide.adoc
@@ -321,6 +321,32 @@ To the following:
           </execution>
         </executions>
       </plugin>
+      <!--
+      Recompile source after generated loader classes have been created.
+      The maven-compiler-plugin must be defined in the POM after the
+      camel-package-maven-plugin so recompile runs after generated
+      sources have been created.
+
+      Adjust configuration for the JDK version your project uses.
+      -->
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+              <source>1.11</source>
+              <target>1.11</target>
+          </configuration>
+          <executions>
+              <execution>
+                  <id>recompile</id>
+                  <goals>
+                      <goal>compile</goal>
+                  </goals>
+                  <phase>process-classes</phase>
+              </execution>
+          </executions>
+      </plugin>
 ----
 
 === API changes


### PR DESCRIPTION
sources for type converter loaders were generated too late in the Maven
build cycle. The result is that the source would be generated after the
compile, test compile, and test phases, so they would not be available
to unit tests.

~~The fix is to run the maven plugin in the `pre-compile` phase rather
than `process-classes`.~~

The fix is to have Maven re-compile after type converter loaders have been generated. The PR documents how to configure maven-compiler-plugin to do so.
