### PR TITLE
[CAMEL-7810] Fix JdbcAggregationRepository optimistic locking feature (master)

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -17,7 +17,7 @@
     limitations under the License.
 
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -284,7 +284,7 @@ from("direct:withSplitModel")
             .to("mock:result")
         .end();
 ----
- 
+
 [[sql-component-header-values]]
 == Header values
 
@@ -485,7 +485,7 @@ from("direct:query")
     .to("log:query")
     .to("mock:query");
 ----
- 
+
 
 == Using the JDBC based idempotent repository
 
@@ -511,7 +511,7 @@ idempotent repository. We use the following schema:
 CREATE TABLE CAMEL_MESSAGEPROCESSED ( processorName VARCHAR(255),
 messageId VARCHAR(100) )
 ----
- 
+
 
 We added the createdAt column:
 
@@ -620,11 +620,13 @@ Here is the SQL query used to create the tables, just replace
 CREATE TABLE aggregation (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  constraint aggregation_pk PRIMARY KEY (id)
 );
 CREATE TABLE aggregation_completed (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  constraint aggregation_completed_pk PRIMARY KEY (id)
 );
 -----
@@ -644,6 +646,7 @@ store the body, and the following two headers `companyName` and
 CREATE TABLE aggregationRepo3 (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  body varchar(1000),
  companyName varchar(1000),
  accountName varchar(1000),
@@ -652,13 +655,14 @@ CREATE TABLE aggregationRepo3 (
 CREATE TABLE aggregationRepo3_completed (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  body varchar(1000),
  companyName varchar(1000),
  accountName varchar(1000),
  constraint aggregationRepo3_completed_pk PRIMARY KEY (id)
 );
 ----
- 
+
 And then configure the repository to enable this behavior as shown
 below:
 

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
@@ -16,13 +16,14 @@
  */
 package org.apache.camel.processor.aggregate.jdbc;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -38,12 +39,10 @@ import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Constants;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.AbstractLobCreatingPreparedStatementCallback;
-import org.springframework.jdbc.core.support.AbstractLobStreamingResultSetExtractor;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobCreator;
 import org.springframework.jdbc.support.lob.LobHandler;
@@ -54,7 +53,6 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.FileCopyUtils;
 
 /**
  * JDBC based {@link org.apache.camel.spi.AggregationRepository}
@@ -68,6 +66,10 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
     protected static final String EXCHANGE = "exchange";
     protected static final String ID = "id";
     protected static final String BODY = "body";
+
+    // optimistic locking: version identifier needed to avoid the lost update problem
+    private static final String VERSION = "version";
+    private static final String VERSION_PROPERTY = "CamelOptimisticLockVersion";
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcAggregationRepository.class);
     private static final Constants PROPAGATION_CONSTANTS = new Constants(TransactionDefinition.class);
@@ -150,10 +152,10 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
                 final String key = correlationId;
 
                 try {
-                    LOG.debug("Adding exchange with key: [{}]", key);
+                    LOG.debug("Adding exchange with key {}", key);
 
                     boolean present = jdbcTemplate.queryForObject(
-                            "SELECT COUNT(*) FROM " + getRepositoryName() + " WHERE " + ID + " = ?", Integer.class, key) != 0;
+                        "SELECT COUNT(1) FROM " + getRepositoryName() + " WHERE " + ID + " = ?", Integer.class, key) != 0;
 
                     // Recover existing exchange with that ID
                     if (isReturnOldExchange() && present) {
@@ -161,9 +163,12 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
                     }
 
                     if (present) {
-                        update(camelContext, correlationId, exchange, getRepositoryName());
+                        long version = exchange.getProperty(VERSION_PROPERTY, Long.class);
+                        LOG.debug("Updating record with key {} and version {}", key, version);
+                        update(camelContext, correlationId, exchange, getRepositoryName(), version);
                     } else {
-                        insert(camelContext, correlationId, exchange, getRepositoryName());
+                        LOG.debug("Inserting record with key {}");
+                        insert(camelContext, correlationId, exchange, getRepositoryName(), 1L);
                     }
 
                 } catch (Exception e) {
@@ -176,18 +181,21 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
     }
 
     /**
-     * Updates the current exchange details in the given repository table
+     * Updates the current exchange details in the given repository table.
      *
-     * @param camelContext   the current CamelContext
-     * @param key            the correlation key
-     * @param exchange       the aggregated exchange
-     * @param repositoryName The name of the table
+     * @param camelContext   Current CamelContext
+     * @param key            Correlation key
+     * @param exchange       Aggregated exchange
+     * @param repositoryName Table's name
+     * @param version        Version identifier
      */
-    protected void update(final CamelContext camelContext, final String key, final Exchange exchange, String repositoryName) throws Exception {
+    protected void update(final CamelContext camelContext, final String key, final Exchange exchange, String repositoryName, Long version) throws Exception {
         StringBuilder queryBuilder = new StringBuilder()
                 .append("UPDATE ").append(repositoryName)
                 .append(" SET ")
-                .append(EXCHANGE).append(" = ?");
+                .append(EXCHANGE).append(" = ?")
+                .append(", ")
+                .append(VERSION).append(" = ?");
         if (storeBodyAsText) {
             queryBuilder.append(", ").append(BODY).append(" = ?");
         }
@@ -198,29 +206,33 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
             }
         }
 
-        queryBuilder.append(" WHERE ").append(ID).append(" = ?");
+        queryBuilder.append(" WHERE ")
+            .append(ID).append(" = ?")
+            .append(" AND ")
+            .append(VERSION).append(" = ?");
 
         String sql = queryBuilder.toString();
-        insertAndUpdateHelper(camelContext, key, exchange, sql, false);
+        updateHelper(camelContext, key, exchange, sql, version);
     }
 
     /**
      * Inserts a new record into the given repository table.
-     * note : the exchange properties are NOT persisted.
+     * Note: the exchange properties are NOT persisted.
      *
-     * @param camelContext   the current CamelContext
-     * @param correlationId  the correlation key
-     * @param exchange       the aggregated exchange to insert. The headers will be persisted but not the properties.
-     * @param repositoryName The name of the table
+     * @param camelContext   Current CamelContext
+     * @param correlationId  Correlation key
+     * @param exchange       Aggregated exchange to insert
+     * @param repositoryName Table's name
+     * @param version        Version identifier
      */
-    protected void insert(final CamelContext camelContext, final String correlationId, final Exchange exchange, String repositoryName) throws Exception {
-        // The default totalParameterIndex is 2 for ID and Exchange. Depending on logic this will be increased
-        int totalParameterIndex = 2;
+    protected void insert(final CamelContext camelContext, final String correlationId, final Exchange exchange, String repositoryName, Long version) throws Exception {
+        // The default totalParameterIndex is 3 for ID, Exchange and version. Depending on logic this will be increased.
+        int totalParameterIndex = 3;
         StringBuilder queryBuilder = new StringBuilder()
                 .append("INSERT INTO ").append(repositoryName)
-                .append('(')
-                .append(EXCHANGE).append(", ")
-                .append(ID);
+                .append('(').append(EXCHANGE)
+                .append(", ").append(ID)
+                .append(", ").append(VERSION);
 
         if (storeBodyAsText) {
             queryBuilder.append(", ").append(BODY);
@@ -243,20 +255,19 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
 
         String sql = queryBuilder.toString();
 
-        insertAndUpdateHelper(camelContext, correlationId, exchange, sql, true);
+        insertHelper(camelContext, correlationId, exchange, sql, version);
     }
 
-    protected int insertAndUpdateHelper(final CamelContext camelContext, final String key, final Exchange exchange, String sql, final boolean idComesFirst) throws Exception {
+    protected int insertHelper(final CamelContext camelContext, final String key, final Exchange exchange, String sql, final Long version) throws Exception {
         final byte[] data = codec.marshallExchange(camelContext, exchange, allowSerializedHeaders);
-        Integer updateCount = jdbcTemplate.execute(sql,
+        Integer insertCount = jdbcTemplate.execute(sql,
                 new AbstractLobCreatingPreparedStatementCallback(getLobHandler()) {
                     @Override
                     protected void setValues(PreparedStatement ps, LobCreator lobCreator) throws SQLException {
                         int totalParameterIndex = 0;
                         lobCreator.setBlobAsBytes(ps, ++totalParameterIndex, data);
-                        if (idComesFirst) {
-                            ps.setString(++totalParameterIndex, key);
-                        }
+                        ps.setString(++totalParameterIndex, key);
+                        ps.setLong(++totalParameterIndex, version);
                         if (storeBodyAsText) {
                             ps.setString(++totalParameterIndex, exchange.getIn().getBody(String.class));
                         }
@@ -266,21 +277,45 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
                                 ps.setString(++totalParameterIndex, headerValue);
                             }
                         }
-                        if (!idComesFirst) {
-                            ps.setString(++totalParameterIndex, key);
-                        }
                     }
                 });
-        return updateCount == null ? 0 : updateCount;
+        return insertCount == null ? 0 : insertCount;
+    }
+
+    protected int updateHelper(final CamelContext camelContext, final String key, final Exchange exchange, String sql, final Long version) throws Exception {
+        final byte[] data = codec.marshallExchange(camelContext, exchange, allowSerializedHeaders);
+        Integer updateCount = jdbcTemplate.execute(sql,
+                new AbstractLobCreatingPreparedStatementCallback(getLobHandler()) {
+                    @Override
+                    protected void setValues(PreparedStatement ps, LobCreator lobCreator) throws SQLException {
+                        int totalParameterIndex = 0;
+                        lobCreator.setBlobAsBytes(ps, ++totalParameterIndex, data);
+                        ps.setLong(++totalParameterIndex, version + 1);
+                        if (storeBodyAsText) {
+                            ps.setString(++totalParameterIndex, exchange.getIn().getBody(String.class));
+                        }
+                        if (hasHeadersToStoreAsText()) {
+                            for (String headerName : headersToStoreAsText) {
+                                String headerValue = exchange.getIn().getHeader(headerName, String.class);
+                                ps.setString(++totalParameterIndex, headerValue);
+                            }
+                        }
+                        ps.setString(++totalParameterIndex, key);
+                        ps.setLong(++totalParameterIndex, version);
+                    }
+                });
+        if (updateCount == 1) {
+            return updateCount;
+        } else {
+            throw new RuntimeException(String.format("Stale version: error updating record with key %s and version %s", key, version));
+        }
     }
 
     @Override
     public Exchange get(final CamelContext camelContext, final String correlationId) {
         final String key = correlationId;
         Exchange result = get(key, getRepositoryName(), camelContext);
-
-        LOG.debug("Getting key  [{}] -> {}", key, result);
-
+        LOG.debug("Getting key {} -> {}", key, result);
         return result;
     }
 
@@ -288,15 +323,18 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
         return transactionTemplateReadOnly.execute(new TransactionCallback<Exchange>() {
             public Exchange doInTransaction(TransactionStatus status) {
                 try {
-                    String sql = "SELECT " + EXCHANGE + " FROM " + repositoryName + " WHERE " + ID + " = ?";
-                    ByteArrayOutputStream bis = new ByteArrayOutputStream();
-                    jdbcTemplate.query(sql, new Object[] {key}, new AbstractLobStreamingResultSetExtractor<Object>() {
-                        @Override
-                        protected void streamData(ResultSet rs) throws SQLException, IOException, DataAccessException {
-                            FileCopyUtils.copy(getLobHandler().getBlobAsBinaryStream(rs, EXCHANGE), bis);
-                        }
-                    });
-                    return codec.unmarshallExchange(camelContext, bis.toByteArray());
+
+                    Map<String, Object> columns = jdbcTemplate.queryForMap(
+                        String.format("SELECT %1$s, %2$s FROM %3$s WHERE %4$s=?", EXCHANGE, VERSION, repositoryName, ID),
+                        new Object[]{key}, new int[]{Types.VARCHAR});
+
+                    byte[] marshalledExchange = (byte[]) columns.get(EXCHANGE);
+                    long version = (long) columns.get(VERSION);
+
+                    Exchange result = codec.unmarshallExchange(camelContext, marshalledExchange);
+                    result.setProperty(VERSION_PROPERTY, version);
+                    return result;
+
                 } catch (EmptyResultDataAccessException ex) {
                     return null;
                 } catch (IOException ex) {
@@ -316,12 +354,13 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
             protected void doInTransactionWithoutResult(TransactionStatus status) {
                 final String key = correlationId;
                 final String confirmKey = exchange.getExchangeId();
+                final long version = exchange.getProperty(VERSION_PROPERTY, Long.class);
                 try {
-                    LOG.debug("Removing key [{}]", key);
+                    LOG.debug("Removing key {}", key);
 
-                    jdbcTemplate.update("DELETE FROM " + getRepositoryName() + " WHERE " + ID + " = ?", key);
+                    jdbcTemplate.update("DELETE FROM " + getRepositoryName() + " WHERE " + ID + " = ? AND " + VERSION + " = ?", key, version);
 
-                    insert(camelContext, confirmKey, exchange, getRepositoryNameCompleted());
+                    insert(camelContext, confirmKey, exchange, getRepositoryNameCompleted(), version);
 
                 } catch (Exception e) {
                     throw new RuntimeException("Error removing key " + key + " from repository " + repositoryName, e);
@@ -334,7 +373,7 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
     public void confirm(final CamelContext camelContext, final String exchangeId) {
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             protected void doInTransactionWithoutResult(TransactionStatus status) {
-                LOG.debug("Confirming exchangeId [{}]", exchangeId);
+                LOG.debug("Confirming exchangeId {}", exchangeId);
                 final String confirmKey = exchangeId;
 
                 jdbcTemplate.update("DELETE FROM " + getRepositoryNameCompleted() + " WHERE " + ID + " = ?",
@@ -367,7 +406,7 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
                         new RowMapper<String>() {
                             public String mapRow(ResultSet rs, int rowNum) throws SQLException {
                                 String id = rs.getString(ID);
-                                LOG.trace("getKey [{}]", id);
+                                LOG.trace("getKey {}", id);
                                 return id;
                             }
                         });
@@ -380,9 +419,7 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
     public Exchange recover(CamelContext camelContext, String exchangeId) {
         final String key = exchangeId;
         Exchange answer = get(key, getRepositoryNameCompleted(), camelContext);
-
-        LOG.debug("Recovering exchangeId [{}] -> {}", key, answer);
-
+        LOG.debug("Recovering exchangeId {} -> {}", key, answer);
         return answer;
     }
 

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/PostgresAggregationRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/PostgresAggregationRepository.java
@@ -82,7 +82,7 @@ public class PostgresAggregationRepository extends JdbcAggregationRepository {
 
         String sql = queryBuilder.toString();
 
-        int updateCount = insertAndUpdateHelper(camelContext, correlationId, exchange, sql, true);
+        int updateCount = insertHelper(camelContext, correlationId, exchange, sql, 1L);
         if (updateCount == 0 && getRepositoryName().equals(repositoryName)) {
             throw new DataIntegrityViolationException("No row was inserted due to data violation");
         }

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/AbstractJdbcAggregationTestSupport.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/AbstractJdbcAggregationTestSupport.java
@@ -30,14 +30,14 @@ public abstract class AbstractJdbcAggregationTestSupport extends CamelSpringTest
     @Override
     public void postProcessTest() throws Exception {
         super.postProcessTest();
-        
+
         repo = applicationContext.getBean("repo1", JdbcAggregationRepository.class);
         configureJdbcAggregationRepository();
     }
-    
+
     void configureJdbcAggregationRepository() {
     }
-    
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -54,14 +54,21 @@ public abstract class AbstractJdbcAggregationTestSupport extends CamelSpringTest
             // END SNIPPET: e1
         };
     }
-    
+
     long getCompletionInterval() {
         return 5000;
     }
-    
+
     @Override
     protected AbstractApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/processor/aggregate/jdbc/JdbcSpringDataSource.xml");
+    }
+
+    protected Exchange repoAddAndGet(String key, Exchange exchange) {
+        repo.add(context, key, exchange);
+        // recover the exchange with the new version to be able to add again
+        exchange = repo.get(context, key);
+        return exchange;
     }
 
     public static class MyAggregationStrategy implements AggregationStrategy {

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregateNotLostTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregateNotLostTest.java
@@ -35,7 +35,7 @@ public class JdbcAggregateNotLostTest extends AbstractJdbcAggregationTestSupport
         template.sendBodyAndHeader("direct:start", "D", "id", 123);
         template.sendBodyAndHeader("direct:start", "E", "id", 123);
 
-        assertMockEndpointsSatisfied(30, TimeUnit.SECONDS);
+        assertMockEndpointsSatisfied(5, TimeUnit.SECONDS);
 
         String exchangeId = getMockEndpoint("mock:aggregated").getReceivedExchanges().get(0).getExchangeId();
 
@@ -63,7 +63,7 @@ public class JdbcAggregateNotLostTest extends AbstractJdbcAggregationTestSupport
                         .completionSize(5).aggregationRepository(repo)
                         .log("aggregated exchange id ${exchangeId} with ${body}")
                         .to("mock:aggregated")
-                                // throw an exception to fail, which we then will loose this message
+                        // throw an exception to fail, which we then will loose this message
                         .throwException(new IllegalArgumentException("Damn"))
                         .to("mock:result")
                         .end();

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryAlotDataTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryAlotDataTest.java
@@ -24,45 +24,39 @@ public class JdbcAggregationRepositoryAlotDataTest extends AbstractJdbcAggregati
 
     @Test
     public void testWithAlotOfDataSameKey() {
+        final String key = "foo";
+        Exchange exchange = new DefaultExchange(context);
         for (int i = 0; i < 100; i++) {
-            Exchange exchange1 = new DefaultExchange(context);
-            exchange1.getIn().setBody("counter:" + i);
-            repo.add(context, "foo", exchange1);
+            exchange.getIn().setBody("counter:" + i);
+            exchange = repoAddAndGet(key, exchange);
         }
 
         // Get it back..
-        Exchange actual = repo.get(context, "foo");
+        Exchange actual = repo.get(context, key);
         assertEquals("counter:99", actual.getIn().getBody());
     }
 
-    @Test
+    @Test(expected = RuntimeException.class)
     public void testWithAlotOfDataTwoKeys() {
-        for (int i = 0; i < 100; i++) {
-            Exchange exchange1 = new DefaultExchange(context);
-            exchange1.getIn().setBody("counter:" + i);
+        for (int i = 0; i < 10; i++) {
+            Exchange exchange = new DefaultExchange(context);
+            exchange.getIn().setBody("counter:" + i);
             String key = i % 2 == 0 ? "foo" : "bar";
-            repo.add(context, key, exchange1);
+            repoAddAndGet(key, exchange);
         }
-
-        // Get it back..
-        Exchange actual = repo.get(context, "foo");
-        assertEquals("counter:98", actual.getIn().getBody());
-
-        actual = repo.get(context, "bar");
-        assertEquals("counter:99", actual.getIn().getBody());
     }
 
     @Test
     public void testWithAlotOfDataWithDifferentKeys() {
-        for (int i = 0; i < 100; i++) {
-            Exchange exchange1 = new DefaultExchange(context);
-            exchange1.getIn().setBody("counter:" + i);
+        for (int i = 0; i < 10; i++) {
+            Exchange exchange = new DefaultExchange(context);
+            exchange.getIn().setBody("counter:" + i);
             String key = "key" + i;
-            repo.add(context, key, exchange1);
+            repoAddAndGet(key, exchange);
         }
 
         // Get it back..
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 10; i++) {
             Exchange actual = repo.get(context, "key" + i);
             assertEquals("counter:" + i, actual.getIn().getBody());
         }

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryMultipleRepoTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryMultipleRepoTest.java
@@ -53,8 +53,9 @@ public class JdbcAggregationRepositoryMultipleRepoTest extends CamelSpringTestSu
         assertEquals("counter:1", actual.getIn().getBody());
         assertEquals(null, repo2.get(context, "foo"));
 
-        // Change it..
+        // Change it after reading the current exchange with version
         Exchange exchange2 = new DefaultExchange(context);
+        exchange2 = repo1.get(context, "foo");
         exchange2.getIn().setBody("counter:2");
         actual = repo1.add(context, "foo", exchange2);
         // the old one

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryRecoverExistingTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryRecoverExistingTest.java
@@ -28,7 +28,7 @@ public class JdbcAggregationRepositoryRecoverExistingTest extends AbstractJdbcAg
         repo.setReturnOldExchange(true);
         repo.setUseRecovery(true);
     }
-    
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -48,7 +48,8 @@ public class JdbcAggregationRepositoryRecoverExistingTest extends AbstractJdbcAg
         Exchange actual = repo.add(context, "foo", exchange1);
         assertEquals(null, actual);
 
-        // Remove it, which makes it in the pre confirm stage
+        // Get and remove it, which makes it in the pre confirm stage
+        exchange1 = repo.get(context, "foo");
         repo.remove(context, "foo", exchange1);
 
         String id = exchange1.getExchangeId();

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryTest.java
@@ -26,7 +26,7 @@ public class JdbcAggregationRepositoryTest extends AbstractJdbcAggregationTestSu
     void configureJdbcAggregationRepository() {
         repo.setReturnOldExchange(true);
     }
-    
+
     @Test
     public void testOperations() {
         // Can't get something we have not put in...
@@ -43,8 +43,9 @@ public class JdbcAggregationRepositoryTest extends AbstractJdbcAggregationTestSu
         actual = repo.get(context, "foo");
         assertEquals("counter:1", actual.getIn().getBody());
 
-        // Change it..
+        // Change it after reading the current exchange with version
         Exchange exchange2 = new DefaultExchange(context);
+        exchange2 = repo.get(context, "foo");
         exchange2.getIn().setBody("counter:2");
         actual = repo.add(context, "foo", exchange2);
         // the old one

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcExchangeSerializationTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcExchangeSerializationTest.java
@@ -26,6 +26,7 @@ public class JdbcExchangeSerializationTest extends AbstractJdbcAggregationTestSu
 
     @Test
     public void testExchangeSerialization() {
+        final String key = "foo";
         Exchange exchange = new DefaultExchange(context);
         exchange.getIn().setBody("Hello World");
         exchange.getIn().setHeader("name", "Olivier");
@@ -35,9 +36,9 @@ public class JdbcExchangeSerializationTest extends AbstractJdbcAggregationTestSu
         Date now = new Date();
         exchange.getIn().setHeader("date", now);
 
-        repo.add(context, "foo", exchange);
+        exchange = repoAddAndGet(key, exchange);
 
-        Exchange actual = repo.get(context, "foo");
+        Exchange actual = repo.get(context, key);
         assertEquals("Hello World", actual.getIn().getBody());
         assertEquals("Olivier", actual.getIn().getHeader("name"));
         assertEquals(123, actual.getIn().getHeader("number"));
@@ -53,9 +54,9 @@ public class JdbcExchangeSerializationTest extends AbstractJdbcAggregationTestSu
         exchange.getIn().setHeader("name", "Thomas");
         exchange.getIn().removeHeader("date");
 
-        repo.add(context, "foo", exchange);
+        exchange = repoAddAndGet(key, exchange);
 
-        actual = repo.get(context, "foo");
+        actual = repo.get(context, key);
         assertEquals("Bye World", actual.getIn().getBody());
         assertEquals("Thomas", actual.getIn().getHeader("name"));
         assertEquals(123, actual.getIn().getHeader("number"));
@@ -63,4 +64,5 @@ public class JdbcExchangeSerializationTest extends AbstractJdbcAggregationTestSu
         assertNull(date);
         assertSame(context, actual.getContext());
     }
+
 }

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcGrowIssueTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcGrowIssueTest.java
@@ -31,8 +31,8 @@ public class JdbcGrowIssueTest extends AbstractJdbcAggregationTestSupport {
         for (int i = 0; i < SIZE; i++) {
             sb.append("X");
         }
-        Exchange item = new DefaultExchange(context);
-        item.getIn().setBody(sb.toString(), String.class);
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(sb.toString(), String.class);
 
         // the key
         final String key = "foo";
@@ -40,7 +40,7 @@ public class JdbcGrowIssueTest extends AbstractJdbcAggregationTestSupport {
         // we update using the same key, which means we should be able to do this within the file size limit
         for (int i = 0; i < SIZE; i++) {
             log.debug("Updating " + i);
-            repo.add(context, key, item);
+            exchange = repoAddAndGet(key, exchange);
         }
 
         // get the last

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryCustomTableNameTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryCustomTableNameTest.java
@@ -36,23 +36,23 @@ public class JdbcMessageIdRepositoryCustomTableNameTest extends CamelSpringTestS
 
     protected JdbcTemplate jdbcTemplate;
     protected DataSource dataSource;
-    
+
     @EndpointInject("mock:result")
     protected MockEndpoint resultEndpoint;
 
     @EndpointInject("mock:error")
     protected MockEndpoint errorEndpoint;
-    
+
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        
+
         dataSource = context.getRegistry().lookupByNameAndType("dataSource", DataSource.class);
         jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.afterPropertiesSet();
     }
-    
+
     @Test
     public void testDuplicateMessagesAreFilteredOut() throws Exception {
         resultEndpoint.expectedBodiesReceived("one", "two", "three");
@@ -75,7 +75,7 @@ public class JdbcMessageIdRepositoryCustomTableNameTest extends CamelSpringTestS
         assertTrue(receivedMessageIds.contains("2"));
         assertTrue(receivedMessageIds.contains("3"));
     }
-    
+
     @Override
     protected AbstractApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/processor/idempotent/jdbc/customized-tablename-spring.xml");

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryTest.java
@@ -42,23 +42,23 @@ public class JdbcMessageIdRepositoryTest extends CamelSpringTestSupport {
 
     protected JdbcTemplate jdbcTemplate;
     protected DataSource dataSource;
-    
+
     @EndpointInject("mock:result")
     protected MockEndpoint resultEndpoint;
 
     @EndpointInject("mock:error")
     protected MockEndpoint errorEndpoint;
-    
+
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        
+
         dataSource = context.getRegistry().lookupByNameAndType("dataSource", DataSource.class);
         jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.afterPropertiesSet();
     }
-    
+
     @Test
     public void testDuplicateMessagesAreFilteredOut() throws Exception {
         resultEndpoint.expectedBodiesReceived("one", "two", "three");
@@ -113,7 +113,7 @@ public class JdbcMessageIdRepositoryTest extends CamelSpringTestSupport {
         template.sendBodyAndHeader("direct:start", "three", "messageId", "3");
 
         assertMockEndpointsSatisfied();
-        
+
         jdbcTemplate.update(CLEAR_STRING, PROCESSOR_NAME);
 
         // only message 1 and 3 should be in jdbc repo
@@ -123,7 +123,7 @@ public class JdbcMessageIdRepositoryTest extends CamelSpringTestSupport {
         assertFalse("Should not contain message 1", receivedMessageIds.contains("1"));
         assertFalse("Should not contain message 3", receivedMessageIds.contains("3"));
     }
-    
+
     @Override
     protected AbstractApplicationContext createApplicationContext() {
         return new ClassPathXmlApplicationContext("org/apache/camel/processor/idempotent/jdbc/spring.xml");

--- a/components/camel-sql/src/test/resources/sql/init.sql
+++ b/components/camel-sql/src/test/resources/sql/init.sql
@@ -18,10 +18,12 @@
 CREATE TABLE aggregationRepo1 (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     constraint aggregationRepo1_pk PRIMARY KEY (id)
 );
 CREATE TABLE aggregationRepo1_completed (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     constraint aggregationRepo1_completed_pk PRIMARY KEY (id)
 );

--- a/components/camel-sql/src/test/resources/sql/init2.sql
+++ b/components/camel-sql/src/test/resources/sql/init2.sql
@@ -18,10 +18,12 @@
 CREATE TABLE aggregationRepo2 (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     constraint aggregationRepo2_pk PRIMARY KEY (id)
 );
 CREATE TABLE aggregationRepo2_completed (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     constraint aggregationRepo2_completed_pk PRIMARY KEY (id)
 );

--- a/components/camel-sql/src/test/resources/sql/init3.sql
+++ b/components/camel-sql/src/test/resources/sql/init3.sql
@@ -18,6 +18,7 @@
 CREATE TABLE aggregationRepo3 (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     body varchar(1000),
     companyName varchar(1000),
     accountName varchar(1000),
@@ -26,6 +27,7 @@ CREATE TABLE aggregationRepo3 (
 CREATE TABLE aggregationRepo3_completed (
     id varchar(255) NOT NULL,
     exchange blob NOT NULL,
+    version bigint NOT NULL,
     body varchar(1000),
     companyName varchar(1000),
     accountName varchar(1000),

--- a/docs/components/modules/ROOT/pages/sql-component.adoc
+++ b/docs/components/modules/ROOT/pages/sql-component.adoc
@@ -286,7 +286,7 @@ from("direct:withSplitModel")
             .to("mock:result")
         .end();
 ----
- 
+
 [[sql-component-header-values]]
 == Header values
 
@@ -487,7 +487,7 @@ from("direct:query")
     .to("log:query")
     .to("mock:query");
 ----
- 
+
 
 == Using the JDBC based idempotent repository
 
@@ -513,7 +513,7 @@ idempotent repository. We use the following schema:
 CREATE TABLE CAMEL_MESSAGEPROCESSED ( processorName VARCHAR(255),
 messageId VARCHAR(100) )
 ----
- 
+
 
 We added the createdAt column:
 
@@ -622,11 +622,13 @@ Here is the SQL query used to create the tables, just replace
 CREATE TABLE aggregation (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  constraint aggregation_pk PRIMARY KEY (id)
 );
 CREATE TABLE aggregation_completed (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  constraint aggregation_completed_pk PRIMARY KEY (id)
 );
 -----
@@ -646,6 +648,7 @@ store the body, and the following two headers `companyName` and
 CREATE TABLE aggregationRepo3 (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  body varchar(1000),
  companyName varchar(1000),
  accountName varchar(1000),
@@ -654,13 +657,14 @@ CREATE TABLE aggregationRepo3 (
 CREATE TABLE aggregationRepo3_completed (
  id varchar(255) NOT NULL,
  exchange blob NOT NULL,
+ version BIGINT NOT NULL,
  body varchar(1000),
  companyName varchar(1000),
  accountName varchar(1000),
  constraint aggregationRepo3_completed_pk PRIMARY KEY (id)
 );
 ----
- 
+
 And then configure the repository to enable this behavior as shown
 below:
 

--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -349,6 +349,27 @@ This means that you should use `xslt` and `xslt-saxon` as component name in your
 If you are using XSLT aggregation strategy, then use `org.apache.camel.component.xslt.saxon.XsltSaxonAggregationStrategy` for Saxon support.
 And use `org.apache.camel.component.xslt.saxon.XsltSaxonBuilder` for Saxon support if using xslt builder. Also notice that `allowStax` is also only supported in `camel-xslt-saxon` as this is not supported by the JDK XSLT.
 
+=== camel-sql
+
+The `JdbcAggregationRepository` optimistic locking feature has been fixed to work on a distributed environment and every database.
+There is a new `version` column that is required and must be added to the repository:
+
+[source,sql]
+----
+CREATE TABLE aggregation (
+ id varchar(255) NOT NULL,
+ exchange blob NOT NULL,
+ version BIGINT NOT NULL,
+ constraint aggregation_pk PRIMARY KEY (id)
+);
+CREATE TABLE aggregation_completed (
+ id varchar(255) NOT NULL,
+ exchange blob NOT NULL,
+ version BIGINT NOT NULL,
+ constraint aggregation_completed_pk PRIMARY KEY (id)
+);
+----
+
 === Configuring global options on CamelContext
 
 In Camel 2.x we have deprecated `getProperties` on `CamelContext` in favour of `getGlobalOptions`, so you should migrate to:

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_4.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_4.adoc
@@ -6,6 +6,18 @@ from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.3 to 3.4
 
+<<<<<<< HEAD
+=======
+=== camel-servlet and camel-http-common
+HttpRegistry and DefaultHttpRegistry classes from camel-servlet are moved from camel-servlet into camel-http-common.
+HttpRegistryProvider is added and used in DefaultHttpRegistry instead of CamelServlet which is implementing HttpRegistryProvider
+since DefaultHttpRegistry is used in camel-resteasy component where CamelResteasy servlet also implementing HttpRegistryProvider.
+
+These changes had effects on camel-atmosphere-websocket and camel-servlet and also camel-resteasy.
+Users of these components where they would have custom implemetations on DefaultHttpRegistry and using CamelServlet class should
+take this change into account.
+
+>>>>>>> 282044701e9... [CAMEL-7810] Fix JdbcAggregationRepository optimistic locking feature
 === camel-test and JMX
 
 The `camel-test` module no longer has dependency on `camel-management` out of the box.
@@ -64,3 +76,24 @@ This actuator was becoming problematic to maintain during Spring Boot upgrades d
 
 These changes had effects on camel-atmosphere-websocket and camel-servlet and also camel-resteasy.
 Users of these components where they would have custom implemetations on `DefaultHttpRegistry` and using `CamelServlet` class should take this change into account.
+
+=== camel-sql
+
+The `JdbcAggregationRepository` optimistic locking feature has been fixed to work on a distributed environment and every database.
+There is a new `version` column that is required and must be added to the repository:
+
+[source,sql]
+----
+CREATE TABLE aggregation (
+ id varchar(255) NOT NULL,
+ exchange blob NOT NULL,
+ version BIGINT NOT NULL,
+ constraint aggregation_pk PRIMARY KEY (id)
+);
+CREATE TABLE aggregation_completed (
+ id varchar(255) NOT NULL,
+ exchange blob NOT NULL,
+ version BIGINT NOT NULL,
+ constraint aggregation_completed_pk PRIMARY KEY (id)
+);
+----


### PR DESCRIPTION
Running JdbcAggregationRepository on a distributed environment (multiple independent
threads or multiple JVMs) we have silently dropped exchanges. This PR aims at introducing
a version identifier to avoid the lost update problem (overwrites when updating the
aggregate row) as stated by the OptimisticLockingAggregationRepository SPI.

Tested running 100 threads to aggregate 10k messages on MySQL 5.7 and PostgreSQL 11.5.

**Do not merge yet.** I'm having some problems running [my test application](https://github.com/fvaleri/integ-examples/blob/master/standalone/distributed-aggr/src/main/java/it/fvaleri/integ/Application.java) with the new routing engine. Will look at it later and once fixed we could add it as an example or test.
