### PR TITLE
[CAMEL-15188] Add proxy type query parameter to camel-telegram component, add support for SOCKS proxy

### DIFF
--- a/components/camel-telegram/src/main/docs/telegram-component.adoc
+++ b/components/camel-telegram/src/main/docs/telegram-component.adoc
@@ -84,7 +84,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (24 parameters):
+=== Query Parameters (25 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -92,6 +92,7 @@ with the following path and query parameters:
 | Name | Description | Default | Type
 | *proxyHost* (common) | The proxyHost which could be used when sending out the message. |  | String
 | *proxyPort* (common) | The proxyPort which could be used when sending out the message. |  | Integer
+| *proxyType* (common) | The proxyType which could be used when sending out the message. | HTTP | TelegramProxyType
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *limit* (consumer) | Limit on the number of updates that can be received in a single polling request. | 100 | Integer
 | *sendEmptyMessageWhenIdle* (consumer) | If the polling consumer did not poll any files, you can enable this option to send an empty message (no body) instead. | false | boolean
@@ -359,16 +360,16 @@ from("telegram:bots/123456789:insertYourAuthorizationTokenHere")
 
         OutgoingTextMessage msg = new OutgoingTextMessage();
         msg.setText("Choose one option!");
-        
+
         InlineKeyboardButton buttonOptionOneI = InlineKeyboardButton.builder()
                 .text("Option One - I").build();
-        
+
         InlineKeyboardButton buttonOptionOneII = InlineKeyboardButton.builder()
                 .text("Option One - II").build();
-        
+
         InlineKeyboardButton buttonOptionTwoI = InlineKeyboardButton.builder()
                 .text("Option Two - I").build();
-        
+
         ReplyKeyboardMarkup replyMarkup = ReplyKeyboardMarkup.builder()
                 .keyboard()
                     .addRow(Arrays.asList(buttonOptionOneI, buttonOptionOneII))
@@ -376,7 +377,7 @@ from("telegram:bots/123456789:insertYourAuthorizationTokenHere")
                     .close()
                 .oneTimeKeyboard(true)
                 .build();
-        
+
         msg.setReplyKeyboardMarkup(replyMarkup);
 
         exchange.getIn().setBody(msg);
@@ -393,11 +394,11 @@ from("telegram:bots/123456789:insertYourAuthorizationTokenHere")
 
         OutgoingTextMessage msg = new OutgoingTextMessage();
         msg.setText("Your answer was accepted!");
-        
+
         ReplyKeyboardMarkup replyMarkup = ReplyKeyboardMarkup.builder()
                 .removeKeyboard(true)
                 .build();
-        
+
         msg.setReplyKeyboardMarkup(replyMarkup);
 
         exchange.getIn().setBody(msg);

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramConfiguration.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramConfiguration.java
@@ -43,6 +43,9 @@ public class TelegramConfiguration {
     @UriParam(description = "The proxyPort which could be used when sending out the message.")
     private Integer proxyPort;
 
+    @UriParam(description = "The proxyType which could be used when sending out the message.", defaultValue = "HTTP")
+    private TelegramProxyType proxyType = TelegramProxyType.HTTP;
+
     @UriParam(description = "The identifier of the chat that will receive the produced messages. Chat ids can be first obtained from incoming messages "
             + "(eg. when a telegram user starts a conversation with a bot, its client sends automatically a '/start' message containing the chat id). "
             + "It is an optional parameter, as the chat id can be set dynamically for each outgoing message (using body or headers).", label = "producer")
@@ -120,8 +123,15 @@ public class TelegramConfiguration {
       this.proxyPort = proxyPort;
     }
 
+    public TelegramProxyType getProxyType() {
+        return proxyType;
+    }
 
-  public String getChatId() {
+    public void setProxyType(TelegramProxyType proxyType) {
+        this.proxyType = proxyType;
+    }
+
+    public String getChatId() {
         return chatId;
     }
 

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramEndpoint.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.camel.impl.ScheduledPollEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.cxf.transports.http.configuration.ProxyServerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +45,9 @@ public class TelegramEndpoint extends ScheduledPollEndpoint {
         this.configuration = configuration;
         // setup the proxy setting here
         if (ObjectHelper.isNotEmpty(configuration.getProxyHost()) && ObjectHelper.isNotEmpty(configuration.getProxyPort())) {
-            LOG.debug("Setup http proxy host:{} port:{} for TelegramService", configuration.getProxyHost(), configuration.getProxyPort());
-            TelegramServiceProvider.get().getService().setHttpProxy(configuration.getProxyHost(), configuration.getProxyPort());
+            ProxyServerType proxyServerType = getProxyServerType(configuration.getProxyType());
+            LOG.debug("Setup {} proxy host:{} port:{} for TelegramService", proxyServerType, configuration.getProxyHost(), configuration.getProxyPort());
+            TelegramServiceProvider.get().getService().setProxy(configuration.getProxyHost(), configuration.getProxyPort(), proxyServerType);
         }
     }
 
@@ -94,4 +96,18 @@ public class TelegramEndpoint extends ScheduledPollEndpoint {
         this.configuration = configuration;
     }
 
+    private ProxyServerType getProxyServerType(TelegramProxyType type) {
+        if (type == null) {
+            return ProxyServerType.HTTP;
+        }
+
+        switch (type) {
+            case HTTP:
+                return ProxyServerType.HTTP;
+            case SOCKS:
+                return ProxyServerType.SOCKS;
+            default:
+                throw new IllegalArgumentException("Unknown proxy type: " + type);
+        }
+    }
 }

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramProxyType.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramProxyType.java
@@ -1,0 +1,8 @@
+package org.apache.camel.component.telegram;
+
+/**
+ * Possible proxy server types
+ */
+public enum TelegramProxyType {
+    HTTP, SOCKS
+}

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramService.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramService.java
@@ -18,14 +18,15 @@ package org.apache.camel.component.telegram;
 
 import org.apache.camel.component.telegram.model.OutgoingMessage;
 import org.apache.camel.component.telegram.model.UpdateResult;
+import org.apache.cxf.transports.http.configuration.ProxyServerType;
 
 /**
  * Allows interacting with the Telegram server to exchange messages.
  */
 public interface TelegramService {
 
-    void setHttpProxy(String host, Integer port);
-  
+    void setProxy(String host, Integer port, ProxyServerType type);
+
     UpdateResult getUpdates(String authorizationToken, Long offset, Integer limit, Integer timeoutSeconds);
 
     void sendMessage(String authorizationToken, OutgoingMessage message);

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/service/TelegramServiceRestBotAPIAdapter.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/service/TelegramServiceRestBotAPIAdapter.java
@@ -41,6 +41,7 @@ import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
 import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.ProxyServerType;
 
 /**
  * Adapts the {@code RestBotAPI} to the {@code TelegramService} interface.
@@ -56,10 +57,11 @@ public class TelegramServiceRestBotAPIAdapter implements TelegramService {
     }
 
     @Override
-    public void setHttpProxy(String host, Integer port) {
+    public void setProxy(String host, Integer port, ProxyServerType type) {
         HTTPConduit httpConduit = WebClient.getConfig(this.api).getHttpConduit();
         httpConduit.getClient().setProxyServer(host);
         httpConduit.getClient().setProxyServerPort(port);
+        httpConduit.getClient().setProxyServerType(type);
     }
 
     @Override
@@ -186,10 +188,10 @@ public class TelegramServiceRestBotAPIAdapter implements TelegramService {
     private String escapeMimeName(String name) {
         return name.replace("\"", "");
     }
-    
+
     private JacksonJsonProvider providerByCustomObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(Include.NON_NULL);
         return new JacksonJsonProvider(mapper);
-    }    
+    }
 }

--- a/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramComponentParametersTest.java
+++ b/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramComponentParametersTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.telegram;
 
+import org.apache.camel.TypeConversionException;
 import org.apache.camel.component.telegram.util.TelegramTestSupport;
 import org.junit.Test;
 
@@ -30,6 +31,7 @@ public class TelegramComponentParametersTest extends TelegramTestSupport {
 
         TelegramEndpoint ep1 = (TelegramEndpoint) component.createEndpoint("telegram:bots");
         assertEquals("DEFAULT", ep1.getConfiguration().getAuthorizationToken());
+        assertEquals(TelegramProxyType.HTTP, ep1.getConfiguration().getProxyType());
 
         TelegramEndpoint ep2 = (TelegramEndpoint) component.createEndpoint("telegram:bots/CUSTOM");
         assertEquals("CUSTOM", ep2.getConfiguration().getAuthorizationToken());
@@ -57,6 +59,13 @@ public class TelegramComponentParametersTest extends TelegramTestSupport {
         TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
         component.setAuthorizationToken("ANY");
         component.createEndpoint("telegram:bots/token/s");
+    }
+
+    @Test(expected = TypeConversionException.class)
+    public void testWrongURI3() throws Exception {
+        TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
+        component.setAuthorizationToken("ANY");
+        component.createEndpoint("telegram:bots?proxyType=ANY");
     }
 
 }

--- a/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramConfigurationTest.java
+++ b/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramConfigurationTest.java
@@ -40,6 +40,7 @@ public class TelegramConfigurationTest extends TelegramTestSupport {
         assertEquals(Integer.valueOf(60), config.getLimit());
         assertEquals("127.0.0.1", config.getProxyHost());
         assertEquals(Integer.valueOf(1234), config.getProxyPort());
+        assertEquals(TelegramProxyType.SOCKS, config.getProxyType());
     }
 
 
@@ -50,7 +51,7 @@ public class TelegramConfigurationTest extends TelegramTestSupport {
             public void configure() throws Exception {
 
                 from("direct:telegram")
-                        .to("telegram:bots/mock-token?chatId=12345&delay=2000&timeout=10&limit=60&proxyHost=127.0.0.1&proxyPort=1234");
+                        .to("telegram:bots/mock-token?chatId=12345&delay=2000&timeout=10&limit=60&proxyHost=127.0.0.1&proxyPort=1234&proxyType=SOCKS");
             }
         };
     }

--- a/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/integration/TelegramServiceProxyTest.java
+++ b/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/integration/TelegramServiceProxyTest.java
@@ -1,0 +1,58 @@
+package org.apache.camel.component.telegram.integration;
+
+import org.apache.camel.component.telegram.TelegramService;
+import org.apache.camel.component.telegram.TelegramServiceProvider;
+import org.apache.camel.component.telegram.model.OutgoingTextMessage;
+import org.apache.camel.component.telegram.model.UpdateResult;
+import org.apache.cxf.transports.http.configuration.ProxyServerType;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests if the BotAPI are working correctly over proxy.
+ */
+public class TelegramServiceProxyTest {
+
+    private static String authorizationToken;
+
+    private static String chatId;
+
+    private static String proxyHost;
+
+    private static int proxyPort;
+
+    private static ProxyServerType proxyType;
+
+    @BeforeClass
+    public static void init() {
+        authorizationToken = System.getenv("TELEGRAM_AUTHORIZATION_TOKEN");
+        chatId = System.getenv("TELEGRAM_CHAT_ID");
+        proxyHost = System.getenv("TELEGRAM_PROXY_HOST");
+        proxyPort = Integer.parseInt(System.getenv("TELEGRAM_PROXY_PORT"));
+        proxyType = ProxyServerType.valueOf(System.getenv("TELEGRAM_PROXY_TYPE"));
+    }
+
+    @Test
+    public void testGetUpdates() {
+        TelegramService service = TelegramServiceProvider.get().getService();
+        service.setProxy(proxyHost, proxyPort, proxyType);
+
+        UpdateResult res = service.getUpdates(authorizationToken, null, null, null);
+
+        Assert.assertNotNull(res);
+        Assert.assertTrue(res.isOk());
+    }
+
+    @Test
+    public void testSendMessage() {
+        TelegramService service = TelegramServiceProvider.get().getService();
+        service.setProxy(proxyHost, proxyPort, proxyType);
+
+        OutgoingTextMessage msg = new OutgoingTextMessage();
+        msg.setChatId(chatId);
+        msg.setText("This is an auto-generated message from the Bot");
+
+        service.sendMessage(authorizationToken, msg);
+    }
+}


### PR DESCRIPTION
Added support of SOCKS proxy to telegram component by adding `proxyType` query parameter.
Nothing fancy, just passing `proxyServerType` to `HTTPClientPolicy`.
Default value for `proxyType` is HTTP, that ensures existing configuration will not be touched by this patch.
