### PR TITLE
Resolves CAMEL-15182: use generated dlist in summary pages

### DIFF
--- a/components/camel-aws-cw/src/main/docs/aws-summary.adoc
+++ b/components/camel-aws-cw/src/main/docs/aws-summary.adoc
@@ -6,26 +6,9 @@ https://aws.amazon.com/[AWS].
 AWS offers a great palette of different components like elastic, email and queue services. It also 
 provides streaming for Apache Kafka and more. The main reason to use AWS is its cloud computing platform.
 
-== AWS Components
 
-See the following for each component usage:
+== {docTitle} components
 
-* xref:aws-cw-component.adoc[AWS CloudWatch]
-* xref:aws-ddb-component.adoc[AWS DynamoDB]
-* xref:aws-ddbstream-component.adoc[AWS DynamoDB Streams]
-* xref:aws-ec2-component.adoc[AWS Elastic Compute Cloud (EC2)]
-* xref:aws-ecs-component.adoc[AWS Elastic Container Service (ECS)]
-* xref:aws-eks-component.adoc[AWS Elastic Kubernetes Service (EKS)]
-* xref:aws-iam-component.adoc[AWS Identity and Access Management (IAM)]
-* xref:aws-kms-component.adoc[AWS Key Management Service (KMS)]
-* xref:aws-kinesis-component.adoc[AWS Kinesis]
-* xref:aws-kinesis-firehose-component.adoc[AWS Kinesis Firehose]
-* xref:aws-lambda-component.adoc[AWS Lambda]
-* xref:aws-msk-component.adoc[AWS Managed Streaming for Apache Kafka (MSK)]
-* xref:aws-mq-component.adoc[AWS MQ]
-* xref:aws-s3-component.adoc[AWS S3 Storage Service]
-* xref:aws-ses-component.adoc[AWS Simple Email Service (SES)]
-* xref:aws-sns-component.adoc[AWS Simple Notification System (SNS)]
-* xref:aws-sqs-component.adoc[AWS Simple Queue Service (SQS)]
-* xref:aws-swf-component.adoc[AWS Simple Workflow (SWF)]
-* xref:aws-sdb-component.adoc[AWS SimpleDB]
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/components/camel-aws2-cw/src/main/docs/aws2-summary.adoc
+++ b/components/camel-aws2-cw/src/main/docs/aws2-summary.adoc
@@ -6,25 +6,9 @@ https://aws.amazon.com/[AWS 2].
 AWS 2 offers a great palette of different components like cloudwatch, DynamoDB streams, 
 storage service, email and queue services. The main reason to use AWS is its cloud computing platform.
 
-== AWS 2 components
 
-See the following for each component usage:
+== {docTitle} components
 
-* xref:aws2-cw-component.adoc[AWS 2 CloudWatch]
-* xref:aws2-ddb-component.adoc[AWS 2 DynamoDB]
-* xref:aws2-ddbstream-component.adoc[AWS 2 DynamoDB Streams]
-* xref:aws2-ec2-component.adoc[AWS 2 Elastic Compute Cloud (EC2)]
-* xref:aws2-ecs-component.adoc[AWS 2 Elastic Container Service (ECS)]
-* xref:aws2-eks-component.adoc[AWS 2 Elastic Kubernetes Service (EKS)]
-* xref:aws2-iam-component.adoc[AWS 2 Identity and Access Management (IAM)]
-* xref:aws2-kms-component.adoc[AWS 2 Key Management Service (KMS)]
-* xref:aws2-kinesis-component.adoc[AWS 2 Kinesis]
-* xref:aws2-kinesis-firehose-component.adoc[AWS 2 Kinesis Firehose]
-* xref:aws2-lambda-component.adoc[AWS 2 Lambda]
-* xref:aws2-msk-component.adoc[AWS 2 Managed Streaming for Apache Kafka (MSK)]
-* xref:aws2-mq-component.adoc[AWS 2 MQ]
-* xref:aws2-s3-component.adoc[AWS 2 S3 Storage Service]
-* xref:aws2-ses-component.adoc[AWS 2 Simple Email Service (SES)]
-* xref:aws2-sns-component.adoc[AWS 2 Simple Notification System (SNS)]
-* xref:aws2-sqs-component.adoc[AWS 2 Simple Queue Service (SQS)]
-* xref:aws2-translate-component.adoc[AWS 2 Translate]
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/components/camel-azure/src/main/docs/azure-summary.adoc
+++ b/components/camel-azure/src/main/docs/azure-summary.adoc
@@ -6,13 +6,10 @@
 The Camel Components for https://azure.microsoft.com/[Windows Azure Services]
 provide connectivity to Azure services from Camel.
 
- 
-[width="100%",cols="30%,10%,50%",options="header",]
-|=======================================================================
-|Azure Service |Camel Component |Component Description
+== {docTitle} components
 
-|https://azure.microsoft.com/services/storage/blobs[Storage Blob Service] |xref:azure-blob-component.adoc[Azure-Blob] |Supports storing and retrieving of blobs
-|https://azure.microsoft.com/services/storage/queues[Storage Queue Service] |xref:azure-queue-component.adoc[Azure-Queue] |Supports storing and retrieving of messages in the queues
-|=======================================================================
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
 
 include::camel-spring-boot::page$azure-starter.adoc[]

--- a/components/camel-google-bigquery/src/main/docs/google-summary.adoc
+++ b/components/camel-google-bigquery/src/main/docs/google-summary.adoc
@@ -7,17 +7,8 @@ https://gsuite.google.co.in/[G Suite].
 Google offers a great palette of different components like use of calender, mail, sheets and 
 drive . The main reason to use Google is the G Suite features.
 
-== Google Components
+== {docTitle} components
 
-See the following for each component usage:
+See the following for usage of each component:
 
-*  xref:google-bigquery-component.adoc[Google BigQuery]
-*  xref:google-bigquery-sql-component.adoc[Google BigQuery Standard SQL]
-*  xref:google-calendar-component.adoc[Google Calendar]
-*  xref:google-calendar-stream-component.adoc[Google Calendar Stream]
-*  xref:google-drive-component.adoc[Google Drive]
-*  xref:google-mail-component.adoc[Google Mail]
-*  xref:google-mail-stream-component.adoc[Google Mail Stream]
-*  xref:google-pubsub-component.adoc[Google Pubsub]
-*  xref:google-sheets-component.adoc[Google Sheets]
-*  xref:google-sheets-stream-component.adoc[Google Sheets Stream]
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
@@ -18,6 +18,14 @@ persistence, network configuration (if needed), near cache, eviction
 and so on. For more information consult the Hazelcast documentation on
 http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
+
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:
 
@@ -30,24 +38,6 @@ for this component:
     <!-- use the same version as your Camel core version -->
 </dependency>
 ------------------------------------------------------------
-
-
-== Hazelcast components
-
-See the following for each component usage:
-
-* xref:hazelcast-map-component.adoc[map]
-* xref:hazelcast-multimap-component.adoc[multimap]
-* xref:hazelcast-queue-component.adoc[queue]
-* xref:hazelcast-topic-component.adoc[topic]
-* xref:hazelcast-list-component.adoc[list]
-* xref:hazelcast-seda-component.adoc[seda]
-* xref:hazelcast-set-component.adoc[set]
-* xref:hazelcast-atomicvalue-component.adoc[atomic number]
-* xref:hazelcast-instance-component.adoc[cluster support (instance)]
-* xref:hazelcast-replicatedmap-component.adoc[replicatedmap] 
-* xref:hazelcast-ringbuffer-component.adoc[ringbuffer] 
-
 
 
 == Using hazelcast reference

--- a/components/camel-ignite/src/main/docs/ignite-summary.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-summary.adoc
@@ -9,15 +9,14 @@ https://ignite.apache.org/[Apache Ignite] In-Memory Data Fabric is a high-perfor
 
 image::apache-ignite.png[]
 
-This component offers seven endpoints to cover much of Ignite's functionality:
 
-* xref:ignite-cache-component.adoc[Ignite Cache].
-* xref:ignite-compute-component.adoc[Ignite Compute].
-* xref:ignite-messaging-component.adoc[Ignite Messaging].
-* xref:ignite-events-component.adoc[Ignite Events].
-* xref:ignite-set-component.adoc[Ignite Sets].
-* xref:ignite-queue-component.adoc[Ignite Queues].
-* xref:ignite-idgen-component.adoc[Ignite ID Generator].
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 To use this component, add the following dependency to your pom.xml:
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
@@ -5,28 +5,16 @@
 
 *Since Camel {since}*
 
-The Kubernetes components integrate your application with Kubernetes standalone or on top of Openshift. 
-
-The camel-kubernetes consists of 13 components:
-
-* xref:kubernetes-config-maps-component.adoc[Kubernetes ConfigMap]
-* xref:kubernetes-namespaces-component.adoc[Kubernetes Namespace]
-* xref:kubernetes-nodes-component.adoc[Kubernetes Node]
-* xref:kubernetes-persistent-volumes-component.adoc[Kubernetes Persistent Volume]
-* xref:kubernetes-persistent-volumes-claims-component.adoc[Kubernetes Persistent Volume Claim]
-* xref:kubernetes-pods-component.adoc[Kubernetes Pod]
-* xref:kubernetes-replication-controllers-component.adoc[Kubernetes Replication Controller]
-* xref:kubernetes-resources-quota-component.adoc[Kubernetes Resource Quota]
-* xref:kubernetes-secrets-component.adoc[Kubernetes Secrets]
-* xref:kubernetes-service-accounts-component.adoc[Kubernetes Service Account]
-* xref:kubernetes-services-component.adoc[Kubernetes Service]
-
-In OpenShift, also:
-
-* xref:openshift-build-configs-component.adoc[Kubernetes Build Config]
-* Kubernetes Build
+The Kubernetes components integrate your application with Kubernetes standalone or on top of Openshift.
 
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 Maven users will need to add the following dependency to
 their `pom.xml` for this component:

--- a/components/camel-openstack/src/main/docs/openstack-summary.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-summary.adoc
@@ -1,13 +1,21 @@
 [[Openstack-OpenstackComponent]]
-= Openstack Component
+= OpenStack Component
 //attributes written by hand, not generated
-:docTitle: Openstack
+:docTitle: OpenStack
 :since: 2.19
 
 *Since Camel {since}*
 
-The Openstack component is a component for managing your
-https://www.openstack.org//[OpenStack] applications. 
+The OpenStack component is a component for managing your
+https://www.openstack.org//[OpenStack] applications.
+
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:
@@ -20,18 +28,6 @@ for this component:
     <!-- use the same version as your Camel core version -->
 </dependency>
 ------------------------------------------------------------
-
-[width="100%", options="header"]
-|=======================================================================
-| OpenStack service | Camel Component| Description
-| https://wiki.openstack.org/wiki/Cinder[OpenStack Cinder] | xref:openstack-cinder-component.adoc[openstack-cinder] | Component to maintain OpenStack cinder.
-| https://wiki.openstack.org/wiki/Glance[OpenStack Glance] | xref:openstack-glance-component.adoc[openstack-glance] | Component to maintain OpenStack glance.
-| https://wiki.openstack.org/wiki/Keystone[OpenStack Keystone] | xref:openstack-keystone-component.adoc[openstack-keystone] | Component to maintain OpenStack keystone.
-| https://wiki.openstack.org/wiki/Neutron[OpenStack Neutron] | xref:openstack-neutron-component.adoc[openstack-neutron] | Component to maintain OpenStack neutron.
-| https://wiki.openstack.org/wiki/Nova[OpenStack Nova] | xref:openstack-nova-component.adoc[openstack-nova] | Component to maintain OpenStack nova.
-| https://wiki.openstack.org/wiki/Swift[OpenStack Swift] | xref:openstack-swift-component.adoc[openstack-swift] | Component to maintain OpenStack swift.
-|=======================================================================
-
 
 
 include::camel-spring-boot::page$openstack-starter.adoc[]

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -3,6 +3,12 @@
 //attributes written by hand, not generated
 :docTitle: Spring
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.
 

--- a/docs/components/modules/ROOT/nav.adoc
+++ b/docs/components/modules/ROOT/nav.adoc
@@ -248,7 +248,7 @@
 ** xref:olingo4-component.adoc[Olingo4]
 ** xref:milo-client-component.adoc[OPC UA Client]
 ** xref:milo-server-component.adoc[OPC UA Server]
-** xref:openstack-summary.adoc[Openstack]
+** xref:openstack-summary.adoc[OpenStack]
 *** xref:openstack-cinder-component.adoc[OpenStack Cinder]
 *** xref:openstack-glance-component.adoc[OpenStack Glance]
 *** xref:openstack-keystone-component.adoc[OpenStack Keystone]

--- a/docs/components/modules/ROOT/pages/aws-summary.adoc
+++ b/docs/components/modules/ROOT/pages/aws-summary.adoc
@@ -8,26 +8,9 @@ https://aws.amazon.com/[AWS].
 AWS offers a great palette of different components like elastic, email and queue services. It also 
 provides streaming for Apache Kafka and more. The main reason to use AWS is its cloud computing platform.
 
-== AWS Components
 
-See the following for each component usage:
+== {docTitle} components
 
-* xref:aws-cw-component.adoc[AWS CloudWatch]
-* xref:aws-ddb-component.adoc[AWS DynamoDB]
-* xref:aws-ddbstream-component.adoc[AWS DynamoDB Streams]
-* xref:aws-ec2-component.adoc[AWS Elastic Compute Cloud (EC2)]
-* xref:aws-ecs-component.adoc[AWS Elastic Container Service (ECS)]
-* xref:aws-eks-component.adoc[AWS Elastic Kubernetes Service (EKS)]
-* xref:aws-iam-component.adoc[AWS Identity and Access Management (IAM)]
-* xref:aws-kms-component.adoc[AWS Key Management Service (KMS)]
-* xref:aws-kinesis-component.adoc[AWS Kinesis]
-* xref:aws-kinesis-firehose-component.adoc[AWS Kinesis Firehose]
-* xref:aws-lambda-component.adoc[AWS Lambda]
-* xref:aws-msk-component.adoc[AWS Managed Streaming for Apache Kafka (MSK)]
-* xref:aws-mq-component.adoc[AWS MQ]
-* xref:aws-s3-component.adoc[AWS S3 Storage Service]
-* xref:aws-ses-component.adoc[AWS Simple Email Service (SES)]
-* xref:aws-sns-component.adoc[AWS Simple Notification System (SNS)]
-* xref:aws-sqs-component.adoc[AWS Simple Queue Service (SQS)]
-* xref:aws-swf-component.adoc[AWS Simple Workflow (SWF)]
-* xref:aws-sdb-component.adoc[AWS SimpleDB]
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/docs/components/modules/ROOT/pages/aws2-summary.adoc
+++ b/docs/components/modules/ROOT/pages/aws2-summary.adoc
@@ -8,25 +8,9 @@ https://aws.amazon.com/[AWS 2].
 AWS 2 offers a great palette of different components like cloudwatch, DynamoDB streams, 
 storage service, email and queue services. The main reason to use AWS is its cloud computing platform.
 
-== AWS 2 components
 
-See the following for each component usage:
+== {docTitle} components
 
-* xref:aws2-cw-component.adoc[AWS 2 CloudWatch]
-* xref:aws2-ddb-component.adoc[AWS 2 DynamoDB]
-* xref:aws2-ddbstream-component.adoc[AWS 2 DynamoDB Streams]
-* xref:aws2-ec2-component.adoc[AWS 2 Elastic Compute Cloud (EC2)]
-* xref:aws2-ecs-component.adoc[AWS 2 Elastic Container Service (ECS)]
-* xref:aws2-eks-component.adoc[AWS 2 Elastic Kubernetes Service (EKS)]
-* xref:aws2-iam-component.adoc[AWS 2 Identity and Access Management (IAM)]
-* xref:aws2-kms-component.adoc[AWS 2 Key Management Service (KMS)]
-* xref:aws2-kinesis-component.adoc[AWS 2 Kinesis]
-* xref:aws2-kinesis-firehose-component.adoc[AWS 2 Kinesis Firehose]
-* xref:aws2-lambda-component.adoc[AWS 2 Lambda]
-* xref:aws2-msk-component.adoc[AWS 2 Managed Streaming for Apache Kafka (MSK)]
-* xref:aws2-mq-component.adoc[AWS 2 MQ]
-* xref:aws2-s3-component.adoc[AWS 2 S3 Storage Service]
-* xref:aws2-ses-component.adoc[AWS 2 Simple Email Service (SES)]
-* xref:aws2-sns-component.adoc[AWS 2 Simple Notification System (SNS)]
-* xref:aws2-sqs-component.adoc[AWS 2 Simple Queue Service (SQS)]
-* xref:aws2-translate-component.adoc[AWS 2 Translate]
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/docs/components/modules/ROOT/pages/azure-storage-blob-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-storage-blob-component.adoc
@@ -56,7 +56,7 @@ located on the `container1` in the `camelazure` storage account, use the followi
 
 [source,java]
 --------------------------------------------------------------------------------
-from("azure-storage-blob:/camelazure/container1?blobName=hello.txt&accountName=yourAccountName&accessKey=yourAccessKey").
+from("azure-storage-blob:/camelazure/container1?blobName=hello.txt&accessKey=yourAccessKey").
 to("file://blobdirectory");
 --------------------------------------------------------------------------------
 
@@ -172,8 +172,8 @@ can be used to retrieve lower level clients.
 |`CamelAzureStorageBlobContentMD5`|`BlobConstants.CONTENT_MD5`|`byte[]`|Most operations related to upload blob|An MD5 hash of the block content. This hash is used to verify the integrity of the block during transport. When this header is specified, the storage service compares the hash of the content that has arrived with this header value. Note that this MD5 hash is not stored with the blob. If the two hashes do not match, the operation will fail.
 |`CamelAzureStorageBlobPageBlobRange`|`BlobConstants.PAGE_BLOB_RANGE`|`PageRange`|Operations related to page blob| A {@link PageRange} object. Given that pages must be aligned with 512-byte boundaries, the start offset must be a modulus of 512 and the end offset must be a modulus of 512 - 1. Examples of valid byte ranges are 0-511, 512-1023, etc.
 |`CamelAzureStorageBlobCommitBlobBlockListLater`|`BlobConstants.COMMIT_BLOCK_LIST_LATER`|`boolean`|`stageBlockBlobList`| When is set to `true`, the staged blocks will not be committed directly.
-|`CamelAzureStorageBlobAppendBlobCreated`|`BlobConstants.APPEND_BLOCK_CREATED`|`boolean`|`commitAppendBlob`| When is set to `true`, the append blocks will not be created when committing append blocks.
-|`CamelAzureStorageBlobPageBlockCreated`|`BlobConstants.PAGE_BLOCK_CREATED`|`boolean`|`uploadPageBlob`| When is set to `true`, the page blob will not be created when uploading page blob.
+|`CamelAzureStorageBlobCreateAppendBlob`|`BlobConstants.CREATE_APPEND_BLOB`|`boolean`|`commitAppendBlob`| When is set to `true`, the append blocks will be created when committing append blocks.
+|`CamelAzureStorageBlobCreatePageBlob`|`BlobConstants.CREATE_PAGE_BLOB`|`boolean`|`uploadPageBlob`| When is set to `true`, the page blob will be created when uploading page blob.
 |`CamelAzureStorageBlobBlockListType`|`BlobConstants.BLOCK_LIST_TYPE`|`BlockListType`|`getBlobBlockList`| Specifies which type of blocks to return.
 |`CamelAzureStorageBlobPageBlobSize`|`BlobConstants.PAGE_BLOB_SIZE`|`Long`|`createPageBlob`, `resizePageBlob`| Specifies the maximum size for the page blob, up to 8 TB. The page blob size must be aligned to a 512-byte boundary.
 |`CamelAzureStorageBlobSequenceNumber`|`BlobConstants.BLOB_SEQUENCE_NUMBER`|`Long`|`createPageBlob`|A user-controlled value that you can use to track requests. The value of the sequence number must be between 0 and 2^63 - 1.The default value is 0.
@@ -301,9 +301,9 @@ For these operations, `accountName`, `containerName` and `blobName` are *require
                                     and existing blocks together. Any blocks not specified in the block list and permanently deleted.
 |`getBlobBlockList`  |`BlockBlob`|Returns the list of blocks that have been uploaded as part of a block blob using the specified block list filter.
 |`createAppendBlob` |`AppendBlob`|Creates a 0-length append blob. Call commitAppendBlo`b operation to append data to an append blob.
-|`commitAppendBlob` |`AppendBlob`|Commits a new block of data to the end of the existing append blob. In case of header `CamelAzureStorageBlobAppendBlobCreated` is set to false, it will attempt to create the appendBlob through internal call to `createAppendBlob` operation.
+|`commitAppendBlob` |`AppendBlob`|Commits a new block of data to the end of the existing append blob. In case of header `CamelAzureStorageBlobCreateAppendBlob` is set to true, it will attempt to create the appendBlob through internal call to `createAppendBlob` operation.
 |`createPageBlob`|`PageBlob`|Creates a page blob of the specified length. Call `uploadPageBlob` operation to upload data data to a page blob.
-|`uploadPageBlob`|`PageBlob`|Writes one or more pages to the page blob. The write size must be a multiple of 512. In case of header `CamelAzureStorageBlobPageBlockCreated` is set to false, it will attempt to create the appendBlob through internal call to `createPageBlob` operation.
+|`uploadPageBlob`|`PageBlob`|Writes one or more pages to the page blob. The write size must be a multiple of 512. In case of header `CamelAzureStorageBlobCreatePageBlob` is set to true, it will attempt to create the appendBlob through internal call to `createPageBlob` operation.
 |`resizePageBlob`|`PageBlob`| Resizes the page blob to the specified size (which must be a multiple of 512).
 |`clearPageBlob`|`PageBlob`| Frees the specified pages from the page blob. The size of the range must be a multiple of 512.
 |`getPageBlobRanges`|`PageBlob`|Returns the list of valid page ranges for a page blob or snapshot of a page blob.

--- a/docs/components/modules/ROOT/pages/azure-summary.adoc
+++ b/docs/components/modules/ROOT/pages/azure-summary.adoc
@@ -8,13 +8,10 @@
 The Camel Components for https://azure.microsoft.com/[Windows Azure Services]
 provide connectivity to Azure services from Camel.
 
- 
-[width="100%",cols="30%,10%,50%",options="header",]
-|=======================================================================
-|Azure Service |Camel Component |Component Description
+== {docTitle} components
 
-|https://azure.microsoft.com/services/storage/blobs[Storage Blob Service] |xref:azure-blob-component.adoc[Azure-Blob] |Supports storing and retrieving of blobs
-|https://azure.microsoft.com/services/storage/queues[Storage Queue Service] |xref:azure-queue-component.adoc[Azure-Queue] |Supports storing and retrieving of messages in the queues
-|=======================================================================
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
 
 include::camel-spring-boot::page$azure-starter.adoc[]

--- a/docs/components/modules/ROOT/pages/google-summary.adoc
+++ b/docs/components/modules/ROOT/pages/google-summary.adoc
@@ -9,17 +9,8 @@ https://gsuite.google.co.in/[G Suite].
 Google offers a great palette of different components like use of calender, mail, sheets and 
 drive . The main reason to use Google is the G Suite features.
 
-== Google Components
+== {docTitle} components
 
-See the following for each component usage:
+See the following for usage of each component:
 
-*  xref:google-bigquery-component.adoc[Google BigQuery]
-*  xref:google-bigquery-sql-component.adoc[Google BigQuery Standard SQL]
-*  xref:google-calendar-component.adoc[Google Calendar]
-*  xref:google-calendar-stream-component.adoc[Google Calendar Stream]
-*  xref:google-drive-component.adoc[Google Drive]
-*  xref:google-mail-component.adoc[Google Mail]
-*  xref:google-mail-stream-component.adoc[Google Mail Stream]
-*  xref:google-pubsub-component.adoc[Google Pubsub]
-*  xref:google-sheets-component.adoc[Google Sheets]
-*  xref:google-sheets-stream-component.adoc[Google Sheets Stream]
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]

--- a/docs/components/modules/ROOT/pages/hazelcast-summary.adoc
+++ b/docs/components/modules/ROOT/pages/hazelcast-summary.adoc
@@ -20,6 +20,14 @@ persistence, network configuration (if needed), near cache, eviction
 and so on. For more information consult the Hazelcast documentation on
 http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
+
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:
 
@@ -32,24 +40,6 @@ for this component:
     <!-- use the same version as your Camel core version -->
 </dependency>
 ------------------------------------------------------------
-
-
-== Hazelcast components
-
-See the following for each component usage:
-
-* xref:hazelcast-map-component.adoc[map]
-* xref:hazelcast-multimap-component.adoc[multimap]
-* xref:hazelcast-queue-component.adoc[queue]
-* xref:hazelcast-topic-component.adoc[topic]
-* xref:hazelcast-list-component.adoc[list]
-* xref:hazelcast-seda-component.adoc[seda]
-* xref:hazelcast-set-component.adoc[set]
-* xref:hazelcast-atomicvalue-component.adoc[atomic number]
-* xref:hazelcast-instance-component.adoc[cluster support (instance)]
-* xref:hazelcast-replicatedmap-component.adoc[replicatedmap] 
-* xref:hazelcast-ringbuffer-component.adoc[ringbuffer] 
-
 
 
 == Using hazelcast reference

--- a/docs/components/modules/ROOT/pages/ignite-summary.adoc
+++ b/docs/components/modules/ROOT/pages/ignite-summary.adoc
@@ -11,15 +11,14 @@ https://ignite.apache.org/[Apache Ignite] In-Memory Data Fabric is a high-perfor
 
 image::apache-ignite.png[]
 
-This component offers seven endpoints to cover much of Ignite's functionality:
 
-* xref:ignite-cache-component.adoc[Ignite Cache].
-* xref:ignite-compute-component.adoc[Ignite Compute].
-* xref:ignite-messaging-component.adoc[Ignite Messaging].
-* xref:ignite-events-component.adoc[Ignite Events].
-* xref:ignite-set-component.adoc[Ignite Sets].
-* xref:ignite-queue-component.adoc[Ignite Queues].
-* xref:ignite-idgen-component.adoc[Ignite ID Generator].
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 To use this component, add the following dependency to your pom.xml:
 

--- a/docs/components/modules/ROOT/pages/kubernetes-summary.adoc
+++ b/docs/components/modules/ROOT/pages/kubernetes-summary.adoc
@@ -7,28 +7,16 @@
 
 *Since Camel {since}*
 
-The Kubernetes components integrate your application with Kubernetes standalone or on top of Openshift. 
-
-The camel-kubernetes consists of 13 components:
-
-* xref:kubernetes-config-maps-component.adoc[Kubernetes ConfigMap]
-* xref:kubernetes-namespaces-component.adoc[Kubernetes Namespace]
-* xref:kubernetes-nodes-component.adoc[Kubernetes Node]
-* xref:kubernetes-persistent-volumes-component.adoc[Kubernetes Persistent Volume]
-* xref:kubernetes-persistent-volumes-claims-component.adoc[Kubernetes Persistent Volume Claim]
-* xref:kubernetes-pods-component.adoc[Kubernetes Pod]
-* xref:kubernetes-replication-controllers-component.adoc[Kubernetes Replication Controller]
-* xref:kubernetes-resources-quota-component.adoc[Kubernetes Resource Quota]
-* xref:kubernetes-secrets-component.adoc[Kubernetes Secrets]
-* xref:kubernetes-service-accounts-component.adoc[Kubernetes Service Account]
-* xref:kubernetes-services-component.adoc[Kubernetes Service]
-
-In OpenShift, also:
-
-* xref:openshift-build-configs-component.adoc[Kubernetes Build Config]
-* Kubernetes Build
+The Kubernetes components integrate your application with Kubernetes standalone or on top of Openshift.
 
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 Maven users will need to add the following dependency to
 their `pom.xml` for this component:

--- a/docs/components/modules/ROOT/pages/openstack-summary.adoc
+++ b/docs/components/modules/ROOT/pages/openstack-summary.adoc
@@ -1,15 +1,23 @@
 [[Openstack-OpenstackComponent]]
-= Openstack Component
+= OpenStack Component
 //THIS FILE IS COPIED: EDIT THE SOURCE FILE:
 :page-source: components/camel-openstack/src/main/docs/openstack-summary.adoc
 //attributes written by hand, not generated
-:docTitle: Openstack
+:docTitle: OpenStack
 :since: 2.19
 
 *Since Camel {since}*
 
-The Openstack component is a component for managing your
-https://www.openstack.org//[OpenStack] applications. 
+The OpenStack component is a component for managing your
+https://www.openstack.org//[OpenStack] applications.
+
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
+== Installation
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:
@@ -22,18 +30,6 @@ for this component:
     <!-- use the same version as your Camel core version -->
 </dependency>
 ------------------------------------------------------------
-
-[width="100%", options="header"]
-|=======================================================================
-| OpenStack service | Camel Component| Description
-| https://wiki.openstack.org/wiki/Cinder[OpenStack Cinder] | xref:openstack-cinder-component.adoc[openstack-cinder] | Component to maintain OpenStack cinder.
-| https://wiki.openstack.org/wiki/Glance[OpenStack Glance] | xref:openstack-glance-component.adoc[openstack-glance] | Component to maintain OpenStack glance.
-| https://wiki.openstack.org/wiki/Keystone[OpenStack Keystone] | xref:openstack-keystone-component.adoc[openstack-keystone] | Component to maintain OpenStack keystone.
-| https://wiki.openstack.org/wiki/Neutron[OpenStack Neutron] | xref:openstack-neutron-component.adoc[openstack-neutron] | Component to maintain OpenStack neutron.
-| https://wiki.openstack.org/wiki/Nova[OpenStack Nova] | xref:openstack-nova-component.adoc[openstack-nova] | Component to maintain OpenStack nova.
-| https://wiki.openstack.org/wiki/Swift[OpenStack Swift] | xref:openstack-swift-component.adoc[openstack-swift] | Component to maintain OpenStack swift.
-|=======================================================================
-
 
 
 include::camel-spring-boot::page$openstack-starter.adoc[]

--- a/docs/components/modules/ROOT/pages/spring-summary.adoc
+++ b/docs/components/modules/ROOT/pages/spring-summary.adoc
@@ -5,6 +5,12 @@
 //attributes written by hand, not generated
 :docTitle: Spring
 
+== {docTitle} components
+
+See the following for usage of each component:
+
+indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.
 


### PR DESCRIPTION
Replaces the hardcoded summary lists with generated dlists, and uniformizes the layout a bit.
Note that https://github.com/apache/camel-website/pull/395 needs to be applied first to get the updated indexer extension that can generated lists.