### PR TITLE
Fix spring boot archetype spacing

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    ## ------------------------------------------------------------------------
-    ## Licensed to the Apache Software Foundation (ASF) under one or more
-    ## contributor license agreements.  See the NOTICE file distributed with
-    ## this work for additional information regarding copyright ownership.
-    ## The ASF licenses this file to You under the Apache License, Version 2.0
-    ## (the "License"); you may not use this file except in compliance with
-    ## the License.  You may obtain a copy of the License at
-    ##
-    ##      http://www.apache.org/licenses/LICENSE-2.0
-    ##
-    ## Unless required by applicable law or agreed to in writing, software
-    ## distributed under the License is distributed on an "AS IS" BASIS,
-    ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    ## See the License for the specific language governing permissions and
-    ## limitations under the License.
-    ## ------------------------------------------------------------------------
+## ------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ------------------------------------------------------------------------
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 


### PR DESCRIPTION
Those spaces cause extra spaces in autogenerated `pom.xml`.
Before `<project>` node.
For example:
```
<?xml version="1.0" encoding="UTF-8"?>
                                                                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
```
So now it is the same as in [camel-spring-archetype](https://github.com/apache/camel/blob/f257e16d100b14c0a24b748d9df997f32497f823/archetypes/camel-archetype-spring/src/main/resources/archetype-resources/pom.xml#L2)