### PR TITLE
CAMEL-15457: Ensure exchange has fromRouteId and fromEndpoint

### DIFF
--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifier.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifier.java
@@ -78,12 +78,14 @@ public class MicrometerExchangeEventNotifier extends AbstractMicrometerEventNoti
     }
 
     private void handleExchangeEvent(ExchangeEvent exchangeEvent) {
-        String name = namingStrategy.getInflightExchangesName(exchangeEvent.getExchange(),
-                exchangeEvent.getExchange().getFromEndpoint());
-        Tags tags = namingStrategy.getInflightExchangesTags(exchangeEvent, exchangeEvent.getExchange().getFromEndpoint());
-        Gauge.builder(name, () -> getInflightExchangesInRoute(exchangeEvent))
-                .tags(tags)
-                .register(getMeterRegistry());
+        Exchange exchange = exchangeEvent.getExchange();
+        if (exchange.getFromRouteId() != null && exchange.getFromEndpoint() != null) {
+            String name = namingStrategy.getInflightExchangesName(exchange, exchange.getFromEndpoint());
+            Tags tags = namingStrategy.getInflightExchangesTags(exchangeEvent, exchange.getFromEndpoint());
+            Gauge.builder(name, () -> getInflightExchangesInRoute(exchangeEvent))
+                    .tags(tags)
+                    .register(getMeterRegistry());
+        }
     }
 
     protected void handleSentEvent(ExchangeSentEvent sentEvent) {


### PR DESCRIPTION
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body. If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md

**Description**
MicrometerExchangeEventNotifier indirectly caused NullPointer exceptions in some circumstances, though they are caught and logged as "WARN".

[A fix](https://github.com/apache/camel/commit/df0dfddeb205bf29a8148cb2862308f7a5b8a853#diff-4725dcf446a342f1473a8228e42dfa48) was implemented. Unfortunately, the fix is somewhat incompatible with prometheus, as it potentially tries to register multiple metrics with the same name but different tags, which prometheus doesn't allow.

This PR solves this by implementing a check so that we dont create inflight metrics unless we can extract fromEndpoint and fromRouteId from the ExchangeEvent.
