### PR TITLE
camel-cdi: fixed deprecation warnings

### DIFF
--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/ExpectedDeploymentException.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/ExpectedDeploymentException.java
@@ -28,8 +28,8 @@ import org.junit.runners.model.Statement;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
 
 public final class ExpectedDeploymentException implements TestRule {
 

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/LogVerifier.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/rule/LogVerifier.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.rules.Verifier;
 import org.junit.runner.Description;
@@ -70,7 +71,8 @@ public class LogVerifier extends Verifier {
                   null,
                   PatternLayout.newBuilder()
                           .withPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
-                          .build());
+                          .build(),
+                  true, Property.EMPTY_ARRAY);
         }
 
         @Override

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/AmbiguousCamelContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/AmbiguousCamelContextTest.java
@@ -29,9 +29,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class AmbiguousCamelContextTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/BeanInjectTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/BeanInjectTest.java
@@ -37,10 +37,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class BeanInjectTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/Camel9973Test.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/Camel9973Test.java
@@ -32,9 +32,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class Camel9973Test {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextAwareTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextAwareTest.java
@@ -29,9 +29,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CamelContextAwareTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextProducerFieldTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextProducerFieldTest.java
@@ -42,9 +42,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CamelContextProducerFieldTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextProducerMethodTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelContextProducerMethodTest.java
@@ -39,9 +39,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CamelContextProducerMethodTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelEventEndpointTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelEventEndpointTest.java
@@ -36,10 +36,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 
 @Ignore
 @RunWith(Arquillian.class)

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelEventNotifierTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelEventNotifierTest.java
@@ -51,8 +51,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CamelEventNotifierTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelRouteEventNotifierTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CamelRouteEventNotifierTest.java
@@ -43,13 +43,13 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CamelRouteEventNotifierTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ConsumerTemplateTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ConsumerTemplateTest.java
@@ -32,9 +32,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class ConsumerTemplateTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CustomCamelContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/CustomCamelContextTest.java
@@ -39,9 +39,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class CustomCamelContextTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventComponentTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventComponentTest.java
@@ -30,10 +30,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventEndpointCdi12Test.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventEndpointCdi12Test.java
@@ -47,8 +47,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class EventEndpointCdi12Test {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventEndpointTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/EventEndpointTest.java
@@ -48,8 +48,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class EventEndpointTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/InjectedTypeConverterTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/InjectedTypeConverterTest.java
@@ -44,9 +44,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class InjectedTypeConverterTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ManualCamelContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ManualCamelContextTest.java
@@ -40,9 +40,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class ManualCamelContextTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/MockEndpointTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/MockEndpointTest.java
@@ -36,9 +36,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class MockEndpointTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NamedCamelContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NamedCamelContextTest.java
@@ -33,10 +33,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class NamedCamelContextTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NoCamelContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NoCamelContextTest.java
@@ -31,9 +31,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class NoCamelContextTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NoTCCLSetTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/NoTCCLSetTest.java
@@ -34,9 +34,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class NoTCCLSetTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ProgrammaticLookupTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/ProgrammaticLookupTest.java
@@ -40,9 +40,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class ProgrammaticLookupTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertiesLocationTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertiesLocationTest.java
@@ -33,9 +33,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class PropertiesLocationTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertiesMultipleLocationTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertiesMultipleLocationTest.java
@@ -28,9 +28,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class PropertiesMultipleLocationTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertyInjectTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/PropertyInjectTest.java
@@ -42,9 +42,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class PropertyInjectTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UndefinedPropertyTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UndefinedPropertyTest.java
@@ -34,10 +34,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextBeanTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextBeanTest.java
@@ -38,9 +38,9 @@ import org.junit.rules.Verifier;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class UnstoppedCamelContextBeanTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextProducerFieldTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextProducerFieldTest.java
@@ -41,9 +41,9 @@ import org.junit.rules.Verifier;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class UnstoppedCamelContextProducerFieldTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextProducerMethodTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/UnstoppedCamelContextProducerMethodTest.java
@@ -41,9 +41,9 @@ import org.junit.rules.Verifier;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class UnstoppedCamelContextProducerMethodTest {

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlConsumerTemplateTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlConsumerTemplateTest.java
@@ -36,9 +36,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlEndpointTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlEndpointTest.java
@@ -43,10 +43,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlErrorHandlerPolicyTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlErrorHandlerPolicyTest.java
@@ -44,13 +44,13 @@ import org.junit.runner.RunWith;
 
 import static org.apache.camel.cdi.rule.LogEventMatcher.logEvent;
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlProducerTemplateTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlProducerTemplateTest.java
@@ -37,9 +37,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlPropertyPlaceholderTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlPropertyPlaceholderTest.java
@@ -30,9 +30,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlProxyFactoryTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlProxyFactoryTest.java
@@ -33,9 +33,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRestContextTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRestContextTest.java
@@ -41,10 +41,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource({

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRouteContextImportTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRouteContextImportTest.java
@@ -39,10 +39,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRouteTemplateContextImportTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlRouteTemplateContextImportTest.java
@@ -37,9 +37,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlServiceExporterTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlServiceExporterTest.java
@@ -33,9 +33,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlThreadPoolProfileTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlThreadPoolProfileTest.java
@@ -35,11 +35,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")

--- a/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlThreadPoolTest.java
+++ b/components/camel-cdi/src/test/java/org/apache/camel/cdi/test/XmlThreadPoolTest.java
@@ -35,10 +35,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 @ImportResource("imported-context.xml")


### PR DESCRIPTION
Includes:
- fixed usages of deprecated assertThat
- fixed usages of deprecated AbstractAppender constructor

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md