### PR TITLE
CAMEL-15486 Move skipping of context start to method `beforeTestClass`

### DIFF
--- a/components/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelSpringBootExecutionListener.java
+++ b/components/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelSpringBootExecutionListener.java
@@ -42,14 +42,8 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
 
     @Override
     public void beforeTestClass(TestContext testContext) throws Exception {
-        // we are customizing the Camel context with
-        // CamelAnnotationsHandler so we do not want to start it
-        // automatically, which would happen when SpringCamelContext
-        // is added to Spring ApplicationContext, so we set the flag
-        // as early as possible to also prevent other extensions
-        // to start it before it is ready
-        SpringCamelContext.setNoStart(true);
-        System.setProperty(PROPERTY_SKIP_STARTING_CAMEL_CONTEXT, "true");
+        // prevent other extensions to start the Camel context
+        preventContextStart();
     }
 
     @Override
@@ -62,6 +56,8 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
         CamelAnnotationsHandler.handleDisableJmx(null, testClass);
         CamelAnnotationsHandler.handleExcludeRoutes(null, testClass);
 
+        // prevent the Camel context to be started to be able to extend it.
+        preventContextStart();
         ConfigurableApplicationContext context = (ConfigurableApplicationContext) testContext.getApplicationContext();
 
         CamelAnnotationsHandler.handleUseOverridePropertiesWithPropertiesComponent(context, testClass);
@@ -75,6 +71,17 @@ public class CamelSpringBootExecutionListener extends AbstractTestExecutionListe
 
         System.clearProperty(PROPERTY_SKIP_STARTING_CAMEL_CONTEXT);
         SpringCamelContext.setNoStart(false);
+    }
+
+    /**
+     * Sets the {@link SpringCamelContext#setNoStart(boolean)} and the system property
+     * <code>skipStartingCamelContext</code>to <code>true</code> to let us customizing the Camel context with
+     * {@link CamelAnnotationsHandler} before it has been started. It's needed as early as possible to prevent other
+     * extensions to start it <b>and</b> before every test run.
+     */
+    private void preventContextStart() {
+        SpringCamelContext.setNoStart(true);
+        System.setProperty(PROPERTY_SKIP_STARTING_CAMEL_CONTEXT, "true");
     }
 
     @Override


### PR DESCRIPTION
CAMEL-15486 Move skipping of context start to method `beforeTestClass` to have the settings earlier in the test lifecycle.

Some other libraries (for example:  `spring-cloud-contract-wiremock` ) are starting up the context already in this phase of the test lifecycle and prevent camel of setting up the mocking of endpoints.