### PR TITLE
CAMEL-15023 camel-restdsl-openapi-plugin: pass configOptions to swagger-codegen-maven-plugin

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
@@ -115,6 +115,7 @@ The plugin supports the following *additional* options
 | `modelNamePrefix` | | Sets the pre- or suffix for model classes and enums
 | `modelNameSuffix` | | Sets the pre- or suffix for model classes and enums
 | `modelWithXml` | true | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
+| `configOptions` | | Pass a map of language-specific parameters to `swagger-codegen-maven-plugin`
 |========================================
 
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
@@ -182,5 +182,6 @@ The plugin supports the following *additional* options
 | `modelNamePrefix` | | Sets the pre- or suffix for model classes and enums
 | `modelNameSuffix` | | Sets the pre- or suffix for model classes and enums
 | `modelWithXml` | true | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
+| `configOptions` | | Pass a map of language-specific parameters to `swagger-codegen-maven-plugin`
 |========================================
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
@@ -31,12 +31,9 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.BaseJsonNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import org.apache.camel.generator.openapi.DestinationGenerator;
-import org.apache.camel.model.dataformat.YAMLLibrary;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.maven.execution.MavenSession;
@@ -114,6 +111,9 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
     @Component
     private BuildPluginManager pluginManager;
 
+    @Parameter
+    private Map<String, String> configOptions;
+
     DestinationGenerator createDestinationGenerator() throws MojoExecutionException {
         final Class<DestinationGenerator> destinationGeneratorClass;
 
@@ -183,6 +183,10 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
         }
         if (modelWithXml != null) {
             elements.add(new MojoExecutor.Element("withXml", modelPackage));
+        }
+        if (configOptions != null) {
+            elements.add(new MojoExecutor.Element("configOptions", configOptions.entrySet().stream()
+                .map(e -> new MojoExecutor.Element(e.getKey(), e.getValue())).toArray(MojoExecutor.Element[]::new)));
         }
 
         executeMojo(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-15023

There are a lot of useful options [1].
Usage:

```
<configuration>
    <configOptions>
       <library>jersey2</library>
       <dateLibrary>java8</dateLibrary>
    </configOptions>
...
</configuration>

```
 

1.   https://github.com/swagger-api/swagger-codegen/issues/7795

