### PR TITLE
CAMEL-14883 CamelBeanPostProcessor implements Ordered interface provided by Spring with lowest precedence

### DIFF
--- a/components/camel-spring/src/main/java/org/apache/camel/spring/CamelBeanPostProcessor.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/CamelBeanPostProcessor.java
@@ -40,6 +40,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.Ordered;
 
 /**
  * Spring specific {@link DefaultCamelBeanPostProcessor} which uses Spring {@link BeanPostProcessor} to post process beans.
@@ -49,7 +50,7 @@ import org.springframework.context.ApplicationContextAware;
 @Metadata(label = "spring,configuration")
 @XmlRootElement(name = "beanPostProcessor")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class CamelBeanPostProcessor implements org.apache.camel.spi.CamelBeanPostProcessor, BeanPostProcessor, ApplicationContextAware {
+public class CamelBeanPostProcessor implements org.apache.camel.spi.CamelBeanPostProcessor, BeanPostProcessor, ApplicationContextAware, Ordered {
     private static final Logger LOG = LoggerFactory.getLogger(CamelBeanPostProcessor.class);
     @XmlTransient
     Set<String> prototypeBeans = new LinkedHashSet<>();
@@ -180,6 +181,11 @@ public class CamelBeanPostProcessor implements org.apache.camel.spi.CamelBeanPos
             }
             throw new GenericBeansException("Error post processing bean: " + beanName, e);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        return LOWEST_PRECEDENCE;
     }
 
     // Properties


### PR DESCRIPTION
This avoids issues e.g. described in https://github.com/spring-projects/spring-framework/issues/24058 and additionally according to Spring it is best practice to have BeanPostProcessors implement Ordered interface.