### PR TITLE
Change xref links for splitting FAQ in camel-2.x

### DIFF
--- a/camel-core/src/main/docs/modules/ROOT/pages/properties-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/properties-component.adoc
@@ -96,7 +96,7 @@ This works much like you would do if using Spring's
 `<property-placeholder>` tag. However Spring have a limitation which
 prevents 3rd party frameworks to leverage Spring property placeholders
 to the fullest. See more at
-xref:latest@manual::faq/how-do-i-use-spring-property-placeholder-with-camel-xml.adoc[How do
+xref:latest@manual:faq:how-do-i-use-spring-property-placeholder-with-camel-xml.adoc[How do
 I use Spring Property Placeholder with Camel XML].
 
 [TIP]

--- a/camel-core/src/main/docs/modules/ROOT/pages/timer-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/timer-component.adoc
@@ -29,7 +29,7 @@ advanced scheduling.
 
 TIP:*Specify time in human friendly format*
 In *Camel 2.3* onwards you can specify the time in
-xref:latest@manual::faq/how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
+xref:latest@manual:faq:how-do-i-specify-time-period-in-a-human-friendly-syntax.adoc[human
 friendly syntax].
 
 

--- a/camel-core/src/main/docs/modules/ROOT/pages/xslt-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/xslt-component.adoc
@@ -278,7 +278,7 @@ With Spring XML:
 == Dynamic stylesheets
 
 To provide a dynamic stylesheet at runtime you can define a dynamic URI.
-See xref:latest@manual::faq/how-to-use-a-dynamic-uri-in-to.adoc[How to use a dynamic URI in
+See xref:latest@manual:faq:how-to-use-a-dynamic-uri-in-to.adoc[How to use a dynamic URI in
 to()] for more information.
 
 *Available as of Camel 2.9 (removed in 2.11.4, 2.12.3 and 2.13.0)*

--- a/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
+++ b/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
@@ -47,7 +47,7 @@ beanstalk://localhost:11300/tube1+tube2
 
 Tube name will be URL decoded, so if your tube names include special
 characters like + or ?, you need to URL-encode them appropriately, or
-use the RAW syntax, see xref:latest@manual::faq/how-do-i-configure-endpoints.adoc[more
+use the RAW syntax, see xref:latest@manual:faq:how-do-i-configure-endpoints.adoc[more
 details here].
 
 By the way, you cannot specify several tubes when you are writing jobs

--- a/components/camel-jetty9/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty9/src/main/docs/jetty-component.adoc
@@ -315,7 +315,7 @@ If you need to expose a Jetty endpoint on all network interfaces, the
 `0.0.0.0` address should be used.
 
 To listen across an entire URI prefix, see
-xref:latest@manual::faq/how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match
+xref:latest@manual:faq:how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match
 wildcards].
 
 If you actually want to expose routes by HTTP and already have a

--- a/components/camel-spring/src/main/docs/spring.adoc
+++ b/components/camel-spring/src/main/docs/spring.adoc
@@ -337,7 +337,7 @@ SpringCamelContext lazily fetching components from the spring context
 for the scheme name you use for Endpoint
 URIs.
 
-For more detail see xref:latest@manual::faq/how-do-i-configure-endpoints.adoc[Configuring
+For more detail see xref:latest@manual:faq:how-do-i-configure-endpoints.adoc[Configuring
 Endpoints and Components].
 
 == CamelContextAware

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -220,7 +220,7 @@ If you need to expose an Undertow endpoint on all network interfaces, the
 `0.0.0.0` address should be used.
 
 To listen across an entire URI prefix, see
-xref:latest@manual::faq/how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match wildcards].
+xref:latest@manual:faq:how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match wildcards].
 
 If you actually want to expose routes by HTTP and already have a
 Servlet, you should instead refer to the

--- a/components/camel-zipkin/src/main/docs/zipkin.adoc
+++ b/components/camel-zipkin/src/main/docs/zipkin.adoc
@@ -75,14 +75,14 @@ uses the rules from Intercept.
 |includeMessageBody |false |Whether to include the Camel message body in the zipkin traces.
 This is not recommended for production usage, or when having big
 payloads. You can limit the size by configuring the
-xref:latest@manual::faq/how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
+xref:latest@manual:faq:how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
 debug log size]. 
 
 |includeMessageBodyStreams |false |Whether to include message bodies that are stream based in the zipkin
 traces. This requires enabling streamcaching on the
 routes or globally on the CamelContext. This is not recommended for production usage, or when having big
 payloads. You can limit the size by configuring the
-xref:latest@manual::faq/how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
+xref:latest@manual:faq:how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
 debug log size].  
 |===
 

--- a/docs/components/modules/ROOT/pages/beanstalk-component.adoc
+++ b/docs/components/modules/ROOT/pages/beanstalk-component.adoc
@@ -48,7 +48,7 @@ beanstalk://localhost:11300/tube1+tube2
 
 Tube name will be URL decoded, so if your tube names include special
 characters like + or ?, you need to URL-encode them appropriately, or
-use the RAW syntax, see xref:latest@manual::faq/how-do-i-configure-endpoints.adoc[more
+use the RAW syntax, see xref:latest@manual:faq:how-do-i-configure-endpoints.adoc[more
 details here].
 
 By the way, you cannot specify several tubes when you are writing jobs

--- a/docs/components/modules/ROOT/pages/jetty-component.adoc
+++ b/docs/components/modules/ROOT/pages/jetty-component.adoc
@@ -316,7 +316,7 @@ If you need to expose a Jetty endpoint on all network interfaces, the
 `0.0.0.0` address should be used.
 
 To listen across an entire URI prefix, see
-xref:latest@manual::faq/how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match
+xref:latest@manual:faq:how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match
 wildcards].
 
 If you actually want to expose routes by HTTP and already have a

--- a/docs/components/modules/ROOT/pages/spring.adoc
+++ b/docs/components/modules/ROOT/pages/spring.adoc
@@ -338,7 +338,7 @@ SpringCamelContext lazily fetching components from the spring context
 for the scheme name you use for Endpoint
 URIs.
 
-For more detail see xref:latest@manual::faq/how-do-i-configure-endpoints.adoc[Configuring
+For more detail see xref:latest@manual:faq:how-do-i-configure-endpoints.adoc[Configuring
 Endpoints and Components].
 
 == CamelContextAware

--- a/docs/components/modules/ROOT/pages/undertow-component.adoc
+++ b/docs/components/modules/ROOT/pages/undertow-component.adoc
@@ -221,7 +221,7 @@ If you need to expose an Undertow endpoint on all network interfaces, the
 `0.0.0.0` address should be used.
 
 To listen across an entire URI prefix, see
-xref:latest@manual::faq/how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match wildcards].
+xref:latest@manual:faq:how-do-i-let-jetty-match-wildcards.adoc[How do I let Jetty match wildcards].
 
 If you actually want to expose routes by HTTP and already have a
 Servlet, you should instead refer to the

--- a/docs/components/modules/ROOT/pages/zipkin.adoc
+++ b/docs/components/modules/ROOT/pages/zipkin.adoc
@@ -76,14 +76,14 @@ uses the rules from Intercept.
 |includeMessageBody |false |Whether to include the Camel message body in the zipkin traces.
 This is not recommended for production usage, or when having big
 payloads. You can limit the size by configuring the
-xref:latest@manual::faq/how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
+xref:latest@manual:faq:how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
 debug log size]. 
 
 |includeMessageBodyStreams |false |Whether to include message bodies that are stream based in the zipkin
 traces. This requires enabling streamcaching on the
 routes or globally on the CamelContext. This is not recommended for production usage, or when having big
 payloads. You can limit the size by configuring the
-xref:latest@manual::faq/how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
+xref:latest@manual:faq:how-do-i-set-the-max-chars-when-debug-logging-messages-in-camel.adoc[max
 debug log size].  
 |===
 


### PR DESCRIPTION
Changing xref links for splitting FAQ into a separate module within user-manual. Changes are corresponding to PR #3693 on master.