### PR TITLE
Fixed doc: option 'isImplicit' in FTPS implicit sample

### DIFF
--- a/components/camel-ftp/src/main/docs/ftp-component.adoc
+++ b/components/camel-ftp/src/main/docs/ftp-component.adoc
@@ -623,7 +623,7 @@ And the route using Spring DSL:
 
 [source,java]
 ----
-from("ftps://admin@localhost:2222/public/camel?password=admin&securityProtocol=SSL&isImplicit=true
+from("ftps://admin@localhost:2222/public/camel?password=admin&securityProtocol=SSL&implicit=true
       &ftpClient.keyStore.file=./src/test/resources/server.jks
       &ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password")
   .to("bean:foo");


### PR DESCRIPTION
option was still called `isImplicit` (Camel 2.x). Changed to `implicit`.