### PR TITLE
[CAMEL-15187] fixes bug in camel-jsonpath StreamCache not reset

### DIFF
--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
@@ -33,6 +33,7 @@ import com.jayway.jsonpath.Option;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
+import org.apache.camel.StreamCache;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -214,6 +215,10 @@ public class JsonPathEngine {
         LOG.trace("JSonPath: {} is read as InputStream: {}", path, json);
 
         InputStream is = exchange.getContext().getTypeConverter().tryConvertTo(InputStream.class, exchange, json);
+
+        if (json instanceof StreamCache)
+            ((StreamCache) json).reset();
+
         if (is != null) {
             String jsonEncoding = exchange.getIn().getHeader(JsonPathConstants.HEADER_JSON_ENCODING, String.class);
             if (jsonEncoding != null) {
@@ -239,6 +244,10 @@ public class JsonPathEngine {
         if (adapter != null) {
             LOG.trace("Attempting to use JacksonJsonAdapter: {}", adapter);
             Map map = adapter.readValue(json, exchange);
+
+            if (json instanceof StreamCache)
+                ((StreamCache) json).reset();
+
             if (map != null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("JacksonJsonAdapter converted object from: {} to: java.util.Map", ObjectHelper.classCanonicalName(json));

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
@@ -216,8 +216,9 @@ public class JsonPathEngine {
 
         InputStream is = exchange.getContext().getTypeConverter().tryConvertTo(InputStream.class, exchange, json);
 
-        if (json instanceof StreamCache)
+        if (json instanceof StreamCache) {
             ((StreamCache) json).reset();
+        }
 
         if (is != null) {
             String jsonEncoding = exchange.getIn().getHeader(JsonPathConstants.HEADER_JSON_ENCODING, String.class);
@@ -245,8 +246,9 @@ public class JsonPathEngine {
             LOG.trace("Attempting to use JacksonJsonAdapter: {}", adapter);
             Map map = adapter.readValue(json, exchange);
 
-            if (json instanceof StreamCache)
+            if (json instanceof StreamCache) {
                 ((StreamCache) json).reset();
+            }
 
             if (map != null) {
                 if (LOG.isDebugEnabled()) {

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathStreamCachingCBRTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathStreamCachingCBRTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.camel.jsonpath;
 
+import java.io.File;
+import java.io.FileInputStream;
+
 import org.apache.camel.builder.ExpressionBuilder;
 import org.apache.camel.builder.PredicateBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.converter.stream.FileInputStreamCache;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.FileInputStream;
 
 public class JsonPathStreamCachingCBRTest extends CamelTestSupport {
 
@@ -45,7 +45,7 @@ public class JsonPathStreamCachingCBRTest extends CamelTestSupport {
                             .to("mock:average")
                         .otherwise()
                             .to("mock:expensive");
-                
+
                 from("direct:bicycle")
                     .streamCaching()
                     .choice()
@@ -53,7 +53,7 @@ public class JsonPathStreamCachingCBRTest extends CamelTestSupport {
                             .to("mock:cheap")
                         .otherwise()
                             .to("mock:expensive");
-                
+
                 from("direct:bicycle2")
                     .streamCaching()
                     .choice()
@@ -64,20 +64,20 @@ public class JsonPathStreamCachingCBRTest extends CamelTestSupport {
             }
         };
     }
-    
+
     public static class BeanPredicate {
         public boolean checkPrice(@JsonPath("$.store.bicycle.price") double price) {
             return price < 100;
         }
     }
-    
+
     @Test
     public void testCheapBicycle() throws Exception {
         sendMessageToBicycleRoute("direct:bicycle");
         resetMocks();
         sendMessageToBicycleRoute("direct:bicycle2");
     }
-    
+
     private void sendMessageToBicycleRoute(String startPoint) throws Exception {
         getMockEndpoint("mock:cheap").expectedMessageCount(1);
         getMockEndpoint("mock:average").expectedMessageCount(0);

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathStreamCachingCBRTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathStreamCachingCBRTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.jsonpath;
+
+import org.apache.camel.builder.ExpressionBuilder;
+import org.apache.camel.builder.PredicateBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.converter.stream.FileInputStreamCache;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+public class JsonPathStreamCachingCBRTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                context.getStreamCachingStrategy().setSpoolDirectory("target/tmp");
+                context.getStreamCachingStrategy().setSpoolThreshold(-1);
+
+                from("direct:start")
+                    .streamCaching()
+                    .choice()
+                        .when().jsonpath("$.store.book[?(@.price < 10)]")
+                            .to("mock:cheap")
+                        .when().jsonpath("$.store.book[?(@.price < 30)]")
+                            .to("mock:average")
+                        .otherwise()
+                            .to("mock:expensive");
+                
+                from("direct:bicycle")
+                    .streamCaching()
+                    .choice()
+                        .when().method(new BeanPredicate())
+                            .to("mock:cheap")
+                        .otherwise()
+                            .to("mock:expensive");
+                
+                from("direct:bicycle2")
+                    .streamCaching()
+                    .choice()
+                    .when(PredicateBuilder.isLessThan(ExpressionBuilder.languageExpression("jsonpath", "$.store.bicycle.price"), ExpressionBuilder.constantExpression(100)))
+                        .to("mock:cheap")
+                    .otherwise()
+                        .to("mock:expensive");
+            }
+        };
+    }
+    
+    public static class BeanPredicate {
+        public boolean checkPrice(@JsonPath("$.store.bicycle.price") double price) {
+            return price < 100;
+        }
+    }
+    
+    @Test
+    public void testCheapBicycle() throws Exception {
+        sendMessageToBicycleRoute("direct:bicycle");
+        resetMocks();
+        sendMessageToBicycleRoute("direct:bicycle2");
+    }
+    
+    private void sendMessageToBicycleRoute(String startPoint) throws Exception {
+        getMockEndpoint("mock:cheap").expectedMessageCount(1);
+        getMockEndpoint("mock:average").expectedMessageCount(0);
+        getMockEndpoint("mock:expensive").expectedMessageCount(0);
+
+        template.sendBody(startPoint, new FileInputStream(new File("src/test/resources/cheap.json")));
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testCheap() throws Exception {
+        getMockEndpoint("mock:cheap").expectedMessageCount(1);
+        getMockEndpoint("mock:average").expectedMessageCount(0);
+        getMockEndpoint("mock:expensive").expectedMessageCount(0);
+
+        template.sendBody("direct:start", new FileInputStream(new File("src/test/resources/cheap.json")));
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testAverage() throws Exception {
+        getMockEndpoint("mock:cheap").expectedMessageCount(0);
+        getMockEndpoint("mock:average").expectedMessageCount(1);
+        getMockEndpoint("mock:expensive").expectedMessageCount(0);
+
+        template.sendBody("direct:start", new FileInputStream(new File("src/test/resources/average.json")));
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testExpensive() throws Exception {
+        getMockEndpoint("mock:cheap").expectedMessageCount(0);
+        getMockEndpoint("mock:average").expectedMessageCount(0);
+        getMockEndpoint("mock:expensive").expectedMessageCount(1);
+
+        template.sendBody("direct:start", new FileInputStream(new File("src/test/resources/expensive.json")));
+
+        assertMockEndpointsSatisfied();
+    }
+
+}


### PR DESCRIPTION
When using jsonpath as a predicate in a CBR the StreamCache is not reset and therefore the content is lost. The first commit adds a failing JsonPathStreamCachingCBRTest which is just a copy of JsonPathCBRTest with streaming. The second commit adds `StreamCache.reset()`s wherever it seemed appropriate after content is read.