### PR TITLE
CAMEL-15311: calling dumpTrace from traceBeforeRoute

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultTracer.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultTracer.java
@@ -126,7 +126,7 @@ public class DefaultTracer extends ServiceSupport implements CamelContextAware, 
         String data = exchangeFormatter.format(exchange);
         sb.append(data);
         String out = sb.toString();
-        LOG.info(out);
+        dumpTrace(out);
     }
 
     @Override


### PR DESCRIPTION
In order to make the default tracer fully customizable, method `dumpTrace` should be called from all places traces are written. This fixes the fact that `dumpTrace` was not being called from `traceBeforeRoute`.