### PR TITLE
Camel 15349

### DIFF
--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppConsumer.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppConsumer.java
@@ -95,7 +95,7 @@ public class XmppConsumer extends DefaultConsumer implements IncomingChatMessage
         }
 
         if (endpoint.getRoom() == null) {
-            privateChat = chatManager.chatWith(JidCreate.entityBareFrom(endpoint.getChatId()));
+            privateChat = chatManager.chatWith(JidCreate.entityBareFrom(endpoint.resolveParticipant(connection)));
         } else {
             // add the presence packet listener to the connection so we only get packets that concerns us
             // we must add the listener before creating the muc

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
@@ -234,6 +234,20 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
         return new XMPPTCPConnection(conf);
     }
 
+    /**
+     * If there is no "@" symbol in the participant, find the service domain
+     * JID and return the fully qualified JID for the participant as user@server.domain
+     */
+	public String resolveParticipant(XMPPConnection connection) {
+		String participant = getParticipant();
+
+		if (participant.indexOf('@', 0) != -1) {
+			return participant;
+		}
+
+		return participant + "@" + connection.getXMPPServiceDomain().toString();
+	}
+
     /*
      * If there is no "@" symbol in the room, find the chat service JID and
      * return fully qualified JID for the room as room@conference.server.domain

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
@@ -238,16 +238,16 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
      * If there is no "@" symbol in the participant, find the service domain
      * JID and return the fully qualified JID for the participant as user@server.domain
      */
-	public String resolveParticipant(XMPPConnection connection) {
-		String participant = getParticipant();
-
-		if (participant.indexOf('@', 0) != -1) {
-			return participant;
-		}
-
-		return participant + "@" + connection.getXMPPServiceDomain().toString();
-	}
-
+    public String resolveParticipant(XMPPConnection connection) {
+        String participant = getParticipant();
+        
+        if (participant.indexOf('@', 0) != -1) {
+            return participant;
+        }
+        
+        return participant + "@" + connection.getXMPPServiceDomain().toString();
+    }
+    
     /*
      * If there is no "@" symbol in the room, find the chat service JID and
      * return fully qualified JID for the room as room@conference.server.domain


### PR DESCRIPTION
Updated the XmppConsumer to "chatWith" the Participant instead of the ChatId. This solves an error when configuring a route to consume from a participant with a domain id and without a room defined the call to 'JidCreate.entityBareFrom(endpoint.getChatId())' would throw and exception because of the ill-formed JID returned by getChatId.

Added a function to XmppEndpoint to resolved the Fully qualified JID of the configured participant. This function when used by the XmppConsumer for direct chats will allow route participants to be defined without their domain and assume the domain of the server being connected too. This solves an error when configuring a route to consume from a participant without a domain id and without a room defined the call to 'JidCreate.entityBareFrom(endpoint.getChatId())' would throw and exception because of the ill-formed JID returned by getChatId.