### PR TITLE
CAMEL-15091: fixed AvailablePortFinder.getNextAvailable(int fromPort,…

### DIFF
--- a/components/camel-test/src/main/java/org/apache/camel/test/AvailablePortFinder.java
+++ b/components/camel-test/src/main/java/org/apache/camel/test/AvailablePortFinder.java
@@ -45,37 +45,49 @@ public final class AvailablePortFinder {
      * @return the available port
      */
     public static int getNextAvailable() {
-        try (ServerSocket ss = new ServerSocket()) {
-            ss.setReuseAddress(true);
-            ss.bind(new InetSocketAddress((InetAddress) null, 0), 1);
-            int port = ss.getLocalPort();
-            LOG.info("getNextAvailable() -> {}", port);
-            return port;
-        } catch (IOException e) {
-            throw new IllegalStateException("Cannot find free port", e);
-        }
+        return probePort(0);
     }
 
 
     /**
      * Gets the next available port in the given range.
      *
+     * @param fromPort port number start range.
+     * @param toPort port number end range.
+     *
      * @throws IllegalStateException if there are no ports available
      * @return the available port
      */
     public static int getNextAvailable(int fromPort, int toPort) {
         for (int i = fromPort; i <= toPort; i++) {
-            try (ServerSocket ss = new ServerSocket()) {
-                ss.setReuseAddress(true);
-                ss.bind(new InetSocketAddress((InetAddress) null, i), 1);
-                int port = ss.getLocalPort();
-                LOG.info("getNextAvailable() -> {}", port);
-                return port;
-            } catch (IOException e) {
-                throw new IllegalStateException("Cannot find free port", e);
+            try {
+                return probePort(i);
+            } catch (IllegalStateException e) {
+                // do nothing, let's try the next port
             }
         }
-
         throw new IllegalStateException("Cannot find free port");
     }
+
+
+    /**
+     * Probe a port to see if it is free
+     *
+     * @param port an integer port number to be tested. If port is 0, then the next available port is returned.
+     * @throws IllegalStateException if the port is not free or, in casi of port 0, if there are no ports available at all.
+     * @return the port number itself if the port is free or, inc ase of port 0, the first available port number.
+     */
+    private static int probePort(int port) {
+        try (ServerSocket ss = new ServerSocket()) {
+            ss.setReuseAddress(true);
+            ss.bind(new InetSocketAddress((InetAddress) null, port), 1);
+            int probedPort = ss.getLocalPort();
+            LOG.info("Available port is -> {}", probedPort);
+            return probedPort;
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot find free port", e);
+        }
+    }
+
+
 }

--- a/components/camel-test/src/test/java/org/apache/camel/test/AvailablePortFinderTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/AvailablePortFinderTest.java
@@ -60,6 +60,16 @@ public class AvailablePortFinderTest {
     }
 
     @Test
+    public void testPortRange() throws Exception {
+        int p1 = AvailablePortFinder.getNextAvailable(49152, 65535);
+        ServerSocket socket1 = new ServerSocket(p1);
+        int p2 = AvailablePortFinder.getNextAvailable(49152, 65535);
+        ServerSocket socket2 = new ServerSocket(p2);
+        socket1.close();
+        socket2.close();
+    }
+
+    @Test
     public void testAvailablePortFinderPropertiesFunction() throws Exception {
         AvailablePortFinderPropertiesFunction function = new AvailablePortFinderPropertiesFunction();
 


### PR DESCRIPTION
… int toPort) stops at the first port in use.

`AvailablePortFinder.getNextAvailable(int fromPort, int toPort)` was not taking into account the port range and simply failing if the first port probed wasn't free.

The problem has been fixed by catching an exception and continue with the next port in rage to try. 
A little refactoring has been done to remove some code duplication. 
A test has been added.