### PR TITLE
camel-itest: fixed deprecation warnings

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/TransactionSupport.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/TransactionSupport.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.itest;
+
+import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.apache.camel.spring.spi.TransactionErrorHandlerBuilder;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public final class TransactionSupport {
+    private TransactionSupport() {
+    }
+
+    /**
+     * Creates a transaction error handler.
+     *
+     * @param  policy using this transaction policy (eg: required, supports, ...)
+     * @return        the created error handler
+     */
+    public static TransactionErrorHandlerBuilder transactionErrorHandler(SpringTransactionPolicy policy) {
+        return transactionErrorHandler(policy.getTransactionTemplate());
+    }
+
+    /**
+     * Creates a transaction error handler.
+     *
+     * @param  template the spring transaction template
+     * @return          the created error handler
+     */
+    private static TransactionErrorHandlerBuilder transactionErrorHandler(TransactionTemplate template) {
+        TransactionErrorHandlerBuilder answer = new TransactionErrorHandlerBuilder();
+        answer.setTransactionTemplate(template);
+        return answer;
+    }
+}

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/async/HttpJmsAsyncTimeoutTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/async/HttpJmsAsyncTimeoutTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.itest.async;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.itest.utils.extensions.JmsServiceExtension;
 import org.apache.camel.spi.Registry;
 import org.junit.jupiter.api.Test;

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsShutdownInProgressTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsShutdownInProgressTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.itest.utils.extensions.JmsServiceExtension;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.spring.junit5.CamelSpringTest;

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettySimulateFailoverRoundRobinTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettySimulateFailoverRoundRobinTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.ExtendedExchange;
 import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -158,7 +159,7 @@ public class JettySimulateFailoverRoundRobinTest extends CamelTestSupport {
         private void prepareExchangeForFailover(Exchange exchange) {
             exchange.setException(null);
 
-            exchange.setProperty(Exchange.ERRORHANDLER_HANDLED, null);
+            exchange.adapt(ExtendedExchange.class).setErrorHandlerHandled(null);
             exchange.setProperty(Exchange.FAILURE_HANDLED, null);
             exchange.setProperty(Exchange.EXCEPTION_CAUGHT, null);
             exchange.getIn().removeHeader(Exchange.REDELIVERED);

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueTest.java
@@ -50,7 +50,7 @@ public class JmsHttpPostIssueTest extends CamelTestSupport {
 
         template.sendBody("jms:queue:in", "Hello World");
 
-        assertTrue(notify.matchesMockWaitTime(), "Should complete the JMS route");
+        assertTrue(notify.matchesWaitTime(), "Should complete the JMS route");
     }
 
     @Test

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.java
@@ -89,7 +89,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
         assertTrue(notify.matchesWaitTime(), "Should complete 1 message");
 
         // check that there is a message in the database and JMS queue
-        assertEquals(new Integer(1), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(1),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         Object out = consumer.receiveBody("activemq2:queue:outbox", 3000);
         assertEquals("DONE-A", out);
     }
@@ -120,7 +121,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
         assertTrue(notify.matchesWaitTime(), "Should complete 7 message");
 
         // check that there is a message in the database and JMS queue
-        assertEquals(new Integer(0), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(0),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         assertNull(consumer.receiveBody("activemq2:queue:outbox", 3000));
 
         // the message should have been moved to the AMQ DLQ queue
@@ -153,7 +155,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
         assertTrue(notify.matchesWaitTime(), "Should complete 7 messages");
 
         // check that there is a message in the database and JMS queue
-        assertEquals(new Integer(0), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(0),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         assertNull(consumer.receiveBody("activemq2:queue:outbox", 3000));
 
         // the message should have been moved to the AMQ DLQ queue
@@ -181,7 +184,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
         assertTrue(notify.matchesWaitTime(), "Should complete 3 messages");
 
         // check that there is two messages in the database and JMS queue
-        assertEquals(new Integer(2), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(2),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         assertEquals("DONE-D", consumer.receiveBody("activemq2:queue:outbox", 3000));
         assertEquals("DONE-E", consumer.receiveBody("activemq2:queue:outbox", 3000));
     }
@@ -217,7 +221,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
         assertTrue(notify.matchesWaitTime(), "Should complete 4 messages");
 
         // check that there is two messages in the database and JMS queue
-        assertEquals(new Integer(3), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(3),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         assertEquals("DONE-D", consumer.receiveBody("activemq2:queue:outbox", 3000));
         assertEquals("DONE-E", consumer.receiveBody("activemq2:queue:outbox", 3000));
         assertEquals("DONE-F", consumer.receiveBody("activemq2:queue:outbox", 3000));
@@ -225,7 +230,8 @@ public class FromJmsToJdbcIdempotentConsumerToJmsTest extends CamelSpringTestSup
 
     protected void checkInitialState() {
         // check there are no messages in the database and JMS queue
-        assertEquals(new Integer(0), jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
+        assertEquals(Integer.valueOf(0),
+                jdbcTemplate.queryForObject("select count(*) from CAMEL_MESSAGEPROCESSED", Integer.class));
         assertNull(consumer.receiveBody("activemq2:queue:outbox", 2000));
     }
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpRoute.java
@@ -22,16 +22,18 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.spring.SpringRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.apache.camel.test.AvailablePortFinder;
+
+import static org.apache.camel.itest.TransactionSupport.transactionErrorHandler;
 
 /**
  * Route that listen on a JMS queue and send a request/reply over http before returning a response. Is transacted.
  * <p/>
  * Notice we use the SpringRouteBuilder that supports transacted error handler.
  */
-public class JmsToHttpRoute extends SpringRouteBuilder {
+public class JmsToHttpRoute extends RouteBuilder {
     protected static int counter;
     protected int port;
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute.java
@@ -19,7 +19,7 @@ package org.apache.camel.itest.tx;
 import org.apache.camel.Exchange;
 import org.apache.camel.Predicate;
 import org.apache.camel.Processor;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.test.AvailablePortFinder;
 
 /**

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionRoute.java
@@ -21,17 +21,19 @@ import javax.annotation.Resource;
 import org.apache.camel.Exchange;
 import org.apache.camel.Predicate;
 import org.apache.camel.Processor;
-import org.apache.camel.http.common.HttpOperationFailedException;
-import org.apache.camel.spring.SpringRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.apache.camel.test.AvailablePortFinder;
+
+import static org.apache.camel.itest.TransactionSupport.transactionErrorHandler;
 
 /**
  * Route that listen on a JMS queue and send a request/reply over http before returning a response. Is transacted.
  * <p/>
  * Notice we use the SpringRouteBuilder that supports transacted error handler.
  */
-public class JmsToHttpWithOnExceptionRoute extends SpringRouteBuilder {
+public class JmsToHttpWithOnExceptionRoute extends RouteBuilder {
     protected static int counter;
     protected int port;
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithRollbackRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithRollbackRoute.java
@@ -22,16 +22,18 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.spring.SpringRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.apache.camel.test.AvailablePortFinder;
+
+import static org.apache.camel.itest.TransactionSupport.transactionErrorHandler;
 
 /**
  * Route that listen on a JMS queue and send a request/reply over http before returning a response. Is transacted.
  * <p/>
  * Notice we use the SpringRouteBuilder that supports transacted error handler.
  */
-public class JmsToHttpWithRollbackRoute extends SpringRouteBuilder {
+public class JmsToHttpWithRollbackRoute extends RouteBuilder {
     protected static int counter;
     protected int port;
 


### PR DESCRIPTION
Includes:
- replaced deprecated usages of HttpOperationFailedException
- replaced usages of new Integer with Integer.valueOf
- stop using Exchange.ERRORHANDLER_HANDLED
- replaced usages of SpringRouteBuilder with RouteBuilder

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md