### PR TITLE
Fix minor issues in camel maven archetypes in 3.4.x

### DIFF
--- a/archetypes/camel-archetype-api-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-api-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -27,9 +27,6 @@
     <requiredProperty key="camel-version">
       <defaultValue>${project.version}</defaultValue>
     </requiredProperty>
-    <requiredProperty key="log4j-version">
-      <defaultValue>${log4j-version}</defaultValue>
-    </requiredProperty>
     <requiredProperty key="maven-compiler-plugin-version">
       <defaultValue>${maven-compiler-plugin-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/pom.xml
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/__artifactId__-component/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>camel-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/camel-archetype-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-component/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -35,6 +35,9 @@
     <requiredProperty key="maven-resources-plugin-version">
       <defaultValue>${maven-resources-plugin-version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="build-helper-maven-plugin-version">
+      <defaultValue>${build-helper-maven-plugin-version}</defaultValue>
+    </requiredProperty>
     <requiredProperty key="slf4j-version">
       <defaultValue>${slf4j-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
@@ -110,6 +110,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin-version}</version>
         <executions>
           <execution>
             <phase>initialize</phase>

--- a/archetypes/camel-archetype-dataformat/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-dataformat/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -35,6 +35,9 @@
     <requiredProperty key="maven-resources-plugin-version">
       <defaultValue>${maven-resources-plugin-version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="build-helper-maven-plugin-version">
+      <defaultValue>${build-helper-maven-plugin-version}</defaultValue>
+    </requiredProperty>
     <requiredProperty key="slf4j-version">
       <defaultValue>${slf4j-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
@@ -109,6 +109,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin-version}</version>
         <executions>
           <execution>
             <phase>initialize</phase>


### PR DESCRIPTION
This the same as #3995 but for the 3.4.x branch (relates to CAMEL-15043)

**camel-archetype-api-component**
  - Add `camel-test-junit5` test dependency  to fix build failures in generated test sources
  - Remove deprecated `log4j.version` property (CAMEL-14317)

**camel-archetype-component** and **camel-archetype-dataformat**
  - Fix missing plugin version WARNING for `build-helper-maven-plugin`
  by adding a new property `build-helper-maven-plugin-version`
