### PR TITLE
CAMEL-15260 - opentracing: fixes header extraction regression

### DIFF
--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -23,10 +23,12 @@ import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
+import org.apache.camel.Exchange;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.opentelemetry.propagators.OpenTelemetrySetter;
 import org.apache.camel.tracing.InjectAdapter;
 import org.apache.camel.tracing.SpanAdapter;
+import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.SpanKind;
 
 @ManagedResource(description = "OpenTelemetryTracer")
@@ -76,7 +78,7 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
     }
 
     @Override
-    protected SpanAdapter startExchangeBeginSpan(String operationName, SpanKind kind, SpanAdapter parent) {
+    protected SpanAdapter startExchangeBeginSpan(Exchange exchange, SpanDecorator sd, String operationName, SpanKind kind, SpanAdapter parent) {
         Span.Builder builder = tracer.spanBuilder(operationName);
         if (parent != null) {
             OpenTelemetrySpanAdapter oTelSpanWrapper = (OpenTelemetrySpanAdapter) parent;

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -20,9 +20,11 @@ import java.util.Set;
 
 import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.context.propagation.DefaultContextPropagators;
-import io.opentelemetry.trace.*;
+import io.opentelemetry.trace.DefaultTracer;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.TracingContextUtils;
 import org.apache.camel.Exchange;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.opentelemetry.propagators.OpenTelemetryGetter;
@@ -87,7 +89,7 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         Span.Builder builder = tracer.spanBuilder(operationName);
         if (parent != null) {
             OpenTelemetrySpanAdapter spanFromExchange = (OpenTelemetrySpanAdapter) parent;
-            builder = builder.setParent((spanFromExchange).getOpenTelemetrySpan());
+            builder = builder.setParent(spanFromExchange.getOpenTelemetrySpan());
         } else {
             Context ctx = OpenTelemetry.getPropagators().getHttpTextFormat().extract(Context.current(), sd.getExtractAdapter(exchange.getIn().getHeaders(), encoding), new OpenTelemetryGetter());
             Span span = TracingContextUtils.getSpan(ctx);

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -20,16 +20,18 @@ import java.util.Set;
 
 import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.trace.DefaultTracer;
-import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.trace.*;
 import org.apache.camel.Exchange;
 import org.apache.camel.api.management.ManagedResource;
+import org.apache.camel.opentelemetry.propagators.OpenTelemetryGetter;
 import org.apache.camel.opentelemetry.propagators.OpenTelemetrySetter;
 import org.apache.camel.tracing.InjectAdapter;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.SpanKind;
+import org.apache.camel.tracing.decorators.AbstractInternalSpanDecorator;
 
 @ManagedResource(description = "OpenTelemetryTracer")
 public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
@@ -45,10 +47,13 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
     }
 
     private Span.Kind mapToSpanKind(SpanKind kind) {
-        if (kind == SpanKind.SPAN_KIND_CLIENT) {
-            return Span.Kind.CLIENT;
+        switch (kind) {
+            case SPAN_KIND_CLIENT: return Span.Kind.CLIENT;
+            case SPAN_KIND_SERVER: return Span.Kind.SERVER;
+            case CONSUMER: return Span.Kind.CONSUMER;
+            case PRODUCER: return Span.Kind.PRODUCER;
+            default: return Span.Kind.SERVER;
         }
-        return Span.Kind.SERVER;
     }
 
     @Override
@@ -81,8 +86,18 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
     protected SpanAdapter startExchangeBeginSpan(Exchange exchange, SpanDecorator sd, String operationName, SpanKind kind, SpanAdapter parent) {
         Span.Builder builder = tracer.spanBuilder(operationName);
         if (parent != null) {
-            OpenTelemetrySpanAdapter oTelSpanWrapper = (OpenTelemetrySpanAdapter) parent;
-            builder = builder.setParent(((OpenTelemetrySpanAdapter) parent).getOpenTelemetrySpan());
+            OpenTelemetrySpanAdapter spanFromExchange = (OpenTelemetrySpanAdapter) parent;
+            builder = builder.setParent((spanFromExchange).getOpenTelemetrySpan());
+        } else {
+            Context ctx = OpenTelemetry.getPropagators().getHttpTextFormat().extract(Context.current(), sd.getExtractAdapter(exchange.getIn().getHeaders(), encoding), new OpenTelemetryGetter());
+            Span span = TracingContextUtils.getSpan(ctx);
+            SpanContext parentFromHeaders = span.getContext();
+
+            if (parentFromHeaders != null && parentFromHeaders.isValid()) {
+                builder.setParent(parentFromHeaders).setSpanKind(mapToSpanKind(sd.getReceiverSpanKind()));
+            } else if (!(sd instanceof AbstractInternalSpanDecorator)) {
+                builder.setSpanKind(mapToSpanKind(sd.getReceiverSpanKind()));
+            }
         }
 
         return new OpenTelemetrySpanAdapter(builder.startSpan());

--- a/components/camel-opentracing/pom.xml
+++ b/components/camel-opentracing/pom.xml
@@ -96,6 +96,28 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jetty</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-http-client</artifactId>
+            <version>1.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-grizzly-ahc</artifactId>
+            <version>0.1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/CamelOpenTracingTestSupport.java
@@ -162,7 +162,7 @@ public class CamelOpenTracingTestSupport extends CamelTestSupport {
 
         if (!td.getTags().isEmpty()) {
             for (Map.Entry<String, String> entry : td.getTags().entrySet()) {
-                assertEquals(entry.getValue(), span.tags().get(entry.getKey()));
+                assertEquals(entry.getValue(), String.valueOf(span.tags().get(entry.getKey())));
             }
         }
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/EIPTracingActiveSpanTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/EIPTracingActiveSpanTest.java
@@ -24,8 +24,8 @@ import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.InterceptStrategy;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class EIPTracingActiveSpanTest extends CamelOpenTracingTestSupport {
 
@@ -41,8 +41,8 @@ public class EIPTracingActiveSpanTest extends CamelOpenTracingTestSupport {
         super(testdata);
     }
 
-    @BeforeAll
-    public void setUp() throws Exception {
+    @Override
+    public void doPreSetup() {
         GlobalTracerTestUtil.resetGlobalTracer();
     }
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/OpentracingSpanCollectorInRegistryTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/OpentracingSpanCollectorInRegistryTest.java
@@ -22,8 +22,8 @@ import io.opentracing.util.GlobalTracerTestUtil;
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.CamelContext;
 import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,8 +34,8 @@ public class OpentracingSpanCollectorInRegistryTest extends CamelTestSupport {
     @BindToRegistry("tracer")
     private NoopTracer c = NoopTracerFactory.create();
 
-    @BeforeAll
-    public void setUp() throws Exception {
+    @Override
+    public void doPreSetup() {
         GlobalTracerTestUtil.resetGlobalTracer();
     }
 

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/integration/InterprocessTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/integration/InterprocessTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentracing.integration;
+
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import io.opentracing.contrib.grizzly.ahc.TracingRequestFilter;
+import io.opentracing.tag.Tags;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.opentracing.CamelOpenTracingTestSupport;
+import org.apache.camel.opentracing.SpanTestData;
+import org.apache.camel.test.AvailablePortFinder;
+import org.junit.jupiter.api.Test;
+
+
+public class InterprocessTest extends CamelOpenTracingTestSupport {
+    private static final String URL = "http://localhost:" + AvailablePortFinder.getNextAvailable() + "/test";
+    private static final String URI = "jetty:" + URL;
+
+    private static SpanTestData[] testdata = {
+            new SpanTestData().setLabel("jetty:start server").setUri(URI).setOperation("GET")
+                    .setKind("server")
+                    .addTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                    .addTag(Tags.COMPONENT.getKey(), "camel-jetty")
+                    .addTag(Tags.HTTP_URL.getKey(), URL)
+                    .addTag(Tags.HTTP_METHOD.getKey(), "GET")
+                    // jetty does not set the http response code header
+                    // this is where instrumentation has value
+                    // .addTag(Tags.HTTP_STATUS.getKey(), "200")
+                    .setParentId(1),
+            new SpanTestData().setLabel("ahc: client").setUri(null).setOperation("HTTP::GET")
+                    .setKind("client")
+                    .addTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                    .addTag(Tags.COMPONENT.getKey(), "java-grizzly-ahc")
+                    .addTag(Tags.HTTP_URL.getKey(), URL)
+                    .addTag(Tags.HTTP_METHOD.getKey(), "GET")
+                    .addTag(Tags.HTTP_STATUS.getKey(), "200")
+    };
+
+    public InterprocessTest() {
+        super(testdata);
+    }
+
+    @Test
+    public void testBridgeEndpoint() throws Exception {
+        AsyncHttpClientConfig config = new AsyncHttpClientConfig.Builder()
+                .addRequestFilter(new TracingRequestFilter(getTracer()))
+                .build();
+
+        try (AsyncHttpClient client = new AsyncHttpClient(config)) {
+            client.prepareGet(URL).execute().get();
+        }
+
+        verify();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                Processor serviceProc = new Processor() {
+                    public void process(Exchange exchange) throws Exception {
+                        // get the request URL and copy it to the request body
+                        String uri = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
+                        exchange.getMessage().setBody(uri);
+                    }
+                };
+
+                from(URI).process(serviceProc);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This fixes a regression introduced with https://github.com/apache/camel/pull/4001 spotted by @valdar here https://github.com/apache/camel/pull/4001#issuecomment-662892861

This change makes the tracer fall back to camel's header extract adapter when a span is not found for the exchange. That's a span that would be there when utilizing instrumentation. So this would work with instrumentation, or without as it worked before the regression. It also introduces an integration test to prevent issues in the future.

@valdar let me know if this satisfies the issue for you and I'll mark the PR as ready.