### PR TITLE
fix of test for CAMEL-14950

### DIFF
--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithServletTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/spi/ProviderWithServletTest.java
@@ -43,7 +43,7 @@ public class ProviderWithServletTest extends AbstractProviderServletTest {
 
     @BeforeClass
     public static void initProvider() throws Exception {
-        createSecurtyProviderConfigurationFile(org.apache.camel.component.undertow.spi.ProviderWithoutServletTest.MockSecurityProvider.class);
+        createSecurtyProviderConfigurationFile(org.apache.camel.component.undertow.spi.ProviderWithServletTest.MockSecurityProvider.class);
     }
 
     @Test


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-14950

@davsclaus , @oscerd 
I've noticed small error with big impact. Test for scenario with servlet was testing scenario without servlet. This simple change it fixes, but there is a problem.
By  previous commit version of servlet-api was set to 3.1.0.Final to be consistent with camel - correct move. *But undertow is not able to start servlet without 4.0 api.*
So with this fix, test will show an error *NoClassDefFoundError: javax/servlet/http/MappingMatch*
(error will be solved in case of servlet-api org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec)

Which seems to be blocker for this change. What do you think?

Only solution I see is to keep servlet-api required for undertow in pom. 

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md