### PR TITLE
CAMEL-15216 : Omit the warning for example tag from camel 3.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ components/camel-cxf/activemq-data
 *.swp
 .flattened-pom.xml
 .java-version
+node_modules/

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
@@ -45,7 +45,9 @@ transform the message
 
 [source,java]
 ----
-include::{examplesdir}/core/camel-core/src/test/java/org/apache/camel/processor/TransformViaDSLTest.java[tags=example]
+from("direct:start")
+    .setBody(body().append(" World!"))
+    .to("mock:result");
 ----
 
 In this example we add our own xref:latest@manual:ROOT:processor.adoc[Processor] using
@@ -53,7 +55,14 @@ explicit Java
 
 [source,java]
 ----
-include::{examplesdir}/core/camel-core/src/test/java/org/apache/camel/processor/TransformTest.java[tags=example]
+from("direct:start")
+    .process(new Processor() {
+        public void process(Exchange exchange) {
+            Message in = exchange.getIn();
+            in.setBody(in.getBody(String.class) + " World!");
+        }
+    })
+    .to("mock:result");
 ----
 
 we can use xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to use any Java


### PR DESCRIPTION
* There is a particular warning regarding the `content-enricher.adoc` related to the example tag while building the camel-website. 

```
asciidoctor: WARNING: content-enricher.adoc: line 48: tag 'example' not found in include file: modules/eips/examples/core/camel-core/src/test/java/org/apache/camel/processor/TransformViaDSLTest.java
asciidoctor: WARNING: content-enricher.adoc: line 56: tag 'example' not found in include file: modules/eips/examples/core/camel-core/src/test/java/org/apache/camel/processor/TransformTest.java
```

I observed that within the camel repo for the master branch, this warning is already dealt with however the warning still persist 'cause in the `antora-playbook.yml` for the camel-website, it also extracts the docs from the `camel-3.3.x` branch and the change weren't made in it, thus I have added the change similar to that of the master branch.

```
antora-playbook.yml 
- url: git@github.com:apache/camel.git
      branches: camel-3.3.x
      start_paths:
        # eip
        - core/camel-core-engine/src/main/docs
```