### PR TITLE
[CAMEL-14292] Fixes NoClassDefFoundError in camel-google-pubsub, references util class from google-http-client

### DIFF
--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConnectionFactory.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConnectionFactory.java
@@ -30,9 +30,9 @@ import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.Base64;
-import com.google.api.client.util.Strings;
 import com.google.api.services.pubsub.Pubsub;
 import com.google.api.services.pubsub.PubsubScopes;
+import org.apache.camel.util.ObjectHelper;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -80,14 +80,14 @@ public class GooglePubsubConnectionFactory {
 
         GoogleCredential credential = null;
 
-        if (!Strings.isNullOrEmpty(serviceAccount) && !Strings.isNullOrEmpty(serviceAccountKey)) {
+        if (!ObjectHelper.isEmpty(serviceAccount) && !ObjectHelper.isEmpty(serviceAccountKey)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Service Account and Key have been set explicitly. Initialising PubSub using Service Account " + serviceAccount);
             }
             credential = createFromAccountKeyPair(httpTransport);
         }
 
-        if (credential == null && !Strings.isNullOrEmpty(credentialsFileLocation)) {
+        if (credential == null && !ObjectHelper.isEmpty(credentialsFileLocation)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Key File Name has been set explicitly. Initialising PubSub using Key File " + credentialsFileLocation);
             }

--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
@@ -20,7 +20,6 @@ import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.api.services.pubsub.Pubsub;
 import com.google.api.services.pubsub.model.PubsubMessage;
 import com.google.api.services.pubsub.model.PullRequest;
@@ -31,6 +30,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.google.pubsub.consumer.ExchangeAckTransaction;
 import org.apache.camel.impl.DefaultConsumer;
 import org.apache.camel.spi.Synchronization;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ class GooglePubsubConsumer extends DefaultConsumer {
 
         String loggerId = endpoint.getLoggerId();
 
-        if (Strings.isNullOrEmpty(loggerId)) {
+        if (ObjectHelper.isEmpty(loggerId)) {
             loggerId = this.getClass().getName();
         }
 

--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.google.pubsub;
 
 import java.util.concurrent.ExecutorService;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.api.services.pubsub.Pubsub;
 import org.apache.camel.Component;
 import org.apache.camel.Consumer;

--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubProducer.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubProducer.java
@@ -23,12 +23,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.api.client.util.Strings;
 import com.google.api.services.pubsub.model.PublishRequest;
 import com.google.api.services.pubsub.model.PublishResponse;
 import com.google.api.services.pubsub.model.PubsubMessage;
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultProducer;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ public class GooglePubsubProducer extends DefaultProducer {
 
         String loggerId = endpoint.getLoggerId();
 
-        if (Strings.isNullOrEmpty(loggerId)) {
+        if (ObjectHelper.isEmpty(loggerId)) {
             loggerId = this.getClass().getName();
         }
 

--- a/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/consumer/PubsubAcknowledgement.java
+++ b/components/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/consumer/PubsubAcknowledgement.java
@@ -18,10 +18,10 @@ package org.apache.camel.component.google.pubsub.consumer;
 
 import java.util.List;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.api.services.pubsub.model.AcknowledgeRequest;
 import com.google.api.services.pubsub.model.ModifyAckDeadlineRequest;
 import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public abstract class PubsubAcknowledgement {
 
         String loggerId = endpoint.getLoggerId();
 
-        if (Strings.isNullOrEmpty(loggerId)) {
+        if (ObjectHelper.isEmpty(loggerId)) {
             loggerId = this.getClass().getName();
         }
 


### PR DESCRIPTION
I'm still seeing this issue in 2.25.0: https://issues.apache.org/jira/browse/CAMEL-14292

I have removed the remaining references to `com.google.api.client.repackaged.com.google.common.base.Strings`
which is the main problem.

Also decided to remove the remaining calls to `com.google.api.client.util.Strings` and instead use `org.apache.camel.util.ObjectHelper` as it seemed natural to me to use an internal string util.
For the GooglePubsubConnectionFactory we're using so many com.google.api.client imports anyways that I was in doubt - but made the same change there.

Let me know if you want any modifications and I'll push it right away. Tested locally and my app now loads without the exception I got before:

```
java.lang.NoClassDefFoundError: com/google/api/client/repackaged/com/google/common/base/Strings
	at org.apache.camel.component.google.pubsub.consumer.PubsubAcknowledgement.<init>(PubsubAcknowledgement.java:43) ~[camel-google-pubsub-2.25.0.jar:2.25.0]
	at org.apache.camel.component.google.pubsub.consumer.ExchangeAckTransaction.<init>(ExchangeAckTransaction.java:30) ~[camel-google-pubsub-2.25.0.jar:2.25.0]
	at org.apache.camel.component.google.pubsub.GooglePubsubConsumer.<init>(GooglePubsubConsumer.java:52) ~[camel-google-pubsub-2.25.0.jar:2.25.0]
	at org.apache.camel.component.google.pubsub.GooglePubsubEndpoint.createConsumer(GooglePubsubEndpoint.java:112) ~[camel-google-pubsub-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.EventDrivenConsumerRoute.addServices(EventDrivenConsumerRoute.java:69) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultRoute.onStartingServices(DefaultRoute.java:107) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.RouteService.doWarmUp(RouteService.java:172) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.RouteService.warmUp(RouteService.java:145) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.doWarmUpRoutes(DefaultCamelContext.java:3954) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.safelyStartRouteServices(DefaultCamelContext.java:3861) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.doStartOrResumeRoutes(DefaultCamelContext.java:3647) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.doStartCamel(DefaultCamelContext.java:3488) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext$4.call(DefaultCamelContext.java:3247) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext$4.call(DefaultCamelContext.java:3243) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.doWithDefinedClassLoader(DefaultCamelContext.java:3266) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.doStart(DefaultCamelContext.java:3243) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.support.ServiceSupport.start(ServiceSupport.java:72) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.impl.DefaultCamelContext.start(DefaultCamelContext.java:3159) ~[camel-core-2.25.0.jar:2.25.0]
	at org.apache.camel.spring.SpringCamelContext.start(SpringCamelContext.java:133) ~[camel-spring-2.25.0.jar:2.25.0]
	at org.apache.camel.spring.SpringCamelContext.onApplicationEvent(SpringCamelContext.java:174) ~[camel-spring-2.25.0.jar:2.25.0]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:403) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:360) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:897) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.finishRefresh(ServletWebServerApplicationContext.java:162) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:553) ~[spring-context-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:141) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:747) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:315) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1215) ~[spring-boot-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.cloudwheel.lowell.aptic.orchestrator.ApticOrchestratorKt.main(ApticOrchestrator.kt:13) ~[classes/:na]
Caused by: java.lang.ClassNotFoundException: com.google.api.client.repackaged.com.google.common.base.Strings
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521) ~[na:na]
	... 35 common frames omitted
```

PS: I see there are a couple of references to google Strings util on the master branch as well. If you'd like I can also submit a PR for those.

[x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[x] Each commit in the pull request should have a meaningful subject line and body.
[x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md