### PR TITLE
Note specifying the OAuth scope required to view messages in a channel

### DIFF
--- a/components/camel-slack/src/main/docs/slack-component.adoc
+++ b/components/camel-slack/src/main/docs/slack-component.adoc
@@ -177,5 +177,6 @@ from("slack://general?token=RAW(<YOUR_TOKEN>)&maxResults=1")
 
 In this way you'll get the last message from general channel. The consumer will take track of the timestamp of the last message consumed and in the next poll it will check from that timestamp.
 
+IMPORTANT: Add the `channels:history` user token scope to your app to grant it permission to view messages in the user's public channels.
 
 include::camel-spring-boot::page$slack-starter.adoc[]


### PR DESCRIPTION
This note will help users configure the required permissions to access messages written in channels.