### PR TITLE
Update documentation for aggregation strategies in pre-completion mode

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aggregate-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aggregate-eip.adoc
@@ -132,7 +132,7 @@ exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
 completionPredicate is configured. The configured aggregationStrategy can
-implement `PreCompletionAwareAggregationStrategy` and will be used as
+override the `preComplete` method and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * completionFromBatchConsumer - Special option for
@@ -159,9 +159,8 @@ There can be use-cases where you want the incoming
 xref:latest@manual:ROOT:exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
 xref:latest@manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch. To
-determine this the `AggregationStrategy` can
-implement `PreCompletionAwareAggregationStrategy` which has
-a `preComplete` method:
+determine this the `AggregationStrategy` must override the `canPreComplete` method
+which has to return `true`.
 
 [source,java]
 ----
@@ -183,8 +182,6 @@ so the group would contain only that new incoming exchange. This is
 known as pre-completion mode. And when the aggregation is in
 pre-completion mode, then only the following completions are in use
 
-* aggregationStrategy must
-implement `PreCompletionAwareAggregationStrategy` xxx
 * completionTimeout or completionInterval can also be used as fallback
 completions
 * any other completion are not used (such as by size, from batch

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -132,7 +132,7 @@ exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
 completionPredicate is configured. The configured aggregationStrategy can
-implement `PreCompletionAwareAggregationStrategy` and will be used as
+override the `preComplete` method and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * completionFromBatchConsumer - Special option for
@@ -158,10 +158,9 @@ aggregator. If not provided Camel will thrown an Exception on startup.
 There can be use-cases where you want the incoming
 xref:latest@manual:ROOT:exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch. To
-determine this the `AggregationStrategy` can
-implement `PreCompletionAwareAggregationStrategy` which has
-a `preComplete` method:
+xref:latest@manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch. o
+determine this the `AggregationStrategy` must override the `canPreComplete` method
+which has to return `true`.
 
 [source,java]
 ----
@@ -183,8 +182,6 @@ so the group would contain only that new incoming exchange. This is
 known as pre-completion mode. And when the aggregation is in
 pre-completion mode, then only the following completions are in use
 
-* aggregationStrategy must
-implement `PreCompletionAwareAggregationStrategy` xxx
 * completionTimeout or completionInterval can also be used as fallback
 completions
 * any other completion are not used (such as by size, from batch


### PR DESCRIPTION
I've updated the documentation to describe how to set an aggregation strategy in pre-completion mode since version 3.0.0. If I didn't massively misunderstand something , then the `PreCompletionAwareAggregationStrategy` interface was removed in `camel-core` 3.0.0 (see commit e441457951b7d7cb6ede65a62fd8460a6485e322) and `AggregationStrategy` new default methods replace the removed methods.

So you'll need to implement the `canPreComplete` method by your own, it's not possible to implement/extend `PreCompletionAwareAggregationStrategy`.