### PR TITLE
CAMEL-15031: Accept FQHN for splunk-hec endpoint

### DIFF
--- a/components/camel-splunk-hec/pom.xml
+++ b/components/camel-splunk-hec/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>httpclient</artifactId>
             <version>${httpclient4-version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>${commons-validator-version}</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECEndpoint.java
+++ b/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECEndpoint.java
@@ -36,7 +36,7 @@ import org.apache.commons.validator.routines.DomainValidator;
         syntax = "splunk-hec:splunkURL/token", label = "log,monitoring")
 public class SplunkHECEndpoint extends DefaultEndpoint {
 
-    private static final Pattern URI_PARSER = Pattern.compile("splunk-hec\\:\\/?\\/?\\s*(.*?):(\\d+)\\s*/(\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\??.*");
+    private static final Pattern URI_PARSER = Pattern.compile("splunk-hec\\:\\/?\\/?(.*?):(\\d+)/(\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\??.*");
 
     @UriPath @Metadata(required = true)
     private String splunkURL;

--- a/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECEndpoint.java
+++ b/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECEndpoint.java
@@ -27,6 +27,7 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 import org.apache.camel.support.DefaultEndpoint;
+import org.apache.commons.validator.routines.DomainValidator;
 
 /**
  * The splunk component allows to publish events in Splunk using the HTTP Event Collector.
@@ -35,7 +36,7 @@ import org.apache.camel.support.DefaultEndpoint;
         syntax = "splunk-hec:splunkURL/token", label = "log,monitoring")
 public class SplunkHECEndpoint extends DefaultEndpoint {
 
-    private static final Pattern URI_PARSER = Pattern.compile("splunk-hec\\:\\/?\\/?(\\w+):(\\d+)/(\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\??.*");
+    private static final Pattern URI_PARSER = Pattern.compile("splunk-hec\\:\\/?\\/?\\s*(.*?):(\\d+)\\s*/(\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\??.*");
 
     @UriPath @Metadata(required = true)
     private String splunkURL;
@@ -51,7 +52,7 @@ public class SplunkHECEndpoint extends DefaultEndpoint {
         super(uri, component);
         this.configuration = configuration;
         Matcher match = URI_PARSER.matcher(uri);
-        if (!match.matches()) {
+        if (!match.matches() || !DomainValidator.getInstance(true).isValid(match.group(1))) {
             throw new IllegalArgumentException("Invalid URI: " + uri);
         }
         int port = Integer.parseInt(match.group(2));

--- a/components/camel-splunk-hec/src/test/java/org/apache/camel/component/splunkhec/SplunkHECEndpointTest.java
+++ b/components/camel-splunk-hec/src/test/java/org/apache/camel/component/splunkhec/SplunkHECEndpointTest.java
@@ -37,11 +37,20 @@ public class SplunkHECEndpointTest {
     }
 
     @Test
-    public void testValid() {
+    public void testLocalHostValid() {
         SplunkHECConfiguration configuration = new SplunkHECConfiguration();
         SplunkHECComponent component = new SplunkHECComponent();
         SplunkHECEndpoint endpoint = new SplunkHECEndpoint("splunk-hec:localhost:18808/11111111-1111-1111-1111-111111111111", component, configuration);
         assertEquals("localhost:18808", endpoint.getSplunkURL());
+        assertEquals("11111111-1111-1111-1111-111111111111", endpoint.getToken());
+    }
+
+    @Test
+    public void testFQHNValid() {
+        SplunkHECConfiguration configuration = new SplunkHECConfiguration();
+        SplunkHECComponent component = new SplunkHECComponent();
+        SplunkHECEndpoint endpoint = new SplunkHECEndpoint("splunk-hec:http-input.splunkcloud.com:18808/11111111-1111-1111-1111-111111111111", component, configuration);
+        assertEquals("http-input.splunkcloud.com:18808", endpoint.getSplunkURL());
         assertEquals("11111111-1111-1111-1111-111111111111", endpoint.getToken());
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,6 +126,7 @@
         <commons-pool-version>1.6</commons-pool-version>
         <commons-pool2-version>2.8.0</commons-pool2-version>
         <commons-text-version>1.8</commons-text-version>
+        <commons-validator-version>1.4.1</commons-validator-version>
         <compress-lzf-version>1.0.4</compress-lzf-version>
         <conscrypt-uber-version>2.2.1</conscrypt-uber-version>
         <consul-client-version>1.3.3</consul-client-version>


### PR DESCRIPTION
This PR fixes https://issues.apache.org/jira/browse/CAMEL-15031 and allows FQHNs on splunk-hec endpoints.

This PR introduces a dependancy to the Apache commons-validator lib. Even though I'm not completely happy with pulling in a new dependancy I decided to go this route, because any own implementation would be a (ugly?) clone of that code. Nevertheless I'm more than happy to change the implementation if anyone has something more suitable at hand. 