### PR TITLE
CAMEL-15271 - Add examples back to "how to stop a route" docs

### DIFF
--- a/docs/user-manual/en/faq/how-can-i-stop-a-route-from-a-route.adoc
+++ b/docs/user-manual/en/faq/how-can-i-stop-a-route-from-a-route.adoc
@@ -28,7 +28,60 @@ is not advised to do, and can cause unforeseen side effects.
 In this example we use a `CountdownLatch` to signal when Camel should
 stop, triggered from a route.
 
+[source,java]
+----
+// use a latch as signal when to stop Camel
+private final CountDownLatch latch = new CountDownLatch(1);
+
+public void testStopCamelFromRoute() throws Exception {
+    // create camel, add routes, and start camel
+    CamelContext context = new DefaultCamelContext();
+    context.addRoutes(createMyRoutes());
+    context.start();
+
+    // setup mock expectations for unit test
+    MockEndpoint start = context.getEndpoint("mock:start", MockEndpoint.class);
+    start.expectedMessageCount(1);
+    MockEndpoint done = context.getEndpoint("mock:done", MockEndpoint.class);
+    done.expectedMessageCount(1);
+
+    // send a message to the route
+    ProducerTemplate template = context.createProducerTemplate();
+    template.sendBody("direct:start", "Hello Camel");
+
+    // wait for the latch (use 1 minute as fail safe, due unit test)
+    assertTrue(latch.await(1, TimeUnit.MINUTES));
+
+    // stop camel
+    context.stop();
+
+    // unit test assertions
+    start.assertIsSatisfied();
+    done.assertIsSatisfied();
+}
+----
+
 And in the route we call the latch as shown:
+
+[source,java]
+----
+public RouteBuilder createMyRoutes() throws Exception {
+    return new RouteBuilder() {
+        @Override
+        public void configure() throws Exception {
+            from("direct:start").routeId("myRoute")
+                .to("mock:start")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        // stop Camel by signalling to the latch
+                        latch.countDown();
+                    }
+                }).to("mock:done");
+        }
+    };
+}
+----
 
 [[HowcanIstoparoutefromaroute-Usingathreadtostoparoutefromaroute]]
 ==== Using a thread to stop a route from a route
@@ -36,8 +89,85 @@ And in the route we call the latch as shown:
 In this example we use a separate `Thread` to stop the route, triggered
 from the route itself.
 
+[source,java]
+----
+public void testStopRouteFromRoute() throws Exception {
+    // create camel, add routes, and start camel
+    CamelContext context = new DefaultCamelContext();
+    context.addRoutes(createMyRoutes());
+    context.start();
+
+    assertTrue("Route myRoute should be started", context.getRouteStatus("myRoute").isStarted());
+    assertTrue("Route bar should be started", context.getRouteStatus("bar").isStarted());
+
+    // setup mock expectations for unit test
+    MockEndpoint start = context.getEndpoint("mock:start", MockEndpoint.class);
+    start.expectedMessageCount(1);
+    MockEndpoint done = context.getEndpoint("mock:done", MockEndpoint.class);
+    done.expectedMessageCount(1);
+
+    // send a message to the route
+    ProducerTemplate template = context.createProducerTemplate();
+    template.sendBody("direct:start", "Hello Camel");
+
+    // just wait a bit for the thread to stop the route
+    Thread.sleep(1000);
+
+    // the route should now be stopped
+    assertTrue("Route myRoute should be stopped", context.getRouteStatus("myRoute").isStopped());
+    assertTrue("Route bar should be started", context.getRouteStatus("bar").isStarted());
+
+    // stop camel
+    context.stop();
+
+    // unit test assertions
+    start.assertIsSatisfied();
+    done.assertIsSatisfied();
+}
+----
+
 And in the route we create the thread and call the `stopRoute` method as
 shown:
+
+[source,java]
+----
+public RouteBuilder createMyRoutes() throws Exception {
+    return new RouteBuilder() {
+        @Override
+        public void configure() throws Exception {
+            from("direct:start").routeId("myRoute")
+                .to("mock:start")
+                .process(new Processor() {
+                    Thread stop;
+
+                    @Override
+                    public void process(final Exchange exchange) throws Exception {
+                        // stop this route using a thread that will stop
+                        // this route gracefully while we are still running
+                        if (stop == null) {
+                            stop = new Thread() {
+                                @Override
+                                public void run() {
+                                    try {
+                                        exchange.getContext().stopRoute("myRoute");
+                                    } catch (Exception e) {
+                                        // ignore
+                                    }
+                                }
+                            };
+                        }
+
+                        // start the thread that stops this route
+                        stop.start();
+                    }
+                }).to("mock:done");
+            
+            from("direct:bar").routeId("bar")
+                .to("mock:bar");
+        }
+    };
+}
+----
 
 [[HowcanIstoparoutefromaroute-Alternativesolutions]]
 ==== Alternative solutions


### PR DESCRIPTION
This pull request adds back examples to the `how-can-i-stop-a-route-from-a-route.adoc faq` page which were accidentally removed when migrating the documentation.