### PR TITLE
CAMEL-15025 camel-restdsl-openapi-plugin: fix 'modelWithXml' parameter propagation

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
@@ -114,7 +114,7 @@ The plugin supports the following *additional* options
 | `modelPackage` | `io.swagger.client.model` | The package to use for generated model objects/classes
 | `modelNamePrefix` | | Sets the pre- or suffix for model classes and enums
 | `modelNameSuffix` | | Sets the pre- or suffix for model classes and enums
-| `modelWithXml` | true | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
+| `modelWithXml` | false | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
 | `configOptions` | | Pass a map of language-specific parameters to `swagger-codegen-maven-plugin`
 |========================================
 
@@ -181,7 +181,7 @@ The plugin supports the following *additional* options
 | `modelPackage` | `io.swagger.client.model` | The package to use for generated model objects/classes
 | `modelNamePrefix` | | Sets the pre- or suffix for model classes and enums
 | `modelNameSuffix` | | Sets the pre- or suffix for model classes and enums
-| `modelWithXml` | true | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
+| `modelWithXml` | false | Enable XML annotations inside the generated models (only works with ibraries that provide support for JSON and XML)
 | `configOptions` | | Pass a map of language-specific parameters to `swagger-codegen-maven-plugin`
 |========================================
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
@@ -84,7 +84,7 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
     @Parameter
     String modelPackage;
 
-    @Parameter(defaultValue = "true")
+    @Parameter(defaultValue = "false")
     String modelWithXml;
 
     @Parameter(defaultValue = "${project}")
@@ -182,7 +182,7 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
             elements.add(new MojoExecutor.Element("modelNameSuffix", modelNameSuffix));
         }
         if (modelWithXml != null) {
-            elements.add(new MojoExecutor.Element("withXml", modelPackage));
+            elements.add(new MojoExecutor.Element("withXml", modelWithXml));
         }
         if (configOptions != null) {
             elements.add(new MojoExecutor.Element("configOptions", configOptions.entrySet().stream()


### PR DESCRIPTION
pass correct value to swagger-codegen-maven-plugin and set default value to 'false' for backward compatibility

https://issues.apache.org/jira/browse/CAMEL-15025