### PR TITLE
CAMEL-14950 camel-undertow: secure with spring-security 5 

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>undertow-core</artifactId>
             <version>${undertow-version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${undertow-version}</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/spi/UndertowSecurityProvider.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/spi/UndertowSecurityProvider.java
@@ -72,4 +72,12 @@ public interface UndertowSecurityProvider {
     default HttpHandler wrapHttpHandler(HttpHandler httpHandler) throws Exception {
         return  httpHandler;
     }
+
+    /**
+     * Security provider may need for its functionality also working servlet context.
+     * This feature could be used for example in case of execution of servletFilters for security reasons.
+     */
+    default boolean requireServletContext() {
+        return false;
+    }
 }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/AbstractProviderServletTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/AbstractProviderServletTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow.spi;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.handlers.ServletRequestContext;
+import io.undertow.util.AttachmentKey;
+import io.undertow.util.StatusCodes;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.undertow.BaseUndertowTest;
+import org.apache.camel.component.undertow.UndertowComponent;
+
+
+
+/**
+ * Abstract parent for test verifying that UndertowSecurityProvider.requireServletContext really causes servletContext to be created.
+ */
+public abstract class AbstractProviderServletTest extends BaseUndertowTest {
+
+    private static final AttachmentKey<String> PRINCIPAL_NAME_KEY = AttachmentKey.create(String.class);
+
+    public abstract static class MockSecurityProvider implements UndertowSecurityProvider {
+
+        @Override
+        public void addHeader(BiConsumer<String, Object> consumer, HttpServerExchange httpExchange) throws Exception {
+            String principalName = httpExchange.getAttachment(PRINCIPAL_NAME_KEY);
+            consumer.accept(AbstractSecurityProviderTest.PRINCIPAL_PARAMETER, principalName);
+        }
+
+        @Override
+        public int authenticate(HttpServerExchange httpExchange, List<String> allowedRoles) throws Exception {
+            ServletRequestContext servletRequestContext = httpExchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+            assertServletContext(servletRequestContext);
+
+            //put some information into servletContext
+            httpExchange.putAttachment(PRINCIPAL_NAME_KEY, "user");
+            return StatusCodes.OK;
+        }
+
+        @Override
+        public boolean acceptConfiguration(Object configuration, String endpointUri) {
+            return true;
+        }
+
+        @Override
+        public  abstract boolean requireServletContext();
+
+        abstract void assertServletContext(ServletRequestContext servletRequestContext);
+    }
+
+
+    static void createSecurtyProviderConfigurationFile(Class<? extends MockSecurityProvider> clazz) throws Exception {
+        URL location = MockSecurityProvider.class.getProtectionDomain().getCodeSource().getLocation();
+        File file = new File(location.getPath() + "META-INF/services/" + UndertowSecurityProvider.class.getName());
+        file.getParentFile().mkdirs();
+
+        Writer output = new FileWriter(file);
+        output.write(clazz.getName());
+        output.close();
+
+        file.deleteOnExit();
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext =  super.createCamelContext();
+        UndertowComponent component = camelContext.getComponent("undertow", UndertowComponent.class);
+
+        //put mock object asconfiguration, it is not used
+        component.setSecurityConfiguration(new Object());
+        return camelContext;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("undertow:http://localhost:{{port}}/foo?allowedRoles=user")
+                        .to("mock:input")
+                        .transform(simple("${in.header." + AbstractSecurityProviderTest.PRINCIPAL_PARAMETER + "}"));
+            }
+        };
+    }
+
+}

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithServletTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithServletTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow.spi;
+
+import io.undertow.servlet.handlers.ServletRequestContext;
+import org.apache.camel.Exchange;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test for case that UndertowSecurityProvider.requireServletContext returns true.
+ * ServletContext has to be present in httpExchange.
+ */
+public class ProviderWithServletTest extends AbstractProviderServletTest {
+
+    public static class MockSecurityProvider extends AbstractProviderServletTest.MockSecurityProvider {
+
+        @Override
+        public boolean requireServletContext() {
+            return true;
+        }
+
+        @Override
+        void assertServletContext(ServletRequestContext servletRequestContext) {
+            Assert.assertNotNull(servletRequestContext);
+        }
+    }
+
+    @BeforeClass
+    public static void initProvider() throws Exception {
+        createSecurtyProviderConfigurationFile(org.apache.camel.component.undertow.spi.ProviderWithoutServletTest.MockSecurityProvider.class);
+    }
+
+    @Test
+    public void test() throws Exception {
+        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+
+        String out = template.requestBody("undertow:http://localhost:{{port}}/foo", null, String.class);
+
+        Assert.assertEquals("user", out);
+
+        assertMockEndpointsSatisfied();
+    }
+
+}

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithoutServletTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithoutServletTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow.spi;
+
+import io.undertow.servlet.handlers.ServletRequestContext;
+import org.apache.camel.Exchange;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test for case that UndertowSecurityProvider.requireServletContext returns false.
+ * ServletContext can not be present in httpExchange.
+ */
+public class ProviderWithoutServletTest extends AbstractProviderServletTest {
+
+    public static class MockSecurityProvider extends AbstractProviderServletTest.MockSecurityProvider {
+
+        @Override
+        public boolean requireServletContext() {
+            return false;
+        }
+
+        @Override
+        void assertServletContext(ServletRequestContext servletRequestContext) {
+            Assert.assertNull(servletRequestContext);
+        }
+    }
+
+    @BeforeClass
+    public static void initProvider() throws Exception {
+        createSecurtyProviderConfigurationFile(MockSecurityProvider.class);
+    }
+
+    @Test
+    public void test() throws Exception {
+        getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+
+        String out = template.requestBody("undertow:http://localhost:{{port}}/foo", null, String.class);
+
+        Assert.assertEquals("user", out);
+
+        assertMockEndpointsSatisfied();
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14950

To allow usage of spring security 5 with camel-undertow, it has to be allowed to execute servlet filters, which are used to secure endpoints. 
This change adds property 'requireServletContext'  into 'UndertowSecurityProvider'. This change allows to use spring security 5 with camel-undertow. The exact useage of spring security 5 is covered by following issue:  https://issues.apache.org/jira/browse/CAMEL-14962

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md