### PR TITLE
Update recipientList-eip.adoc

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
@@ -49,7 +49,7 @@ The following example shows how to route a request from an input *queue:a* endpo
 [source,java]
 ----
 from("jms:queue:a")
-    .recipientList("direct:b,direct:c,direct:d");
+    .recipientList(constant("direct:b,direct:c,direct:d"));
 ----
 
 And in XML:


### PR DESCRIPTION
recipientList(String) accepts a string that is the delimiter to be used. In this case, we're specifying the route list, so we need to use the recipientList(Expression) overload and the simplest thing is to just wrap the string in constant().
