### PR TITLE
Introduce Catalog methods to allow iterating over all parts

### DIFF
--- a/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/CamelCatalog.java
+++ b/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/CamelCatalog.java
@@ -21,6 +21,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.tooling.model.BaseModel;
+import org.apache.camel.tooling.model.ComponentModel;
+import org.apache.camel.tooling.model.DataFormatModel;
+import org.apache.camel.tooling.model.EipModel;
+import org.apache.camel.tooling.model.LanguageModel;
+import org.apache.camel.tooling.model.OtherModel;
+
 /**
  * Catalog of components, data formats, models (EIPs), languages, and more from this Apache Camel release.
  */
@@ -189,6 +196,27 @@ public interface CamelCatalog {
      * Find all the other (miscellaneous) names from the Camel catalog
      */
     List<String> findOtherNames();
+
+    /**
+     * @param kind the kind to look for
+     * @return the list of part names of the given {@link Kind} available in this {@link CamelCatalog}
+     */
+    default List<String> findNames(Kind kind) {
+        switch (kind) {
+            case component:
+                return findComponentNames();
+            case dataformat:
+                return findDataFormatNames();
+            case language:
+                return findLanguageNames();
+            case other:
+                return findOtherNames();
+            case eip:
+                return findModelNames();
+            default:
+                throw new IllegalArgumentException("Unexpected kind " + kind);
+        }
+    }
 
     /**
      * Find all the component names from the Camel catalog that matches the label
@@ -530,5 +558,57 @@ public interface CamelCatalog {
      * Reports a summary what the catalog contains in JSon
      */
     String summaryAsJson();
+
+    /**
+     * @param name the component name to look up
+     * @return the requested component or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    ComponentModel componentModel(String name);
+
+    /**
+     * @param name the data format name to look up
+     * @return the requested data format or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    DataFormatModel dataFormatModel(String name);
+
+    /**
+     * @param name the language name to look up
+     * @return the requested language or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    LanguageModel languageModel(String name);
+
+    /**
+     * @param name the other name to look up
+     * @return the requested other or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    OtherModel otherModel(String name);
+
+    /**
+     * @param name the EIP model name to look up
+     * @return the requested EIP model or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    EipModel eipModel(String name);
+
+    /**
+     * @param kind the requested kind
+     * @param name the name to look up
+     * @return the requested model or {@code null} in case it is not available in this {@link CamelCatalog}
+     */
+    default BaseModel<?> model(Kind kind, String name) {
+        switch (kind) {
+            case component:
+                return componentModel(name);
+            case dataformat:
+                return dataFormatModel(name);
+            case language:
+                return languageModel(name);
+            case other:
+                return otherModel(name);
+            case eip:
+                return eipModel(name);
+            default:
+                throw new IllegalArgumentException("Unexpected kind " + kind);
+        }
+    }
 
 }

--- a/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/Kind.java
+++ b/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/Kind.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.catalog;
+
+/**
+ * Kind of a Camel part, such as component, dataformat, language, etc.
+ */
+public enum Kind {
+    component, dataformat, language, other, eip
+}


### PR DESCRIPTION
This change makes it easier to perform the following tasks:

* Given some artifactId, list all components, languages, dataformats, etc. implemented in the associated artifact. This is useful when scaffolding Camel Quarkus extensions.
* Save some code when Docs pages form Camel Catalog

With this change in place, I can do something like

```
for (Kind kind: Kind.values()) {
    for (String name : catalog.findNames(kind)) {
        BaseModel model = catalog.model(kind, name);
    }
}
```