### PR TITLE
[CAMEL-15027] Do not propagate record specific Kafka headers

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
@@ -16,9 +16,15 @@
  */
 package org.apache.camel.component.kafka;
 
+import java.util.regex.Pattern;
 import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 public class KafkaHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+
+    /**
+     * A filter pattern that only accepts keys starting with <tt>Camel</tt> or <tt>org.apache.camel.</tt>
+     */
+    public static final Pattern CAMEL_KAFKA_FILTER_PATTERN = Pattern.compile("(?i)(Camel|org\\.apache\\.camel|kafka\\.)[\\.|a-z|A-z|0-9]*");
 
     public KafkaHeaderFilterStrategy() {
         initialize();
@@ -28,8 +34,8 @@ public class KafkaHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
         // filter out kafka record metadata
         getInFilter().add("org.apache.kafka.clients.producer.RecordMetadata");
 
-        // filter headers begin with "Camel" or "org.apache.camel"
-        setOutFilterPattern(CAMEL_FILTER_PATTERN);
-        setInFilterPattern(CAMEL_FILTER_PATTERN);
+        // filter headers beginning with "Camel" or "org.apache.camel" or "kafka."
+        setOutFilterPattern(CAMEL_KAFKA_FILTER_PATTERN);
+        setInFilterPattern(CAMEL_KAFKA_FILTER_PATTERN);
     }
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaHeaderFilterStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kafka;
 
 import java.util.regex.Pattern;
+
 import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 public class KafkaHeaderFilterStrategy extends DefaultHeaderFilterStrategy {

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaEndpointTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaEndpointTest.java
@@ -69,7 +69,7 @@ public class KafkaEndpointTest {
     }
 
     @Test
-    public void isSingletonShoudlReturnTrue() {
+    public void isSingletonShouldReturnTrue() {
         assertTrue(endpoint.isSingleton());
     }
 


### PR DESCRIPTION
This prevents propagation of `kafka.` headers when consuming from Kafka or producing back to Kafka. The values of these headers are populated by the `KafkaEndpoint` from values specific to a consumed Kafka record, such as the timestamp or topic, and do not make sense once going to the scope of a new produced Kafka record which has its own values for topic and timestamp.