### PR TITLE
[CAMEL-15204] Correct IBM i naming/branding in the jt400 component

### DIFF
--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -2,7 +2,7 @@
 = JT400 Component
 :docTitle: JT400
 :artifactId: camel-jt400
-:description: Exchanges messages with an AS/400 system using data queues, message queues, or program call.
+:description: Exchanges messages with an IBM i system using data queues, message queues, or program call. IBM i is the replacement for AS/400 and iSeries servers.
 :since: 1.5
 :supportLevel: Stable
 :component-header: Both producer and consumer are supported
@@ -11,7 +11,7 @@
 
 *{component-header}*
 
-The JT400 component allows you to exchanges messages with an AS/400
+The JT400 component allows you to exchanges messages with an IBM i
 system using data queues.
 
 Maven users will need to add the following dependency to their `pom.xml`
@@ -86,9 +86,9 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *userID* | *Required* Returns the ID of the AS/400 user. |  | String
-| *password* | *Required* Returns the password of the AS/400 user. |  | String
-| *systemName* | *Required* Returns the name of the AS/400 system. |  | String
+| *userID* | *Required* Returns the ID of the IBM i user. |  | String
+| *password* | *Required* Returns the password of the IBM i user. |  | String
+| *systemName* | *Required* Returns the name of the IBM i system. |  | String
 | *objectPath* | *Required* Returns the fully qualified integrated file system path name of the target object of this endpoint. |  | String
 | *type* | *Required* Whether to work with data queues or remote program call. The value can be one of: DTAQ, PGM, SRVPGM, MSGQ |  | Jt400Type
 |===
@@ -100,9 +100,9 @@ with the following path and query parameters:
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *ccsid* (common) | Sets the CCSID to use for the connection with the AS/400 system. |  | int
+| *ccsid* (common) | Sets the CCSID to use for the connection with the IBM i system. |  | int
 | *format* (common) | Sets the data format for sending messages. The value can be one of: text, binary | text | Format
-| *guiAvailable* (common) | Sets whether AS/400 prompting is enabled in the environment running Camel. | false | boolean
+| *guiAvailable* (common) | Sets whether IBM i prompting is enabled in the environment running Camel. | false | boolean
 | *keyed* (common) | Whether to use keyed or non-keyed data queues. | false | boolean
 | *searchKey* (common) | Search key for keyed data queues. |  | String
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
@@ -115,7 +115,7 @@ with the following path and query parameters:
 | *pollStrategy* (consumer) | A pluggable org.apache.camel.PollingConsumerPollingStrategy allowing you to provide your custom implementation to control error handling usually occurred during the poll operation before an Exchange have been created and being routed in Camel. |  | PollingConsumerPollStrategy
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
 | *outputFieldsIdxArray* (producer) | Specifies which fields (program parameters) are output parameters. |  | Integer[]
-| *outputFieldsLengthArray* (producer) | Specifies the fields (program parameters) length as in the AS/400 program definition. |  | Integer[]
+| *outputFieldsLengthArray* (producer) | Specifies the fields (program parameters) length as in the IBM i program definition. |  | Integer[]
 | *procedureName* (producer) | Procedure name from a service program to call |  | String
 | *basicPropertyBinding* (advanced) | Whether the endpoint should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
 | *synchronous* (advanced) | Sets whether synchronous processing should be strictly used, or Camel is allowed to use asynchronous processing (if supported). | false | boolean
@@ -133,7 +133,7 @@ with the following path and query parameters:
 | *startScheduler* (scheduler) | Whether the scheduler should be auto started. | true | boolean
 | *timeUnit* (scheduler) | Time unit for initialDelay and delay options. The value can be one of: NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS | MILLISECONDS | TimeUnit
 | *useFixedDelay* (scheduler) | Controls if fixed delay or fixed rate is used. See ScheduledExecutorService in JDK for details. | true | boolean
-| *secured* (security) | Whether connections to AS/400 are secured with SSL. | false | boolean
+| *secured* (security) | Whether connections to IBM i are secured with SSL. | false | boolean
 |===
 // endpoint options: END
 

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Component.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Component.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link org.apache.camel.Component} to provide integration with AS/400 objects.
+ * {@link org.apache.camel.Component} to provide integration with IBM i objects (IBM i is the replacement for AS/400 and iSeries servers).
  * 
  * Current implementation supports working with data queues (*DTAQ) and Program calls (*PGM)
  */

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
@@ -178,7 +178,7 @@ public class Jt400Configuration {
     }
 
     /**
-     * Returns the name of the AS/400 system.
+     * Returns the name of the IBM i system.
      */
     public String getSystemName() {
         return systemName;
@@ -189,7 +189,7 @@ public class Jt400Configuration {
     }
 
     /**
-     * Returns the ID of the AS/400 user.
+     * Returns the ID of the IBM i user.
      */
     public String getUserID() {
         return userID;
@@ -200,7 +200,7 @@ public class Jt400Configuration {
     }
 
     /**
-     * Returns the password of the AS/400 user.
+     * Returns the password of the IBM i user.
      */
     public String getPassword() {
         return password;
@@ -225,7 +225,7 @@ public class Jt400Configuration {
     // Options
     
     /**
-     * Returns the CCSID to use for the connection with the AS/400 system.
+     * Returns the CCSID to use for the connection with the IBM i system.
      * Returns -1 if the CCSID to use is the default system CCSID.
      */
     public int getCssid() {
@@ -233,7 +233,7 @@ public class Jt400Configuration {
     }
     
     /**
-     * Sets the CCSID to use for the connection with the AS/400 system.
+     * Sets the CCSID to use for the connection with the IBM i system.
      */
     public void setCcsid(int ccsid) {
         this.ccsid = (ccsid < 0) ? DEFAULT_SYSTEM_CCSID : ccsid;
@@ -255,7 +255,7 @@ public class Jt400Configuration {
     }
     
     /**
-     * Returns whether AS/400 prompting is enabled in the environment running
+     * Returns whether IBM i prompting is enabled in the environment running
      * Camel.
      */
     public boolean isGuiAvailable() {
@@ -263,7 +263,7 @@ public class Jt400Configuration {
     }
     
     /**
-     * Sets whether AS/400 prompting is enabled in the environment running
+     * Sets whether IBM i prompting is enabled in the environment running
      * Camel.
      */
     public void setGuiAvailable(boolean guiAvailable) {
@@ -316,7 +316,7 @@ public class Jt400Configuration {
     }
 
     /**
-     * Whether connections to AS/400 are secured with SSL.
+     * Whether connections to IBM i are secured with SSL.
      */
     public void setSecured(boolean secured) {
         this.secured = secured;
@@ -334,7 +334,7 @@ public class Jt400Configuration {
     }
 
     /**
-     * Specifies the fields (program parameters) length as in the AS/400 program definition.
+     * Specifies the fields (program parameters) length as in the IBM i program definition.
      */
     public void setOutputFieldsLengthArray(Integer[] outputFieldsLengthArray) {
         this.outputFieldsLengthArray = outputFieldsLengthArray;
@@ -426,11 +426,11 @@ public class Jt400Configuration {
             try {
                 system.setGuiAvailable(guiAvailable);
             } catch (PropertyVetoException e) {
-                LOG.warn("Failed to disable AS/400 prompting in the environment running Camel. This exception will be ignored.", e);
+                LOG.warn("Failed to disable IBM i prompting in the environment running Camel. This exception will be ignored.", e);
             }
             return system; // Not null here.
         } catch (ConnectionPoolException e) {
-            throw new RuntimeCamelException(String.format("Unable to obtain an AS/400 connection for system name '%s' and user ID '%s'", systemName, userID), e);
+            throw new RuntimeCamelException(String.format("Unable to obtain an IBM i connection for system name '%s' and user ID '%s'", systemName, userID), e);
         } catch (PropertyVetoException e) {
             throw new RuntimeCamelException("Unable to set the CSSID to use with " + system, e);
         }

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueProducer.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400DataQueueProducer.java
@@ -24,7 +24,7 @@ import org.apache.camel.Producer;
 import org.apache.camel.support.DefaultProducer;
 
 /**
- * {@link Producer} to send data to an AS/400 data queue.
+ * {@link Producer} to send data to an IBM i data queue.
  */
 public class Jt400DataQueueProducer extends DefaultProducer {
 
@@ -39,7 +39,7 @@ public class Jt400DataQueueProducer extends DefaultProducer {
     }
 
     /**
-     * Sends the {@link Exchange}'s in body to the AS/400 data queue. If the
+     * Sends the {@link Exchange}'s in body to the IBM i data queue. If the
      * endpoint's format is set to {@link org.apache.camel.component.jt400.Jt400Configuration.Format#binary}, the data queue entry's
      * data will be sent as a <code>byte[]</code>. If the endpoint's format is
      * set to {@link org.apache.camel.component.jt400.Jt400Configuration.Format#text}, the data queue entry's data will be sent as a

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Endpoint.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Endpoint.java
@@ -36,7 +36,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
 
 /**
- * Exchanges messages with an AS/400 system using data queues, message queues, or program call.
+ * Exchanges messages with an IBM i system using data queues, message queues, or program call. IBM i is the replacement for AS/400 and iSeries servers.
  */
 @UriEndpoint(firstVersion = "1.5.0", scheme = "jt400", title = "JT400", syntax = "jt400:userID:password/systemName/objectPath.type", category = {Category.MESSAGING})
 public class Jt400Endpoint extends ScheduledPollEndpoint implements MultipleConsumersSupport {
@@ -48,7 +48,7 @@ public class Jt400Endpoint extends ScheduledPollEndpoint implements MultipleCons
     private final Jt400Configuration configuration;
 
     /**
-     * Creates a new AS/400 data queue endpoint using a default connection pool
+     * Creates a new IBM i data queue endpoint using a default connection pool
      * provided by the component.
      *
      * @throws NullPointerException if {@code component} is null
@@ -58,7 +58,7 @@ public class Jt400Endpoint extends ScheduledPollEndpoint implements MultipleCons
     }
 
     /**
-     * Creates a new AS/400 data queue endpoint using the specified connection
+     * Creates a new IBM i data queue endpoint using the specified connection
      * pool.
      */
     protected Jt400Endpoint(String endpointUri, Jt400Component component, AS400ConnectionPool connectionPool) throws CamelException {


### PR DESCRIPTION
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-15204) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.

**Description**
The current documentation for the JT400 component references AS/400 systems throughout. AS/400 no longer exists in any suppported capacity. AS/400 was rebranded in 2000, with its successor being fully discontinued on [Sep 30, 2013](https://en.wikipedia.org/wiki/IBM_System_i). In 2008, AS/400 was replaced by [IBM i](https://en.wikipedia.org/wiki/IBM_i) on Power Systems.

However, since the IBM i system supports many of the same constructs as AS/400 and has the ability to run AS/400 programs, people (understandably) have a tendency to incorrectly identify IBM i systems as "AS/400."

This trivial PR simply intends to correct the server name accordingly, to properly reflect reality.