### PR TITLE
[CAMEL-15255] Extend set of metrics provided by the camel-micrometer component

### DIFF
--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConstants.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConstants.java
@@ -31,10 +31,13 @@ public final class MicrometerConstants {
     public static final String HEADER_METRIC_TAGS = HEADER_PREFIX + "Tags";
 
     public static final String DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME = "CamelMessageHistory";
+    public static final String DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME = "CamelExchangesFailed";
+    public static final String DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME = "CamelExchangesSucceeded";
     public static final String DEFAULT_CAMEL_ROUTE_POLICY_METER_NAME = "CamelRoutePolicy";
     public static final String DEFAULT_CAMEL_EXCHANGE_EVENT_METER_NAME = "CamelExchangeEventNotifier";
     public static final String DEFAULT_CAMEL_ROUTES_ADDED = "CamelRoutesAdded";
     public static final String DEFAULT_CAMEL_ROUTES_RUNNING = "CamelRoutesRunning";
+    public static final String DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT = "CamelExchangesInflight";
 
     public static final String ROUTE_ID_TAG = "routeId";
     public static final String NODE_ID_TAG = "nodeId";

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
@@ -26,9 +26,11 @@ import org.apache.camel.spi.CamelEvent.ExchangeEvent;
 
 import static org.apache.camel.component.micrometer.MicrometerConstants.CAMEL_CONTEXT_TAG;
 import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_EXCHANGE_EVENT_METER_NAME;
+import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT;
 import static org.apache.camel.component.micrometer.MicrometerConstants.ENDPOINT_NAME;
 import static org.apache.camel.component.micrometer.MicrometerConstants.EVENT_TYPE_TAG;
 import static org.apache.camel.component.micrometer.MicrometerConstants.FAILED_TAG;
+import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
 import static org.apache.camel.component.micrometer.MicrometerConstants.SERVICE_NAME;
 
 public interface MicrometerExchangeEventNotifierNamingStrategy {
@@ -38,6 +40,10 @@ public interface MicrometerExchangeEventNotifierNamingStrategy {
 
     String getName(Exchange exchange, Endpoint endpoint);
 
+    default String getInflightExchangesName(Exchange exchange, Endpoint endpoint) {
+        return DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT;
+    }
+
     default Tags getTags(ExchangeEvent event, Endpoint endpoint) {
         return Tags.of(
                 CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
@@ -45,6 +51,14 @@ public interface MicrometerExchangeEventNotifierNamingStrategy {
                 EVENT_TYPE_TAG, event.getClass().getSimpleName(),
                 ENDPOINT_NAME, endpoint.getEndpointUri(),
                 FAILED_TAG, Boolean.toString(event.getExchange().isFailed())
+        );
+    }
+
+    default Tags getInflightExchangesTags(ExchangeEvent event, Endpoint endpoint) {
+        return Tags.of(
+            CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
+            SERVICE_NAME, MicrometerEventNotifierService.class.getSimpleName(),
+            ROUTE_ID_TAG, event.getExchange().getFromRouteId()
         );
     }
 }

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyNamingStrategy.java
@@ -24,6 +24,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Route;
 
 import static org.apache.camel.component.micrometer.MicrometerConstants.CAMEL_CONTEXT_TAG;
+import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME;
+import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME;
 import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_METER_NAME;
 import static org.apache.camel.component.micrometer.MicrometerConstants.FAILED_TAG;
 import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
@@ -40,6 +42,14 @@ public interface MicrometerRoutePolicyNamingStrategy {
 
     String getName(Route route);
 
+    default String getExchangesSucceededName(Route route) {
+        return DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME;
+    }
+
+    default String getExchangesFailedName(Route route) {
+        return DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME;
+    }
+
     default Tags getTags(Route route, Exchange exchange) {
         return Tags.of(
                 CAMEL_CONTEXT_TAG, route.getCamelContext().getName(),
@@ -49,4 +59,11 @@ public interface MicrometerRoutePolicyNamingStrategy {
         );
     }
 
+    default Tags getExchangeStatusTags(Route route) {
+        return Tags.of(
+                CAMEL_CONTEXT_TAG, route.getCamelContext().getName(),
+                SERVICE_NAME, MicrometerRoutePolicyService.class.getSimpleName(),
+                ROUTE_ID_TAG, route.getId()
+        );
+    }
 }

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventNotifier/MicrometerExchangeEventNotifierTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventNotifier/MicrometerExchangeEventNotifierTest.java
@@ -28,6 +28,9 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.ExpressionAdapter;
 import org.junit.Test;
 
+import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT;
+import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
+
 public class MicrometerExchangeEventNotifierTest extends AbstractMicrometerEventNotifierTest {
 
     private static final String ROUTE_ID = "test";
@@ -50,6 +53,7 @@ public class MicrometerExchangeEventNotifierTest extends AbstractMicrometerEvent
             @Override
             public Object evaluate(Exchange exchange) {
                 try {
+                    assertEquals(1.0D, currentInflightExchanges(), 0.1D);
                     Thread.sleep(SLEEP);
                     return exchange.getIn().getBody();
                 } catch (InterruptedException e) {
@@ -63,9 +67,16 @@ public class MicrometerExchangeEventNotifierTest extends AbstractMicrometerEvent
         for (int i = 0; i < count; i++) {
             template.sendBody(DIRECT_IN, new Object());
         }
+
+        mock.assertIsSatisfied();
         Timer timer = meterRegistry.find(MOCK_OUT).timer();
         assertEquals(count, timer.count());
         assertTrue(timer.mean(TimeUnit.MILLISECONDS) > SLEEP.doubleValue());
+        assertEquals(0.0D, currentInflightExchanges(), 0.1D);
+    }
+
+    private double currentInflightExchanges() {
+        return meterRegistry.find(DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT).tag(ROUTE_ID_TAG, ROUTE_ID).gauge().value();
     }
 
     @Override

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/ManagedMicrometerRoutePolicyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/ManagedMicrometerRoutePolicyTest.java
@@ -48,9 +48,9 @@ public class ManagedMicrometerRoutePolicyTest extends AbstractMicrometerRoutePol
 
         assertMockEndpointsSatisfied();
 
-        // there should be 3 names
+        // there should be 7 names
         List<Meter> meters = meterRegistry.getMeters();
-        assertEquals(3, meters.size());
+        assertEquals(7, meters.size());
 
         String name = String.format("org.apache.camel:context=%s,type=services,name=MicrometerRoutePolicyService", context.getManagementName());
         ObjectName on = ObjectName.getInstance(name);

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyExchangeStatusTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyExchangeStatusTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.micrometer.routepolicy;
+
+import io.micrometer.core.instrument.Counter;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+import static org.apache.camel.component.micrometer.MicrometerConstants.*;
+
+public class MicrometerRoutePolicyExchangeStatusTest extends AbstractMicrometerRoutePolicyTest {
+
+    @Test
+    public void testMetricsExchangeStatus() throws Exception {
+        int count = 10;
+        MockEndpoint mockEndpoint = getMockEndpoint("mock:result");
+        mockEndpoint.expectedMessageCount(count / 2);
+
+        for (int i = 0; i < count; i++) {
+            if (i % 2 == 0) {
+                template.sendBody("direct:completing", "Hello");
+            } else {
+                assertThrows(RuntimeException.class, () -> template.sendBody("direct:failing", "Hello"));
+            }
+        }
+
+        assertMockEndpointsSatisfied();
+        Counter exchangesSucceededCounter = meterRegistry.find(DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME).tag(ROUTE_ID_TAG, "completing").counter();
+        Counter exchangesFailedCounter = meterRegistry.find(DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME).tag(ROUTE_ID_TAG, "failing").counter();
+        assertEquals(count / 2.0D, exchangesSucceededCounter.count(), 0.01D);
+        assertEquals(count / 2.0D, exchangesFailedCounter.count(), 0.01D);
+
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:completing").routeId("completing")
+                    .to("mock:result");
+
+                from("direct:failing").routeId("failing")
+                    .throwException(RuntimeException.class, "Failing")
+                    .to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyMulticastSubRouteTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyMulticastSubRouteTest.java
@@ -18,10 +18,13 @@ package org.apache.camel.component.micrometer.routepolicy;
 
 import java.util.List;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
+
+import static org.apache.camel.component.micrometer.MicrometerConstants.*;
 
 /**
  * CAMEL-9226 - check metrics are counted correctly in multicast sub-routes
@@ -42,14 +45,32 @@ public class MicrometerRoutePolicyMulticastSubRouteTest extends AbstractMicromet
 
         assertMockEndpointsSatisfied();
 
-        // there should be 3 names
+        // there should be 9 names
         List<Meter> meters = meterRegistry.getMeters();
-        assertEquals(3, meters.size());
-
+        assertEquals(9, meters.size());
 
         meters.forEach(meter -> {
-            Timer timer = (Timer) meter;
-            assertEquals("Timer " + timer.getId() + " should have count of " + count,  count, timer.count());
+            String meterName = meter.getId().getName();
+            switch (meterName) {
+                case DEFAULT_CAMEL_ROUTE_POLICY_METER_NAME:
+                    Timer timer = (Timer) meter;
+                    assertEquals("Timer " + timer.getId() + " should have count of " + count, count, timer.count());
+                    break;
+                case DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME: {
+                    Counter counter = (Counter) meter;
+                    assertEquals("Counter " + counter.getId() + " should have count of " + count, count, counter.count(), 0.01D);
+                    break;
+                }
+                case DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME: {
+                    Counter counter = (Counter) meter;
+                    assertEquals("Counter " + counter.getId() + " should have count of " + 0, 0, counter.count(), 0.01D);
+                    break;
+                }
+                default: {
+                    fail("Unexpected meter " + meterName);
+                    break;
+                }
+            }
         });
     }
 

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicySubRouteTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicySubRouteTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.micrometer.routepolicy;
 
 import java.util.List;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import org.apache.camel.builder.RouteBuilder;
@@ -37,10 +38,10 @@ public class MicrometerRoutePolicySubRouteTest extends AbstractMicrometerRoutePo
 
         assertMockEndpointsSatisfied();
 
-        // there should be 2 names
+        // there should be 6 names
         List<Meter> meters = meterRegistry.getMeters();
-        assertEquals(2, meters.size());
-        meters.forEach(meter -> assertTrue(meter instanceof Timer));
+        assertEquals(6, meters.size());
+        meters.forEach(meter -> assertTrue(meter instanceof Timer || meter instanceof Counter));
     }
 
     @Override


### PR DESCRIPTION
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body. If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md

**Description**
The camel-micrometer component currently includes a `RoutePolicy`, `EventNotifier`s and a `MessageHistory`, which provides a set of metrics. This PR introduces some additional metrics, by expanding `MicrometerRoutePolicy` and `MicrometerExchangeEventNotifier`.

New metrics are:

- Total count of exchanges succeeded, per route
- Total count of exchanges failed, per route
- Current count of exchanges inflight, per route