### PR TITLE
[CAMEL-7810] Use OptimisticLockingException for version conflicts

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/DefaultJdbcOptimisticLockingExceptionMapper.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/DefaultJdbcOptimisticLockingExceptionMapper.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.camel.spi.OptimisticLockingAggregationRepository.OptimisticLockingException;
 import org.apache.camel.util.ObjectHelper;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -47,6 +48,9 @@ public class DefaultJdbcOptimisticLockingExceptionMapper implements JdbcOptimist
         Iterator<Throwable> it = ObjectHelper.createExceptionIterator(cause);
         while (it.hasNext()) {
             Throwable throwable = it.next();
+            if (throwable instanceof OptimisticLockingException) {
+                return true;
+            }
             // if its a SQL exception
             if (throwable instanceof SQLException) {
                 SQLException se = (SQLException) throwable;

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
@@ -33,6 +33,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.OptimisticLockingAggregationRepository;
+import org.apache.camel.spi.OptimisticLockingAggregationRepository.OptimisticLockingException;
 import org.apache.camel.spi.RecoverableAggregationRepository;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ObjectHelper;
@@ -307,7 +308,8 @@ public class JdbcAggregationRepository extends ServiceSupport implements Recover
         if (updateCount == 1) {
             return updateCount;
         } else {
-            throw new RuntimeException(String.format("Stale version: error updating record with key %s and version %s", key, version));
+            // Found stale version while updating record
+            throw new OptimisticLockingException();
         }
     }
 


### PR DESCRIPTION
To trigger optimistic locking handling in case of version conflicts, we need to raise `OptimisticLockingException` not just `RuntimeCamelException`. With this change my test application works also on master. I'm going to create the same PR for 2.25.x branch and another PR to contribute the app to the example repository. 
