### PR TITLE
Resolves CAMEL-15033: fix xrefs

### DIFF
--- a/components/camel-bam/src/main/docs/bam-example.adoc
+++ b/components/camel-bam/src/main/docs/bam-example.adoc
@@ -62,8 +62,8 @@ occurs in this example we just send it to the log component
 component to log out an error level message to commons-logging / log4j.
 You could change this to use some of the other
 Components such as ActiveMQ,
-xref:jms-component.adoc[JMS], xref:irc-component.adoc[IRC], xref:mail-component.adoc[Mail],
-xref:xmpp-component.adoc[XMPP] etc.
+xref:ROOT:jms-component.adoc[JMS], xref:ROOT:irc-component.adoc[IRC], xref:ROOT:mail-component.adoc[Mail],
+xref:ROOT:xmpp-component.adoc[XMPP] etc.
 
 == Running the example
 

--- a/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
@@ -8,7 +8,7 @@
 
 *Since Camel {since}*
 
-The *OpenShift Build Config* component is one of xref:kubernetes.adoc[Kubernetes Components] which
+The *OpenShift Build Config* component is one of xref:kubernetes-summary.adoc[Kubernetes Components] which
 provides a producer to execute kubernetes build config operations. 
 
 

--- a/components/camel-scala/src/main/docs/scala-eip.adoc
+++ b/components/camel-scala/src/main/docs/scala-eip.adoc
@@ -203,5 +203,5 @@ transformation and pass that to the `process` method instead. The
 example below uses pattern matching to enrich the message content:
 
 Off course, you can also use any other Camel component (e.g.
-xref:velocity-component.adoc[Velocity]) to enrich the content and add it to a
+xref:ROOT:velocity-component.adoc[Velocity]) to enrich the content and add it to a
 pipeline

--- a/components/camel-shiro/src/main/docs/shiro.adoc
+++ b/components/camel-shiro/src/main/docs/shiro.adoc
@@ -135,7 +135,7 @@ of the roles in the list are applicable.
 these or pass in your own Cipher implementation
 
 |`base64` |`false` |`boolean` |*Camel 2.12:* To use base64 encoding for the security token header,
-which allows transferring the header over xref:jms-component.adoc[JMS] etc. This
+which allows transferring the header over xref:ROOT:jms-component.adoc[JMS] etc. This
 option must also be set on `ShiroSecurityTokenInjector` as well.
 
 |`allPermissionsRequired` |`false` |`boolean` |*Camel 2.13:* The default is that authorization is granted if any of the

--- a/components/camel-spring-security/src/main/docs/spring-security.adoc
+++ b/components/camel-spring-security/src/main/docs/spring-security.adoc
@@ -88,7 +88,7 @@ authorization is not specified by this component. You can write your own
 processors or components which get authentication information from the
 exchange depending on your needs. For example, you might create a
 processor that gets credentials from an HTTP request header originating
-in the xref:jetty-component.adoc[Jetty] component. No matter how the credentials
+in the xref:ROOT:jetty-component.adoc[Jetty] component. No matter how the credentials
 are collected, they need to be placed in the In message or the
 `SecurityContextHolder` so the Camel Spring Security component can access them:
 
@@ -146,7 +146,7 @@ implementation of the
 `org.apache.camel.component.spring.security.AuthenticationAdapter` to
 your `<authorizationPolicy>` bean. This can be useful if you are working
 with components that do not use Spring Security but do provide a
-`Subject`. At this time, only the xref:cxf-component.adoc[CXF] component populates
+`Subject`. At this time, only the xref:ROOT:cxf-component.adoc[CXF] component populates
 the `Exchange.AUTHENTICATION` header.
 
 [[SpringSecurity-Handlingauthenticationandauthorizationerrors]]

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -25,7 +25,7 @@ and auto-expose Spring beans as components and endpoints.
 framework to simplify your unit and integration testing using
 xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful Mock and
-xref:test.adoc[Test] endpoints
+xref:others:test.adoc[Test] endpoints
 Camel supports Spring Boot using the `camel-spring-boot` component.
 
 == Using Spring to configure the CamelContext

--- a/components/camel-test-cdi/src/main/docs/test-cdi.adoc
+++ b/components/camel-test-cdi/src/main/docs/test-cdi.adoc
@@ -284,7 +284,7 @@ Using ShrinkWarp Descriptors, you have a complete control over the
 configuration and kind of Camel CDI applications you want to test. For
 example, to test a Camel CDI application that uses the Camel
 REST DSL configured with the
-xref:servlet-component.adoc[Servlet component], you need to create a Web archive,
+xref:ROOT:servlet-component.adoc[Servlet component], you need to create a Web archive,
 e.g.:
 
 [source,java]

--- a/components/camel-test-spring/src/main/docs/test-spring.adoc
+++ b/components/camel-test-spring/src/main/docs/test-spring.adoc
@@ -16,7 +16,7 @@ This documentation is old and needs to be updated
 
 xref:latest@manual::testing.adoc[Testing] is a crucial part of any development or integration work. The Spring Framework offers a number of features that makes it easy to test while using Spring for Inversion of Control which works with JUnit 3.x, JUnit 4.x, and http://testng.org[TestNG].
 
-We can use Spring for IoC and the Camel xref:mock-component.adoc[Mock] and xref:test.adoc[Test] endpoints to create sophisticated integration/unit tests that are easy to run and debug inside your IDE.  There are three supported approaches for testing with Spring in Camel.
+We can use Spring for IoC and the Camel xref:ROOT:mock-component.adoc[Mock] and xref:test.adoc[Test] endpoints to create sophisticated integration/unit tests that are easy to run and debug inside your IDE.  There are three supported approaches for testing with Spring in Camel.
 [width="100%",cols="1,1,4,1",options="header",]
 |=======================================================================
 |Name |Testing Frameworks Supported |Description |Required Camel Test Dependencies

--- a/components/camel-urlrewrite/src/main/docs/urlrewrite.adoc
+++ b/components/camel-urlrewrite/src/main/docs/urlrewrite.adoc
@@ -9,16 +9,16 @@
 *Since Camel {since}*
 
 The `camel-urlrewrite` component allows to plugin url rewrite
-functionality to xref:http-component.adoc[HTTP], xref:http4-component.adoc[HTTP4],
-xref:jetty-component.adoc[Jetty], or xref:ahc-component.adoc[AHC] components. This component
+functionality to xref:ROOT:http-component.adoc[HTTP], xref:ROOT:http4-component.adoc[HTTP4],
+xref:ROOT:jetty-component.adoc[Jetty], or xref:ROOT:ahc-component.adoc[AHC] components. This component
 integrates the
 http://code.google.com/p/urlrewritefilter/[UrlRewriteFilter] project
 with Apache Camel. This allows you to use the capabilities from the url
 rewrite project with your Camel routes.
 
 This component *requires* that your Camel routes starts from a servlet
-based endpoint such as xref:jetty-component.adoc[Jetty] or
-xref:servlet-component.adoc[Servlet component].
+based endpoint such as xref:ROOT:jetty-component.adoc[Jetty] or
+xref:ROOT:servlet-component.adoc[Servlet component].
 
 [[UrlRewrite-Options]]
 == Options
@@ -55,8 +55,8 @@ remove the context-path.
 == Usage
 
 The following component producers supports using together with the
-`camel-urlrewrite` component: xref:http-component.adoc[HTTP],
-xref:http4-component.adoc[HTTP4] and xref:jetty-component.adoc[Jetty].
+`camel-urlrewrite` component: xref:ROOT:http-component.adoc[HTTP],
+xref:ROOT:http4-component.adoc[HTTP4] and xref:ROOT:jetty-component.adoc[Jetty].
 
 [width="100%",cols="10%,90%",options="header",]
 |=======================================================================
@@ -78,7 +78,7 @@ with any of the components.
 
 You setup the url rewrite as a bean of the type
 `org.apache.camel.component.urlrewrite.http.HttpUrlRewrite` (when using
-xref:http-component.adoc[HTTP] component) as shown below:
+xref:ROOT:http-component.adoc[HTTP] component) as shown below:
 
 And in XML DSL you can do:
 
@@ -151,8 +151,8 @@ Component(s): camel-http4
 
 The former is a simple and generic interface, which is not dependent on
 the Servlet API. The later is servlet based which requires the Camel route to start from
-a servlet based component such as xref:jetty-component.adoc[Jetty] or
-xref:servlet-component.adoc[Servlet component]. The servlet based is more feature rich and
+a servlet based component such as xref:ROOT:jetty-component.adoc[Jetty] or
+xref:ROOT:servlet-component.adoc[Servlet component]. The servlet based is more feature rich and
 that's the API we use to integrate with the
 http://code.google.com/p/urlrewritefilter/[UrlRewriteFilter] project in
 this `camel-urlrewrite` component.

--- a/docs/components/modules/ROOT/pages/openshift-build-configs-component.adoc
+++ b/docs/components/modules/ROOT/pages/openshift-build-configs-component.adoc
@@ -10,7 +10,7 @@
 
 *Since Camel {since}*
 
-The *OpenShift Build Config* component is one of xref:kubernetes.adoc[Kubernetes Components] which
+The *OpenShift Build Config* component is one of xref:kubernetes-summary.adoc[Kubernetes Components] which
 provides a producer to execute kubernetes build config operations. 
 
 

--- a/docs/components/modules/ROOT/pages/spring-summary.adoc
+++ b/docs/components/modules/ROOT/pages/spring-summary.adoc
@@ -27,7 +27,7 @@ and auto-expose Spring beans as components and endpoints.
 framework to simplify your unit and integration testing using
 xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful Mock and
-xref:test.adoc[Test] endpoints
+xref:others:test.adoc[Test] endpoints
 Camel supports Spring Boot using the `camel-spring-boot` component.
 
 == Using Spring to configure the CamelContext

--- a/docs/components/modules/others/pages/bam-example.adoc
+++ b/docs/components/modules/others/pages/bam-example.adoc
@@ -64,8 +64,8 @@ occurs in this example we just send it to the log component
 component to log out an error level message to commons-logging / log4j.
 You could change this to use some of the other
 Components such as ActiveMQ,
-xref:jms-component.adoc[JMS], xref:irc-component.adoc[IRC], xref:mail-component.adoc[Mail],
-xref:xmpp-component.adoc[XMPP] etc.
+xref:ROOT:jms-component.adoc[JMS], xref:ROOT:irc-component.adoc[IRC], xref:ROOT:mail-component.adoc[Mail],
+xref:ROOT:xmpp-component.adoc[XMPP] etc.
 
 == Running the example
 

--- a/docs/components/modules/others/pages/scala-eip.adoc
+++ b/docs/components/modules/others/pages/scala-eip.adoc
@@ -205,5 +205,5 @@ transformation and pass that to the `process` method instead. The
 example below uses pattern matching to enrich the message content:
 
 Off course, you can also use any other Camel component (e.g.
-xref:velocity-component.adoc[Velocity]) to enrich the content and add it to a
+xref:ROOT:velocity-component.adoc[Velocity]) to enrich the content and add it to a
 pipeline

--- a/docs/components/modules/others/pages/shiro.adoc
+++ b/docs/components/modules/others/pages/shiro.adoc
@@ -137,7 +137,7 @@ of the roles in the list are applicable.
 these or pass in your own Cipher implementation
 
 |`base64` |`false` |`boolean` |*Camel 2.12:* To use base64 encoding for the security token header,
-which allows transferring the header over xref:jms-component.adoc[JMS] etc. This
+which allows transferring the header over xref:ROOT:jms-component.adoc[JMS] etc. This
 option must also be set on `ShiroSecurityTokenInjector` as well.
 
 |`allPermissionsRequired` |`false` |`boolean` |*Camel 2.13:* The default is that authorization is granted if any of the

--- a/docs/components/modules/others/pages/spring-security.adoc
+++ b/docs/components/modules/others/pages/spring-security.adoc
@@ -90,7 +90,7 @@ authorization is not specified by this component. You can write your own
 processors or components which get authentication information from the
 exchange depending on your needs. For example, you might create a
 processor that gets credentials from an HTTP request header originating
-in the xref:jetty-component.adoc[Jetty] component. No matter how the credentials
+in the xref:ROOT:jetty-component.adoc[Jetty] component. No matter how the credentials
 are collected, they need to be placed in the In message or the
 `SecurityContextHolder` so the Camel Spring Security component can access them:
 
@@ -148,7 +148,7 @@ implementation of the
 `org.apache.camel.component.spring.security.AuthenticationAdapter` to
 your `<authorizationPolicy>` bean. This can be useful if you are working
 with components that do not use Spring Security but do provide a
-`Subject`. At this time, only the xref:cxf-component.adoc[CXF] component populates
+`Subject`. At this time, only the xref:ROOT:cxf-component.adoc[CXF] component populates
 the `Exchange.AUTHENTICATION` header.
 
 [[SpringSecurity-Handlingauthenticationandauthorizationerrors]]

--- a/docs/components/modules/others/pages/test-cdi.adoc
+++ b/docs/components/modules/others/pages/test-cdi.adoc
@@ -286,7 +286,7 @@ Using ShrinkWarp Descriptors, you have a complete control over the
 configuration and kind of Camel CDI applications you want to test. For
 example, to test a Camel CDI application that uses the Camel
 REST DSL configured with the
-xref:servlet-component.adoc[Servlet component], you need to create a Web archive,
+xref:ROOT:servlet-component.adoc[Servlet component], you need to create a Web archive,
 e.g.:
 
 [source,java]

--- a/docs/components/modules/others/pages/test-spring.adoc
+++ b/docs/components/modules/others/pages/test-spring.adoc
@@ -18,7 +18,7 @@ This documentation is old and needs to be updated
 
 xref:latest@manual::testing.adoc[Testing] is a crucial part of any development or integration work. The Spring Framework offers a number of features that makes it easy to test while using Spring for Inversion of Control which works with JUnit 3.x, JUnit 4.x, and http://testng.org[TestNG].
 
-We can use Spring for IoC and the Camel xref:mock-component.adoc[Mock] and xref:test.adoc[Test] endpoints to create sophisticated integration/unit tests that are easy to run and debug inside your IDE.  There are three supported approaches for testing with Spring in Camel.
+We can use Spring for IoC and the Camel xref:ROOT:mock-component.adoc[Mock] and xref:test.adoc[Test] endpoints to create sophisticated integration/unit tests that are easy to run and debug inside your IDE.  There are three supported approaches for testing with Spring in Camel.
 [width="100%",cols="1,1,4,1",options="header",]
 |=======================================================================
 |Name |Testing Frameworks Supported |Description |Required Camel Test Dependencies

--- a/docs/components/modules/others/pages/urlrewrite.adoc
+++ b/docs/components/modules/others/pages/urlrewrite.adoc
@@ -11,16 +11,16 @@
 *Since Camel {since}*
 
 The `camel-urlrewrite` component allows to plugin url rewrite
-functionality to xref:http-component.adoc[HTTP], xref:http4-component.adoc[HTTP4],
-xref:jetty-component.adoc[Jetty], or xref:ahc-component.adoc[AHC] components. This component
+functionality to xref:ROOT:http-component.adoc[HTTP], xref:ROOT:http4-component.adoc[HTTP4],
+xref:ROOT:jetty-component.adoc[Jetty], or xref:ROOT:ahc-component.adoc[AHC] components. This component
 integrates the
 http://code.google.com/p/urlrewritefilter/[UrlRewriteFilter] project
 with Apache Camel. This allows you to use the capabilities from the url
 rewrite project with your Camel routes.
 
 This component *requires* that your Camel routes starts from a servlet
-based endpoint such as xref:jetty-component.adoc[Jetty] or
-xref:servlet-component.adoc[Servlet component].
+based endpoint such as xref:ROOT:jetty-component.adoc[Jetty] or
+xref:ROOT:servlet-component.adoc[Servlet component].
 
 [[UrlRewrite-Options]]
 == Options
@@ -57,8 +57,8 @@ remove the context-path.
 == Usage
 
 The following component producers supports using together with the
-`camel-urlrewrite` component: xref:http-component.adoc[HTTP],
-xref:http4-component.adoc[HTTP4] and xref:jetty-component.adoc[Jetty].
+`camel-urlrewrite` component: xref:ROOT:http-component.adoc[HTTP],
+xref:ROOT:http4-component.adoc[HTTP4] and xref:ROOT:jetty-component.adoc[Jetty].
 
 [width="100%",cols="10%,90%",options="header",]
 |=======================================================================
@@ -80,7 +80,7 @@ with any of the components.
 
 You setup the url rewrite as a bean of the type
 `org.apache.camel.component.urlrewrite.http.HttpUrlRewrite` (when using
-xref:http-component.adoc[HTTP] component) as shown below:
+xref:ROOT:http-component.adoc[HTTP] component) as shown below:
 
 And in XML DSL you can do:
 
@@ -153,8 +153,8 @@ Component(s): camel-http4
 
 The former is a simple and generic interface, which is not dependent on
 the Servlet API. The later is servlet based which requires the Camel route to start from
-a servlet based component such as xref:jetty-component.adoc[Jetty] or
-xref:servlet-component.adoc[Servlet component]. The servlet based is more feature rich and
+a servlet based component such as xref:ROOT:jetty-component.adoc[Jetty] or
+xref:ROOT:servlet-component.adoc[Servlet component]. The servlet based is more feature rich and
 that's the API we use to integrate with the
 http://code.google.com/p/urlrewritefilter/[UrlRewriteFilter] project in
 this `camel-urlrewrite` component.


### PR DESCRIPTION
This fixes the xref problems (locally) and there are no link check errors, but I see 

```
✖ 26017 problems (26017 errors, 0 warnings)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "check:html" exited with 1.
```
These don't immediately appear to relate to the antora-build pages.