### PR TITLE
camel-box: fix a possible NPE when dereferencing BoxUser information

### DIFF
--- a/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxTasksManager.java
+++ b/components/camel-box/camel-box-api/src/main/java/org/apache/camel/component/box/api/BoxTasksManager.java
@@ -210,13 +210,13 @@ public class BoxTasksManager {
                                // == null)' clause is dead code.
     public BoxTask addAssignmentToTask(String taskId, BoxUser assignTo) {
         try {
-            LOG.debug("Assigning task(id=" + taskId + ") to user(id=" + assignTo.getID() + ")");
             if (taskId == null) {
                 throw new IllegalArgumentException("Parameter 'commentId' can not be null");
             }
             if (assignTo == null) {
                 throw new IllegalArgumentException("Parameter 'assignTo' can not be null");
             }
+            LOG.debug("Assigning task(id=" + taskId + ") to user(id=" + assignTo.getID() + ")");
 
             BoxTask task = new BoxTask(boxConnection, taskId);
             task.addAssignment(assignTo);


### PR DESCRIPTION
Calling the getID during log would throw a NPE

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md