### PR TITLE
CAMEL-15183: Exclude abstract classes from package scanning in stand-alone apps

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
@@ -404,7 +406,11 @@ public abstract class BaseMainSupport extends BaseService {
 
         if (mainConfigurationProperties.getPackageScanRouteBuilders() != null) {
             String[] pkgs = mainConfigurationProperties.getPackageScanRouteBuilders().split(",");
-            Set<Class<?>> set = camelContext.adapt(ExtendedCamelContext.class).getPackageScanClassResolver().findImplementations(RoutesBuilder.class, pkgs);
+            Set<Class<?>> set = camelContext.adapt(ExtendedCamelContext.class)
+                    .getPackageScanClassResolver()
+                    .findImplementations(RoutesBuilder.class, pkgs)
+                    .stream().filter(c -> !Modifier.isAbstract(c.getModifiers()))
+                    .collect(Collectors.toSet());
             for (Class<?> routeClazz : set) {
                 Object builder = camelContext.getInjector().newInstance(routeClazz);
                 if (builder instanceof RoutesBuilder) {

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainRoutesCollectorPackageScanTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainRoutesCollectorPackageScanTest.java
@@ -32,18 +32,22 @@ public class MainRoutesCollectorPackageScanTest {
 
         CamelContext camelContext = main.getCamelContext();
         assertNotNull(camelContext);
-        assertEquals(2, camelContext.getRoutes().size());
+        assertEquals(3, camelContext.getRoutes().size());
 
         MockEndpoint endpoint = camelContext.getEndpoint("mock:scan", MockEndpoint.class);
         endpoint.expectedBodiesReceived("Hello World");
         MockEndpoint endpoint2 = camelContext.getEndpoint("mock:dummy", MockEndpoint.class);
         endpoint2.expectedBodiesReceived("Bye World");
+        MockEndpoint endpoint3 = camelContext.getEndpoint("mock:concrete", MockEndpoint.class);
+        endpoint3.expectedBodiesReceived("Hola World");
 
         main.getCamelTemplate().sendBody("direct:scan", "Hello World");
         main.getCamelTemplate().sendBody("direct:dummy", "Bye World");
+        main.getCamelTemplate().sendBody("direct:concrete", "Hola World");
 
         endpoint.assertIsSatisfied();
         endpoint2.assertIsSatisfied();
+        endpoint3.assertIsSatisfied();
 
         main.stop();
     }

--- a/core/camel-main/src/test/java/org/apache/camel/main/scan/MyAbstractRouteBuilder.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/scan/MyAbstractRouteBuilder.java
@@ -1,0 +1,6 @@
+package org.apache.camel.main.scan;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public abstract class MyAbstractRouteBuilder extends RouteBuilder {
+}

--- a/core/camel-main/src/test/java/org/apache/camel/main/scan/MyAbstractRouteBuilder.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/scan/MyAbstractRouteBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.main.scan;
 
 import org.apache.camel.builder.RouteBuilder;

--- a/core/camel-main/src/test/java/org/apache/camel/main/scan/MyConcreteRouteBuilder.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/scan/MyConcreteRouteBuilder.java
@@ -1,0 +1,9 @@
+package org.apache.camel.main.scan;
+
+public class MyConcreteRouteBuilder extends MyAbstractRouteBuilder{
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:concrete").to("mock:concrete");
+    }
+}

--- a/core/camel-main/src/test/java/org/apache/camel/main/scan/MyConcreteRouteBuilder.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/scan/MyConcreteRouteBuilder.java
@@ -1,6 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.main.scan;
 
-public class MyConcreteRouteBuilder extends MyAbstractRouteBuilder{
+public class MyConcreteRouteBuilder extends MyAbstractRouteBuilder {
 
     @Override
     public void configure() throws Exception {


### PR DESCRIPTION
This PR updates the "stand-alone" package scanning algorithm in camel-main to exclude abstract classes which extend Route Builder.