### PR TITLE
CAMEL-15310 S3 Component failing test

### DIFF
--- a/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/S3ComponentClientRegistryTest.java
+++ b/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/S3ComponentClientRegistryTest.java
@@ -19,11 +19,7 @@ package org.apache.camel.component.aws.s3;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class S3ComponentClientRegistryTest extends CamelTestSupport {
 
@@ -51,5 +47,16 @@ public class S3ComponentClientRegistryTest extends CamelTestSupport {
         S3Component component = context.getComponent("aws-s3", S3Component.class);
         assertThrows(IllegalArgumentException.class,
             () -> component.createEndpoint("aws-s3://MyBucket"));
+    }
+
+    @Test
+    public void createEndpointWithCredentialsAndClientExistInRegistry() throws Exception {
+        AmazonS3ClientMock clientMock = new AmazonS3ClientMock();
+        context.getRegistry().bind("amazonS3Client", clientMock);
+        S3Component component = context.getComponent("aws-s3", S3Component.class);
+        S3Endpoint endpoint = (S3Endpoint)component.createEndpoint("aws-s3://MyBucket?accessKey=RAW(XXX)&secretKey=RAW(XXX)");
+
+        assertEquals("MyBucket", endpoint.getConfiguration().getBucketName());
+        assertNotSame(clientMock, endpoint.getConfiguration().getAmazonS3Client());
     }
 }


### PR DESCRIPTION
Failing test for [https://issues.apache.org/jira/browse/CAMEL-15310](CAMEL-15310).

Background : 

When an endpoint is configured to use given credentials, for eg : 

```
from("aws-s3://MyBucket?accessKey=RAW(XXX)&secretKey=RAW(XXX)")
```

And there is a client in the registry ( but for the purpose of it to be used on another endpoint ), the current behaviour is that the S3 component will use by default the registry client, instead of creating a new one from the parameters given on the endpoint.