### PR TITLE
CAMEL-14892 Camel-influxdb uses deprecated methods in doInsert action

### DIFF
--- a/components/camel-influxdb/src/main/java/org/apache/camel/component/influxdb/InfluxDbProducer.java
+++ b/components/camel-influxdb/src/main/java/org/apache/camel/component/influxdb/InfluxDbProducer.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 public class InfluxDbProducer extends DefaultProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(InfluxDbProducer.class);
+    private static final String CREATE_DATABASE = "CREATE DATABASE ";
+    private static final String SHOW_DATABASES = "SHOW DATABASES";
 
     InfluxDbEndpoint endpoint;
     InfluxDB connection;
@@ -76,10 +78,7 @@ public class InfluxDbProducer extends DefaultProducer {
             Point p = exchange.getIn().getMandatoryBody(Point.class);
             try {
                 LOG.debug("Writing point {}", p.lineProtocol());
-                if (!connection.databaseExists(dataBaseName)) {
-                    LOG.debug("Database {} doesn't exist. Creating it...", dataBaseName);
-                    connection.createDatabase(dataBaseName);
-                }
+                ensureDatabaseExists(dataBaseName);
                 connection.write(dataBaseName, retentionPolicy, p);
             } catch (Exception ex) {
                 exchange.setException(new CamelInfluxDbException(ex));
@@ -136,6 +135,26 @@ public class InfluxDbProducer extends DefaultProducer {
             throw new IllegalArgumentException("The query option must be set if you want to run a query operation");
         }
         return query;
+    }
+
+    private void ensureDatabaseExists(String dataBaseName) {
+        QueryResult result = connection.query(new Query(SHOW_DATABASES));
+
+        //values are located in the first item in series, where list of values is the first item in the Serie's values,
+        //if any object on the 'path' is null, database does not exist
+        boolean exists;
+        try {
+            //NPE could be thrown from objects deep in the structure.
+            //try catch block with NullPointerException is used on purpose
+            exists = result.getResults().get(0).getSeries().get(0).getValues().get(0).contains(dataBaseName);
+        } catch (NullPointerException e) {
+            exists = false;
+        }
+
+        if (!exists) {
+            LOG.debug("Database {} doesn't exist. Creating it...", dataBaseName);
+            connection.query(new Query(CREATE_DATABASE + dataBaseName, ""));
+        }
     }
 
 }

--- a/components/camel-influxdb/src/test/java/org/apache/camel/component/influxdb/AbstractInfluxDbTest.java
+++ b/components/camel-influxdb/src/test/java/org/apache/camel/component/influxdb/AbstractInfluxDbTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 
 public class AbstractInfluxDbTest extends CamelTestSupport {
 
-    private InfluxDB mockedDbConnection = mock(InfluxDBImpl.class);
+    InfluxDB mockedDbConnection = mock(InfluxDBImpl.class);
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-influxdb/src/test/java/org/apache/camel/component/influxdb/InfluxDbEnsureDatabaseExistsTest.java
+++ b/components/camel-influxdb/src/test/java/org/apache/camel/component/influxdb/InfluxDbEnsureDatabaseExistsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.influxdb;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class InfluxDbEnsureDatabaseExistsTest extends AbstractInfluxDbTest {
+
+    private static final String DB_NAME = "dbName";
+
+    @EndpointInject("mock:test")
+    MockEndpoint successEndpoint;
+
+    @EndpointInject("mock:error")
+    MockEndpoint errorEndpoint;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+
+                errorHandler(deadLetterChannel("mock:error").redeliveryDelay(0).maximumRedeliveries(0));
+
+                //test route
+                from("direct:test")
+                        .to("influxdb:influxDbBean?databaseName=dbName")
+                        .to("mock:test");
+            }
+        };
+    }
+
+    @Before
+    public void resetEndpoints() {
+        errorEndpoint.reset();
+        successEndpoint.reset();
+    }
+
+    @Test
+    public void testWithExistingDB() throws InterruptedException {
+
+        errorEndpoint.expectedMessageCount(0);
+        successEndpoint.expectedMessageCount(1);
+
+        QueryResult queryResult = new QueryResult();
+        queryResult.setResults(null);
+        QueryResult.Result result = new QueryResult.Result();
+        QueryResult.Series serie = new QueryResult.Series();
+        serie.setValues(Collections.singletonList(Collections.singletonList(DB_NAME)));
+        result.setSeries(Collections.singletonList(serie));
+        queryResult.setResults(Collections.singletonList(result));
+
+        Mockito.when(mockedDbConnection.query(Mockito.any(Query.class))).thenReturn(queryResult);
+
+        sendBody("direct:test", createPoint());
+
+        //if db exist, there will be only 1 call to show databases.
+        Mockito.verify(mockedDbConnection, Mockito.times(1)).query(Mockito.any(Query.class));
+
+        errorEndpoint.assertIsSatisfied();
+        successEndpoint.assertIsSatisfied();
+    }
+
+    @Test
+    public void testWithNonExistingDB() throws InterruptedException {
+
+        errorEndpoint.expectedMessageCount(0);
+        successEndpoint.expectedMessageCount(1);
+
+        QueryResult queryResult = new QueryResult();
+        queryResult.setResults(Collections.singletonList(new QueryResult.Result()));
+
+        sendBody("direct:test", createPoint());
+
+        //if db does not exist, there will be 2 queries (show databases and create database)
+        Mockito.verify(mockedDbConnection, Mockito.times(2)).query(Mockito.any(Query.class));
+
+        errorEndpoint.assertIsSatisfied();
+        successEndpoint.assertIsSatisfied();
+    }
+
+    private Point createPoint() {
+        return Point.measurement("cpu")
+                .time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
+                .addField("idle", 90L)
+                .addField("user", 9L)
+                .addField("system", 1L)
+                .build();
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14892

2 depricated calls are replaced with the correct ones. (queries with `SHOW DATABASES` and `CREATE DATABASE ` are called instead of depricated method on `InfluxDB`).
Test covering call is added.

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md