### PR TITLE
Fix minor issues in camel maven archetypes

### DIFF
--- a/archetypes/camel-archetype-api-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-api-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -27,9 +27,6 @@
     <requiredProperty key="camel-version">
       <defaultValue>${project.version}</defaultValue>
     </requiredProperty>
-    <requiredProperty key="log4j-version">
-      <defaultValue>${log4j-version}</defaultValue>
-    </requiredProperty>
     <requiredProperty key="maven-compiler-plugin-version">
       <defaultValue>${maven-compiler-plugin-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/pom.xml
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>camel-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/__name__Endpoint.java
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/__name__Endpoint.java
@@ -72,7 +72,7 @@ public class ${name}Endpoint extends AbstractApiEndpoint<${name}ApiName, ${name}
 
     @Override
     protected ApiMethodPropertiesHelper<${name}Configuration> getPropertiesHelper() {
-        return ${name}PropertiesHelper.getHelper();
+        return ${name}PropertiesHelper.getHelper(getCamelContext());
     }
 
     protected String getThreadProfileName() {

--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/__name__Producer.java
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/__name__Producer.java
@@ -24,6 +24,6 @@ import ${package}.internal.${name}PropertiesHelper;
 public class ${name}Producer extends AbstractApiProducer<${name}ApiName, ${name}Configuration> {
 
     public ${name}Producer(${name}Endpoint endpoint) {
-        super(endpoint, ${name}PropertiesHelper.getHelper());
+        super(endpoint, ${name}PropertiesHelper.getHelper(endpoint.getCamelContext()));
     }
 }

--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/internal/__name__PropertiesHelper.java
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/src/main/java/internal/__name__PropertiesHelper.java
@@ -16,6 +16,7 @@
 ## ------------------------------------------------------------------------
 package ${package}.internal;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
 
 import ${package}.${name}Configuration;
@@ -27,13 +28,13 @@ public final class ${name}PropertiesHelper extends ApiMethodPropertiesHelper<${n
 
     private static ${name}PropertiesHelper helper;
 
-    private ${name}PropertiesHelper() {
-        super(${name}Configuration.class, ${name}Constants.PROPERTY_PREFIX);
+    private ${name}PropertiesHelper(CamelContext context) {
+        super(context, ${name}Configuration.class, ${name}Constants.PROPERTY_PREFIX);
     }
 
-    public static synchronized ${name}PropertiesHelper getHelper() {
+    public static synchronized ${name}PropertiesHelper getHelper(CamelContext context) {
         if (helper == null) {
-            helper = new ${name}PropertiesHelper();
+            helper = new ${name}PropertiesHelper(context);
         }
         return helper;
     }

--- a/archetypes/camel-archetype-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -35,6 +35,9 @@
     <requiredProperty key="maven-resources-plugin-version">
       <defaultValue>${maven-resources-plugin-version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="build-helper-maven-plugin-version">
+      <defaultValue>${build-helper-maven-plugin-version}</defaultValue>
+    </requiredProperty>
     <requiredProperty key="slf4j-version">
       <defaultValue>${slf4j-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
@@ -110,6 +110,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin-version}</version>
         <executions>
           <execution>
             <phase>initialize</phase>

--- a/archetypes/camel-archetype-dataformat/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-dataformat/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -35,6 +35,9 @@
     <requiredProperty key="maven-resources-plugin-version">
       <defaultValue>${maven-resources-plugin-version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="build-helper-maven-plugin-version">
+      <defaultValue>${build-helper-maven-plugin-version}</defaultValue>
+    </requiredProperty>
     <requiredProperty key="slf4j-version">
       <defaultValue>${slf4j-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
@@ -109,6 +109,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin-version}</version>
         <executions>
           <execution>
             <phase>initialize</phase>


### PR DESCRIPTION
This is related to CAMEL-15043

**camel-archetype-api-component**
  - Add `camel-test-junit5` test dependency  to fix build failures
  in generated test sources
  - Remove deprecated `log4j.version` property (CAMEL-14317)
  - The generated component was broken due to a missing argument in
    constuctor of the PropertiesHelper class due to a change in the
    ApiMethodPropertiesHelper parent class

**camel-archetype-component** and **camel-archetype-dataformat**
  - Fix missing plugin version WARNING for `build-helper-maven-plugin`
  by adding a new property `build-helper-maven-plugin-version`



