### PR TITLE
camel-itest-sjms2: fix deprecation warnings

### DIFF
--- a/tests/camel-itest-jms2/src/test/java/org/apache/camel/itest/jms2/BaseJms2TestSupport.java
+++ b/tests/camel-itest-jms2/src/test/java/org/apache/camel/itest/jms2/BaseJms2TestSupport.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.itest.jms2;
 
-import java.util.Arrays;
-
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.MessageConsumer;
@@ -32,13 +30,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
-import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
-import org.apache.activemq.artemis.jms.server.config.JMSQueueConfiguration;
-import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
@@ -62,7 +54,7 @@ public class BaseJms2TestSupport extends CamelTestSupport {
     protected ProducerTemplate template;
     protected String brokerUri;
     protected int port;
-    protected EmbeddedJMS broker;
+    protected EmbeddedActiveMQ broker;
     protected Connection connection;
     protected Session session;
 
@@ -75,7 +67,7 @@ public class BaseJms2TestSupport extends CamelTestSupport {
      */
     @Override
     protected void doPreSetup() throws Exception {
-        broker = new EmbeddedJMS();
+        broker = new EmbeddedActiveMQ();
         deleteDirectory("target/data");
         port = AvailablePortFinder.getNextAvailable();
         brokerUri = "tcp://localhost:" + port;
@@ -83,7 +75,7 @@ public class BaseJms2TestSupport extends CamelTestSupport {
         startBroker();
     }
 
-    protected void configureBroker(EmbeddedJMS broker) throws Exception {
+    protected void configureBroker(EmbeddedActiveMQ broker) throws Exception {
         Configuration configuration = new ConfigurationImpl()
                 .setPersistenceEnabled(false)
                 .setJournalDirectory("target/data/journal")
@@ -92,21 +84,7 @@ public class BaseJms2TestSupport extends CamelTestSupport {
                 .addAcceptorConfiguration("vm", "vm://123")
                 .addConnectorConfiguration("connector", new TransportConfiguration(NettyConnectorFactory.class.getName()));
 
-        JMSConfiguration jmsConfig = new JMSConfigurationImpl();
-
-        ConnectionFactoryConfiguration cfConfig = new ConnectionFactoryConfigurationImpl().setName("cf").setConnectorNames(
-                Arrays.asList("connector")).setBindings("cf");
-        jmsConfig.getConnectionFactoryConfigurations().add(cfConfig);
-
-        JMSQueueConfiguration queueConfig
-                = new JMSQueueConfigurationImpl().setName("queue1").setDurable(false).setBindings("queue/queue1");
-        jmsConfig.getQueueConfigurations().add(queueConfig);
-
-        JMSQueueConfiguration topicConfig
-                = new JMSQueueConfigurationImpl().setName("foo").setDurable(true).setBindings("topic/foo");
-        jmsConfig.getQueueConfigurations().add(topicConfig);
-
-        broker.setConfiguration(configuration).setJmsConfiguration(jmsConfig);
+        broker.setConfiguration(configuration);
     }
 
     private void startBroker() throws Exception {


### PR DESCRIPTION
Replaced embedded deprecated JMS broker with EmbeddedActiveMQ since the embedded one is deprecated since Artemis 2.0.

Reference: https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md