### PR TITLE
camel-jetty: fixed deprecation warnings in tests

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/CustomFiltersTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/CustomFiltersTest.java
@@ -113,7 +113,7 @@ public class CustomFiltersTest extends BaseJettyTest {
                                 String request = in.getBody(String.class);
                                 // The other form date can be get from the message
                                 // header
-                                exchange.getOut().setBody(request + " response");
+                                exchange.getMessage().setBody(request + " response");
                             }
                         });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsRouteTest.java
@@ -57,7 +57,7 @@ public class ExplicitHttpsRouteTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsSslContextParametersRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsSslContextParametersRouteTest.java
@@ -75,7 +75,7 @@ public class ExplicitHttpsSslContextParametersRouteTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitJettyAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitJettyAsyncRouteTest.java
@@ -65,7 +65,7 @@ public class ExplicitJettyAsyncRouteTest extends BaseJettyTest {
             assertEquals("bookid=123", body);
 
             // send a html response
-            exchange.getOut().setBody("<html><body>Book 123 is Camel in Action</body></html>");
+            exchange.getMessage().setBody("<html><body>Book 123 is Camel in Action</body></html>");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitJettyRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitJettyRouteTest.java
@@ -63,7 +63,7 @@ public class ExplicitJettyRouteTest extends BaseJettyTest {
             assertEquals("bookid=123", body);
 
             // send a html response
-            exchange.getOut().setBody("<html><body>Book 123 is Camel in Action</body></html>");
+            exchange.getMessage().setBody("<html><body>Book 123 is Camel in Action</body></html>");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HandlerTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HandlerTest.java
@@ -103,20 +103,20 @@ public class HandlerTest extends BaseJettyTest {
 
                 from("jetty:http://localhost:" + port1 + "/?handlers=#statisticsHandler1").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody(htmlResponse);
+                        exchange.getMessage().setBody(htmlResponse);
                     }
                 });
 
                 from("jetty:http://localhost:" + port2 + "/?handlers=#statisticsHandler2,#statisticsHandler3")
                         .process(new Processor() {
                             public void process(Exchange exchange) throws Exception {
-                                exchange.getOut().setBody(htmlResponse);
+                                exchange.getMessage().setBody(htmlResponse);
                             }
                         });
                 from("jetty:http://localhost:" + port2 + "/endpoint2?handlers=#statisticsHandler2,#statisticsHandler3")
                         .process(new Processor() {
                             public void process(Exchange exchange) throws Exception {
-                                exchange.getOut().setBody(htmlResponse);
+                                exchange.getMessage().setBody(htmlResponse);
                             }
                         });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpAuthMethodPriorityTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpAuthMethodPriorityTest.java
@@ -28,7 +28,7 @@ import org.apache.camel.FailedToCreateProducerException;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBasicAuthTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBasicAuthTest.java
@@ -27,7 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBindingMapHttpMessageFormUrlEncodedFalseBodyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBindingMapHttpMessageFormUrlEncodedFalseBodyTest.java
@@ -59,7 +59,7 @@ public class HttpBindingMapHttpMessageFormUrlEncodedFalseBodyTest extends BaseJe
                                         "Get a wrong form parameter from the message header");
 
                                 // send a response
-                                exchange.getOut().setBody("Request message is OK");
+                                exchange.getMessage().setBody("Request message is OK");
                             }
                         });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBindingPreservePostFormUrlEncodedBodyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBindingPreservePostFormUrlEncodedBodyTest.java
@@ -38,7 +38,7 @@ public class HttpBindingPreservePostFormUrlEncodedBodyTest extends BaseJettyTest
 
         });
         // convert the response to a String
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertEquals("Request message is OK", body);
     }
 
@@ -62,7 +62,7 @@ public class HttpBindingPreservePostFormUrlEncodedBodyTest extends BaseJettyTest
                                 "Get a wrong form parameter from the message header");
 
                         // send a response
-                        exchange.getOut().setBody("Request message is OK");
+                        exchange.getMessage().setBody("Request message is OK");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeAsyncRouteTest.java
@@ -35,7 +35,7 @@ public class HttpBridgeAsyncRouteTest extends HttpBridgeRouteTest {
                     public void process(Exchange exchange) throws Exception {
                         // get the request URL and copy it to the request body
                         String uri = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
-                        exchange.getOut().setBody(uri);
+                        exchange.getMessage().setBody(uri);
                     }
                 };
                 from("jetty:http://localhost:" + port2 + "/test/hello?async=true&useContinuation=false")

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeMultipartRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeMultipartRouteTest.java
@@ -86,8 +86,8 @@ public class HttpBridgeMultipartRouteTest extends BaseJettyTest {
                     public void process(Exchange exchange) throws Exception {
                         AttachmentMessage in = exchange.getIn(AttachmentMessage.class);
                         // put the number of attachments in a response header
-                        exchange.getOut().setHeader("numAttachments", in.getAttachments().size());
-                        exchange.getOut().setBody(in.getHeader("body"));
+                        exchange.getMessage().setHeader("numAttachments", in.getAttachments().size());
+                        exchange.getMessage().setBody(in.getHeader("body"));
                     }
                 };
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpBridgeRouteTest.java
@@ -64,7 +64,7 @@ public class HttpBridgeRouteTest extends BaseJettyTest {
                     public void process(Exchange exchange) throws Exception {
                         // get the request URL and copy it to the request body
                         String uri = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
-                        exchange.getOut().setBody(uri);
+                        exchange.getMessage().setBody(uri);
                     }
                 };
                 from("jetty:http://localhost:" + port2 + "/test/hello")

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpCharacterEncodingTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpCharacterEncodingTest.java
@@ -36,7 +36,7 @@ public class HttpCharacterEncodingTest extends BaseJettyTest {
 
         });
         // convert the response to a String
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertEquals("Response message is Thai Elephant \u0E08", body);
     }
 
@@ -59,8 +59,8 @@ public class HttpCharacterEncodingTest extends BaseJettyTest {
             assertEquals("Hello World Thai Elephant \u0E08", body);
 
             // send a html response
-            exchange.getOut().setHeader("Content-Type", "text/html; charset=utf-8");
-            exchange.getOut().setBody("Response message is Thai Elephant \u0E08");
+            exchange.getMessage().setHeader("Content-Type", "text/html; charset=utf-8");
+            exchange.getMessage().setBody("Response message is Thai Elephant \u0E08");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpClientRouteEnableChunkedTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpClientRouteEnableChunkedTest.java
@@ -82,7 +82,7 @@ public class HttpClientRouteEnableChunkedTest extends BaseJettyTest {
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         ByteArrayInputStream bis = new ByteArrayInputStream("<b>Hello World</b>".getBytes());
-                        exchange.getOut().setBody(bis);
+                        exchange.getMessage().setBody(bis);
                     }
                 };
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpClientRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpClientRouteTest.java
@@ -103,7 +103,7 @@ public class HttpClientRouteTest extends BaseJettyTest {
                 exchange.getIn().setHeader(Exchange.HTTP_URI, "http://localhost:" + port2 + "/querystring?id=test");
             }
         });
-        assertEquals("test", exchange.getOut().getBody(String.class), "Get a wrong response.");
+        assertEquals("test", exchange.getMessage().getBody(String.class), "Get a wrong response.");
     }
 
     @Override
@@ -131,7 +131,7 @@ public class HttpClientRouteTest extends BaseJettyTest {
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         ByteArrayInputStream bis = new ByteArrayInputStream("<b>Hello World</b>".getBytes());
-                        exchange.getOut().setBody(bis);
+                        exchange.getMessage().setBody(bis);
                     }
                 };
                 from("jetty:http://localhost:" + port1 + "/hello").process(proc).setHeader(Exchange.HTTP_CHUNKED)
@@ -141,7 +141,7 @@ public class HttpClientRouteTest extends BaseJettyTest {
 
                 from("jetty:http://localhost:" + port2 + "/Query%20/test").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody(exchange.getIn().getHeader("myQuery", String.class));
+                        exchange.getMessage().setBody(exchange.getIn().getHeader("myQuery", String.class));
                     }
                 });
 
@@ -151,7 +151,7 @@ public class HttpClientRouteTest extends BaseJettyTest {
                         if (result == null) {
                             result = "No id header";
                         }
-                        exchange.getOut().setBody(result);
+                        exchange.getMessage().setBody(result);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpEndpointUriEncodingIssueTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpEndpointUriEncodingIssueTest.java
@@ -60,7 +60,7 @@ public class HttpEndpointUriEncodingIssueTest extends BaseJettyTest {
                 from("jetty:http://localhost:{{port}}/myapp/mytest").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String columns = exchange.getIn().getHeader("columns", String.class);
-                        exchange.getOut().setBody("We got " + columns + " columns");
+                        exchange.getMessage().setBody("We got " + columns + " columns");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpFilterCamelHeadersTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpFilterCamelHeadersTest.java
@@ -43,11 +43,11 @@ public class HttpFilterCamelHeadersTest extends BaseJettyTest {
         });
 
         assertNotNull(out);
-        assertEquals("Hi Claus", out.getOut().getBody(String.class));
+        assertEquals("Hi Claus", out.getMessage().getBody(String.class));
 
         // there should be no internal Camel headers
         // except for the response code
-        Map<String, Object> headers = out.getOut().getHeaders();
+        Map<String, Object> headers = out.getMessage().getHeaders();
         for (String key : headers.keySet()) {
             boolean valid
                     = key.equalsIgnoreCase(Exchange.HTTP_RESPONSE_CODE) || key.equalsIgnoreCase(Exchange.HTTP_RESPONSE_TEXT);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpFilterNoCamelHeadersTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpFilterNoCamelHeadersTest.java
@@ -49,7 +49,7 @@ public class HttpFilterNoCamelHeadersTest extends BaseJettyTest {
         });
 
         assertNotNull(out);
-        assertEquals("Bye World", out.getOut().getBody(String.class));
+        assertEquals("Bye World", out.getMessage().getBody(String.class));
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpGZipEncodingTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpGZipEncodingTest.java
@@ -98,13 +98,13 @@ public class HttpGZipEncodingTest extends BaseJettyTest {
                             String requestBody = exchange.getIn().getBody(String.class);
                             assertEquals("<Hello>World</Hello>", requestBody, "Get a wrong request string");
                         }
-                        exchange.getOut().setHeader(Exchange.CONTENT_ENCODING, "gzip");
+                        exchange.getMessage().setHeader(Exchange.CONTENT_ENCODING, "gzip");
                         // check the Accept Encoding header
                         String header = exchange.getIn().getHeader("Accept-Encoding", String.class);
                         if (header != null && header.indexOf("gzip") > -1) {
-                            exchange.getOut().setBody("<b>Hello World for gzip</b>");
+                            exchange.getMessage().setBody("<b>Hello World for gzip</b>");
                         } else {
-                            exchange.getOut().setBody("<b>Hello World</b>");
+                            exchange.getMessage().setBody("<b>Hello World</b>");
                         }
                     }
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpHeaderCaseTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpHeaderCaseTest.java
@@ -66,9 +66,9 @@ public class HttpHeaderCaseTest extends BaseJettyTest {
                         assertEquals("Carlsberg", map.get("beer"));
                         assertEquals(null, map.get("Beer"));
 
-                        exchange.getOut().setBody("Bye World");
-                        exchange.getOut().setHeader("MyCaseHeader", "aBc123");
-                        exchange.getOut().setHeader("otherCaseHeader", "456DEf");
+                        exchange.getMessage().setBody("Bye World");
+                        exchange.getMessage().setHeader("MyCaseHeader", "aBc123");
+                        exchange.getMessage().setHeader("otherCaseHeader", "456DEf");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpHeaderTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpHeaderTest.java
@@ -47,8 +47,8 @@ public class HttpHeaderTest extends BaseJettyTest {
             }
         });
 
-        assertNotNull(ex.getOut().getHeader("Server"));
-        assertNull(ex.getOut().getHeader("Date"));
+        assertNotNull(ex.getMessage().getHeader("Server"));
+        assertNull(ex.getMessage().getHeader("Date"));
 
         ex = template.request("http://localhost:{{port2}}/server/mytest", new Processor() {
             @Override
@@ -57,8 +57,8 @@ public class HttpHeaderTest extends BaseJettyTest {
             }
         });
 
-        assertNull(ex.getOut().getHeader("Server"));
-        assertNotNull(ex.getOut().getHeader("Date"));
+        assertNull(ex.getMessage().getHeader("Server"));
+        assertNotNull(ex.getMessage().getHeader("Date"));
     }
 
     @Override
@@ -80,11 +80,11 @@ public class HttpHeaderTest extends BaseJettyTest {
                         for (Entry<String, Object> entry : headers.entrySet()) {
                             if ("SOAPAction".equals(entry.getKey())
                                     && "http://xxx.com/interfaces/ticket".equals(entry.getValue())) {
-                                exchange.getOut().setBody("Find the key!");
+                                exchange.getMessage().setBody("Find the key!");
                                 return;
                             }
                         }
-                        exchange.getOut().setBody("Cannot find the key!");
+                        exchange.getMessage().setBody("Cannot find the key!");
                     }
                 });
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpMethodRestrictTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpMethodRestrictTest.java
@@ -69,7 +69,7 @@ public class HttpMethodRestrictTest extends BaseJettyTest {
                     public void process(Exchange exchange) throws Exception {
                         Message in = exchange.getIn();
                         String request = in.getBody(String.class);
-                        exchange.getOut().setBody(request + " response");
+                        exchange.getMessage().setBody(request + " response");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpOperationsFailedExceptionUriTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpOperationsFailedExceptionUriTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -48,7 +48,7 @@ public class HttpOperationsFailedExceptionUriTest extends BaseJettyTest {
             public void configure() throws Exception {
                 from("jetty://http://localhost:{{port}}/foo").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerConnectionCloseTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerConnectionCloseTest.java
@@ -39,7 +39,7 @@ public class HttpProducerConnectionCloseTest extends BaseJettyTest {
         });
         assertNotNull(exchange);
 
-        Map<?, ?> headers = exchange.getOut().getHeaders();
+        Map<?, ?> headers = exchange.getMessage().getHeaders();
 
         assertEquals("close", headers.get("Connection"));
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerOkStatusCodeRangeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerOkStatusCodeRangeTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.jetty;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerQueryParamTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerQueryParamTest.java
@@ -35,8 +35,8 @@ public class HttpProducerQueryParamTest extends BaseJettyTest {
         Exchange exchange = template.request(url + "?quote=Camel%20rocks", null);
         assertNotNull(exchange);
 
-        String body = exchange.getOut().getBody(String.class);
-        Map<?, ?> headers = exchange.getOut().getHeaders();
+        String body = exchange.getMessage().getBody(String.class);
+        Map<?, ?> headers = exchange.getMessage().getHeaders();
 
         assertEquals("Bye World", body);
         assertEquals("Carlsberg", headers.get("beer"));
@@ -51,8 +51,8 @@ public class HttpProducerQueryParamTest extends BaseJettyTest {
         });
         assertNotNull(exchange);
 
-        String body = exchange.getOut().getBody(String.class);
-        Map<?, ?> headers = exchange.getOut().getHeaders();
+        String body = exchange.getMessage().getBody(String.class);
+        Map<?, ?> headers = exchange.getMessage().getHeaders();
 
         assertEquals("Bye World", body);
         assertEquals("Carlsberg", headers.get("beer"));
@@ -68,8 +68,8 @@ public class HttpProducerQueryParamTest extends BaseJettyTest {
                         String quote = exchange.getIn().getHeader("quote", String.class);
                         assertEquals("Camel rocks", quote);
 
-                        exchange.getOut().setBody("Bye World");
-                        exchange.getOut().setHeader("beer", "Carlsberg");
+                        exchange.getMessage().setBody("Bye World");
+                        exchange.getMessage().setHeader("beer", "Carlsberg");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerTwoParametersWithSameKeyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProducerTwoParametersWithSameKeyTest.java
@@ -39,10 +39,10 @@ public class HttpProducerTwoParametersWithSameKeyTest extends BaseJettyTest {
 
         assertNotNull(out);
         assertFalse(out.isFailed(), "Should not fail");
-        assertEquals("OK", out.getOut().getBody(String.class));
-        assertEquals("yes", out.getOut().getHeader("bar"));
+        assertEquals("OK", out.getMessage().getBody(String.class));
+        assertEquals("yes", out.getMessage().getHeader("bar"));
 
-        List<?> foo = out.getOut().getHeader("foo", List.class);
+        List<?> foo = out.getMessage().getHeader("foo", List.class);
         assertNotNull(foo);
         assertEquals(2, foo.size());
         assertEquals("123", foo.get(0));
@@ -64,10 +64,10 @@ public class HttpProducerTwoParametersWithSameKeyTest extends BaseJettyTest {
 
         assertNotNull(out);
         assertFalse(out.isFailed(), "Should not fail");
-        assertEquals("OK", out.getOut().getBody(String.class));
-        assertEquals("yes", out.getOut().getHeader("bar"));
+        assertEquals("OK", out.getMessage().getBody(String.class));
+        assertEquals("yes", out.getMessage().getHeader("bar"));
 
-        List<?> foo = out.getOut().getHeader("foo", List.class);
+        List<?> foo = out.getMessage().getHeader("foo", List.class);
         assertNotNull(foo);
         assertEquals(2, foo.size());
         assertEquals("123", foo.get(0));
@@ -91,13 +91,13 @@ public class HttpProducerTwoParametersWithSameKeyTest extends BaseJettyTest {
                         assertEquals("bar", to.get(1));
 
                         // response
-                        exchange.getOut().setBody("OK");
+                        exchange.getMessage().setBody("OK");
                         // use multiple values for the foo header in the reply
                         List<Integer> list = new ArrayList<>();
                         list.add(123);
                         list.add(456);
-                        exchange.getOut().setHeader("foo", list);
-                        exchange.getOut().setHeader("bar", "yes");
+                        exchange.getMessage().setHeader("foo", list);
+                        exchange.getMessage().setHeader("bar", "yes");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProxyRouteContentTypeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProxyRouteContentTypeTest.java
@@ -46,7 +46,7 @@ public class HttpProxyRouteContentTypeTest extends BaseJettyTest {
 
                     public void process(Exchange exchange) throws Exception {
 
-                        exchange.getOut().setBody(ExchangeHelper.getContentType(exchange));
+                        exchange.getMessage().setBody(ExchangeHelper.getContentType(exchange));
                     }
 
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProxyRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpProxyRouteTest.java
@@ -96,7 +96,7 @@ public class HttpProxyRouteTest extends BaseJettyTest {
                         // just take out the message body and send it back
                         Message in = exchange.getIn();
                         String request = in.getBody(String.class);
-                        exchange.getOut().setBody(request);
+                        exchange.getMessage().setBody(request);
                     }
 
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRedirectNoLocationTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRedirectNoLocationTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -50,7 +50,7 @@ public class HttpRedirectNoLocationTest extends BaseJettyTest {
             public void configure() throws Exception {
                 from("jetty://http://localhost:{{port}}/test").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 302);
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 302);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRedirectTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRedirectTest.java
@@ -21,7 +21,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -69,13 +69,13 @@ public class HttpRedirectTest extends BaseJettyTest {
             public void configure() throws Exception {
                 from("jetty://http://localhost:{{port}}/test").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 301);
-                        exchange.getOut().setHeader("location", "http://localhost:" + getPort() + "/newtest");
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 301);
+                        exchange.getMessage().setHeader("location", "http://localhost:" + getPort() + "/newtest");
                     }
                 });
                 from("jetty://http://localhost:{{port}}/remove").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 302);
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 302);
                     }
                 });
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRequestResponseTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRequestResponseTest.java
@@ -80,7 +80,7 @@ public class HttpRequestResponseTest extends BaseJettyTest {
             assertEquals("bookid=123", body);
 
             // send a html response
-            exchange.getOut().setBody("<html><body>Book 123 is Camel in Action</body></html>");
+            exchange.getMessage().setBody("<html><body>Book 123 is Camel in Action</body></html>");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpReturnDataNotInputStreamConvertableTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpReturnDataNotInputStreamConvertableTest.java
@@ -38,6 +38,7 @@ public class HttpReturnDataNotInputStreamConvertableTest extends BaseJettyTest {
             public void configure() throws Exception {
                 from("jetty://http://localhost:{{port}}/test").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
+                        // See: CAMEL-15475
                         exchange.getOut().setBody(new MyResponseBean());
                     }
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpRouteTest.java
@@ -219,9 +219,9 @@ public class HttpRouteTest extends BaseJettyTest {
                             HttpSession session = message.getRequest().getSession();
                             assertNotNull(session, "we should get session here");
                         } catch (Exception e) {
-                            exchange.getOut().setBody(e);
+                            exchange.getMessage().setBody(e);
                         }
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
 
@@ -229,7 +229,7 @@ public class HttpRouteTest extends BaseJettyTest {
 
                 Processor printProcessor = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        Message out = exchange.getOut();
+                        Message out = exchange.getMessage();
                         out.copyFrom(exchange.getIn());
                         log.info("The body's object is " + exchange.getIn().getBody());
                         log.info("Process body = " + exchange.getIn().getBody(String.class));
@@ -250,9 +250,9 @@ public class HttpRouteTest extends BaseJettyTest {
                         String value = exchange.getIn().getHeader("request", String.class);
                         if (value != null) {
                             assertNotNull(value, "The value of the parameter should not be null");
-                            exchange.getOut().setBody(value);
+                            exchange.getMessage().setBody(value);
                         } else {
-                            exchange.getOut().setBody("Can't get a right parameter");
+                            exchange.getMessage().setBody("Can't get a right parameter");
                         }
                     }
                 };
@@ -263,7 +263,7 @@ public class HttpRouteTest extends BaseJettyTest {
                     public void process(Exchange exchange) throws Exception {
                         String value = exchange.getIn().getBody(String.class);
                         assertEquals(POST_MESSAGE, value, "The response message is wrong");
-                        exchange.getOut().setBody("OK");
+                        exchange.getMessage().setBody("OK");
                     }
                 });
 
@@ -274,14 +274,14 @@ public class HttpRouteTest extends BaseJettyTest {
                                 assertTrue(is instanceof org.eclipse.jetty.server.HttpInput, "It should be a raw inputstream");
                                 String request = exchange.getIn().getBody(String.class);
                                 assertEquals("This is a test", request, "Got a wrong request");
-                                exchange.getOut().setBody("OK");
+                                exchange.getMessage().setBody("OK");
                             }
                         });
 
                 from("jetty:http://localhost:" + port4 + "/requestBufferSize").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String string = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody(string);
+                        exchange.getMessage().setBody(string);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpSendFileTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpSendFileTest.java
@@ -46,8 +46,8 @@ public class HttpSendFileTest extends BaseJettyTest {
 
         assertMockEndpointsSatisfied();
 
-        assertEquals("OK", out.getOut().getBody(String.class));
-        assertEquals("text/plain", out.getOut().getHeader("Content-Type"));
+        assertEquals("OK", out.getMessage().getBody(String.class));
+        assertEquals("text/plain", out.getMessage().getHeader("Content-Type"));
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpStreamCacheFileTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpStreamCacheFileTest.java
@@ -22,7 +22,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.util.ObjectHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,10 +91,10 @@ public class HttpStreamCacheFileTest extends BaseJettyTest {
                     public void process(Exchange exchange) throws Exception {
                         String body = exchange.getIn().getBody(String.class);
                         if (ObjectHelper.isEmpty(body)) {
-                            exchange.getOut().setBody(responseBody);
-                            exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                            exchange.getMessage().setBody(responseBody);
+                            exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
                         } else {
-                            exchange.getOut().setBody("Bye World");
+                            exchange.getMessage().setBody("Bye World");
                         }
                     }
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpTwoEndpointTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpTwoEndpointTest.java
@@ -34,11 +34,11 @@ public class HttpTwoEndpointTest extends BaseJettyTest {
         Exchange b = template.request("direct:b", null);
         assertNotNull(b);
 
-        assertEquals("Bye cheese", a.getOut().getBody(String.class));
-        assertEquals(246, a.getOut().getHeader("foo", Integer.class).intValue());
+        assertEquals("Bye cheese", a.getMessage().getBody(String.class));
+        assertEquals(246, a.getMessage().getHeader("foo", Integer.class).intValue());
 
-        assertEquals("Bye cake", b.getOut().getBody(String.class));
-        assertEquals(912, b.getOut().getHeader("foo", Integer.class).intValue());
+        assertEquals("Bye cake", b.getMessage().getBody(String.class));
+        assertEquals(912, b.getMessage().getHeader("foo", Integer.class).intValue());
 
         assertEquals(5, context.getEndpoints().size());
     }
@@ -57,8 +57,8 @@ public class HttpTwoEndpointTest extends BaseJettyTest {
                         int foo = exchange.getIn().getHeader("foo", Integer.class);
                         String bar = exchange.getIn().getHeader("bar", String.class);
 
-                        exchange.getOut().setHeader("foo", foo * 2);
-                        exchange.getOut().setBody("Bye " + bar);
+                        exchange.getMessage().setHeader("foo", foo * 2);
+                        exchange.getMessage().setBody("Bye " + bar);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpTwoServerPortsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpTwoServerPortsTest.java
@@ -58,14 +58,14 @@ public class HttpTwoServerPortsTest extends BaseJettyTest {
                 from("jetty://http://localhost:" + port1 + "/myapp").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String in = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody("Bye " + in);
+                        exchange.getMessage().setBody("Bye " + in);
                     }
                 });
 
                 from("jetty://http://localhost:" + port2 + "/myotherapp").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String in = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody("Hi " + in);
+                        exchange.getMessage().setBody("Hi " + in);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
@@ -200,7 +200,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello?async=true&useContinuation=false").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAddSslConnectorPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAddSslConnectorPropertiesTest.java
@@ -42,7 +42,7 @@ public class HttpsRouteAddSslConnectorPropertiesTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAliasTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAliasTest.java
@@ -55,7 +55,7 @@ public class HttpsRouteAliasTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSetupWithSystemPropsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSetupWithSystemPropsTest.java
@@ -53,7 +53,7 @@ public class HttpsRouteSetupWithSystemPropsTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSslContextParametersInComponentTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSslContextParametersInComponentTest.java
@@ -51,7 +51,7 @@ public class HttpsRouteSslContextParametersInComponentTest extends HttpsRouteTes
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSslContextParametersInUriTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSslContextParametersInUriTest.java
@@ -56,7 +56,7 @@ public class HttpsRouteSslContextParametersInUriTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello?sslContextParameters=#sslContextParameters").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
@@ -234,7 +234,7 @@ public class HttpsRouteTest extends BaseJettyTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteWithSslConnectorPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteWithSslConnectorPropertiesTest.java
@@ -42,7 +42,7 @@ public class HttpsRouteWithSslConnectorPropertiesTest extends HttpsRouteTest {
 
                 Processor proc = new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<b>Hello World</b>");
+                        exchange.getMessage().setBody("<b>Hello World</b>");
                     }
                 };
                 from("jetty:https://localhost:" + port1 + "/hello").process(proc);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyCallHttpThenExceptionTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyCallHttpThenExceptionTest.java
@@ -41,9 +41,9 @@ public class JettyCallHttpThenExceptionTest extends BaseJettyTest {
         assertMockEndpointsSatisfied();
 
         assertNotNull(reply);
-        assertTrue(reply.getOut().getBody(String.class).startsWith("java.lang.IllegalArgumentException: I cannot do this"));
-        assertEquals(500, reply.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("Server Error", reply.getOut().getHeader(Exchange.HTTP_RESPONSE_TEXT));
+        assertTrue(reply.getMessage().getBody(String.class).startsWith("java.lang.IllegalArgumentException: I cannot do this"));
+        assertEquals(500, reply.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals("Server Error", reply.getMessage().getHeader(Exchange.HTTP_RESPONSE_TEXT));
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyContentTypeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyContentTypeTest.java
@@ -47,9 +47,9 @@ public class JettyContentTypeTest extends BaseJettyTest {
         }
         template.send(endpoint, exchange);
 
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertEquals("<order>OK</order>", body);
-        assertEquals("text/xml", MessageHelper.getContentType(exchange.getOut()), "Get a wrong content-type ");
+        assertEquals("text/xml", MessageHelper.getContentType(exchange.getMessage()), "Get a wrong content-type ");
     }
 
     @Test
@@ -72,9 +72,9 @@ public class JettyContentTypeTest extends BaseJettyTest {
         exchange.getIn().setHeader("Content-Type", "text/xml");
         template.send(endpoint, exchange);
 
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertEquals("FAIL", body);
-        assertEquals("text/plain", MessageHelper.getContentType(exchange.getOut()), "Get a wrong content-type ");
+        assertEquals("text/plain", MessageHelper.getContentType(exchange.getMessage()), "Get a wrong content-type ");
     }
 
     @Override
@@ -94,18 +94,18 @@ public class JettyContentTypeTest extends BaseJettyTest {
             String body = exchange.getIn().getBody(String.class);
             String encoding = exchange.getIn().getHeader(Exchange.CONTENT_ENCODING, String.class);
             if (encoding != null) {
-                exchange.getOut().setHeader(Exchange.CONTENT_ENCODING, encoding);
+                exchange.getMessage().setHeader(Exchange.CONTENT_ENCODING, encoding);
             }
             if ("Claus".equals(user) && contentType.startsWith("text/xml") && body.equals("<order>123</order>")) {
                 assertEquals("test", exchange.getIn().getHeader("SOAPAction", String.class));
                 if (contentType.endsWith("UTF-8")) {
                     assertEquals("UTF-8", exchange.getProperty(Exchange.CHARSET_NAME), "Get a wrong charset name.");
                 }
-                exchange.getOut().setBody("<order>OK</order>");
-                exchange.getOut().setHeader("Content-Type", "text/xml");
+                exchange.getMessage().setBody("<order>OK</order>");
+                exchange.getMessage().setHeader("Content-Type", "text/xml");
             } else {
-                exchange.getOut().setBody("FAIL");
-                exchange.getOut().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                exchange.getMessage().setBody("FAIL");
+                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
             }
         }
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyContinuationDisabledTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyContinuationDisabledTest.java
@@ -47,7 +47,7 @@ public class JettyContinuationDisabledTest extends BaseJettyTest {
                 from("jetty:http://localhost:{{port}}/myservice").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         Thread.sleep(1000);
-                        exchange.getOut().setBody("Bye World");
+                        exchange.getMessage().setBody("Bye World");
                     }
                 }).to("mock:result");
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyEndpointContinuationDisabledTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyEndpointContinuationDisabledTest.java
@@ -43,7 +43,7 @@ public class JettyEndpointContinuationDisabledTest extends BaseJettyTest {
                 from("jetty:http://localhost:{{port}}/myservice?useContinuation=false").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         Thread.sleep(1000);
-                        exchange.getOut().setBody("Bye World");
+                        exchange.getMessage().setBody("Bye World");
                     }
                 }).to("mock:result");
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHandle404Test.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHandle404Test.java
@@ -21,7 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,16 +94,16 @@ public class JettyHandle404Test extends BaseJettyTest {
                                 // the route breaks
                                 HttpOperationFailedException cause
                                         = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, HttpOperationFailedException.class);
-                                exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, cause.getStatusCode());
-                                exchange.getOut().setBody(cause.getResponseBody());
+                                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, cause.getStatusCode());
+                                exchange.getMessage().setBody(cause.getResponseBody());
                             }
                         }).end();
 
                 // this is our jetty server where we simulate the 404
                 from("jetty://http://localhost:{{port}}/myserver").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("Page not found");
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                        exchange.getMessage().setBody("Page not found");
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHttpBridgeEncodedPathTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHttpBridgeEncodedPathTest.java
@@ -54,7 +54,7 @@ public class JettyHttpBridgeEncodedPathTest extends BaseJettyTest {
                         assertTrue(s.equals(" 447777111222") || s.equals("+447777111222") || s.equals("%2B447777111222"));
 
                         // send back the query
-                        exchange.getOut().setBody(exchange.getIn().getHeader(Exchange.HTTP_QUERY));
+                        exchange.getMessage().setBody(exchange.getIn().getHeader(Exchange.HTTP_QUERY));
                     }
                 };
                 from("jetty://http://localhost:" + port2 + "/jettyTestRouteA?matchOnUriPrefix=true")

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHttpGetWithParamTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyHttpGetWithParamTest.java
@@ -90,9 +90,9 @@ public class JettyHttpGetWithParamTest extends BaseJettyTest {
             assertEquals("uno", message.getRequest().getParameter("one"));
             assertEquals("dos", message.getRequest().getParameter("two"));
 
-            exchange.getOut().setBody("Bye World");
-            exchange.getOut().setHeader("one", "eins");
-            exchange.getOut().setHeader("two", "zwei");
+            exchange.getMessage().setBody("Bye World");
+            exchange.getMessage().setHeader("one", "eins");
+            exchange.getMessage().setHeader("two", "zwei");
         }
     }
 }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyImageFileTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyImageFileTest.java
@@ -41,8 +41,8 @@ public class JettyImageFileTest extends BaseJettyTest {
         }
         template.send(endpoint, exchange);
 
-        assertNotNull(exchange.getOut().getBody());
-        assertEquals("image/jpeg", MessageHelper.getContentType(exchange.getOut()), "Get a wrong content-type");
+        assertNotNull(exchange.getMessage().getBody());
+        assertEquals("image/jpeg", MessageHelper.getContentType(exchange.getMessage()), "Get a wrong content-type");
     }
 
     @Test
@@ -67,8 +67,8 @@ public class JettyImageFileTest extends BaseJettyTest {
     public class MyImageService implements Processor {
         @Override
         public void process(Exchange exchange) throws Exception {
-            exchange.getOut().setBody(new File("src/test/data/logo.jpeg"));
-            exchange.getOut().setHeader("Content-Type", "image/jpeg");
+            exchange.getMessage().setBody(new File("src/test/data/logo.jpeg"));
+            exchange.getMessage().setHeader("Content-Type", "image/jpeg");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyOnExceptionHandledTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyOnExceptionHandledTest.java
@@ -30,8 +30,8 @@ public class JettyOnExceptionHandledTest extends BaseJettyTest {
         Exchange reply = template.request("http://localhost:{{port}}/myserver?throwExceptionOnFailure=false", null);
 
         assertNotNull(reply);
-        assertEquals("Dude something went wrong", reply.getOut().getBody(String.class));
-        assertEquals(500, reply.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals("Dude something went wrong", reply.getMessage().getBody(String.class));
+        assertEquals(500, reply.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyResponseBodyWhenErrorTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyResponseBodyWhenErrorTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteTest.java
@@ -76,7 +76,7 @@ public class JettyRouteTest extends BaseJettyTest {
             assertEquals("bookid=123", body);
 
             // send a html response
-            exchange.getOut().setBody("<html><body>Book 123 is Camel in Action</body></html>");
+            exchange.getMessage().setBody("<html><body>Book 123 is Camel in Action</body></html>");
         }
     }
     // END SNIPPET: e2

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithSocketPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithSocketPropertiesTest.java
@@ -77,7 +77,7 @@ public class JettyRouteWithSocketPropertiesTest extends BaseJettyTest {
             assertEquals("bookid=123", body);
 
             // send a html response
-            exchange.getOut().setBody("<html><body>Book 123 is Camel in Action</body></html>");
+            exchange.getMessage().setBody("<html><body>Book 123 is Camel in Action</body></html>");
         }
     }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySimplifiedHandle404Test.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySimplifiedHandle404Test.java
@@ -70,8 +70,8 @@ public class JettySimplifiedHandle404Test extends BaseJettyTest {
                 // this is our jetty server where we simulate the 404
                 from("jetty://http://localhost:{{port}}/myserver").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("Page not found");
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                        exchange.getMessage().setBody("Page not found");
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
                     }
                 });
                 // END SNIPPET: e1

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyStreamCacheIssueTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyStreamCacheIssueTest.java
@@ -23,9 +23,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class JettyStreamCacheIssueTest extends BaseJettyTest {
+    private String input;
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -42,7 +42,7 @@ public class JettyStreamCacheIssueTest extends BaseJettyTest {
         for (int i = 0; i < 10000; i++) {
             sb.append("0123456789");
         }
-        String input = sb.toString();
+        input = sb.toString();
 
         String out = template.requestBody("direct:input", input, String.class);
         assertEquals(input, out);
@@ -58,7 +58,8 @@ public class JettyStreamCacheIssueTest extends BaseJettyTest {
                 from("jetty:http://localhost:" + getPort() + "/input").process(new Processor() {
                     @Override
                     public void process(final Exchange exchange) throws Exception {
-                        assertFalse(exchange.hasOut());
+                        // Get message returns the in message if an out one is not present, which is the expectation here
+                        assertEquals(input, exchange.getMessage().getBody(String.class));
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendResumeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendResumeTest.java
@@ -17,8 +17,8 @@
 package org.apache.camel.component.jetty;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.http.common.HttpConsumer;
-import org.apache.camel.http.common.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendTest.java
@@ -17,8 +17,8 @@
 package org.apache.camel.component.jetty;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.http.common.HttpConsumer;
-import org.apache.camel.http.common.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendWhileInProgressTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettySuspendWhileInProgressTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormOkHttpTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormOkHttpTest.java
@@ -74,7 +74,7 @@ public class MultiPartFormOkHttpTest extends BaseJettyTest {
                         assertNotNull(data, "Should have data");
                         assertEquals("some data here", data);
 
-                        exchange.getOut().setBody("Thanks");
+                        exchange.getMessage().setBody("Thanks");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormTest.java
@@ -108,7 +108,7 @@ public class MultiPartFormTest extends BaseJettyTest {
                         assertEquals(DataHandler.class, header.getClass());
                         assertEquals(data, header);
 
-                        exchange.getOut().setBody(in.getHeader("comment"));
+                        exchange.getMessage().setBody(in.getHeader("comment"));
                     }
 
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormWithCustomFilterTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormWithCustomFilterTest.java
@@ -133,7 +133,7 @@ public class MultiPartFormWithCustomFilterTest extends BaseJettyTest {
 
                         // The other form date can be get from the message
                         // header
-                        exchange.getOut().setBody(in.getHeader("comment"));
+                        exchange.getMessage().setBody(in.getHeader("comment"));
                     }
                 });
                 // END SNIPPET: e1
@@ -150,7 +150,7 @@ public class MultiPartFormWithCustomFilterTest extends BaseJettyTest {
                                 assertNotNull(data, "Should get the DataHandle log4j2.properties");
                                 // The other form date can be get from the message
                                 // header
-                                exchange.getOut().setBody(in.getHeader("comment"));
+                                exchange.getMessage().setBody(in.getHeader("comment"));
                             }
                         });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiThreadedHttpGetTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiThreadedHttpGetTest.java
@@ -112,7 +112,7 @@ public class MultiThreadedHttpGetTest extends BaseJettyTest {
 
                 from("jetty:http://localhost:{{port}}/search").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("<html>Bye World</html>");
+                        exchange.getMessage().setBody("<html>Bye World</html>");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/TwoCamelContextWithJettyRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/TwoCamelContextWithJettyRouteTest.java
@@ -43,7 +43,7 @@ public class TwoCamelContextWithJettyRouteTest extends BaseJettyTest {
                 from("jetty://http://localhost:" + port2 + "/myotherapp").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String in = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody("Hi " + in);
+                        exchange.getMessage().setBody("Hi " + in);
                     }
                 });
             }
@@ -86,7 +86,7 @@ public class TwoCamelContextWithJettyRouteTest extends BaseJettyTest {
                 from("jetty://http://localhost:" + port1 + "/myapp").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String in = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody("Bye " + in);
+                        exchange.getMessage().setBody("Bye " + in);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/JettyAsyncContinuationTimeoutTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/JettyAsyncContinuationTimeoutTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.jetty.async;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/JettyAsyncDefaultContinuationTimeoutTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/JettyAsyncDefaultContinuationTimeoutTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/MyAsyncProducer.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/async/MyAsyncProducer.java
@@ -56,7 +56,7 @@ public class MyAsyncProducer extends DefaultAsyncProducer {
                     exchange.setException(new CamelExchangeException("Simulated error at attempt " + count, exchange));
                 } else {
                     String reply = getEndpoint().getReply();
-                    exchange.getOut().setBody(reply);
+                    exchange.getMessage().setBody(reply);
                     LOG.info("Setting reply " + reply);
                 }
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/javabody/HttpJavaBodyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/javabody/HttpJavaBodyTest.java
@@ -22,9 +22,9 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.http.HttpComponent;
 import org.apache.camel.component.jetty.BaseJettyTest;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.http.common.HttpCommonComponent;
 import org.apache.camel.http.common.HttpConstants;
-import org.apache.camel.http.common.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -59,8 +59,8 @@ public class HttpJavaBodyTest extends BaseJettyTest {
                         assertEquals("Camel", cool.getName());
 
                         // we send back plain test
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, "text/plain");
-                        exchange.getOut().setBody("OK");
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                        exchange.getMessage().setBody("OK");
                     }
                 });
             }
@@ -96,8 +96,9 @@ public class HttpJavaBodyTest extends BaseJettyTest {
                         assertEquals("Camel", cool.getName());
 
                         MyCoolBean reply = new MyCoolBean(456, "Camel rocks");
-                        exchange.getOut().setBody(reply);
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
+                        exchange.getMessage().setBody(reply);
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE,
+                                HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
                     }
                 });
             }
@@ -132,8 +133,9 @@ public class HttpJavaBodyTest extends BaseJettyTest {
                         assertEquals("Hello World", body);
 
                         MyCoolBean reply = new MyCoolBean(456, "Camel rocks");
-                        exchange.getOut().setBody(reply);
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
+                        exchange.getMessage().setBody(reply);
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE,
+                                HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
                     }
                 });
             }
@@ -166,8 +168,9 @@ public class HttpJavaBodyTest extends BaseJettyTest {
                         assertEquals("Hello World", body);
 
                         MyCoolBean reply = new MyCoolBean(456, "Camel rocks");
-                        exchange.getOut().setBody(reply);
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
+                        exchange.getMessage().setBody(reply);
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE,
+                                HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
                     }
                 });
             }
@@ -200,8 +203,9 @@ public class HttpJavaBodyTest extends BaseJettyTest {
                         assertEquals("Hello World", body);
 
                         MyCoolBean reply = new MyCoolBean(456, "Camel rocks");
-                        exchange.getOut().setBody(reply);
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
+                        exchange.getMessage().setBody(reply);
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE,
+                                HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT);
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/proxy/HttpClientProxyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/proxy/HttpClientProxyTest.java
@@ -22,7 +22,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.builder.ProxyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/proxy/JettyChuckedFalseTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/proxy/JettyChuckedFalseTest.java
@@ -39,7 +39,7 @@ public class JettyChuckedFalseTest extends BaseJettyTest {
             }
 
         });
-        Message out = exchange.getOut();
+        Message out = exchange.getMessage();
         // make sure we have the content-length header
         String len = out.getHeader(Exchange.CONTENT_LENGTH, String.class);
         assertEquals("20", len, "We should have the content-length header here.");
@@ -60,10 +60,10 @@ public class JettyChuckedFalseTest extends BaseJettyTest {
 
                     @Override
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, "image/jpeg");
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "image/jpeg");
                         CachedOutputStream stream = new CachedOutputStream(exchange);
                         stream.write("This is hello world.".getBytes());
-                        exchange.getOut().setBody(stream.getInputStream());
+                        exchange.getMessage().setBody(stream.getInputStream());
                         IOHelper.close(stream);
                     }
                 });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestHttpsClientAuthRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestHttpsClientAuthRouteTest.java
@@ -104,7 +104,7 @@ public class RestHttpsClientAuthRouteTest extends CamelTestSupport {
                 from("direct:get1").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody("Hello " + id);
+                        exchange.getMessage().setBody("Hello " + id);
                     }
                 });
 
@@ -112,8 +112,8 @@ public class RestHttpsClientAuthRouteTest extends CamelTestSupport {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
                         String ct = exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class);
-                        exchange.getOut().setBody("Hello " + id + ": " + exchange.getIn().getBody(String.class));
-                        exchange.getOut().setHeader(Exchange.CONTENT_TYPE, ct);
+                        exchange.getMessage().setBody("Hello " + id + ": " + exchange.getIn().getBody(String.class));
+                        exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, ct);
                     }
                 });
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyAcceptTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyBasicAuthTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyBasicAuthTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.jetty.rest;
 
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyContentTypeTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyCustomContentTypeTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyCustomContentTypeTest.java
@@ -35,8 +35,8 @@ public class RestJettyCustomContentTypeTest extends BaseJettyTest {
             }
         });
 
-        assertEquals("application/foobar", out.getOut().getHeader(Exchange.CONTENT_TYPE));
-        assertEquals("Some foobar stuff goes here", out.getOut().getBody(String.class));
+        assertEquals("application/foobar", out.getMessage().getHeader(Exchange.CONTENT_TYPE));
+        assertEquals("Some foobar stuff goes here", out.getMessage().getBody(String.class));
     }
 
     @Test
@@ -47,8 +47,8 @@ public class RestJettyCustomContentTypeTest extends BaseJettyTest {
             }
         });
 
-        assertEquals("application/json", out.getOut().getHeader(Exchange.CONTENT_TYPE));
-        assertEquals("{\"iso\":\"EN\",\"country\":\"England\"}", out.getOut().getBody(String.class));
+        assertEquals("application/json", out.getMessage().getHeader(Exchange.CONTENT_TYPE));
+        assertEquals("{\"iso\":\"EN\",\"country\":\"England\"}", out.getMessage().getBody(String.class));
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyDefaultValueTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyDefaultValueTest.java
@@ -62,10 +62,10 @@ public class RestJettyDefaultValueTest extends BaseJettyTest {
                                 ObjectHelper.notNull(verbose, "verbose");
 
                                 if ("true".equals(verbose)) {
-                                    exchange.getOut().setBody(id + ";Donald Duck;1113 Quack Street Duckburg");
+                                    exchange.getMessage().setBody(id + ";Donald Duck;1113 Quack Street Duckburg");
                                 }
                                 if ("false".equals(verbose)) {
-                                    exchange.getOut().setBody(id + ";Donald Duck");
+                                    exchange.getMessage().setBody(id + ";Donald Duck");
                                 }
                             }
                         });

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetCorsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetCorsTest.java
@@ -39,12 +39,13 @@ public class RestJettyGetCorsTest extends BaseJettyTest {
             }
         });
 
-        assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_ORIGIN, out.getOut().getHeader("Access-Control-Allow-Origin"));
+        assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_ORIGIN,
+                out.getMessage().getHeader("Access-Control-Allow-Origin"));
         assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_METHODS,
-                out.getOut().getHeader("Access-Control-Allow-Methods"));
+                out.getMessage().getHeader("Access-Control-Allow-Methods"));
         assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_HEADERS,
-                out.getOut().getHeader("Access-Control-Allow-Headers"));
-        assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_MAX_AGE, out.getOut().getHeader("Access-Control-Max-Age"));
+                out.getMessage().getHeader("Access-Control-Allow-Headers"));
+        assertEquals(RestConfiguration.CORS_ACCESS_CONTROL_MAX_AGE, out.getMessage().getHeader("Access-Control-Max-Age"));
 
         assertMockEndpointsSatisfied();
 
@@ -71,7 +72,7 @@ public class RestJettyGetCorsTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetCustomHttpBindingTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetCustomHttpBindingTest.java
@@ -50,7 +50,7 @@ public class RestJettyGetCustomHttpBindingTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetTest.java
@@ -44,7 +44,7 @@ public class RestJettyGetTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetToDTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetToDTest.java
@@ -52,7 +52,7 @@ public class RestJettyGetToDTest extends BaseJettyTest {
                 from("seda:123").to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetWildcardsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyGetWildcardsTest.java
@@ -56,12 +56,12 @@ public class RestJettyGetWildcardsTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 }).endRest().get("{id}/{query}").route().to("mock:query").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Goofy");
+                        exchange.getMessage().setBody(id + ";Goofy");
                     }
                 }).endRest();
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyMethodNotAllowedTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyMethodNotAllowedTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.jetty.rest;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -60,7 +60,7 @@ public class RestJettyMethodNotAllowedTest extends BaseJettyTest {
                 // use the rest DSL to define the rest services
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(exchange -> {
                     String id = exchange.getIn().getHeader("id", String.class);
-                    exchange.getOut().setBody(id + ";Donald Duck");
+                    exchange.getMessage().setBody(id + ";Donald Duck");
                 });
             }
         };

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyOptionsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyOptionsTest.java
@@ -35,15 +35,15 @@ public class RestJettyOptionsTest extends BaseJettyTest {
             }
         });
 
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("GET,OPTIONS", exchange.getOut().getHeader("ALLOW"));
-        assertEquals("", exchange.getOut().getBody(String.class));
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals("GET,OPTIONS", exchange.getMessage().getHeader("ALLOW"));
+        assertEquals("", exchange.getMessage().getBody(String.class));
 
         exchange = fluentTemplate.to("http://localhost:" + getPort() + "/users/v1/id/123")
                 .withHeader(Exchange.HTTP_METHOD, "OPTIONS").send();
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("PUT,OPTIONS", exchange.getOut().getHeader("ALLOW"));
-        assertEquals("", exchange.getOut().getBody(String.class));
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals("PUT,OPTIONS", exchange.getMessage().getHeader("ALLOW"));
+        assertEquals("", exchange.getMessage().getBody(String.class));
     }
 
     @Test
@@ -55,9 +55,9 @@ public class RestJettyOptionsTest extends BaseJettyTest {
             }
         });
 
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
-        assertEquals("GET,POST,OPTIONS", exchange.getOut().getHeader("ALLOW"));
-        assertEquals("", exchange.getOut().getBody(String.class));
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals("GET,POST,OPTIONS", exchange.getMessage().getHeader("ALLOW"));
+        assertEquals("", exchange.getMessage().getBody(String.class));
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRemoveAddRestAndRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRemoveAddRestAndRouteTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.jetty.rest;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
@@ -34,10 +35,10 @@ public class RestJettyRemoveAddRestAndRouteTest extends BaseJettyTest {
     @Test
     public void testCallRoute() throws Exception {
         InputStream stream = new URL("http://localhost:" + getPort() + "/issues/35").openStream();
-        assertEquals("Here's your issue 35", IOUtils.toString(stream));
+        assertEquals("Here's your issue 35", IOUtils.toString(stream, Charset.defaultCharset()));
 
         stream = new URL("http://localhost:" + getPort() + "/listings").openStream();
-        assertEquals("some listings", IOUtils.toString(stream));
+        assertEquals("some listings", IOUtils.toString(stream, Charset.defaultCharset()));
     }
 
     @Test
@@ -56,7 +57,7 @@ public class RestJettyRemoveAddRestAndRouteTest extends BaseJettyTest {
             @Override
             public void configure() throws Exception {
                 rest("/").get("/issues/{isin}/{sedol}").route().id("issues")
-                        .process(e -> e.getOut().setBody(
+                        .process(e -> e.getMessage().setBody(
                                 "Here's your issue " + e.getIn().getHeader("isin") + ":" + e.getIn().getHeader("sedol")))
                         .endRest();
             }
@@ -68,7 +69,7 @@ public class RestJettyRemoveAddRestAndRouteTest extends BaseJettyTest {
         // exception
 
         InputStream stream = new URL("http://localhost:" + getPort() + "/issues/35/65").openStream();
-        assertEquals("Here's your issue 35:65", IOUtils.toString(stream));
+        assertEquals("Here's your issue 35:65", IOUtils.toString(stream, Charset.defaultCharset()));
     }
 
     @Override
@@ -79,9 +80,9 @@ public class RestJettyRemoveAddRestAndRouteTest extends BaseJettyTest {
                 restConfiguration().host("localhost").port(getPort());
 
                 rest("/").get("/issues/{isin}").route().id("issues")
-                        .process(e -> e.getOut().setBody("Here's your issue " + e.getIn().getHeader("isin"))).endRest()
+                        .process(e -> e.getMessage().setBody("Here's your issue " + e.getIn().getHeader("isin"))).endRest()
                         .get("/listings")
-                        .route().id("listings").process(e -> e.getOut().setBody("some listings"));
+                        .route().id("listings").process(e -> e.getMessage().setBody("some listings"));
             }
         };
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredHttpHeaderTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredHttpHeaderTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredQueryParameterTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredQueryParameterTest.java
@@ -20,7 +20,7 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/HttpRestProducerGetTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/HttpRestProducerGetTest.java
@@ -47,7 +47,7 @@ public class HttpRestProducerGetTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerGetTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerGetTest.java
@@ -46,7 +46,7 @@ public class JettyRestProducerGetTest extends BaseJettyTest {
                 rest("/users/").get("{id}/basic").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerGetUriParameterTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerGetUriParameterTest.java
@@ -46,7 +46,7 @@ public class JettyRestProducerGetUriParameterTest extends BaseJettyTest {
                 rest("/users/").get("basic/?id={id}").route().to("mock:input").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerThrowExceptionOnErrorTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerThrowExceptionOnErrorTest.java
@@ -39,7 +39,7 @@ public class JettyRestProducerThrowExceptionOnErrorTest extends BaseJettyTest {
         Exchange out = fluentTemplate.withHeader("id", "666").to("direct:start").request(Exchange.class);
         assertNotNull(out);
         assertFalse(out.isFailed(), "Should not have thrown exception");
-        assertEquals(500, out.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE));
+        assertEquals(500, out.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
     }
 
     @Override
@@ -60,7 +60,7 @@ public class JettyRestProducerThrowExceptionOnErrorTest extends BaseJettyTest {
                         if ("666".equals(id)) {
                             throw new IllegalArgumentException("Bad id number");
                         }
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerVerbUpperCaseTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/producer/JettyRestProducerVerbUpperCaseTest.java
@@ -49,7 +49,7 @@ public class JettyRestProducerVerbUpperCaseTest extends BaseJettyTest {
                         assertEquals("GET", method);
 
                         String id = exchange.getIn().getHeader("id", String.class);
-                        exchange.getOut().setBody(id + ";Donald Duck");
+                        exchange.getMessage().setBody(id + ";Donald Duck");
                     }
                 });
             }


### PR DESCRIPTION
Includes:
- fixed deprecated usage of HttpOperationFailedException
- fixed usages of deprecated getOut()
- fixed usages of deprecated hasOut
- fixed usage of IOUtils.toString

A few warnings remain but they are either related to CAMEL-15475 or are in the component itself.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md