### PR TITLE
[CAMEL-15316] Fixes bug in camel zipkin trace headers, backporting pr#4022 to camel 3.4.x

### DIFF
--- a/components/camel-zipkin/pom.xml
+++ b/components/camel-zipkin/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/CamelRequest.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/CamelRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.zipkin;
+
+import brave.Request;
+import brave.Span;
+import brave.Span.Kind;
+import org.apache.camel.Message;
+
+public class CamelRequest extends Request {
+
+    private final Message message;
+    private final Span.Kind spanKind;
+
+    public CamelRequest(Message message, Span.Kind spanKind) {
+        this.message = message;
+        this.spanKind = spanKind;
+    }
+
+    @Override
+    public Kind spanKind() {
+        return this.spanKind;
+    }
+
+    @Override
+    public Object unwrap() {
+        return this.message;
+    }
+
+    public void setHeader(String key, String value) {
+        message.setHeader(key, value);
+    }
+
+    public String getHeader(String key) {
+        return message.getHeader(key, String.class);
+    }
+
+}

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/CamelRequestTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/CamelRequestTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.zipkin;
+
+import brave.Span;
+import org.apache.camel.Message;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CamelRequestTest {
+
+    @Test
+    public void testCamelRequest() {
+        Message message = mock(Message.class);
+        when(message.getHeader("X-B3-TraceId", String.class)).thenReturn("924c5b125daaaec8");
+        CamelRequest request = new CamelRequest(message, Span.Kind.PRODUCER);
+        request.setHeader("X-B3-SpanId", "db1ccb94946711b0");
+        assertThat(request.spanKind()).isEqualTo(Span.Kind.PRODUCER);
+        assertThat(request.unwrap()).isEqualTo(message);
+        verify(message).setHeader("X-B3-SpanId", "db1ccb94946711b0");
+        assertThat(request.getHeader("X-B3-TraceId")).isEqualTo("924c5b125daaaec8");
+    }
+
+}

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinProducerSpanKindTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinProducerSpanKindTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.zipkin;
+
+import brave.Span;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+
+public class ZipkinProducerSpanKindTest extends CamelTestSupport {
+
+    private ZipkinTracer zipkin;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+
+        zipkin = new ZipkinTracer();
+        zipkin.addProducerComponentSpanKind("seda", Span.Kind.PRODUCER);
+        setSpanReporter(zipkin);
+
+        // attaching ourself to CamelContext
+        zipkin.init(context);
+
+        return context;
+    }
+
+    @Test
+    public void testB3SingleHeaderPresent() throws Exception {
+        template.requestBody("direct:start", "Hello World");
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").to("seda:a").routeId("start");
+
+                from("seda:a").routeId("a")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        String b3Header = exchange.getIn().getHeader("b3", String.class);
+                        Assertions.assertThat(b3Header).isNotNull();
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinTracerTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ZipkinTracerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.zipkin;
+
+import brave.Span;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ZipkinTracerTest extends CamelTestSupport {
+
+    private ZipkinTracer zipkin;
+
+    private Endpoint endpoint;
+
+    protected void setSpanReporter(ZipkinTracer zipkin) {
+        zipkin.setSpanReporter(Reporter.NOOP);
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        zipkin = new ZipkinTracer();
+        setSpanReporter(zipkin);
+        // attaching ourself to CamelContext
+        zipkin.init(context);
+        return context;
+
+    }
+
+    @Test
+    public void testJmsProducerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("jms:queue");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.PRODUCER);
+    }
+
+    @Test
+    public void testKafkaProducerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("kafka:topic");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.PRODUCER);
+    }
+
+    @Test
+    public void testSJMSProducerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("sjms:queue");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.PRODUCER);
+    }
+
+    @Test
+    public void testActiveMQProducerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("activemq:queue");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.PRODUCER);
+    }
+
+    @Test
+    public void testNonProducerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("http:www");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CLIENT);
+    }
+
+    @Test
+    public void testNonProducerInvalidEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("jms&queue");
+        Span.Kind spankind = zipkin.getProducerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CLIENT);
+    }
+
+    @Test
+    public void testJmsConsumerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("jms:queue");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CONSUMER);
+    }
+
+    @Test
+    public void testKafkaConsumerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("kafka:topic");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CONSUMER);
+    }
+
+    @Test
+    public void testSJMSConsumerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("sjms:queue");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CONSUMER);
+    }
+
+    @Test
+    public void testActiveMQConsumerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("activemq:queue");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.CONSUMER);
+    }
+
+    @Test
+    public void testNonConsumerEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("rest:customer?");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.SERVER);
+    }
+
+    @Test
+    public void testNonConsumerInvalidEndpoint() {
+        endpoint = mock(Endpoint.class);
+        when(endpoint.getEndpointBaseUri()).thenReturn("rest&customer?");
+        Span.Kind spankind = zipkin.getConsumerComponentSpanKind(endpoint);
+        Assertions.assertThat(spankind).isEqualTo(Span.Kind.SERVER);
+    }
+
+}


### PR DESCRIPTION
setting span kind as producer/consumer depending on the type of component in the route. If the span kind if producer then this changes the tracing header being set to b3 single format. Original PR https://github.com/apache/camel/pull/4022