### PR TITLE
docs (mongodb): add a note for default _id type

### DIFF
--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -203,6 +203,16 @@ from("direct:findById")
     .to("mock:resultFindById");
 ------------------------------------------------------------------------------
 
+Please, note that the default _id is treated by Mongo as and `ObjectId` type, so you may need to convert it properly.
+
+[source,java]
+------------------------------------------------------------------------------
+from("direct:findById")
+    .convertBodyTo(ObjectId.class)
+    .to("mongodb:myDb?database=flights&collection=tickets&operation=findById")
+    .to("mock:resultFindById");
+------------------------------------------------------------------------------
+
 [TIP]
 ====
 *Supports optional parameters*.


### PR DESCRIPTION
No changes in code, just some note in the documentation to highlight the default _id treated by Mongo as an ObjectId type.