### PR TITLE
CAMEL-14826: Add unit tests to the platform-http component

### DIFF
--- a/components/camel-platform-http/pom.xml
+++ b/components/camel-platform-http/pom.xml
@@ -37,6 +37,34 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty9-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.orbit</groupId>
+                    <artifactId>javax.servlet</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpConsumer.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpConsumer.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.support.CamelContextHelper;
+import org.apache.camel.support.DefaultConsumer;
+import org.apache.camel.support.DefaultMessage;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ContextHandler;
+
+public class JettyCustomPlatformHttpConsumer extends DefaultConsumer {
+    private static final Pattern PATH_PARAMETER_PATTERN = Pattern.compile("\\{([^/}]+)\\}");
+
+    public JettyCustomPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
+        super(endpoint, processor);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        final PlatformHttpEndpoint endpoint = getEndpoint();
+        final String path = configureEndpointPath(endpoint);
+
+        JettyServerTest jettyServerTest = CamelContextHelper.mandatoryLookup(
+                getEndpoint().getCamelContext(),
+                JettyServerTest.JETTY_SERVER_NAME,
+                JettyServerTest.class
+        );
+
+        ContextHandler contextHandler = createHandler(endpoint, path);
+        // add handler after starting server.
+        jettyServerTest.addHandler(contextHandler);
+
+
+    }
+
+    private ContextHandler createHandler(PlatformHttpEndpoint endpoint, String path) {
+        ContextHandler contextHandler = new ContextHandler();
+        contextHandler.setContextPath(path);
+        contextHandler.setResourceBase(".");
+        contextHandler.setClassLoader(Thread.currentThread().getContextClassLoader());
+        contextHandler.setAllowNullPathInfo(true);
+        contextHandler.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String s, Request request, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException, ServletException {
+                Exchange exchg = null;
+                try {
+                    BufferedReader reader = httpServletRequest.getReader();
+                    String bodyRequest = "";
+                    String strCurrentLine = "";
+                    while ((strCurrentLine = reader.readLine()) != null) {
+                        bodyRequest += strCurrentLine;
+                    }
+                    final Exchange exchange = exchg = toExchange(request, bodyRequest);
+                    createUoW(exchange);
+                    getProcessor().process(
+                            exchange);
+                    httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+                    request.setHandled(true);
+                    httpServletResponse.getWriter().println(exchange.getMessage().getBody());
+                } catch (Exception e) {
+                    getExceptionHandler().handleException("Failed handling platform-http endpoint " + endpoint.getPath(), exchg, e);
+                } finally {
+                    if (exchg != null) {
+                        doneUoW(exchg);
+                    }
+                }
+            }
+        });
+        return contextHandler;
+    }
+
+
+    private Exchange toExchange(Request request, String body) {
+        final Exchange exchange = getEndpoint().createExchange();
+        final Message message = new DefaultMessage(exchange);
+
+        final String charset = request.getHeader("charset");
+        if (charset != null) {
+            exchange.setProperty(Exchange.CHARSET_NAME, charset);
+            message.setHeader(Exchange.HTTP_CHARACTER_ENCODING, charset);
+        }
+
+        message.setBody(body.length() != 0 ? body : null);
+        exchange.setMessage(message);
+        return exchange;
+    }
+
+
+    @Override
+    public PlatformHttpEndpoint getEndpoint() {
+        return (PlatformHttpEndpoint) super.getEndpoint();
+    }
+
+    private String configureEndpointPath(PlatformHttpEndpoint endpoint) {
+        String path = endpoint.getPath();
+        if (endpoint.isMatchOnUriPrefix()) {
+            path += "*";
+        }
+        // Transform from the Camel path param syntax /path/{key} to vert.x web's /path/:key
+        return PATH_PARAMETER_PATTERN.matcher(path).replaceAll(":$1");
+    }
+
+}

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpEngine.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpEngine.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
+
+public class JettyCustomPlatformHttpEngine implements PlatformHttpEngine {
+    @Override
+    public Consumer createConsumer(PlatformHttpEndpoint platformHttpEndpoint, Processor processor) {
+
+        return new JettyCustomPlatformHttpConsumer(platformHttpEndpoint, processor);
+    }
+}

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyServerTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyServerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+
+public class JettyServerTest {
+    public static final String JETTY_SERVER_NAME = "JettyServerTest";
+
+    private Server server;
+    private HandlerCollection contextHandlerCollection;
+
+    public JettyServerTest(int port) {
+        server = new Server(port);
+        contextHandlerCollection = new HandlerCollection(true);
+        server.setHandler(contextHandlerCollection);
+    }
+
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    /**
+     * adds a context handler and starts it
+     *
+     * @param contextHandler
+     * @throws Exception
+     */
+    public void addHandler(ContextHandler contextHandler) throws Exception {
+        contextHandlerCollection.addHandler(contextHandler);
+        contextHandler.start();
+    }
+}

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.AvailablePortFinder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class PlatformHttpTest {
+    private static JettyServerTest server;
+    private static CamelContext ctx;
+    private static int port;
+
+    @BeforeAll
+    public static void init() throws Exception {
+
+        ctx = new DefaultCamelContext();
+        ctx.getRegistry().bind(PlatformHttpConstants.PLATFORM_HTTP_ENGINE_FACTORY, new JettyCustomPlatformHttpEngine());
+
+        port = AvailablePortFinder.getNextAvailable();
+        server = new JettyServerTest(port);
+
+        ctx.getRegistry().bind(JettyServerTest.JETTY_SERVER_NAME, server);
+        server.start();
+
+        ctx.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("platform-http:/get")
+                        .setBody().constant("get");
+                from("platform-http:/post")
+                        .transform().body(String.class, b -> b.toUpperCase());
+            }
+        });
+        ctx.start();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        ctx.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        given()
+                .header("Accept", "application/json")
+                .port(port)
+                .expect()
+                .statusCode(200)
+                .when()
+                .get("/get");
+    }
+
+    @Test
+    public void testPost() {
+        RestAssured.baseURI = "http://localhost:" + port;
+        RequestSpecification request = RestAssured.given();
+        request.body("test");
+        Response response = request.get("/post");
+
+        int statusCode = response.getStatusCode();
+        assertEquals(200, statusCode);
+        assertEquals("TEST", response.body().asString().trim());
+    }
+
+}

--- a/components/camel-platform-http/src/test/resources/log4j2.properties
+++ b/components/camel-platform-http/src/test/resources/log4j2.properties
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+appender.file.type = File
+appender.file.name = file
+appender.file.fileName = target/camel-platform-http-test.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+appender.out.type = Console
+appender.out.name = out
+appender.out.layout.type = PatternLayout
+appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+
+rootLogger.level = INFO
+rootLogger.appenderRef.file.ref = file


### PR DESCRIPTION
A test of platform-http using jetty server. For the test, I needed to create a custom Consumer. 