### PR TITLE
CAMEL-15272 Bump version for jira-rest-client-api

### DIFF
--- a/components/camel-jira/src/test/java/org/apache/camel/component/jira/producer/TransitionIssueProducerTest.java
+++ b/components/camel-jira/src/test/java/org/apache/camel/component/jira/producer/TransitionIssueProducerTest.java
@@ -87,7 +87,7 @@ public class TransitionIssueProducerTest extends CamelTestSupport {
         when(issueRestClient.transition(any(Issue.class), any(TransitionInput.class))).then(inv -> {
             URI doneStatusUri = URI.create(TEST_JIRA_URL + "/rest/api/2/status/1");
             URI doneResolutionUri = URI.create(TEST_JIRA_URL + "/rest/api/2/resolution/1");
-            Status status = new Status(doneStatusUri, 1L, "Done", "Done", null);
+            Status status = new Status(doneStatusUri, 1L, "Done", "Done",null, null);
             Resolution resolution = new Resolution(doneResolutionUri, 1L, "Resolution", "Resolution");
             issue = transitionIssueDone(issue, status, resolution);
             return null;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -324,7 +324,7 @@
         <jgroups-raft-leveldbjni-version>1.8</jgroups-raft-leveldbjni-version>
         <jgroups-raft-mapdb-version>1.0.8</jgroups-raft-mapdb-version>
         <jira-guava-version>26.0-jre</jira-guava-version>
-        <jira-rest-client-api-version>5.1.6</jira-rest-client-api-version>
+        <jira-rest-client-api-version>5.2.1</jira-rest-client-api-version>
         <libthrift-version>0.12.0</libthrift-version>
         <jing-version>20030619</jing-version>
         <jmh-version>1.23</jmh-version>


### PR DESCRIPTION
I believe this should be also in 3.4.x especially because of camel-k. Jira will be used as a quickstart for knative camel event sources and it'd be good to have it working also with JIRA-cloud. 