### PR TITLE
Fix azure-storage-queue example

### DIFF
--- a/docs/components/modules/ROOT/pages/azure-storage-queue-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-storage-queue-component.adoc
@@ -55,7 +55,7 @@ For example in order to get a message content from the queue `messageQueue`
 in the `storageAccount` storage account and, use the following snippet:
 [source,java]
 --------------------------------------------------------------------------------
-from("azure-storage-queue://storageAccount/messageQueue?accessKey=yourURLEncodedAccessKey").
+from("azure-storage-queue://storageAccount/messageQueue?accessKey=yourAccessKey").
 to("file://queuedirectory");
 --------------------------------------------------------------------------------
 

--- a/docs/components/modules/ROOT/pages/azure-storage-queue-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-storage-queue-component.adoc
@@ -52,10 +52,10 @@ The queue will be created if it does not already exist.
 You can append query options to the URI in the following format, ?options=value&option2=value&...
 
 For example in order to get a message content from the queue `messageQueue`
-in the `camelazure` storage account and, use the following snippet:
+in the `storageAccount` storage account and, use the following snippet:
 [source,java]
 --------------------------------------------------------------------------------
-from("azure-storage-queue://camelazure/messageQueue?accountName=yourAccountName&accessKey=yourAccessKey").
+from("azure-storage-queue://storageAccount/messageQueue?accessKey=yourURLEncodedAccessKey").
 to("file://queuedirectory");
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
1. Remove parameter accountName from query parameters
2. Add tip for use url encoding for accessKey because it can contain special chars like `=` or `+`. So `URLEncoder.encode` should solve this problem