### PR TITLE
Send pull requests mails to the commits mailings list instead of to t…

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+notifications:
+  pullrequests: commits@camel.apache.org


### PR DESCRIPTION
…he developer mailing list.

Since the beginning of this week messages for camel (core) e.g.

E.g. https://mail-archives.apache.org/mod_mbox/camel-dev/202004.mbox/%3Ccamel.3762.MDExOlB1bGxSZXF1ZXN0NDA2MDQxMzY0.gitbox%40gitbox.apache.org%3E

are send to dev@camel.apache.org again.

Therefore I created https://issues.apache.org/jira/browse/INFRA-20178. Infra suggested that we add a `.asf.yaml` file to configure it ourself (see: https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories#id-.asf.yamlfeaturesforgitrepositories-Notificationsettingsforrepositories for configuration options.)
