### PR TITLE
CAMEL-15338 salesforce Standard Platform Events support

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -538,11 +538,6 @@ public class SubscriptionHelper extends ServiceSupport {
             channelName.append(topicName);
         }
 
-        final int typeIdx = channelName.indexOf("/", 1);
-        if ("event".equals(channelName.substring(1, typeIdx)) && !topicName.endsWith("__e")) {
-            channelName.append("__e");
-        }
-
         return channelName.toString();
     }
 


### PR DESCRIPTION
removed hardcoded suffix for salesforce Platform Event Channel.

API names of standard platform events, such as AssetTokenEvent, don’t include a suffix. See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_define_ui.htm
Hardcoding the suffix in channel name results in subscription failure for standard salesforce events.