### PR TITLE
CAMEL-14827: Site Documentation Improvement within Camel 

### DIFF
--- a/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
+++ b/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
@@ -120,18 +120,18 @@ You can use your cache with the following code:
 
 [source,java]
 ------------------------------------------------------------
-    @Override
-    protected RouteBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            public void configure() {
-                from("direct://start")
-                    .toF("caffeine-cache://%s?cache=#cache&action=PUT&key=1", "test")
-                    .toF("caffeine-cache://%s?cache=#cache&key=1&action=GET", "test")
-                    .log("Test! ${body}")
-                    .to("mock:result");
-            }
-        };
-    }
+@Override
+protected RouteBuilder createRouteBuilder() throws Exception {
+    return new RouteBuilder() {
+        public void configure() {
+            from("direct://start")
+                .toF("caffeine-cache://%s?cache=#cache&action=PUT&key=1", "test")
+                .toF("caffeine-cache://%s?cache=#cache&key=1&action=GET", "test")
+                .log("Test! ${body}")
+                .to("mock:result");
+        }
+    };
+}
 ------------------------------------------------------------
 
 In this way you'll work always on the same cache in the registry.

--- a/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
+++ b/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
@@ -48,22 +48,22 @@ tag.
 
 [source,xml]
 -----------------------------------------------------------------------------------------------------------------------------
-        <dataFormats>
-            <!-- here we define a CBOR data format with the id test and that it should use the TestPojo as the class type when
-                 doing unmarshal. -->
-            <cbor id="test" unmarshalTypeName="org.apache.camel.component.cbor.TestPojo"/>
-        </dataFormats>
+<dataFormats>
+    <!-- here we define a CBOR data format with the id test and that it should use the TestPojo as the class type when
+    doing unmarshal. -->
+    <cbor id="test" unmarshalTypeName="org.apache.camel.component.cbor.TestPojo"/>
+</dataFormats>
 -----------------------------------------------------------------------------------------------------------------------------
 
 And then you can refer to this id in the route:
 
 [source,xml]
 -------------------------------------
-       <route>
-            <from uri="direct:back"/>
-            <unmarshal><custom ref="test"/></unmarshal>
-            <to uri="mock:reverse"/>
-        </route>
+<route>
+    <from uri="direct:back"/>
+    <unmarshal><custom ref="test"/></unmarshal>
+    <to uri="mock:reverse"/>
+</route>
 -------------------------------------
 
 == Dependencies
@@ -71,9 +71,9 @@ And then you can refer to this id in the route:
 [source,java]
 -------------------------------------
 <dependency>
-  <groupId>org.apache.camel</groupId>
-  <artifactId>camel-cbor</artifactId>
-  <version>x.x.x</version>
+   <groupId>org.apache.camel</groupId>
+   <artifactId>camel-cbor</artifactId>
+   <version>x.x.x</version>
 </dependency>
 -------------------------------------
 

--- a/components/camel-chunk/src/main/docs/chunk-component.adoc
+++ b/components/camel-chunk/src/main/docs/chunk-component.adoc
@@ -18,9 +18,9 @@ their `pom.xml` for this component:
 [source,xml]
 ---------------------------------------------------------------------------------
 <dependency>
-<groupId>org.apache.camel</groupId>
-<artifactId>camel-chunk</artifactId>
-<version>x.x.x</version> <!-- use the same version as your Camel core version -->
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-chunk</artifactId>
+    <version>x.x.x</version> <!-- use the same version as your Camel core version -->
 </dependency>
 ---------------------------------------------------------------------------------
 

--- a/components/camel-hl7/src/main/docs/hl7terser-language.adoc
+++ b/components/camel-hl7/src/main/docs/hl7terser-language.adoc
@@ -29,17 +29,17 @@ The HL7 Terser language supports 1 options, which are listed below.
 
 [source,java]
 ----
-   import static org.apache.camel.component.hl7.HL7.hl7terser;
+import static org.apache.camel.component.hl7.HL7.hl7terser;
 
-   // extract patient ID from field QRD-8 in the QRY_A19 message above and put into message header
-   from("direct:test1")
-      .setHeader("PATIENT_ID", hl7terser("QRD-8(0)-1"))
-      .to("mock:test1");
+// extract patient ID from field QRD-8 in the QRY_A19 message above and put into message header
+from("direct:test1")
+   .setHeader("PATIENT_ID", hl7terser("QRD-8(0)-1"))
+   .to("mock:test1");
 
-   // continue processing if extracted field equals a message header
-   from("direct:test2")
-      .filter(hl7terser("QRD-8(0)-1").isEqualTo(header("PATIENT_ID"))
-      .to("mock:test2");
+// continue processing if extracted field equals a message header
+from("direct:test2")
+   .filter(hl7terser("QRD-8(0)-1").isEqualTo(header("PATIENT_ID"))
+   .to("mock:test2");
 ----
 
 == HL7 Validation predicate
@@ -55,13 +55,13 @@ Sample:
 import static org.apache.camel.component.hl7.HL7.messageConformsTo;
 import ca.uhn.hl7v2.validation.impl.DefaultValidation;
 
-   // Use standard or define your own validation rules
-   ValidationContext defaultContext = new DefaultValidation();
+// Use standard or define your own validation rules
+ValidationContext defaultContext = new DefaultValidation();
 
-   // Throws PredicateValidationException if message does not validate
-   from("direct:test1")
-      .validate(messageConformsTo(defaultContext))
-      .to("mock:test1");
+// Throws PredicateValidationException if message does not validate
+from("direct:test1")
+   .validate(messageConformsTo(defaultContext))
+   .to("mock:test1");
 ----
 
 == HL7 Validation predicate using the HapiContext
@@ -78,30 +78,30 @@ can be easily reused:
 [source,java]
 ----
 import static org.apache.camel.component.hl7.HL7.messageConformsTo;
-import static org.apache.camel.component.hl7.HL7.messageConforms
+import static org.apache.camel.component.hl7.HL7.messageConforms;
 
-  HapiContext hapiContext = new DefaultHapiContext();
-  hapiContext.getParserConfiguration().setValidating(false); // don't validate during parsing
+HapiContext hapiContext = new DefaultHapiContext();
+hapiContext.getParserConfiguration().setValidating(false); // don't validate during parsing
 
-  // customize HapiContext some more ... e.g. enforce that PID-8 in ADT_A01 messages of version 2.4 is not empty
-  ValidationRuleBuilder builder = new ValidationRuleBuilder() {
-      @Override
-      protected void configure() {
-         forVersion(Version.V24)
-              .message("ADT", "A01")
-              .terser("PID-8", not(empty()));
-         }
-      };
-  hapiContext.setValidationRuleBuilder(builder);
+// customize HapiContext some more ... e.g. enforce that PID-8 in ADT_A01 messages of version 2.4 is not empty
+ValidationRuleBuilder builder = new ValidationRuleBuilder() {
+   @Override
+   protected void configure() {
+      forVersion(Version.V24)
+         .message("ADT", "A01")
+         .terser("PID-8", not(empty()));
+   }
+};
+hapiContext.setValidationRuleBuilder(builder);
 
-  HL7DataFormat hl7 = new HL7DataFormat();
-  hl7.setHapiContext(hapiContext);
+HL7DataFormat hl7 = new HL7DataFormat();
+hl7.setHapiContext(hapiContext);
 
-  from("direct:test1")
-     .unmarshal(hl7)                // uses the GenericParser returned from the HapiContext
-     .validate(messageConforms())   // uses the validation rules returned from the HapiContext
+from("direct:test1")
+  .unmarshal(hl7)                // uses the GenericParser returned from the HapiContext
+  .validate(messageConforms())   // uses the validation rules returned from the HapiContext
                                     // equivalent with .validate(messageConformsTo(hapiContext))
-     // route continues from here
+   // route continues from here
 ----
 
 == HL7 Acknowledgement expression
@@ -117,19 +117,19 @@ import static org.apache.camel.component.hl7.HL7.messageConformsTo;
 import static org.apache.camel.component.hl7.HL7.ack;
 import ca.uhn.hl7v2.validation.impl.DefaultValidation;
 
-  // Use standard or define your own validation rules
-   ValidationContext defaultContext = new DefaultValidation();
+// Use standard or define your own validation rules
+ValidationContext defaultContext = new DefaultValidation();
 
-   from("direct:test1")
-      .onException(Exception.class)
-         .handled(true)
-         .transform(ack()) // auto-generates negative ack because of exception in Exchange
-         .end()
-      .validate(messageConformsTo(defaultContext))
-      // do something meaningful here
+from("direct:test1")
+   .onException(Exception.class)
+      .handled(true)
+      .transform(ack()) // auto-generates negative ack because of exception in Exchange
+      .end()
+   .validate(messageConformsTo(defaultContext))
+   // do something meaningful here
 
-      // acknowledgement
-      .transform(ack())
+   // acknowledgement
+  .transform(ack())
 ----
 
 include::camel-spring-boot::page$hl7-starter.adoc[]

--- a/components/camel-ognl/src/main/docs/ognl-language.adoc
+++ b/components/camel-ognl/src/main/docs/ognl-language.adoc
@@ -89,7 +89,7 @@ And the sample using Java DSL:
 
 [source,java]
 ---------------------------------------------------------------------------------
-   from("seda:foo").filter().ognl("request.headers.foo == 'bar'").to("seda:bar");
+from("seda:foo").filter().ognl("request.headers.foo == 'bar'").to("seda:bar");
 ---------------------------------------------------------------------------------
 
 == Loading script from external resource


### PR DESCRIPTION
* I have observed that the code snippets aren't properly indentation and structured well. This is present for various documentation pages. Hence, I have resolved this issue by structuring the indentation and removing any redundant spaces for a few documentation pages.