### PR TITLE
camel-jms: fixes some of the deprecation warnings

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/FileRouteToJmsToFileTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/FileRouteToJmsToFileTest.java
@@ -51,7 +51,7 @@ public class FileRouteToJmsToFileTest extends CamelTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
 
         File file = new File("target/file2file/out/hello.txt");
         assertTrue(file.exists(), "The file should exists");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsErrorHandlerLogStackTraceTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsErrorHandlerLogStackTraceTest.java
@@ -43,7 +43,7 @@ public class JmsErrorHandlerLogStackTraceTest extends CamelTestSupport {
 
         template.sendBody("jms:queue:foo", "Hello World");
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
     }
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutBeanReturnNullTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutBeanReturnNullTest.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -61,7 +61,7 @@ public class JmsInOutBeanReturnNullTest extends CamelTestSupport {
     public void testReturnNullExchange() throws Exception {
         Exchange reply = template.request("activemq:queue:foo", exchange -> exchange.getIn().setBody("foo"));
         assertNotNull(reply);
-        assertTrue(reply.hasOut());
+        assertNotEquals("foo", reply.getMessage().getBody(), "There shouldn't be an out message");
         Message out = reply.getMessage();
         assertNotNull(out);
         Object body = out.getBody();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutTest.java
@@ -20,6 +20,7 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -76,7 +77,7 @@ public class JmsInOutFixedReplyQueueTimeoutTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("activemq:queue:foo?replyTo=queue:bar&requestTimeout=2000")
+                        .to(ExchangePattern.InOut, "activemq:queue:foo?replyTo=queue:bar&requestTimeout=2000")
                         .to("mock:result");
 
                 from("activemq:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutUseMessageIDAsCorrelationIDTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutUseMessageIDAsCorrelationIDTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jms;
 
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 
 /**
@@ -28,7 +29,8 @@ public class JmsInOutFixedReplyQueueTimeoutUseMessageIDAsCorrelationIDTest exten
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("activemq:queue:foo?replyTo=queue:bar&useMessageIDAsCorrelationID=true&requestTimeout=2000")
+                        .to(ExchangePattern.InOut,
+                                "activemq:queue:foo?replyTo=queue:bar&useMessageIDAsCorrelationID=true&requestTimeout=2000")
                         .to("mock:result");
 
                 from("activemq:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutIndividualRequestTimeoutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutIndividualRequestTimeoutTest.java
@@ -20,6 +20,7 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -88,7 +89,7 @@ public class JmsInOutIndividualRequestTimeoutTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("activemq:queue:foo?replyTo=queue:bar&requestTimeout=2000")
+                        .to(ExchangePattern.InOut, "activemq:queue:foo?replyTo=queue:bar&requestTimeout=2000")
                         .to("mock:result");
 
                 from("activemq:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutTransferExchangeTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutTransferExchangeTest.java
@@ -25,6 +25,7 @@ import org.apache.activemq.command.ActiveMQObjectMessage;
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.DefaultExchangeHolder;
@@ -113,7 +114,7 @@ public class JmsInOutTransferExchangeTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from("direct:start")
-                        .inOut("activemq:responseGenerator?transferExchange=true")
+                        .to(ExchangePattern.InOut, "activemq:responseGenerator?transferExchange=true")
                         .to("mock:result");
 
                 from("activemq:responseGenerator?transferExchange=true")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyTempQueueMultipleConsumersTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyTempQueueMultipleConsumersTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.pool.PooledConnectionFactory;
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -101,7 +102,7 @@ public class JmsRequestReplyTempQueueMultipleConsumersTest extends CamelTestSupp
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("direct:start").inOut(
+                from("direct:start").to(ExchangePattern.InOut,
                         "jms:queue:foo?replyToConcurrentConsumers=10&replyToMaxConcurrentConsumers=20&recoveryInterval=10")
                         .process(exchange -> {
                             String threadName = Thread.currentThread().getName();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingDifferentHeadersTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingDifferentHeadersTest.java
@@ -34,13 +34,13 @@ public class JmsRouteUsingDifferentHeadersTest extends CamelTestSupport {
     @Test
     public void testUsingDifferentHeaderTypes() throws Exception {
         Map<String, Object> headers = new LinkedHashMap<>();
-        headers.put("a", new Byte("65"));
+        headers.put("a", Byte.valueOf("65"));
         headers.put("b", Boolean.TRUE);
-        headers.put("c", new Double("44444"));
-        headers.put("d", new Float("55555"));
-        headers.put("e", new Integer("222"));
-        headers.put("f", new Long("7777777"));
-        headers.put("g", new Short("333"));
+        headers.put("c", Double.valueOf("44444"));
+        headers.put("d", Float.valueOf("55555"));
+        headers.put("e", Integer.valueOf("222"));
+        headers.put("f", Long.valueOf("7777777"));
+        headers.put("g", Short.valueOf("333"));
         headers.put("h", "Hello");
 
         MockEndpoint mock = getMockEndpoint("mock:result");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithCustomListenerContainerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithCustomListenerContainerTest.java
@@ -85,7 +85,7 @@ public class JmsRouteWithCustomListenerContainerTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("activemq:queue:inbox?messageListenerContainerFactory=#myListenerContainerFactory").to("mock:inbox")
-                        .inOnly("activemq:topic:order").bean("orderService",
+                        .to(ExchangePattern.InOnly, "activemq:topic:order").bean("orderService",
                                 "handleOrder");
 
                 from("activemq:topic:order").to("mock:topic");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithInOnlyAndMultipleAcksTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithInOnlyAndMultipleAcksTest.java
@@ -20,6 +20,7 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -78,7 +79,8 @@ public class JmsRouteWithInOnlyAndMultipleAcksTest extends CamelTestSupport {
                 // topic subscribers, lets a bean handle
                 // the order and then delivers a reply back to
                 // the original order request initiator
-                from("amq:queue:inbox").to("mock:inbox").inOnly("amq:topic:orderServiceNotification").bean("orderService",
+                from("amq:queue:inbox").to("mock:inbox").to(ExchangePattern.InOnly, "amq:topic:orderServiceNotification").bean(
+                        "orderService",
                         "handleOrder");
 
                 // this route collects an order request notification

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithInOnlyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteWithInOnlyTest.java
@@ -72,7 +72,8 @@ public class JmsRouteWithInOnlyTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("activemq:queue:inbox").to("mock:inbox").inOnly("activemq:topic:order").bean("orderService",
+                from("activemq:queue:inbox").to("mock:inbox").to(ExchangePattern.InOnly, "activemq:topic:order").bean(
+                        "orderService",
                         "handleOrder");
 
                 from("activemq:topic:order").to("mock:topic");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestCustomReplyToTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestCustomReplyToTest.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -65,7 +64,11 @@ public class JmsSimpleRequestCustomReplyToTest extends CamelTestSupport {
 
         result.assertIsSatisfied();
         assertNotNull(out);
-        assertFalse(out.hasOut());
+        /*
+          The getMessage returns the In message if the Out one is not present. Therefore, we check if
+          the body of the returned message equals to the In one and infer that the out one was null.
+         */
+        assertEquals("Hello World", out.getMessage().getBody(), "There shouldn't be an out message");
 
         // get the reply from the special reply queue
         Endpoint end = context.getEndpoint(componentName + ":" + myReplyTo);

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestReply2Test.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestReply2Test.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ public class JmsSimpleRequestReply2Test extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("activemq:queue:foo")
+                        .to(ExchangePattern.InOut, "activemq:queue:foo")
                         .to("mock:result");
 
                 from("activemq:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestReplyFixedReplyQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestReplyFixedReplyQueueTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ public class JmsSimpleRequestReplyFixedReplyQueueTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("activemq:queue:foo?replyTo=queue:bar")
+                        .to(ExchangePattern.InOut, "activemq:queue:foo?replyTo=queue:bar")
                         .to("mock:result");
 
                 from("activemq:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/AsyncConsumerInOutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/AsyncConsumerInOutTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.async;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -67,7 +68,7 @@ public class AsyncConsumerInOutTest extends CamelTestSupport {
                         .choice()
                         .when(body().contains("Camel"))
                         .to("async:camel?delay=2000")
-                        .inOut("activemq:queue:camel")
+                        .to(ExchangePattern.InOut, "activemq:queue:camel")
                         .to("mock:result")
                         .otherwise()
                         .to("log:other")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/AsyncJmsInOutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/AsyncJmsInOutTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -80,7 +81,7 @@ public class AsyncJmsInOutTest extends CamelTestSupport {
                 from("seda:start")
                         // we can only send at fastest the 100 msg in 5 sec due the delay
                         .delay(50)
-                        .inOut("activemq:queue:bar")
+                        .to(ExchangePattern.InOut, "activemq:queue:bar")
                         .to("mock:result");
 
                 from("activemq:queue:bar")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
@@ -59,9 +59,9 @@ public class MyAsyncProducer extends DefaultAsyncProducer {
                 exchange.setException(new CamelExchangeException("Simulated error at attempt " + count, exchange));
             } else {
                 String reply = getEndpoint().getReply();
-                exchange.getOut().setBody(reply);
+                exchange.getMessage().setBody(reply);
                 // propagate headers
-                exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+                exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
                 LOG.info("Setting reply " + reply);
             }
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsChainedEndpointDelayTimeoutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsChainedEndpointDelayTimeoutTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.issues;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
@@ -68,11 +69,11 @@ public class JmsChainedEndpointDelayTimeoutTest extends CamelTestSupport {
                         .to("mock:exception");
 
                 from("activemq:test")
-                        .inOut("activemq:ping?requestTimeout=500")
+                        .to(ExchangePattern.InOut, "activemq:ping?requestTimeout=500")
                         .delay(constant(1000));
 
                 from("activemq:testReplyFixedQueue")
-                        .inOut("activemq:ping?requestTimeout=500&replyToType=Exclusive&replyTo=reply")
+                        .to(ExchangePattern.InOut, "activemq:ping?requestTimeout=500&replyToType=Exclusive&replyTo=reply")
                         .delay(constant(1000));
 
                 from("activemq:ping")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOnlyIssueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOnlyIssueTest.java
@@ -28,7 +28,7 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JmsInOnlyIssueTest extends CamelTestSupport {
 
@@ -64,7 +64,11 @@ public class JmsInOnlyIssueTest extends CamelTestSupport {
                 exchange -> exchange.getIn().setBody("Hello World"));
 
         assertMockEndpointsSatisfied();
-        assertFalse(out.hasOut(), "Should not have OUT");
+        /*
+          The getMessage returns the In message if the Out one is not present. Therefore, we check if
+          the body of the returned message equals to the In one and infer that the out one was null.
+         */
+        assertEquals("Hello World", out.getMessage().getBody(), "There shouldn't be an out message");
     }
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutParallelTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutParallelTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.issues;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -55,9 +56,9 @@ public class JmsInOutParallelTest extends CamelTestSupport {
 
                 from("direct:test")
                         .setBody(constant("1,2,3,4,5"))
-                        .inOut("activemq:queue:test1?requestTimeout=2000")
+                        .to(ExchangePattern.InOut, "activemq:queue:test1?requestTimeout=2000")
                         .split().tokenize(",").parallelProcessing()
-                        .inOut("activemq:queue:test2?requestTimeout=2000")
+                        .to(ExchangePattern.InOut, "activemq:queue:test2?requestTimeout=2000")
                         .to("mock:received")
                         .end()
                         .setBody(constant("Fully done"))

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutPersistentReplyQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutPersistentReplyQueueTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.issues;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -54,7 +55,7 @@ public class JmsInOutPersistentReplyQueueTest extends CamelTestSupport {
             public void configure() throws Exception {
                 from("seda:start")
                         .log("Sending ${body}")
-                        .inOut("activemq:queue:foo?replyTo=myReplies")
+                        .to(ExchangePattern.InOut, "activemq:queue:foo?replyTo=myReplies")
                         // process the remainder of the route concurrently
                         .threads(5)
                         .log("Reply ${body}")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutRepeatedInvocationsTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutRepeatedInvocationsTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.issues;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -54,9 +55,9 @@ public class JmsInOutRepeatedInvocationsTest extends CamelTestSupport {
             public void configure() throws Exception {
 
                 from("direct:test")
-                        .inOut("activemq:queue:test1?requestTimeout=200")
-                        .inOut("activemq:queue:test1?requestTimeout=200")
-                        .inOut("activemq:queue:test1?requestTimeout=200")
+                        .to(ExchangePattern.InOut, "activemq:queue:test1?requestTimeout=200")
+                        .to(ExchangePattern.InOut, "activemq:queue:test1?requestTimeout=200")
+                        .to(ExchangePattern.InOut, "activemq:queue:test1?requestTimeout=200")
                         .to("mock:finished");
 
                 from("activemq:queue:test1")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutTransferExchangeInflightRepositoryFlushTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutTransferExchangeInflightRepositoryFlushTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.issues;
 import javax.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.CamelJmsTestHelper;
 import org.apache.camel.component.jms.SerializableRequestDto;
@@ -59,7 +60,7 @@ public class JmsInOutTransferExchangeInflightRepositoryFlushTest extends CamelTe
         return new RouteBuilder() {
             public void configure() {
                 from("direct:start")
-                        .inOut("activemq:responseGenerator?transferExchange=true&requestTimeout=5000")
+                        .to(ExchangePattern.InOut, "activemq:responseGenerator?transferExchange=true&requestTimeout=5000")
                         .to("mock:result");
 
                 from("activemq:responseGenerator?transferExchange=true")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsRequestReplyTemporaryRefreshFailureOnStartupTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsRequestReplyTemporaryRefreshFailureOnStartupTest.java
@@ -23,6 +23,7 @@ import javax.jms.ConnectionFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -52,7 +53,7 @@ public class JmsRequestReplyTemporaryRefreshFailureOnStartupTest extends CamelTe
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .inOut("jms:queue:foo?recoveryInterval=" + recoveryInterval)
+                        .to(ExchangePattern.InOut, "jms:queue:foo?recoveryInterval=" + recoveryInterval)
                         .to("mock:result");
 
                 from("jms:queue:foo")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AbstractTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AbstractTransactionTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractTransactionTest extends CamelSpringTestSupport {
 
         template.sendBody("activemq:queue:foo", "blah");
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
 
         assertTrue(getConditionalExceptionProcessor().getCount() == 2,
                 "Expected only 2 calls to process() (1 failure, 1 success) but encountered "

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTXInOutPersistentQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTXInOutPersistentQueueTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jms.tx;
 
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,7 @@ public class JMSTXInOutPersistentQueueTest extends CamelSpringTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("direct:start").inOut("activemq:queue:foo?replyTo=myReplies")
+                from("direct:start").to(ExchangePattern.InOut, "activemq:queue:foo?replyTo=myReplies")
                         .to("mock:reply")
                         .process(exchange -> {
                             if (counter++ < 2) {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyTest.java
@@ -21,8 +21,8 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.Handler;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.spring.SpringRouteBuilder;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
@@ -84,7 +84,7 @@ public class JMXTXUseOriginalBodyTest extends CamelSpringTestSupport {
         }
     }
 
-    public static class TestRoutes extends SpringRouteBuilder {
+    public static class TestRoutes extends RouteBuilder {
 
         @Override
         public void configure() throws Exception {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithDLCErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithDLCErrorHandlerTest.java
@@ -21,8 +21,8 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.Handler;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.spring.SpringRouteBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -107,7 +107,7 @@ public class JMXTXUseOriginalBodyWithDLCErrorHandlerTest extends JMXTXUseOrigina
         }
     }
 
-    public static class TestRoutes extends SpringRouteBuilder {
+    public static class TestRoutes extends RouteBuilder {
 
         @Override
         public void configure() throws Exception {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithTXErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithTXErrorHandlerTest.java
@@ -21,8 +21,9 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.Handler;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.spring.SpringRouteBuilder;
+import org.apache.camel.spring.spi.TransactionErrorHandlerBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -86,11 +87,11 @@ public class JMXTXUseOriginalBodyWithTXErrorHandlerTest extends JMXTXUseOriginal
         }
     }
 
-    public static class TestRoutes extends SpringRouteBuilder {
+    public static class TestRoutes extends RouteBuilder {
 
         @Override
         public void configure() throws Exception {
-            errorHandler(transactionErrorHandler());
+            errorHandler(new TransactionErrorHandlerBuilder());
 
             onException(Exception.class)
                     .handled(true)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionWithoutDefineTransactionManagerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionWithoutDefineTransactionManagerTest.java
@@ -50,7 +50,7 @@ public class QueueToQueueTransactionWithoutDefineTransactionManagerTest extends 
 
         template.sendBody("activemq:queue:foo", "blah");
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
 
         assertTrue(getConditionalExceptionProcessor().getCount() == 1,
                 "Expected only 1 calls to process() (1 failure) but encountered "


### PR DESCRIPTION
Including:
- inOut/in/to method deprecations
- usages of deprecated matchesMockWaitTime
- usages of hasOut
- usages of getOut
- use valueOf for Java wrapper classes
- replaces simple usages of SpringRouteBuilder with the stock RouteBuilder


- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md