### PR TITLE
(camel-jt400) Add "AS/400" reference to component header

### DIFF
--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -11,8 +11,9 @@
 
 *{component-header}*
 
-The JT400 component allows you to exchanges messages with an IBM i
-system using data queues.
+The JT400 component allows you to exchange messages with an IBM i system
+using data queues, message queues, or program call. IBM i is the
+replacement for AS/400 and iSeries servers.
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:


### PR DESCRIPTION
fixup of #3936. Sorry for the mistake! I didn't realize that the `:description:` doesn't end up on the web rendering. With this trivial PR, I'm taking the advice of @davsclaus in [this comment](https://github.com/apache/camel/pull/3936#issuecomment-646947807) and updating the component-header field as well to have the "AS/400" reference for web searchability. 

Also a minor grammatical enhancement (`allows you to exchanges messages` -> `allows you to exchange messages`) and adding mention of the message queue and program call support. 