### PR TITLE
camel-sjms2: fix deprecation warnings

### DIFF
--- a/components/camel-sjms2/src/test/java/org/apache/camel/component/sjms2/support/Jms2TestSupport.java
+++ b/components/camel-sjms2/src/test/java/org/apache/camel/component/sjms2/support/Jms2TestSupport.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.sjms2.support;
 
-import java.util.Arrays;
-
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.MessageConsumer;
@@ -31,13 +29,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
-import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
-import org.apache.activemq.artemis.jms.server.config.JMSQueueConfiguration;
-import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
@@ -64,7 +56,7 @@ public class Jms2TestSupport extends CamelTestSupport {
     protected ProducerTemplate template;
     protected String brokerUri;
     protected int port;
-    private EmbeddedJMS broker;
+    private EmbeddedActiveMQ broker;
     private Connection connection;
     private Session session;
     private DestinationCreationStrategy destinationCreationStrategy = new DefaultDestinationCreationStrategy();
@@ -78,7 +70,7 @@ public class Jms2TestSupport extends CamelTestSupport {
      */
     @Override
     protected void doPreSetup() throws Exception {
-        broker = new EmbeddedJMS();
+        broker = new EmbeddedActiveMQ();
         deleteDirectory("target/data");
         port = AvailablePortFinder.getNextAvailable();
         brokerUri = "tcp://localhost:" + port;
@@ -86,7 +78,7 @@ public class Jms2TestSupport extends CamelTestSupport {
         startBroker();
     }
 
-    protected void configureBroker(EmbeddedJMS broker) throws Exception {
+    protected void configureBroker(EmbeddedActiveMQ broker) throws Exception {
         Configuration configuration = new ConfigurationImpl()
                 .setPersistenceEnabled(false)
                 .setJournalDirectory("target/data/journal")
@@ -95,17 +87,7 @@ public class Jms2TestSupport extends CamelTestSupport {
                 .addAcceptorConfiguration("vm", "vm://broker")
                 .addConnectorConfiguration("connector", new TransportConfiguration(NettyConnectorFactory.class.getName()));
 
-        JMSConfiguration jmsConfig = new JMSConfigurationImpl();
-
-        ConnectionFactoryConfiguration cfConfig = new ConnectionFactoryConfigurationImpl().setName("cf").setConnectorNames(
-                Arrays.asList("connector")).setBindings("cf");
-        jmsConfig.getConnectionFactoryConfigurations().add(cfConfig);
-
-        JMSQueueConfiguration queueConfig
-                = new JMSQueueConfigurationImpl().setName("queue1").setDurable(false).setBindings("queue/queue1");
-        jmsConfig.getQueueConfigurations().add(queueConfig);
-
-        broker.setConfiguration(configuration).setJmsConfiguration(jmsConfig);
+        broker.setConfiguration(configuration);
     }
 
     private void startBroker() throws Exception {


### PR DESCRIPTION
Replaced embedded deprecated JMS broker with EmbeddedActiveMQ since the embedded one is deprecated since Artemis 2.0

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md