### PR TITLE
CAMEL-15493 - Fixes NPE thrown in camel-cdi when attempting to inject an array property using Microprofile Config

### DIFF
--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
@@ -317,7 +317,7 @@ public class CdiCamelExtension implements Extension {
         return beans.stream()
             // Is there a Camel bean with the @Default qualifier?
             // Excluding internal components...
-            .filter(bean -> !bean.getBeanClass().getPackage().equals(getClass().getPackage()))
+            .filter(bean -> !getClass().getPackage().equals(bean.getBeanClass().getPackage()))
             .filter(hasType(CamelContextAware.class).or(hasType(Component.class))
                 .or(hasType(RouteContainer.class).or(hasType(RoutesBuilder.class))))
             .map(Bean::getQualifiers)
@@ -337,7 +337,7 @@ public class CdiCamelExtension implements Extension {
             // Or an injection point for Camel primitives?
             || beans.stream()
             // Excluding internal components...
-            .filter(bean -> !bean.getBeanClass().getPackage().equals(getClass().getPackage()))
+            .filter(bean -> !getClass().getPackage().equals(bean.getBeanClass().getPackage()))
             .map(Bean::getInjectionPoints)
             .flatMap(Set::stream)
             .filter(ip -> getRawType(ip.getType()).getName().startsWith("org.apache.camel"))


### PR DESCRIPTION
This fixes a NPE that intermittently occurs in a TomEE 8 microprofile environment on container startup. I prepared a test case that reproduces the issue in a separate branch ([CAMEL-15493-Test](https://github.com/kentfung/camel/tree/CAMEL-15493-Test)) but decided not to include it in this PR as it introduces quite a few dependencies (although all test scoped).

-  [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.

- [x] Each commit in the pull request should have a meaningful subject line and body.

- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.

- [x]  Write a pull request description that is detailed enough to understand what the pull request does, how, and why.

- [x]  Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.

Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md