### PR TITLE
Inprove PropertyBindingSupport

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/IntrospectionSupportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/IntrospectionSupportTest.java
@@ -564,4 +564,34 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         assertEquals(ExampleBean.class, setters.get(0).getParameterTypes()[0]);
         assertEquals(String.class, setters.get(1).getParameterTypes()[0]);
     }
+
+
+    @Test
+    public void testArray() throws Exception {
+        MyBeanWithArray target = new MyBeanWithArray();
+        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[0]", "James");
+        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[1]", "Claus");
+        assertEquals("James", target.getNames()[0]);
+        assertEquals("Claus", target.getNames()[1]);
+
+        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[0]", "JamesX");
+        assertEquals("JamesX", target.getNames()[0]);
+
+        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[2]", "Andrea");
+        assertEquals("JamesX", target.getNames()[0]);
+        assertEquals("Claus", target.getNames()[1]);
+        assertEquals("Andrea", target.getNames()[2]);
+    }
+
+    public class MyBeanWithArray {
+        private String[] names = new String[10];
+
+        public String[] getNames() {
+            return names;
+        }
+
+        public void setNames(String[] names) {
+            this.names = names;
+        }
+    }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/support/PropertyBindingSupportArrayTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/PropertyBindingSupportArrayTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.support;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -34,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Unit test for PropertyBindingSupport
  */
-public class PropertyBindingSupportListTest extends ContextTestSupport {
+public class PropertyBindingSupportArrayTest extends ContextTestSupport {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -58,7 +57,7 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
     }
 
     @Test
-    public void testPropertiesList() throws Exception {
+    public void testPropertiesArray() throws Exception {
         Foo foo = new Foo();
 
         Map<String, Object> prop = new LinkedHashMap<>();
@@ -75,15 +74,15 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
         assertEquals(33, foo.getBar().getAge());
         assertTrue(foo.getBar().isRider());
         assertTrue(foo.getBar().isGoldCustomer());
-        assertEquals(2, foo.getBar().getWorks().size());
-        assertEquals(123, foo.getBar().getWorks().get(0).getId());
-        assertEquals("Acme", foo.getBar().getWorks().get(0).getName());
-        assertEquals(456, foo.getBar().getWorks().get(1).getId());
-        assertEquals("Acme 2", foo.getBar().getWorks().get(1).getName());
+        assertEquals(2, foo.getBar().getWorks().length);
+        assertEquals(123, foo.getBar().getWorks()[0].getId());
+        assertEquals("Acme", foo.getBar().getWorks()[0].getName());
+        assertEquals(456, foo.getBar().getWorks()[1].getId());
+        assertEquals("Acme 2", foo.getBar().getWorks()[1].getName());
     }
 
     @Test
-    public void testPropertiesListWithGaps() throws Exception {
+    public void testPropertiesArrayWithGaps() throws Exception {
         Foo foo = new Foo();
 
         Map<String, Object> prop = new LinkedHashMap<>();
@@ -100,15 +99,15 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
         assertEquals(33, foo.getBar().getAge());
         assertTrue(foo.getBar().isRider());
         assertTrue(foo.getBar().isGoldCustomer());
-        assertEquals(10, foo.getBar().getWorks().size());
-        assertEquals(123, foo.getBar().getWorks().get(5).getId());
-        assertEquals("Acme", foo.getBar().getWorks().get(5).getName());
-        assertEquals(456, foo.getBar().getWorks().get(9).getId());
-        assertEquals("Acme 2", foo.getBar().getWorks().get(9).getName());
+        assertEquals(10, foo.getBar().getWorks().length);
+        assertEquals(123, foo.getBar().getWorks()[5].getId());
+        assertEquals("Acme", foo.getBar().getWorks()[5].getName());
+        assertEquals(456, foo.getBar().getWorks()[9].getId());
+        assertEquals("Acme 2", foo.getBar().getWorks()[9].getName());
     }
 
     @Test
-    public void testPropertiesListNested() throws Exception {
+    public void testPropertiesArrayNested() throws Exception {
         Foo foo = new Foo();
 
         Map<String, Object> prop = new LinkedHashMap<>();
@@ -127,34 +126,36 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
         assertEquals(33, foo.getBar().getAge());
         assertTrue(foo.getBar().isRider());
         assertTrue(foo.getBar().isGoldCustomer());
-        assertEquals(2, foo.getBar().getWorks().size());
-        assertEquals(666, foo.getBar().getWorks().get(0).getId());
-        assertEquals("Acme", foo.getBar().getWorks().get(0).getName());
-        assertEquals(456, foo.getBar().getWorks().get(1).getId());
-        assertEquals("I changed this", foo.getBar().getWorks().get(1).getName());
+        assertEquals(2, foo.getBar().getWorks().length);
+        assertEquals(666, foo.getBar().getWorks()[0].getId());
+        assertEquals("Acme", foo.getBar().getWorks()[0].getName());
+        assertEquals(456, foo.getBar().getWorks()[1].getId());
+        assertEquals("I changed this", foo.getBar().getWorks()[1].getName());
     }
 
     @Test
-    public void testPropertiesListNestedWithType() throws Exception {
+    public void testPropertiesArrayNestedSimple() throws Exception {
         Foo foo = new Foo();
 
-        // use CollectionHelper::mapOf to avoid insertion ordered iteration
         PropertyBindingSupport.build().bind(context, foo, mapOf(
-            "bar.works[0]", "#class:" + Company.class.getName(),
-            "bar.works[0].name", "first",
-            "bar.works[1]", "#class:" + Company.class.getName(),
-            "bar.works[1].name", "second"
+            "bar.works[0].id", "666",
+            "bar.works[1].name", "I changed this"
         ));
 
-        assertEquals(2, foo.getBar().getWorks().size());
-        assertEquals(0, foo.getBar().getWorks().get(0).getId());
-        assertEquals("first", foo.getBar().getWorks().get(0).getName());
-        assertEquals(0, foo.getBar().getWorks().get(1).getId());
-        assertEquals("second", foo.getBar().getWorks().get(1).getName());
+        assertEquals(666, foo.bar.works[0].getId());
+        assertEquals("I changed this", foo.bar.works[1].getName());
+
+        PropertyBindingSupport.build().bind(context, foo, mapOf(
+            "bar.works[0].id", "999",
+            "bar.works[1].name", "I changed this again"
+        ));
+
+        assertEquals(999, foo.bar.works[0].getId());
+        assertEquals("I changed this again", foo.bar.works[1].getName());
     }
 
     @Test
-    public void testPropertiesListFirst() throws Exception {
+    public void testPropertiesArrayFirst() throws Exception {
         Bar bar = new Bar();
 
         Map<String, Object> prop = new LinkedHashMap<>();
@@ -165,15 +166,15 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
 
         PropertyBindingSupport.build().bind(context, bar, prop);
 
-        assertEquals(2, bar.getWorks().size());
-        assertEquals(666, bar.getWorks().get(0).getId());
-        assertEquals("Acme", bar.getWorks().get(0).getName());
-        assertEquals(456, bar.getWorks().get(1).getId());
-        assertEquals("I changed this", bar.getWorks().get(1).getName());
+        assertEquals(2, bar.getWorks().length);
+        assertEquals(666, bar.getWorks()[0].getId());
+        assertEquals("Acme", bar.getWorks()[0].getName());
+        assertEquals(456, bar.getWorks()[1].getId());
+        assertEquals("I changed this", bar.getWorks()[1].getName());
     }
 
     @Test
-    public void testPropertiesNotList() throws Exception {
+    public void testPropertiesNotArray() throws Exception {
         Foo foo = new Foo();
 
         Map<String, Object> prop = new LinkedHashMap<>();
@@ -192,8 +193,8 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
     }
 
     public static class Foo {
-        private String name;
-        private Bar bar = new Bar();
+        String name;
+        Bar bar = new Bar();
 
         public String getName() {
             return name;
@@ -213,10 +214,10 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
     }
 
     public static class Bar {
-        private int age;
-        private boolean rider;
-        private List<Company> works; // should auto-create this via the setter
-        private boolean goldCustomer;
+        int age;
+        boolean rider;
+        Company[] works; // should auto-create this via the setter
+        boolean goldCustomer;
 
         public int getAge() {
             return age;
@@ -234,11 +235,11 @@ public class PropertyBindingSupportListTest extends ContextTestSupport {
             this.rider = rider;
         }
 
-        public List<Company> getWorks() {
+        public Company[] getWorks() {
             return works;
         }
 
-        public void setWorks(List<Company> works) {
+        public void setWorks(Company[] works) {
             this.works = works;
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/support/PropertyBindingSupportMapTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/PropertyBindingSupportMapTest.java
@@ -139,7 +139,7 @@ public class PropertyBindingSupportMapTest extends ContextTestSupport {
         } catch (PropertyBindingException e) {
             assertEquals("bar.gold-customer[foo]", e.getPropertyName());
             IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertTrue(iae.getMessage().startsWith("Cannot set property: gold-customer[foo] as either a Map/List because target bean is not a Map or List type"));
+            assertTrue(iae.getMessage().startsWith("Cannot set property: gold-customer[foo] as either a Map/List/array because target bean is not a Map, List or array type"));
         }
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -16,10 +16,12 @@
  */
 package org.apache.camel.support;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +37,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.PropertyBindingException;
+import org.apache.camel.spi.BeanIntrospection;
 import org.apache.camel.spi.GeneratedPropertyConfigurer;
 import org.apache.camel.spi.PropertyConfigurer;
 import org.apache.camel.spi.PropertyConfigurerGetter;
@@ -778,17 +781,37 @@ public final class PropertyBindingSupport {
 
         // use configurer if possible
         Object answer = null;
-        GeneratedPropertyConfigurer configurer = context.adapt(ExtendedCamelContext.class).getConfigurerResolver().resolvePropertyConfigurer(target.getClass().getSimpleName(), context);
+        Class<?> type = null;
+
+        GeneratedPropertyConfigurer configurer = PropertyConfigurerHelper.resolvePropertyConfigurer(context, target);
         if (configurer instanceof PropertyConfigurerGetter) {
-            answer = ((PropertyConfigurerGetter) configurer).getOptionValue(target, key, ignoreCase);
+            answer = ((PropertyConfigurerGetter)configurer).getOptionValue(target, key, ignoreCase);
             if (answer == null) {
                 answer = defaultValue;
             }
         }
         if (answer == null) {
+            BeanIntrospection introspection = context.adapt(ExtendedCamelContext.class).getBeanIntrospection();
             // fallback to reflection based
-            answer = context.adapt(ExtendedCamelContext.class).getBeanIntrospection().getOrElseProperty(target, key, defaultValue, ignoreCase);
+            answer = introspection.getOrElseProperty(target, key, defaultValue, ignoreCase);
+            if (answer == null) {
+                try {
+                    Method method = introspection.getPropertyGetter(target.getClass(), key, ignoreCase);
+                    if (method != null) {
+                        type = method.getReturnType();
+                    }
+                } catch (NoSuchMethodException e) {
+                    // ignore
+                }
+            }
         }
+
+        if (answer != null) {
+            type = answer.getClass();
+        } else if (configurer instanceof PropertyConfigurerGetter) {
+            type = (Class<?>)((PropertyConfigurerGetter)configurer).getAllOptions(target).get(key);
+        }
+
         if (answer instanceof Map && lookupKey != null) {
             Map map = (Map) answer;
             answer = map.getOrDefault(lookupKey, defaultValue);
@@ -804,6 +827,38 @@ public final class PropertyBindingSupport {
                     answer = list.get(list.size() - 1);
                 }
             }
+        } else if (type != null && type.isArray() && lookupKey != null) {
+            int idx = Integer.parseInt(lookupKey);
+            int size = answer != null ? Array.getLength(answer) : 0;
+            if (idx >= size) {
+                answer = answer != null ? Arrays.copyOf((Object[]) answer, idx + 1) : Array.newInstance(Object.class, idx + 1);
+            }
+
+            Object result = Array.get(answer, idx);
+            if (result == null) {
+                result = context.getInjector().newInstance(type.getComponentType());
+                Array.set(answer, idx, result);
+            }
+
+            if (idx >= size) {
+                // replace array
+                if (configurer != null) {
+                    configurer.configure(context, target, key, answer, true);
+                } else {
+                    // fallback to reflection
+                    boolean hit;
+                    try {
+                        hit = IntrospectionSupport.setProperty(context.getTypeConverter(), target, key, answer);
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException("Cannot set property: " + key + " as an array because target bean has no setter method for the array");
+                    }
+                    if (!hit) {
+                        throw new IllegalArgumentException("Cannot set property: " + key + " as an array because target bean has no setter method for the array");
+                    }
+                }
+            }
+
+            answer = result;
         }
 
         return answer != null ? answer : defaultValue;
@@ -1035,7 +1090,7 @@ public final class PropertyBindingSupport {
                 continue;
             }
             // must be a public static method that returns something
-            if (!Modifier.isStatic(method.getModifiers()) 
+            if (!Modifier.isStatic(method.getModifiers())
                 || !Modifier.isPublic(method.getModifiers())
                 || method.getReturnType() == Void.TYPE) {
                 continue;

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyConfigurerHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyConfigurerHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.spi.GeneratedPropertyConfigurer;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * Helper class for dealing with configurers.
+ *
+ * @see org.apache.camel.spi.PropertyConfigurer
+ * @see org.apache.camel.spi.PropertyConfigurerGetter
+ */
+public final class PropertyConfigurerHelper {
+
+    private PropertyConfigurerHelper() {
+    }
+
+    /**
+     * Resolves the given configurer.
+     *
+     * @param context the camel context
+     * @param target the target object for which we need a {@link org.apache.camel.spi.PropertyConfigurer}
+     * @return the resolved configurer, or <tt>null</tt> if no configurer could be found
+     */
+    public static GeneratedPropertyConfigurer resolvePropertyConfigurer(CamelContext context, Object target) {
+        ObjectHelper.notNull(target, "target");
+        ObjectHelper.notNull(context, "context");
+
+        return context.adapt(ExtendedCamelContext.class)
+            .getConfigurerResolver()
+            .resolvePropertyConfigurer(target.getClass().getSimpleName(), context);
+    }
+
+    /**
+     * Resolves the given configurer.
+     *
+     * @param context the camel context
+     * @param target the target object for which we need a {@link org.apache.camel.spi.PropertyConfigurer}
+     * @param type the specific type of {@link org.apache.camel.spi.PropertyConfigurer}
+     * @return the resolved configurer, or <tt>null</tt> if no configurer could be found
+     */
+    public static <T> T resolvePropertyConfigurer(CamelContext context, Object target, Class<T> type) {
+        ObjectHelper.notNull(target, "target");
+        ObjectHelper.notNull(context, "context");
+
+        GeneratedPropertyConfigurer configurer = resolvePropertyConfigurer(context, target);
+        if (type.isInstance(configurer)) {
+            return type.cast(configurer);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR adds support for arrays in PropertyBindingSupport and fix issues when binding to list when properties have gaps.

See tests in:
- PropertyBindingSupportArrayTest
- PropertyBindingSupportListTest


see:
- https://issues.apache.org/jira/browse/CAMEL-15396
- https://issues.apache.org/jira/browse/CAMEL-15397