### PR TITLE
CAMEL-15121: Fix interchanged method calls of HeaderFilterStrategy

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -493,7 +493,7 @@ public class KafkaConsumer extends DefaultConsumer {
     }
 
     private boolean shouldBeFiltered(Header header, Exchange exchange, HeaderFilterStrategy headerFilterStrategy) {
-        return !headerFilterStrategy.applyFilterToCamelHeaders(header.key(), header.value(), exchange);
+        return !headerFilterStrategy.applyFilterToExternalHeaders(header.key(), header.value(), exchange);
     }
 
     private boolean isAutoCommitEnabled() {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -279,7 +279,7 @@ public class KafkaProducer extends DefaultAsyncProducer {
     }
 
     private boolean shouldBeFiltered(Map.Entry<String, Object> entry, Exchange exchange, HeaderFilterStrategy headerFilterStrategy) {
-        return !headerFilterStrategy.applyFilterToExternalHeaders(entry.getKey(), entry.getValue(), exchange);
+        return !headerFilterStrategy.applyFilterToCamelHeaders(entry.getKey(), entry.getValue(), exchange);
     }
 
     private RecordHeader getRecordHeader(Map.Entry<String, Object> entry, KafkaHeaderSerializer headerSerializer) {


### PR DESCRIPTION
In camel-kafka the two filter methods of HeaderFilterStrategy where used interchanged. 