### PR TITLE
IOHelper#EncodingInputStream#read: Convert read byte into an unsigned…

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
@@ -557,7 +557,7 @@ public final class IOHelper {
                 }
                 bufferBytes = defaultStreamCharset.encode(bufferedChars);
             }
-            return bufferBytes.get();
+            return bufferBytes.get() & 0xFF;
         }
 
         @Override


### PR DESCRIPTION
… byte before returning it.

Sonarqube says the current behavior is a bug, see: https://rules.sonarsource.com/java/RSPEC-4517 for details.