### PR TITLE
[CAMEL-15196] adds support for opentracing tags

### DIFF
--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -104,3 +104,32 @@ You can find an example demonstrating the three ways to configure OpenTracing he
 https://github.com/apache/camel-spring-boot-examples/tree/master/camel-example-spring-boot-opentracing[camel-example-spring-boot-opentracing]
 
 include::camel-spring-boot::page$opentracing-starter.adoc[]
+
+== Span Operations Processors
+
+The OpenTracing Component exposes the Java API span operations as a set of Processors: `TagProcessor`, `SetBaggageProcessor`, and `GetBaggageProcessor`.
+
+=== Example
+
+[source,java]
+---------------------------------------------------------------------------------------------------------
+from("seda:a").routeId("a")
+        .process(new SetBaggageProcessor("a-baggage", simple("${header.request-header}")))
+        .to("seda:b")
+        .to("seda:c");
+
+from("seda:b").routeId("b")
+        .process(new TagProcessor("b-tag", simple("${header.request-header}")));
+
+from("seda:c").routeId("c")
+        .process(new GetBaggageProcessor("a-baggage", "baggage-header"));
+---------------------------------------------------------------------------------------------------------
+
+Where the value of header "request-header" is "foo", the resulting trace from executing route "seda:a" would include:
+
+* Span "a" with a baggage item named "a-baggage" of value "foo"
+* Span "b" with a tag named "b-tag" of value "foo"
+
+and the resulting message would contain:
+
+* Header "baggage-header" of value "foo"

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/GetBaggageProcessor.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/GetBaggageProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.opentracing;
 
 import io.opentracing.Span;

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/SetBaggageProcessor.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/SetBaggageProcessor.java
@@ -13,21 +13,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A processor which adds a tag on the active {@link io.opentracing.Span} with an {@link org.apache.camel.Expression}
+ * A processor which adds a baggage item on the active {@link Span} with an {@link Expression}
  */
-public class TagProcessor extends AsyncProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetBaggageProcessor extends AsyncProcessorSupport implements Traceable, IdAware, RouteIdAware {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TagProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SetBaggageProcessor.class);
 
     private String id;
     private String routeId;
-    private final String tagName;
+    private final String baggageName;
     private final Expression expression;
 
-    public TagProcessor(String tagName, Expression expression) {
-        this.tagName = tagName;
+    public SetBaggageProcessor(String baggageName, Expression expression) {
+        this.baggageName = baggageName;
         this.expression = expression;
-        ObjectHelper.notNull(tagName, "tagName");
+        ObjectHelper.notNull(baggageName, "baggageName");
         ObjectHelper.notNull(expression, "expression");
     }
 
@@ -36,8 +36,8 @@ public class TagProcessor extends AsyncProcessorSupport implements Traceable, Id
         try {
             Span span = ActiveSpanManager.getSpan(exchange);
             if (span != null) {
-                String tag = expression.evaluate(exchange, String.class);
-                span.setTag(tagName, tag);
+                String item = expression.evaluate(exchange, String.class);
+                span.setBaggageItem(baggageName, item);
             } else {
                 LOG.warn("OpenTracing: could not find managed span for exchange={}", exchange);
             }
@@ -58,7 +58,7 @@ public class TagProcessor extends AsyncProcessorSupport implements Traceable, Id
 
     @Override
     public String getTraceLabel() {
-        return "tag[" + tagName + ", " + expression + "]";
+        return "setBaggage[" + baggageName + ", " + expression + "]";
     }
 
     @Override
@@ -81,8 +81,8 @@ public class TagProcessor extends AsyncProcessorSupport implements Traceable, Id
         this.routeId = routeId;
     }
 
-    public String getTagName() {
-        return tagName;
+    public String getBaggageName() {
+        return baggageName.toString();
     }
 
     public Expression getExpression() {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/SetBaggageProcessor.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/SetBaggageProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.opentracing;
 
 import io.opentracing.Span;

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/TagProcessor.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/TagProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.opentracing;
 
 import io.opentracing.Span;

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/TagProcessor.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/TagProcessor.java
@@ -1,0 +1,102 @@
+package org.apache.camel.opentracing;
+
+import io.opentracing.Span;
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
+import org.apache.camel.Traceable;
+import org.apache.camel.spi.IdAware;
+import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.support.AsyncProcessorSupport;
+import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A processor which adds a tag on the active {@link io.opentracing.Span} with an {@link org.apache.camel.Expression}
+ */
+public class TagProcessor extends AsyncProcessorSupport implements Traceable, IdAware, RouteIdAware {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TagProcessor.class);
+
+    private String id;
+    private String routeId;
+    private final Expression tagName;
+    private final Expression expression;
+
+    public TagProcessor(Expression tagName, Expression expression) {
+        this.tagName = tagName;
+        this.expression = expression;
+        ObjectHelper.notNull(tagName, "headerName");
+        ObjectHelper.notNull(expression, "expression");
+    }
+
+    @Override
+    public boolean process(Exchange exchange, AsyncCallback callback) {
+        try {
+            Span span = ActiveSpanManager.getSpan(exchange);
+            if (span != null) {
+                String key = tagName.evaluate(exchange, String.class);
+                String tag = expression.evaluate(exchange, String.class);
+                span.setTag(key, tag);
+            } else {
+                LOG.warn("OpenTracing: could not find managed span for exchange={}", exchange);
+            }
+        } catch (Exception e) {
+            exchange.setException(e);
+        } finally {
+            // callback must be invoked
+            callback.done(true);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    @Override
+    public String getTraceLabel() {
+        return "tag[" + tagName + ", " + expression + "]";
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getRouteId() {
+        return routeId;
+    }
+
+    @Override
+    public void setRouteId(String routeId) {
+        this.routeId = routeId;
+    }
+
+    public String getTagName() {
+        return tagName.toString();
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        // noop
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        // noop
+    }
+}

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
@@ -134,6 +134,18 @@ public class CamelOpenTracingTestSupport extends CamelTestSupport {
                 assertEquals(td.getLogMessages().get(i), span.logEntries().get(i).fields().get("message"));
             }
         }
+
+        if (!td.getTags().isEmpty()) {
+            for (Map.Entry<String, String> entry : td.getTags().entrySet()) {
+                assertEquals(entry.getValue(), span.tags().get(entry.getKey()));
+            }
+        }
+
+        if (!td.getBaggage().isEmpty()) {
+            for (Map.Entry<String, String> entry : td.getBaggage().entrySet()) {
+                assertEquals(entry.getValue(), span.getBaggageItem(entry.getKey()));
+            }
+        }
     }
 
     protected void verifySameTrace() {

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanProcessorsTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanProcessorsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentracing;
+
+import io.opentracing.tag.Tags;
+import org.apache.camel.Exchange;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+
+import static org.apache.camel.language.simple.SimpleLanguage.simple;
+
+public class SpanProcessorsTest extends CamelOpenTracingTestSupport {
+
+    private static final SpanTestData[] testdata = {
+            new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
+                    .setKind(Tags.SPAN_KIND_SERVER).setParentId(1).addLogMessage("routing at b")
+                    .addTag("b-tag", "request-header-value"),
+            new SpanTestData().setLabel("seda:b client").setUri("seda://b").setOperation("b")
+                    .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
+            new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
+                    .setKind(Tags.SPAN_KIND_SERVER).setParentId(3).addLogMessage("Exchange[ExchangePattern: InOut, BodyType: String, Body: Hello]"),
+            new SpanTestData().setLabel("seda:c client").setUri("seda://c").setOperation("c")
+                    .setKind(Tags.SPAN_KIND_CLIENT).setParentId(4),
+            new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
+                    .setKind(Tags.SPAN_KIND_SERVER).setParentId(5).addLogMessage("routing at a").addLogMessage("End of routing")
+                    .addBaggage("a-baggage", "request-header-value"),
+            new SpanTestData().setLabel("seda:a client").setUri("seda://a").setOperation("a")
+                    .setKind(Tags.SPAN_KIND_CLIENT).setParentId(6),
+            new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
+                    .setKind(Tags.SPAN_KIND_SERVER).setParentId(7),
+            new SpanTestData().setLabel("direct:start client").setUri("direct://start").setOperation("start")
+                    .setKind(Tags.SPAN_KIND_CLIENT)
+    };
+
+    public SpanProcessorsTest() {
+        super(testdata);
+    }
+
+    @Test
+    public void testRoute() throws Exception {
+        Exchange result = template.request("direct:start",
+                exchange -> {
+                    exchange.getIn().setBody("Hello");
+                    exchange.getIn().setHeader("request-header", simple("request-header-value"));
+                });
+
+        verify();
+        assertEquals("request-header-value", result.getMessage().getHeader("baggage-header", String.class));
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").to("seda:a").routeId("start");
+
+                from("seda:a").routeId("a")
+                        .log("routing at ${routeId}")
+                        .process(new SetBaggageProcessor("a-baggage", simple("${header.request-header}")))
+                        .to("seda:b")
+                        .delay(2000)
+                        .to("seda:c")
+                        .log("End of routing");
+
+                from("seda:b").routeId("b")
+                        .log("routing at ${routeId}")
+                        .process(new TagProcessor("b-tag", simple("${header.request-header}")))
+                        .delay(simple("${random(1000,2000)}"));
+
+                from("seda:c").routeId("c")
+                        .to("log:test")
+                        .process(new GetBaggageProcessor("a-baggage", "baggage-header"))
+                        .delay(simple("${random(0,100)}"));
+            }
+        };
+    }
+}

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanProcessorsTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanProcessorsTest.java
@@ -26,7 +26,7 @@ import static org.apache.camel.language.simple.SimpleLanguage.simple;
 
 public class SpanProcessorsTest extends CamelOpenTracingTestSupport {
 
-    private static final SpanTestData[] testdata = {
+    private static final SpanTestData[] TEST_DATA = {
             new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
                     .setKind(Tags.SPAN_KIND_SERVER).setParentId(1).addLogMessage("routing at b")
                     .addTag("b-tag", "request-header-value"),
@@ -48,16 +48,16 @@ public class SpanProcessorsTest extends CamelOpenTracingTestSupport {
     };
 
     public SpanProcessorsTest() {
-        super(testdata);
+        super(TEST_DATA);
     }
 
     @Test
     public void testRoute() throws Exception {
         Exchange result = template.request("direct:start",
-                exchange -> {
-                    exchange.getIn().setBody("Hello");
-                    exchange.getIn().setHeader("request-header", simple("request-header-value"));
-                });
+            exchange -> {
+                exchange.getIn().setBody("Hello");
+                exchange.getIn().setHeader("request-header", simple("request-header-value"));
+            });
 
         verify();
         assertEquals("request-header-value", result.getMessage().getHeader("baggage-header", String.class));

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanTestData.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/SpanTestData.java
@@ -17,7 +17,9 @@
 package org.apache.camel.opentracing;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SpanTestData {
 
@@ -27,6 +29,8 @@ public class SpanTestData {
     private String kind;
     private int parentId = -1;
     private List<String> logMessages = new ArrayList<>();
+    private Map<String, String> tags = new HashMap<>();
+    private Map<String, String> baggage = new HashMap<>();
 
     public String getLabel() {
         return label;
@@ -80,5 +84,23 @@ public class SpanTestData {
 
     public List<String> getLogMessages() {
         return logMessages;
+    }
+
+    public SpanTestData addTag(String key, String val) {
+        tags.put(key, val);
+        return this;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public SpanTestData addBaggage(String key, String val) {
+        baggage.put(key, val);
+        return this;
+    }
+
+    public Map<String, String> getBaggage() {
+        return baggage;
     }
 }


### PR DESCRIPTION
Opentracing allows to set tags to a given Span, this exposes that functionality via a processor.
See: https://issues.apache.org/jira/browse/CAMEL-15196
https://opentracing.io/docs/overview/tags-logs-baggage/#tags

I'm still implementing some tests, but wanted to check with you guys first in case I'm headed down the wrong path.