### PR TITLE
Fix duplicate Mina2 in deprecation warning

### DIFF
--- a/docs/components/modules/ROOT/pages/mina-component.adoc
+++ b/docs/components/modules/ROOT/pages/mina-component.adoc
@@ -16,7 +16,7 @@
 *Deprecated*
 
 WARNING: This component is deprecated as the Apache Mina 1.x project is EOL.
-Instead use xref:mina2-component.adoc[Mina 2] or xref:mina2-component.adoc[Mina 2] instead.
+Instead use xref:mina2-component.adoc[Mina 2] or xref:netty-component.adoc[Netty] instead.
 
 The *mina:* component is a transport for working with
 http://mina.apache.org/[Apache MINA]


### PR DESCRIPTION
Replaced duplicate mention of "Mina2" in deprecation warning to advise the use of Mina2 or *Netty*
