### PR TITLE
CAMEL-14989 camel-mongo: add a converter to ObjectId

### DIFF
--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -203,6 +203,16 @@ from("direct:findById")
     .to("mock:resultFindById");
 ------------------------------------------------------------------------------
 
+Please, note that the default _id is treated by Mongo as and `ObjectId` type, so you may need to convert it properly.
+
+[source,java]
+------------------------------------------------------------------------------
+from("direct:findById")
+    .convertBodyTo(ObjectId.class)
+    .to("mongodb:myDb?database=flights&collection=tickets&operation=findById")
+    .to("mock:resultFindById");
+------------------------------------------------------------------------------
+
 [TIP]
 ====
 *Supports optional parameters*.

--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/converters/MongoDbBasicConverters.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/converters/MongoDbBasicConverters.java
@@ -41,6 +41,7 @@ import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
+import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,11 @@ public final class MongoDbBasicConverters {
     @Converter
     public static Document fromStringToDocument(String s) {
         return Document.parse(s);
+    }
+
+    @Converter
+    public static ObjectId fromStringToObjectId(String s) {
+        return new ObjectId(s);
     }
 
     @Converter


### PR DESCRIPTION
* Adding a method to allow conversion to ObjectId type, used as default by MongoDB as _id field type.
* Adding some doc to explain how to use it

Closes CAMEL-14989