### PR TITLE
Fix typo across docs: '3rd' instead of '3th'

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/resequence-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/resequence-eip.adoc
@@ -109,7 +109,7 @@ It's now much easier to use the Resequencer to resequence messages from JMS queu
 from("jms:queue:foo")
     // sort by JMSPriority by allowing duplicates (message can have same JMSPriority)
     // and use reverse ordering so 9 is first output (most important), and 0 is last
-    // use batch mode and fire every 3th second
+    // use batch mode and fire every 3rd second
     .resequence(header("JMSPriority")).batch().timeout(3000).allowDuplicates().reverse()
     .to("mock:result");
 ----

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsBatchResequencerJMSPriorityTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsBatchResequencerJMSPriorityTest.java
@@ -68,7 +68,7 @@ public class JmsBatchResequencerJMSPriorityTest extends CamelTestSupport {
                 from("jms:queue:foo")
                     // sort by JMSPriority by allowing duplicates (message can have same JMSPriority)
                     // and use reverse ordering so 9 is first output (most important), and 0 is last
-                    // use batch mode and fire every 3th second
+                    // use batch mode and fire every 3rd second
                     .resequence(header("JMSPriority")).batch().timeout(3000).allowDuplicates().reverse()
                     .to("mock:result");
                 // END SNIPPET: e1

--- a/components/camel-testcontainers-spring-junit5/src/main/docs/testcontainers-spring-junit5.adoc
+++ b/components/camel-testcontainers-spring-junit5/src/main/docs/testcontainers-spring-junit5.adoc
@@ -8,7 +8,7 @@
 
 *Since Camel {since}*
 
-Testing camel components is sometime complex because the 3th party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers Spring JUnit 5* extends camel spring test support providing a way to create and interact with containerized applications.
+Testing camel components is sometime complex because the 3rd party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers Spring JUnit 5* extends camel spring test support providing a way to create and interact with containerized applications.
 
 This module is an extension to the camel-testcontainers-junit5 component to add support for Spring.
 Therefore see the documentation for testcontainers for more details.

--- a/components/camel-testcontainers-spring/src/main/docs/testcontainers-spring.adoc
+++ b/components/camel-testcontainers-spring/src/main/docs/testcontainers-spring.adoc
@@ -8,7 +8,7 @@
 
 *Since Camel {since}*
 
-Testing camel components is sometime complex because the 3th party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers Spring* extends camel spring test support providing a way to create and interact with containerized applications.
+Testing camel components is sometime complex because the 3rd party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers Spring* extends camel spring test support providing a way to create and interact with containerized applications.
 
 This module is an extension to the camel-testcontainers component to add support for Spring.
 Therefore see the documentation for testcontainers for more details.

--- a/components/camel-testcontainers/src/main/docs/testcontainers.adoc
+++ b/components/camel-testcontainers/src/main/docs/testcontainers.adoc
@@ -8,7 +8,7 @@
 
 *Since Camel {since}*
 
-Testing camel components is sometime complex because the 3th party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers* extends standard camel test support providing a way to create and interact with containerized applications.
+Testing camel components is sometime complex because the 3rd party system a component interacts with does not provide testing facilities and/or is only available as a native application. To reduce this complexity, *Camel Testcontainers* extends standard camel test support providing a way to create and interact with containerized applications.
 
 In order to define leverage testcontainers, add the following dependency to your pom:
 


### PR DESCRIPTION
## Issue
Fixes typos in documentation to use correct form: `3rd`.

## Checklist
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.

Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md