### PR TITLE
ErrorHandlerReifier#configure: Fix setting of Route#setAllowUseOrigin…

### DIFF
--- a/core/camel-core-engine/src/main/java/org/apache/camel/reifier/errorhandler/ErrorHandlerReifier.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/reifier/errorhandler/ErrorHandlerReifier.java
@@ -305,7 +305,7 @@ public abstract class ErrorHandlerReifier<T extends ErrorHandlerBuilderSupport> 
             }
         }
         if (handler instanceof RedeliveryErrorHandler) {
-            boolean original = ((RedeliveryErrorHandler)handler).isUseOriginalMessagePolicy() || ((RedeliveryErrorHandler)handler).isUseOriginalMessagePolicy();
+            boolean original = ((RedeliveryErrorHandler)handler).isUseOriginalMessagePolicy() || ((RedeliveryErrorHandler)handler).isUseOriginalBodyPolicy();
             if (original) {
                 // ensure allow original is turned on
                 route.setAllowUseOriginalMessage(true);


### PR DESCRIPTION
…alMessage

Use RedeliveryErrorHandler#isUseOriginalBodyPolicy for one of the checks instead of checking for RedeliveryErrorHandler#isUseOriginalMessagePolicy twice.

I guess that was the intention of this code?, which was added in:

Revision: 1e9b9dc228cfcaf60b5026eb1d87f05688954512
Message: CAMEL-13175: Added useOriginalBody as alternative to useOriginalMessage and correct docs.