### PR TITLE
Update DefaultShutdownStrategy documented package and add migration note

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -125,6 +125,10 @@ The classes from `org.apache.camel.impl` that are intended to support Camel deve
 
 The `LanguageAnnotation` annotation class has been moved from package `org.apache.camel.language` to `org.apache.camel.support.language`.
 
+== Migrating DefaultShutdownStrategy
+
+The `DefaultShutdownStrategy` class has been moved from package `org.apache.camel.impl` to `org.apache.camel.impl.engine`.
+
 == Deprecated APIs and Components
 
 All deprecated APIs and components from Camel 2.x have been removed in Camel 3.
@@ -383,9 +387,9 @@ is now SHA256withRSA (before it was SHA1WithDSA).
 
 === Crypto DataFormat
 
-The default encryption algorithm has changed for the Crypto (JCE) DataFormat - 
+The default encryption algorithm has changed for the Crypto (JCE) DataFormat -
 it is now required to set a value for it (meaning that the default is null).
-Before the default value was "DES/CBC/PKCS5Padding". 
+Before the default value was "DES/CBC/PKCS5Padding".
 
 === JSon DataFormat
 

--- a/docs/user-manual/modules/ROOT/pages/graceful-shutdown.adoc
+++ b/docs/user-manual/modules/ROOT/pages/graceful-shutdown.adoc
@@ -9,7 +9,7 @@ the problem at hand with properly shutting down all the routes in a
 reliable manner to the `ShutdownStrategy`.
 
 Camel provides a default strategy in the
-`org.apache.camel.impl.DefaultShutdownStrategy` which is capable of
+`org.apache.camel.impl.engine.DefaultShutdownStrategy` which is capable of
 doing that.
 
 [[GracefulShutdown-DefaultShutdownStrategy]]
@@ -94,7 +94,7 @@ long at the current node (eg delay1) and duration is total time in
 mills.
 
 If you enable DEBUG logging level
-on `org.apache.camel.impl.DefaultShutdownStrategy` then it logs the same
+on `org.apache.camel.impl.engine.DefaultShutdownStrategy` then it logs the same
 inflight exchange information during graceful shutdown
 
 [source,bash]
@@ -118,7 +118,7 @@ context.getShutdownStrategy().setLogInflightExchangesOnTimeout(false);
 == Controlling ordering of routes
 
 You can configure the order in which routes should be started, and thus
-also the same order they are being shutdown. 
+also the same order they are being shutdown.
  See more at
 xref:configuring-route-startup-ordering-and-autostartup.adoc[Configuring
 route startup ordering and autostartup].


### PR DESCRIPTION
Minor documentation update for setting the new `DefaultShutdownStrategy` package. I'm also adding a small note about this in the migration guide.