### PR TITLE
CAMEL-14922: Cannot enable cors on platform-http

### DIFF
--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -138,10 +138,6 @@ public class PlatformHttpComponent extends DefaultComponent implements RestConsu
         Map<String, Object> map = RestComponentHelper.initRestEndpointProperties(PlatformHttpConstants.PLATFORM_HTTP_COMPONENT_NAME, config);
 
         boolean cors = config.isEnableCORS();
-        if (cors) {
-            // allow HTTP Options as we want to handle CORS in rest-dsl
-            map.put("optionsEnabled", "true");
-        }
 
         if (api) {
             map.put("matchOnUriPrefix", "true");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-14922

This is fixing the immediate issue reported in CAMEL-14922. However it does not solve the problem that the platform-http component offers no real support for CORS beyond enabling the OPTIONS method handling.