### PR TITLE
Make github actions builds more stable by reducing maven http read ti…

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -34,4 +34,4 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: mvn sourcecheck
-      run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+      run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify

--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -34,4 +34,4 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: mvn sourcecheck
-      run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify
+      run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -e -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify

--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -34,4 +34,4 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: mvn sourcecheck
-      run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+      run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: mvn sourcecheck
-        run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+        run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: mvn sourcecheck
-        run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+        run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.retryhandler.requestSentEnabled=true -Dmaven.wagon.http.retryhandler.class=default -Dmaven.wagon.http.retryhandler.nonRetryableClasses=java.net.UnknownHostException -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify


### PR DESCRIPTION
…meout and adding maven http retries.

The build (especially on Java 11) often fails with 

>Transfer failed for ... Connection timed out (Read failed)

Not sure if this enough to fix it.