### PR TITLE
Fixes small bug in camel-aws2-s3 component in destinationBucketSuffix configuration attribute

### DIFF
--- a/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
+++ b/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
@@ -281,7 +281,7 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
                     builder.append(getConfiguration().getDestinationBucketPrefix());
                 }
                 builder.append(key);
-                if (ObjectHelper.isNotEmpty(getConfiguration().getDestinationBucketPrefix())) {
+                if (ObjectHelper.isNotEmpty(getConfiguration().getDestinationBucketSuffix())) {
                     builder.append(getConfiguration().getDestinationBucketSuffix());
                 }
                 getAmazonS3Client().copyObject(CopyObjectRequest.builder().destinationKey(builder.toString())


### PR DESCRIPTION
fix getDestinationBucketSuffix() empty check

currently when using `destinationBucketPrefix` only a `null` suffix will be appended to the s3 file after moved.