### PR TITLE
CAMEL-14744: fix camel-salesforce lazy-login

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -686,7 +686,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         final String version = endpointConfig.getApiVersion();
         final PayloadFormat format = endpointConfig.getFormat();
 
-        return new DefaultRestClient(httpClient, version, format, session);
+        return new DefaultRestClient(httpClient, version, format, session, loginConfig);
     }
 
     RestClient createRestClient(final Map<String, Object> properties) throws Exception {
@@ -721,7 +721,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         final SalesforceSession session = new SalesforceSession(camelContext, httpClient, httpClient.getTimeout(), loginConfig);
         httpClient.setSession(session);
 
-        return new DefaultRestClient(httpClient, config.getApiVersion(), config.getFormat(), session);
+        return new DefaultRestClient(httpClient, config.getApiVersion(), config.getFormat(), session, loginConfig);
     }
 
     static SalesforceHttpClient createHttpClient(final SslContextFactory sslContextFactory) throws Exception {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultAnalyticsApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultAnalyticsApiClient.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.NoSuchSObjectException;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.TypeReferences;
@@ -58,8 +59,8 @@ public class DefaultAnalyticsApiClient extends AbstractClientBase implements Ana
     private static final String INCLUDE_DETAILS_QUERY_PARAM = "?includeDetails=";
     private ObjectMapper objectMapper;
 
-    public DefaultAnalyticsApiClient(String version, SalesforceSession session, SalesforceHttpClient httpClient) throws SalesforceException {
-        super(version, session, httpClient);
+    public DefaultAnalyticsApiClient(String version, SalesforceSession session, SalesforceHttpClient httpClient, SalesforceLoginConfig loginConfig) throws SalesforceException {
+        super(version, session, httpClient, loginConfig);
 
         objectMapper = JsonUtils.createObjectMapper();
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultBulkApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultBulkApiClient.java
@@ -38,6 +38,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.dto.RestError;
 import org.apache.camel.component.salesforce.api.dto.bulk.BatchInfo;
@@ -65,8 +66,8 @@ public class DefaultBulkApiClient extends AbstractClientBase implements BulkApiC
     private JAXBContext context;
     private ObjectFactory objectFactory;
 
-    public DefaultBulkApiClient(String version, SalesforceSession session, SalesforceHttpClient httpClient) throws SalesforceException {
-        super(version, session, httpClient);
+    public DefaultBulkApiClient(String version, SalesforceSession session, SalesforceHttpClient httpClient, SalesforceLoginConfig loginConfig) throws SalesforceException {
+        super(version, session, httpClient, loginConfig);
 
         try {
             context = JAXBContext.newInstance(JobInfo.class.getPackage().getName(), getClass().getClassLoader());

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultCompositeApiClient.java
@@ -32,6 +32,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.NoSuchSObjectException;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.dto.RestError;
@@ -71,9 +72,9 @@ public class DefaultCompositeApiClient extends AbstractClientBase implements Com
     private final XStream xStreamCompositeTree;
 
     public DefaultCompositeApiClient(final SalesforceEndpointConfig configuration, final PayloadFormat format, final String version, final SalesforceSession session,
-                                     final SalesforceHttpClient httpClient)
+                                     final SalesforceHttpClient httpClient, final SalesforceLoginConfig loginConfig)
         throws SalesforceException {
-        super(version, session, httpClient);
+        super(version, session, httpClient, loginConfig);
         this.format = format;
 
         if (configuration.getObjectMapper() != null) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.XStream;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.NoSuchSObjectException;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.SalesforceMultipleChoicesException;
@@ -60,8 +61,8 @@ public class DefaultRestClient extends AbstractClientBase implements RestClient 
     private ObjectMapper objectMapper;
     private XStream xStream;
 
-    public DefaultRestClient(final SalesforceHttpClient httpClient, final String version, final PayloadFormat format, final SalesforceSession session) throws SalesforceException {
-        super(version, session, httpClient);
+    public DefaultRestClient(final SalesforceHttpClient httpClient, final String version, final PayloadFormat format, final SalesforceSession session, final SalesforceLoginConfig loginConfig) throws SalesforceException {
+        super(version, session, httpClient, loginConfig);
 
         this.format = format;
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AbstractSalesforceProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AbstractSalesforceProcessor.java
@@ -25,6 +25,7 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.component.salesforce.SalesforceComponent;
 import org.apache.camel.component.salesforce.SalesforceEndpoint;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.internal.OperationName;
 import org.apache.camel.component.salesforce.internal.SalesforceSession;
@@ -46,6 +47,7 @@ public abstract class AbstractSalesforceProcessor implements SalesforceProcessor
     protected final OperationName operationName;
     protected final SalesforceSession session;
     protected final SalesforceHttpClient httpClient;
+    protected final SalesforceLoginConfig loginConfig;
     protected final boolean rawPayload;
 
     public AbstractSalesforceProcessor(final SalesforceEndpoint endpoint) {
@@ -55,6 +57,7 @@ public abstract class AbstractSalesforceProcessor implements SalesforceProcessor
 
         final SalesforceComponent component = endpoint.getComponent();
         session = component.getSession();
+        loginConfig = component.getLoginConfig();
         httpClient = endpoint.getConfiguration().getHttpClient();
         rawPayload = endpoint.getConfiguration().isRawPayload();
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AnalyticsApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/AnalyticsApiProcessor.java
@@ -49,7 +49,7 @@ public class AnalyticsApiProcessor extends AbstractSalesforceProcessor {
     public AnalyticsApiProcessor(SalesforceEndpoint endpoint) throws SalesforceException {
         super(endpoint);
 
-        this.analyticsClient = new DefaultAnalyticsApiClient((String)endpointConfigMap.get(SalesforceEndpointConfig.API_VERSION), session, httpClient);
+        this.analyticsClient = new DefaultAnalyticsApiClient((String)endpointConfigMap.get(SalesforceEndpointConfig.API_VERSION), session, httpClient, loginConfig);
     }
 
     @Override

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/BulkApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/BulkApiProcessor.java
@@ -51,7 +51,7 @@ public class BulkApiProcessor extends AbstractSalesforceProcessor {
     public BulkApiProcessor(SalesforceEndpoint endpoint) throws SalesforceException {
         super(endpoint);
 
-        this.bulkClient = new DefaultBulkApiClient((String)endpointConfigMap.get(SalesforceEndpointConfig.API_VERSION), session, httpClient);
+        this.bulkClient = new DefaultBulkApiClient((String)endpointConfigMap.get(SalesforceEndpointConfig.API_VERSION), session, httpClient, loginConfig);
     }
 
     @Override

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/CompositeApiProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/CompositeApiProcessor.java
@@ -64,7 +64,7 @@ public final class CompositeApiProcessor extends AbstractSalesforceProcessor {
             throw new SalesforceException("Unsupported format: " + format, 0);
         }
 
-        compositeClient = new DefaultCompositeApiClient(configuration, format, apiVersion, session, httpClient);
+        compositeClient = new DefaultCompositeApiClient(configuration, format, apiVersion, session, httpClient, loginConfig);
 
     }
 

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
@@ -45,7 +45,11 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class AbstractClientBaseTest {
     static class Client extends AbstractClientBase {

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
@@ -24,6 +24,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.internal.SalesforceSession;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -44,14 +45,12 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class AbstractClientBaseTest {
     static class Client extends AbstractClientBase {
-        Client(final SalesforceSession session) throws SalesforceException {
-            super(null, session, mock(SalesforceHttpClient.class),
+        Client(final SalesforceSession session, final SalesforceLoginConfig loginConfig) throws SalesforceException {
+            super(null, session, mock(SalesforceHttpClient.class), loginConfig,
                   1 /* 1 second termination timeout */);
         }
 
@@ -73,7 +72,7 @@ public class AbstractClientBaseTest {
     final Client client;
 
     public AbstractClientBaseTest() throws SalesforceException {
-        client = new Client(session);
+        client = new Client(session, new SalesforceLoginConfig());
 
         when(session.getAccessToken()).thenReturn("token");
     }
@@ -168,5 +167,29 @@ public class AbstractClientBaseTest {
 
         final long elapsed = System.currentTimeMillis() - stopStartTime;
         assertTrue(elapsed > 900 && elapsed < 1100);
+    }
+
+    @Test
+    public void shouldNotLoginWhenAccessTokenIsNullAndLazyLoginIsTrue() throws SalesforceException {
+        SalesforceLoginConfig loginConfig = new SalesforceLoginConfig();
+        loginConfig.setLazyLogin(true);
+        Client lazyClient = new Client(session, loginConfig);
+        when(session.getAccessToken()).thenReturn(null);
+
+        lazyClient.start();
+
+        verify(session, never()).login(null);
+    }
+
+    @Test
+    public void shouldLoginWhenAccessTokenIsNullAndLazyLoginIsFalse() throws SalesforceException {
+        SalesforceLoginConfig loginConfig = new SalesforceLoginConfig();
+        loginConfig.setLazyLogin(false);
+        Client eagerClient = new Client(session, loginConfig);
+        when(session.getAccessToken()).thenReturn(null);
+
+        eagerClient.start();
+
+        verify(session).login(null);
     }
 }

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSalesforceMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/AbstractSalesforceMojo.java
@@ -209,7 +209,7 @@ abstract class AbstractSalesforceMojo extends AbstractMojo {
 
             // create rest client
 
-            restClient = new DefaultRestClient(httpClient, version, PayloadFormat.JSON, session);
+            restClient = new DefaultRestClient(httpClient, version, PayloadFormat.JSON, session, new SalesforceLoginConfig());
             // remember to start the active client object
             ((DefaultRestClient)restClient).start();
 


### PR DESCRIPTION
This PR is an attempt to fix the lazy-login bug in the camel-salesforce component, which was logged in [CAMEL-14744](https://issues.apache.org/jira/browse/CAMEL-14744).

I would like some feedback on the chosen approach :
1. Passing around SalesforceLoginConfig instead of a boolean value indicating lazyLogin
2. "JIT" login in the SalesforceProducer#process method

This fix was tested against an actual Salesforce instance, via the DefaultRestClient implementation. I am unable to verify the other ApiClient implementations and things like the SubscriptionHelper, AbstractSalesforceMojo.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md