### PR TITLE
Speed-up github actions build

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -33,5 +33,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - name: Cache Maven Repository
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: mvn sourcecheck
-      run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+      run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -33,5 +33,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache Maven Repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: mvn sourcecheck
-        run: ./mvnw -V --no-transfer-progress clean install -DskipTests --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' clean verify
+        run: ./mvnw -V --no-transfer-progress install -DskipTests -Dcompiler.fork=false --projects org.apache.camel:camel-buildtools  && ./mvnw -V --no-transfer-progress -Psourcecheck -DskipTests -Dcompiler.fork=false -Dcheckstyle.failOnViolation=true -pl '!org.apache.camel:apache-camel' verify


### PR DESCRIPTION
- cache maven repository
- remove unnecessary clean
- do not fork for compiling

"Do not fork for compiling" currently does not work for the java 11 build, because fork is set to true in the `jdk9+-build` profile (see: https://github.com/apache/camel/blob/master/parent/pom.xml#L4571). I thought this profile should have been removed?
