### PR TITLE
CAMEL-15216 : Omit the warning of section levels

### DIFF
--- a/components/camel-djl/src/main/docs/djl-component.adoc
+++ b/components/camel-djl/src/main/docs/djl-component.adoc
@@ -53,7 +53,7 @@ djl:application
 
 with the following path and query parameters:
 
-=== Path Parameters (1 parameters):
+== Path Parameters (1 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -63,7 +63,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (6 parameters):
+== Query Parameters (6 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]


### PR DESCRIPTION
In AsciiDoc, it has a highly strict structure on the levels of section i.e it needs to be presented in a sequential manner. However, the parameters table was on `level 2` right after `level 0` which raised the warning. Converting to `level 1` will omit the warning.