### PR TITLE
CAMEL-15460: FTP reconnect to handle pending command and noop result

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
@@ -353,7 +353,6 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
     public boolean renameFile(String from, String to) throws GenericFileOperationFailedException {
         log.debug("Renaming file: {} to: {}", from, to);
         try {
-            reconnectIfNecessary(null);
             return client.rename(from, to);
         } catch (IOException e) {
             throw new GenericFileOperationFailedException(client.getReplyCode(), client.getReplyString(), e.getMessage(), e);
@@ -1009,16 +1008,18 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
     }
 
     private void reconnectIfNecessary(Exchange exchange) throws GenericFileOperationFailedException {
-        if (isConnected()) {
-            log.trace("sendNoOp to check if connection should be reconnected");
-            try {
-                client.sendNoOp();
-            } catch (IOException e) {
-                log.trace("NoOp to server failed, try to reconnect");
-                connect(endpoint.getConfiguration(), exchange);
+        boolean reconnectRequired = false;
+        try {
+            client.completePendingCommand();
+            if (!isConnected() || !sendNoop()) {
+                reconnectRequired = true;
             }
-        } else {
-            log.trace("Client is not connected, try to reconnect");
+        } catch (IOException | GenericFileOperationFailedException e) {
+            // Ignore Exception and reconnect the client
+            reconnectRequired = true;
+        }
+        if (reconnectRequired) {
+            log.trace("Client is not connected anymore, try to reconnect");
             connect(endpoint.getConfiguration(), exchange);
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-15460

Call of completePendingCommand() will read the Stream which potentially still contains a success message from the file retrieval. Afterwards the NOOP will be executed and the result (read from Stream) is interpreted correctly. Also respect the NOOP to return false instead of relying on exception.

Removed redundant reconnectIfNeccessary during rename(), as it will try to delete as first step during execution. The delete will ensure the connection is still alive.