### PR TITLE
CAMEL-15052: Cannot watch user with Google Mail component

### DIFF
--- a/components/camel-google-mail/pom.xml
+++ b/components/camel-google-mail/pom.xml
@@ -170,7 +170,7 @@
                                     <apiName>users</apiName>
                                     <proxyClass>com.google.api.services.gmail.Gmail$Users</proxyClass>
                                     <fromJavadoc>
-                                        <includeMethods>getProfile</includeMethods>
+                                        <includeMethods>getProfile|watch|stop</includeMethods>
                                     </fromJavadoc>
                                 </api>
                             </apis>

--- a/components/camel-google-mail/src/main/docs/google-mail-component.adoc
+++ b/components/camel-google-mail/src/main/docs/google-mail-component.adoc
@@ -106,7 +106,7 @@ with the following path and query parameters:
 |===
 | Name | Description | Default | Type
 | *apiName* | *Required* What kind of operation to perform. The value can be one of: THREADS, MESSAGES, ATTACHMENTS, LABELS, HISTORY, DRAFTS, USERS |  | GoogleMailApiName
-| *methodName* | *Required* What sub operation to use for the selected operation. The value can be one of: attachments, create, delete, get, getProfile, gmailImport, insert, list, modify, patch, send, trash, untrash, update |  | String
+| *methodName* | *Required* What sub operation to use for the selected operation. The value can be one of: attachments, create, delete, get, getProfile, gmailImport, insert, list, modify, patch, send, stop, trash, untrash, update, watch |  | String
 |===
 
 


### PR DESCRIPTION
Google mail users API is restricted to method getProfile. This pull request opens access to two other useful methods: watch and stop.

See here:
https://developers.google.com/gmail/api/v1/reference/users/watch

===

[x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ x] Each commit in the pull request should have a meaningful subject line and body.
[x ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ x ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
