### PR TITLE
CAMEL-15378: File gets locked When using camel-flatpack delimited parser

### DIFF
--- a/components/camel-flatpack/src/main/java/org/apache/camel/component/flatpack/FlatpackEndpoint.java
+++ b/components/camel-flatpack/src/main/java/org/apache/camel/component/flatpack/FlatpackEndpoint.java
@@ -101,16 +101,18 @@ public class FlatpackEndpoint extends DefaultPollingEndpoint {
     }
 
     public Parser createParser(Exchange exchange) throws Exception {
-        Reader bodyReader = exchange.getIn().getMandatoryBody(Reader.class);
+        Reader bodyReader = null;
         try {
             if (FlatpackType.fixed == type) {
+                bodyReader = exchange.getIn().getMandatoryBody(Reader.class);
                 return createFixedParser(resourceUri, bodyReader);
             } else {
                 return createDelimitedParser(exchange);
             }
         } catch (Exception e) {
             // must close reader in case of some exception
-            IOHelper.close(bodyReader);
+            if(bodyReader != null)
+                IOHelper.close(bodyReader);
             throw e;
         }
     }


### PR DESCRIPTION
exchange.getIn().getMandatoryBody(Reader.class); was getting called twice in the case of DelimitedParser. And the BufferedReader is not getting closed the issue of this cause of file locking in the case of DelimitedParser.

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md