### PR TITLE
camel-core: fixed warnings about deprecated usages

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/TestSupport.java
+++ b/core/camel-core/src/test/java/org/apache/camel/TestSupport.java
@@ -157,7 +157,7 @@ public abstract class TestSupport {
      */
     @Deprecated
     public static Object assertOutMessageHeader(Exchange exchange, String name, Object expected) {
-        return assertMessageHeader(exchange.getOut(), name, expected);
+        return assertMessageHeader(exchange.getMessage(), name, expected);
     }
 
     /**
@@ -195,14 +195,14 @@ public abstract class TestSupport {
 
         Object actual;
         if (expected == null) {
-            actual = exchange.getOut().getMandatoryBody();
+            actual = exchange.getMessage().getMandatoryBody();
             assertEquals(expected, actual, "output body of: " + exchange);
         } else {
-            actual = exchange.getOut().getMandatoryBody(expected.getClass());
+            actual = exchange.getMessage().getMandatoryBody(expected.getClass());
         }
         assertEquals(expected, actual, "output body of: " + exchange);
 
-        LOG.debug("Received response: {} with out: {}", exchange, exchange.getOut());
+        LOG.debug("Received response: {} with out: {}", exchange, exchange.getMessage());
     }
 
     public static Object assertMessageHeader(Message message, String name, Object expected) {

--- a/core/camel-core/src/test/java/org/apache/camel/builder/FluentProducerTemplateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/FluentProducerTemplateTest.java
@@ -275,24 +275,24 @@ public class FluentProducerTemplateTest extends ContextTestSupport {
         // with endpoint as string uri
         FluentProducerTemplate template = DefaultFluentProducerTemplate.on(context);
 
-        final Integer expectedResult = new Integer(123);
+        final Integer expectedResult = Integer.valueOf(123);
 
         assertEquals(expectedResult,
-                template.clearBody().clearHeaders().withBody("Hello").to("direct:inout").request(Integer.class));
+                template.withBody("Hello").to("direct:inout").request(Integer.class));
 
-        assertEquals(expectedResult, template.clearBody().clearHeaders().withHeader("foo", "bar").withBody("Hello")
+        assertEquals(expectedResult, template.withHeader("foo", "bar").withBody("Hello")
                 .to("direct:inout").request(Integer.class));
 
         assertEquals(expectedResult,
-                template.clearBody().clearHeaders().withBody("Hello").to("direct:inout").request(Integer.class));
+                template.withBody("Hello").to("direct:inout").request(Integer.class));
 
-        assertEquals(expectedResult, template.clearBody().clearHeaders().withBody("Hello")
+        assertEquals(expectedResult, template.withBody("Hello")
                 .to(context.getEndpoint("direct:inout")).request(Integer.class));
 
-        assertEquals(expectedResult, template.clearBody().clearHeaders().withHeader("foo", "bar").withBody("Hello")
+        assertEquals(expectedResult, template.withHeader("foo", "bar").withBody("Hello")
                 .to(context.getEndpoint("direct:inout")).request(Integer.class));
 
-        assertEquals(expectedResult, template.clearBody().clearHeaders().withBody("Hello")
+        assertEquals(expectedResult, template.withBody("Hello")
                 .to(context.getEndpoint("direct:inout")).request(Integer.class));
     }
 
@@ -390,7 +390,7 @@ public class FluentProducerTemplateTest extends ContextTestSupport {
                         throw new IllegalArgumentException("Expected body of type Integer");
                     }
                 }).to("mock:result");
-                from("direct:out").process(exchange -> exchange.getOut().setBody("Bye Bye World")).to("mock:result");
+                from("direct:out").process(exchange -> exchange.getMessage().setBody("Bye Bye World")).to("mock:result");
 
                 from("direct:exception").process(exchange -> {
                     throw new IllegalArgumentException("Forced exception by unit test");

--- a/core/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderFromRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderFromRouteTest.java
@@ -40,7 +40,7 @@ public class NotifyBuilderFromRouteTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello world!");
 
-        assertTrue(builder.matchesMockWaitTime());
+        assertTrue(builder.matchesWaitTime());
     }
 
     @Test
@@ -51,7 +51,7 @@ public class NotifyBuilderFromRouteTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello world!");
 
-        assertTrue(builder.matchesMockWaitTime());
+        assertTrue(builder.matchesWaitTime());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class NotifyBuilderFromRouteTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello world!");
 
-        assertTrue(builder.matchesMockWaitTime());
+        assertTrue(builder.matchesWaitTime());
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderWhenDoneByIndexTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/NotifyBuilderWhenDoneByIndexTest.java
@@ -44,7 +44,7 @@ public class NotifyBuilderWhenDoneByIndexTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "A,B,C");
 
-        assertEquals(true, notify.matchesMockWaitTime());
+        assertEquals(true, notify.matchesWaitTime());
 
         assertEquals(3, counter.get());
     }

--- a/core/camel-core/src/test/java/org/apache/camel/builder/xml/XsltBuilderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/xml/XsltBuilderTest.java
@@ -66,7 +66,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -172,7 +172,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -185,9 +185,9 @@ public class XsltBuilderTest extends ContextTestSupport {
         exchange.getIn().setBody("<hello>world!</hello>");
 
         builder.process(exchange);
-        assertIsInstanceOf(String.class, exchange.getOut().getBody());
+        assertIsInstanceOf(String.class, exchange.getMessage().getBody());
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getOut().getBody());
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>", exchange.getMessage().getBody());
     }
 
     @Test
@@ -200,10 +200,10 @@ public class XsltBuilderTest extends ContextTestSupport {
         exchange.getIn().setBody("<hello>world!</hello>");
 
         builder.process(exchange);
-        assertIsInstanceOf(byte[].class, exchange.getOut().getBody());
+        assertIsInstanceOf(byte[].class, exchange.getMessage().getBody());
 
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>",
-                exchange.getOut().getBody(String.class));
+                exchange.getMessage().getBody(String.class));
     }
 
     @Test
@@ -216,9 +216,9 @@ public class XsltBuilderTest extends ContextTestSupport {
         exchange.getIn().setBody("<hello>world!</hello>");
 
         builder.process(exchange);
-        assertIsInstanceOf(Document.class, exchange.getOut().getBody());
+        assertIsInstanceOf(Document.class, exchange.getMessage().getBody());
 
-        assertEquals("<goodbye>world!</goodbye>", exchange.getOut().getBody(String.class));
+        assertEquals("<goodbye>world!</goodbye>", exchange.getMessage().getBody(String.class));
     }
 
     @Test
@@ -232,12 +232,12 @@ public class XsltBuilderTest extends ContextTestSupport {
         exchange.getIn().setHeader(Exchange.XSLT_FILE_NAME, "target/data/xslt/xsltout.xml");
 
         builder.process(exchange);
-        assertIsInstanceOf(File.class, exchange.getOut().getBody());
+        assertIsInstanceOf(File.class, exchange.getMessage().getBody());
 
         File file = new File("target/data/xslt/xsltout.xml");
         assertTrue(file.exists(), "Output file should exist");
 
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertTrue(body.endsWith("<goodbye>world!</goodbye>"));
     }
 
@@ -252,12 +252,12 @@ public class XsltBuilderTest extends ContextTestSupport {
         exchange.getIn().setHeader(Exchange.XSLT_FILE_NAME, "target/data/xslt/xsltout.xml");
 
         builder.process(exchange);
-        assertIsInstanceOf(File.class, exchange.getOut().getBody());
+        assertIsInstanceOf(File.class, exchange.getMessage().getBody());
 
         File file = new File("target/data/xslt/xsltout.xml");
         assertTrue(file.exists(), "Output file should exist");
 
-        String body = exchange.getOut().getBody(String.class);
+        String body = exchange.getMessage().getBody(String.class);
         assertTrue(body.endsWith("<goodbye>world!</goodbye>"));
 
         // now done the exchange
@@ -283,7 +283,7 @@ public class XsltBuilderTest extends ContextTestSupport {
         builder.process(exchange);
 
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye>world!</goodbye>",
-                exchange.getOut().getBody(String.class));
+                exchange.getMessage().getBody(String.class));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class XsltBuilderTest extends ContextTestSupport {
 
         builder.process(exchange);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye/>", exchange.getOut().getBody(String.class));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><goodbye/>", exchange.getMessage().getBody(String.class));
     }
 
 }

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanPropagateHeaderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanPropagateHeaderTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.bean;
 
 import org.apache.camel.ContextTestSupport;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.Registry;
@@ -51,7 +52,7 @@ public class BeanPropagateHeaderTest extends ContextTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").setHeader("foo", constant("bar")).convertBodyTo(Integer.class).to("bean:order")
-                        .inOnly("seda:foo").transform(constant("OK"));
+                        .to(ExchangePattern.InOnly, "seda:foo").transform(constant("OK"));
 
                 from("seda:foo").to("mock:result");
             }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeAlterFileNameHeaderIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeAlterFileNameHeaderIssueTest.java
@@ -63,7 +63,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         template.sendBodyAndHeader("file://target/data/files", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         assertFalse(mock.getExchanges().get(0).getIn().hasHeaders(), "Headers should have been removed");
 
@@ -92,7 +92,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         template.sendBodyAndHeader("file://target/data/files", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // the original file should have been deleted, as the file consumer
         // should be resilient against
@@ -118,7 +118,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         template.sendBodyAndHeader("file://target/data/files", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         assertFalse(mock.getExchanges().get(0).getIn().hasHeaders(), "Headers should have been removed");
 
@@ -147,7 +147,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         template.sendBodyAndHeader("file://target/data/files", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // the original file should have been moved, as the file consumer should
         // be resilient against

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeBackoffMultiplierTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeBackoffMultiplierTest.java
@@ -43,7 +43,7 @@ public class FileConsumeBackoffMultiplierTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeCharsetTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeCharsetTest.java
@@ -48,7 +48,7 @@ public class FileConsumeCharsetTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // file should not exists
         assertFalse(new File("target/data/files/report.txt").exists(), "File should been deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeDoneFileIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeDoneFileIssueTest.java
@@ -59,7 +59,7 @@ public class FileConsumeDoneFileIssueTest extends ContextTestSupport {
         context.getRouteController().startRoute("foo");
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         Thread.sleep(50);
 
@@ -87,7 +87,7 @@ public class FileConsumeDoneFileIssueTest extends ContextTestSupport {
         context.getRouteController().startRoute("bar");
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         Thread.sleep(50);
 
@@ -118,7 +118,7 @@ public class FileConsumeDoneFileIssueTest extends ContextTestSupport {
         context.getRouteController().startRoute("bar");
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         Thread.sleep(50);
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeDynamicDoneFileNameWithTwoDotsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeDynamicDoneFileNameWithTwoDotsTest.java
@@ -52,7 +52,7 @@ public class FileConsumeDynamicDoneFileNameWithTwoDotsTest extends ContextTestSu
         template.sendBodyAndHeader("file:" + TARGET_DIR_NAME, "done-body", Exchange.FILE_NAME, "test.twodot.done");
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         assertFalse(new File(TARGET_DIR_NAME, "test.twodot.txt").exists(), "Input file should be deleted");
         assertFalse(new File(TARGET_DIR_NAME, "test.twodot.done").exists(), "Done file should be deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeFilesAndDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeFilesAndDeleteTest.java
@@ -50,7 +50,7 @@ public class FileConsumeFilesAndDeleteTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // file should not exists
         assertFalse(new File("target/data/files/report.txt").exists(), "File should been deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeSimpleDynamicDoneFileNameWithTwoDotsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeSimpleDynamicDoneFileNameWithTwoDotsTest.java
@@ -53,7 +53,7 @@ public class FileConsumeSimpleDynamicDoneFileNameWithTwoDotsTest extends Context
         template.sendBodyAndHeader("file:" + TARGET_DIR_NAME, "done-body", Exchange.FILE_NAME, "test.twodot.done");
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         assertFalse(new File(TARGET_DIR_NAME, "test.twodot.txt").exists(), "Input file should be deleted");
         assertFalse(new File(TARGET_DIR_NAME, "test.twodot.done").exists(), "Done file should be deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCommitRenameStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerCommitRenameStrategyTest.java
@@ -73,7 +73,7 @@ public class FileConsumerCommitRenameStrategyTest extends ContextTestSupport {
 
         mock.assertIsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // content of file should be Hello London
         String content = IOConverter.toString(new File("target/data/done/london.txt"), null);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerFailureHandledTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerFailureHandledTest.java
@@ -52,7 +52,7 @@ public class FileConsumerFailureHandledTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/messages/input/", "Paris", Exchange.FILE_NAME, "paris.txt");
         mock.assertIsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         assertFiles("paris.txt", true);
     }
@@ -66,7 +66,7 @@ public class FileConsumerFailureHandledTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/messages/input/", "London", Exchange.FILE_NAME, "london.txt");
         mock.assertIsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // london should be deleted as we have failure handled it
         assertFiles("london.txt", true);
@@ -81,7 +81,7 @@ public class FileConsumerFailureHandledTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/messages/input/", "Dublin", Exchange.FILE_NAME, "dublin.txt");
         mock.assertIsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // dublin should NOT be deleted, but should be retired on next consumer
         assertFiles("dublin.txt", false);
@@ -96,7 +96,7 @@ public class FileConsumerFailureHandledTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/messages/input/", "Madrid", Exchange.FILE_NAME, "madrid.txt");
         mock.assertIsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // madrid should be deleted as the DLC handles it
         assertFiles("madrid.txt", true);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyNameAndSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyNameAndSizeTest.java
@@ -44,7 +44,7 @@ public class FileConsumerIdempotentKeyNameAndSizeTest extends FileConsumerIdempo
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset mock and set new expectations
         mock.reset();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentOnExceptionHandledTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentOnExceptionHandledTest.java
@@ -37,7 +37,7 @@ public class FileConsumerIdempotentOnExceptionHandledTest extends ContextTestSup
 
         template.sendBodyAndHeader("file:target/data/messages/input/", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         assertMockEndpointsSatisfied();
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentRefTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentRefTest.java
@@ -72,7 +72,7 @@ public class FileConsumerIdempotentRefTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset mock and set new expectations
         mock.reset();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentTest.java
@@ -61,7 +61,7 @@ public class FileConsumerIdempotentTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset mock and set new expectations
         mock.reset();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerMoveExpressionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerMoveExpressionTest.java
@@ -70,7 +70,7 @@ public class FileConsumerMoveExpressionTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/filelanguage/", "Hello World", Exchange.FILE_NAME, "report.txt");
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         String id = mock.getExchanges().get(0).getIn().getMessageId();
         File file = new File("target/data/filelanguage/" + id + ".bak");
@@ -95,7 +95,7 @@ public class FileConsumerMoveExpressionTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/filelanguage/", "Bye World", Exchange.FILE_NAME, "report2.txt");
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         String id = mock.getExchanges().get(0).getIn().getMessageId();
         File file = new File("target/data/filelanguage/backup-" + id + "-report2.bak");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyNotBeginTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyNotBeginTest.java
@@ -61,7 +61,7 @@ public class FileConsumerPollStrategyNotBeginTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // the poll strategy commit is executed after the exchange is done
         Thread.sleep(100);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyTest.java
@@ -61,7 +61,7 @@ public class FileConsumerPollStrategyTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // give file consumer a bit time
         Thread.sleep(20);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveDeleteTest.java
@@ -47,7 +47,7 @@ public class FileConsumerPreMoveDeleteTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File pre = new File("target/data/premove/work/hello.txt");
         assertFalse(pre.exists(), "Pre move file should have been deleted");
@@ -61,7 +61,7 @@ public class FileConsumerPreMoveDeleteTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/premove", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset and drop the same file again
         mock.reset();
@@ -71,7 +71,7 @@ public class FileConsumerPreMoveDeleteTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/premove", "Hello Again World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File pre = new File("target/data/premove/work/hello.txt");
         assertFalse(pre.exists(), "Pre move file should have been deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveNoopTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveNoopTest.java
@@ -46,7 +46,7 @@ public class FileConsumerPreMoveNoopTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File pre = new File("target/data/premove/work/hello.txt");
         assertTrue(pre.exists(), "Pre move file should exist");
@@ -60,7 +60,7 @@ public class FileConsumerPreMoveNoopTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/premove", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset and drop the same file again
         mock.reset();
@@ -70,7 +70,7 @@ public class FileConsumerPreMoveNoopTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/premove", "Hello Again World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File pre = new File("target/data/premove/work/hello.txt");
         assertTrue(pre.exists(), "Pre move file should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPreMoveTest.java
@@ -55,7 +55,7 @@ public class FileConsumerPreMoveTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/premove", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // reset and drop the same file again
         mock.reset();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendAndResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendAndResumeTest.java
@@ -51,7 +51,7 @@ public class FileConsumerSuspendAndResumeTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/suspended", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // the route is suspended by the policy so we should only receive one
         String[] files = new File("target/data/suspended/").list();
@@ -67,7 +67,7 @@ public class FileConsumerSuspendAndResumeTest extends ContextTestSupport {
         myPolicy.resumeConsumer();
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // and the file is now deleted
         files = new File("target/data/suspended/").list();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendTest.java
@@ -48,7 +48,7 @@ public class FileConsumerSuspendTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/suspended", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // the route is suspended by the policy so we should only receive one
         String[] files = new File("target/data/suspended/").list();

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichNoWaitTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichNoWaitTest.java
@@ -45,7 +45,7 @@ public class FilePollEnrichNoWaitTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/pollenrich", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // file should be moved
         File file = new File("target/data/pollenrich/hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichTest.java
@@ -47,7 +47,7 @@ public class FilePollEnrichTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/pollenrich", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // file should be moved
         File file = new File("target/data/pollenrich/hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
@@ -63,7 +63,7 @@ public class FileProducerCharsetUTFOptimizedTest extends ContextTestSupport {
 
     @Test
     public void testFileProducerCharsetUTFOptimized() throws Exception {
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/charset/output.txt");
         assertTrue(file.exists(), "File should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
@@ -69,7 +69,7 @@ public class FileProducerCharsetUTFtoISOConfiguredTest extends ContextTestSuppor
 
     @Test
     public void testFileProducerCharsetUTFtoISO() throws Exception {
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/charset/output.txt");
         assertTrue(file.exists(), "File should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
@@ -70,7 +70,7 @@ public class FileProducerCharsetUTFtoISOConvertBodyToTest extends ContextTestSup
 
     @Test
     public void testFileProducerCharsetUTFtoISOConvertBodyTo() throws Exception {
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/charset/output.txt");
         assertTrue(file.exists(), "File should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOTest.java
@@ -69,7 +69,7 @@ public class FileProducerCharsetUTFtoISOTest extends ContextTestSupport {
 
     @Test
     public void testFileProducerCharsetUTFtoISO() throws Exception {
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/charset/output.txt");
         assertTrue(file.exists(), "File should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
@@ -63,7 +63,7 @@ public class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
 
     @Test
     public void testFileProducerCharsetUTFtoUTF() throws Exception {
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/charset/output.txt");
         assertTrue(file.exists(), "File should exist");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileRenameFileOnCommitIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileRenameFileOnCommitIssueTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -51,7 +52,7 @@ public class FileRenameFileOnCommitIssueTest extends ContextTestSupport {
             public void configure() throws Exception {
                 from("file://target/data/renameissue?noop=false&initialDelay=0&delay=10").setProperty("PartitionID")
                         .simple("${file:name}").convertBodyTo(String.class)
-                        .inOut("direct:source").process(new Processor() {
+                        .to(ExchangePattern.InOut, "direct:source").process(new Processor() {
                             public void process(Exchange exchange) throws Exception {
                                 log.info("The exchange's IN body as String is {}", exchange.getIn().getBody(String.class));
                             }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileRenameReadLockMustUseMarkerFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileRenameReadLockMustUseMarkerFileTest.java
@@ -52,7 +52,7 @@ public class FileRenameReadLockMustUseMarkerFileTest extends ContextTestSupport 
 
         assertMockEndpointsSatisfied();
 
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         // and lock file should be deleted
         File lock = new File("target/data/rename/bye.txt" + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameDeleteTest.java
@@ -58,7 +58,7 @@ public class FilerConsumerDoneFileNameDeleteTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "done");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/done");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNamePrefixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNamePrefixTest.java
@@ -58,7 +58,7 @@ public class FilerConsumerDoneFileNamePrefixTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "done-hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/done-hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameSimplePrefixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameSimplePrefixTest.java
@@ -58,7 +58,7 @@ public class FilerConsumerDoneFileNameSimplePrefixTest extends ContextTestSuppor
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "done-hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/done-hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameSuffixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameSuffixTest.java
@@ -58,7 +58,7 @@ public class FilerConsumerDoneFileNameSuffixTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "hello.txt.ready");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/hello.txt.ready");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameTest.java
@@ -59,7 +59,7 @@ public class FilerConsumerDoneFileNameTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "done");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/done");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNoopTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNoopTest.java
@@ -57,7 +57,7 @@ public class FilerConsumerDoneFileNoopTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "done");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be kept now
         File file = new File("target/data/done/done");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerMoveFailedDoneFileNameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerMoveFailedDoneFileNameTest.java
@@ -48,7 +48,7 @@ public class FilerConsumerMoveFailedDoneFileNameTest extends ContextTestSupport 
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/done");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerPreMoveDoneFileNameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerPreMoveDoneFileNameTest.java
@@ -58,7 +58,7 @@ public class FilerConsumerPreMoveDoneFileNameTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "", Exchange.FILE_NAME, "ready");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         File file = new File("target/data/done/ready");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFilePrefixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFilePrefixTest.java
@@ -64,7 +64,7 @@ public class FilerConsumerShouldSkipDoneFilePrefixTest extends ContextTestSuppor
         template.sendBodyAndHeader("file:target/data/done", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         assertFalse(file.exists(), "Done file should be deleted: " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFileSuffixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFileSuffixTest.java
@@ -64,7 +64,7 @@ public class FilerConsumerShouldSkipDoneFileSuffixTest extends ContextTestSuppor
         template.sendBodyAndHeader("file:target/data/done", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         assertFalse(file.exists(), "Done file should be deleted: " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerShouldSkipDoneFileTest.java
@@ -64,7 +64,7 @@ public class FilerConsumerShouldSkipDoneFileTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/done", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // done file should be deleted now
         assertFalse(file.exists(), "Done file should be deleted: " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FromFileDoNotDeleteFileIfProcessFailsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FromFileDoNotDeleteFileIfProcessFailsTest.java
@@ -50,7 +50,7 @@ public class FromFileDoNotDeleteFileIfProcessFailsTest extends ContextTestSuppor
         mock.expectedMinimumMessageCount(1);
 
         mock.assertIsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // assert the file is deleted
         File file = new File("target/data/deletefile/hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FromFileDoNotMoveFileIfProcessFailsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FromFileDoNotMoveFileIfProcessFailsTest.java
@@ -50,7 +50,7 @@ public class FromFileDoNotMoveFileIfProcessFailsTest extends ContextTestSupport 
         mock.expectedMinimumMessageCount(1);
 
         mock.assertIsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // assert the file is not moved
         File file = new File("target/data/movefile/hello.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
@@ -50,7 +50,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
         getMockEndpoint("mock:result").expectedBodiesReceived(body);
 
         assertMockEndpointsSatisfied();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
         assertEquals(3, counter);
 
         // assert the file is deleted

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/NewFileConsumerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/NewFileConsumerTest.java
@@ -49,7 +49,7 @@ public class NewFileConsumerTest extends ContextTestSupport {
         template.sendBodyAndHeader("file:target/data/myfile", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         await("postPollCheck invocation").atMost(1, TimeUnit.SECONDS).until(myFile::isPost);
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockZeroTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileChangedReadLockZeroTimeoutTest.java
@@ -58,7 +58,7 @@ public class FileChangedReadLockZeroTimeoutTest extends ContextTestSupport {
         template.sendBodyAndHeader("file://target/data/changed/in", "Hello Again World", Exchange.FILE_NAME, "hello2.txt");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/log/ConsumingAppender.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/log/ConsumingAppender.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
 public class ConsumingAppender extends AbstractAppender {
@@ -37,7 +38,8 @@ public class ConsumingAppender extends AbstractAppender {
     }
 
     public ConsumingAppender(String name, String pattern, Consumer<LogEvent> consumer) {
-        super(name, null, PatternLayout.newBuilder().withPattern(pattern).build());
+        super(name, null, PatternLayout.newBuilder().withPattern(pattern).build(), true,
+              Property.EMPTY_ARRAY);
         this.consumer = consumer;
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/DirectRequestReplyAndSedaInOnlyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/DirectRequestReplyAndSedaInOnlyTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.seda;
 
 import org.apache.camel.ContextTestSupport;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +45,7 @@ public class DirectRequestReplyAndSedaInOnlyTest extends ContextTestSupport {
                 // routing
                 // (as we don't want to do request/reply over SEDA)
                 // In EIP patterns the WireTap pattern is what this would be
-                from("direct:start").transform(constant("Bye World")).inOnly("seda:log");
+                from("direct:start").transform(constant("Bye World")).to(ExchangePattern.InOnly, "seda:log");
 
                 from("seda:log").transform(body().prepend("Logging: ")).to("log:log", "mock:log");
             }

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaUnitOfWorkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaUnitOfWorkTest.java
@@ -47,7 +47,7 @@ public class SedaUnitOfWorkTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "Hello World", "foo", "bar");
 
         assertMockEndpointsSatisfied();
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
 
         assertEquals("onCompleteA", sync);
         assertEquals("onCompleteA", lastOne);
@@ -60,7 +60,7 @@ public class SedaUnitOfWorkTest extends ContextTestSupport {
 
         template.sendBodyAndHeader("direct:start", "Hello World", "kaboom", "yes");
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
 
         assertEquals("onFailureA", sync);
         assertEquals("onFailureA", lastOne);

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaWaitForTaskAsPropertyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaWaitForTaskAsPropertyTest.java
@@ -39,7 +39,7 @@ public class SedaWaitForTaskAsPropertyTest extends ContextTestSupport {
                 exchange.setProperty(Exchange.ASYNC_WAIT, WaitForTaskToComplete.IfReplyExpected);
             }
         });
-        assertEquals("Bye World", out.getOut().getBody());
+        assertEquals("Bye World", out.getMessage().getBody());
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/validator/FileValidatorRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/validator/FileValidatorRouteTest.java
@@ -50,7 +50,7 @@ public class FileValidatorRouteTest extends ContextTestSupport {
         MockEndpoint.assertIsSatisfied(validEndpoint, invalidEndpoint, finallyEndpoint);
 
         // should be able to delete the file
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
         assertTrue(FileUtil.deleteFile(new File("target/data/validator/valid.xml")), "Should be able to delete the file");
     }
 
@@ -65,7 +65,7 @@ public class FileValidatorRouteTest extends ContextTestSupport {
         MockEndpoint.assertIsSatisfied(validEndpoint, invalidEndpoint, finallyEndpoint);
 
         // should be able to delete the file
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
         assertTrue(FileUtil.deleteFile(new File("target/data/validator/invalid.xml")), "Should be able to delete the file");
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -48,7 +48,7 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/xslt/hello.xml");
         assertFalse(file.exists(), "File should not exists " + file);
@@ -67,7 +67,7 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/xslt/hello2.xml");
         assertFalse(file.exists(), "File should not exists " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltOutputFileDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltOutputFileDeleteTest.java
@@ -41,7 +41,7 @@ public class XsltOutputFileDeleteTest extends ContextTestSupport {
                 "target/data/xslt/xsltme.xml");
 
         assertMockEndpointsSatisfied();
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // assert file deleted
         File file = new File("target/data/xslt/xsltme.xml");

--- a/core/camel-core/src/test/java/org/apache/camel/converter/ConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/ConverterTest.java
@@ -60,7 +60,7 @@ public class ConverterTest extends TestSupport {
     public static class IntegerPropertyEditor extends PropertyEditorSupport {
         @Override
         public void setAsText(String text) throws IllegalArgumentException {
-            setValue(new Integer(text));
+            setValue(Integer.valueOf(text));
         }
 
         @Override
@@ -80,7 +80,7 @@ public class ConverterTest extends TestSupport {
     public void testIntegerPropertyEditorConversion() throws Exception {
         Integer value = converter.convertTo(Integer.class, "1000");
         assertNotNull(value);
-        assertEquals(new Integer(1000), (Object) value, "Converted to Integer");
+        assertEquals(Integer.valueOf(1000), (Object) value, "Converted to Integer");
 
         String text = converter.convertTo(String.class, value);
         assertEquals("1000", text, "Converted to String");

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExchangeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExchangeTest.java
@@ -94,14 +94,14 @@ public class DefaultExchangeTest extends ExchangeTestSupport {
         assertNotNull(exchange.getIn().getHeaders());
 
         assertEquals(123, exchange.getIn().getHeader("bar"));
-        assertEquals(new Integer(123), exchange.getIn().getHeader("bar", Integer.class));
+        assertEquals(Integer.valueOf(123), exchange.getIn().getHeader("bar", Integer.class));
         assertEquals("123", exchange.getIn().getHeader("bar", String.class));
         assertEquals(123, exchange.getIn().getHeader("bar", 234));
         assertEquals(123, exchange.getIn().getHeader("bar", () -> 456));
         assertEquals(456, exchange.getIn().getHeader("baz", () -> 456));
 
         assertEquals(123, exchange.getIn().getHeader("bar", 234));
-        assertEquals(new Integer(123), exchange.getIn().getHeader("bar", 234, Integer.class));
+        assertEquals(Integer.valueOf(123), exchange.getIn().getHeader("bar", 234, Integer.class));
         assertEquals("123", exchange.getIn().getHeader("bar", "234", String.class));
         assertEquals("123", exchange.getIn().getHeader("bar", () -> "456", String.class));
         assertEquals("456", exchange.getIn().getHeader("baz", () -> "456", String.class));

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultProducerTemplateTest.java
@@ -265,7 +265,7 @@ public class DefaultProducerTemplateTest extends ContextTestSupport {
                 from("direct:out").process(new Processor() {
                     @Override
                     public void process(Exchange exchange) throws Exception {
-                        exchange.getOut().setBody("Bye Bye World");
+                        exchange.getMessage().setBody("Bye Bye World");
                     }
                 }).to("mock:result");
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentParallelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentParallelTest.java
@@ -33,7 +33,7 @@ public class EventNotifierExchangeSentParallelTest extends EventNotifierExchange
 
         // wait for the message to be fully done using oneExchangeDone
         assertMockEndpointsSatisfied();
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         // stop Camel to let all the events complete
         context.stop();

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentTest.java
@@ -111,7 +111,7 @@ public class EventNotifierExchangeSentTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertEquals(12, events.size());
         ExchangeSendingEvent e0 = assertIsInstanceOf(ExchangeSendingEvent.class, events.get(0));

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierRedeliveryEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierRedeliveryEventsTest.java
@@ -80,7 +80,7 @@ public class EventNotifierRedeliveryEventsTest extends ContextTestSupport {
         getMockEndpoint("mock:dead").expectedMessageCount(1);
         template.sendBody("direct:start", "Hello World");
         assertMockEndpointsSatisfied();
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertEquals(12, events.size());
 
@@ -118,7 +118,7 @@ public class EventNotifierRedeliveryEventsTest extends ContextTestSupport {
         getMockEndpoint("mock:dead").expectedMessageCount(1);
         template.sendBody("direct:start", "Hello World");
         assertMockEndpointsSatisfied();
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertEquals(12, events.size());
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/transformer/TransformerRouteTest.java
@@ -167,7 +167,7 @@ public class TransformerRouteTest extends ContextTestSupport {
                         LOG.info("Asserting input -> AOrder convertion");
                         assertEquals(AOrder.class, exchange.getIn().getBody().getClass());
                     }
-                }).inOut("direct:xyz").to("mock:abcresult");
+                }).to(ExchangePattern.InOut, "direct:xyz").to("mock:abcresult");
 
                 from("direct:xyz").inputType(XOrder.class).outputType(XOrderResponse.class).process(new Processor() {
                     public void process(Exchange exchange) throws Exception {
@@ -179,18 +179,19 @@ public class TransformerRouteTest extends ContextTestSupport {
 
                 transformer().scheme("json").withDataFormat(new MyJsonDataFormatDefinition());
                 from("direct:dataFormat").inputType("json:JsonXOrder").outputType("json:JsonXOrderResponse")
-                        .inOut("direct:xyz");
+                        .to(ExchangePattern.InOut, "direct:xyz");
 
                 context.addComponent("myxml", new MyXmlComponent());
                 transformer().fromType("xml:XmlXOrder").toType(XOrder.class).withUri("myxml:endpoint");
                 transformer().fromType(XOrderResponse.class).toType("xml:XmlXOrderResponse").withUri("myxml:endpoint");
-                from("direct:endpoint").inputType("xml:XmlXOrder").outputType("xml:XmlXOrderResponse").inOut("direct:xyz");
+                from("direct:endpoint").inputType("xml:XmlXOrder").outputType("xml:XmlXOrderResponse").to(ExchangePattern.InOut,
+                        "direct:xyz");
 
                 transformer().fromType("other:OtherXOrder").toType(XOrder.class).withJava(OtherToXOrderTransformer.class);
                 transformer().fromType(XOrderResponse.class).toType("other:OtherXOrderResponse")
                         .withJava(XOrderResponseToOtherTransformer.class);
                 from("direct:custom").inputType("other:OtherXOrder").outputType("other:OtherXOrderResponse")
-                        .inOut("direct:xyz");
+                        .to(ExchangePattern.InOut, "direct:xyz");
             }
         };
     }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/NotifyBuilderOnFailureShutdownCamelIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/NotifyBuilderOnFailureShutdownCamelIssueTest.java
@@ -31,7 +31,7 @@ public class NotifyBuilderOnFailureShutdownCamelIssueTest extends ContextTestSup
     @Test
     public void testIssue() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(10).create();
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentIssueTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.Registry;
@@ -74,7 +75,7 @@ public class SedaFileIdempotentIssueTest extends ContextTestSupport {
                 onException(RuntimeException.class).process(new ShutDown());
 
                 from("file:target/data/inbox?idempotent=true&noop=true&idempotentRepository=#repo&initialDelay=0&delay=10")
-                        .to("log:begin").inOut("seda:process");
+                        .to("log:begin").to(ExchangePattern.InOut, "seda:process");
 
                 from("seda:process").throwException(new RuntimeException("Testing with exception"));
             }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentNoTimeoutIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentNoTimeoutIssueTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.issues;
 
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 
 /**
@@ -31,7 +32,7 @@ public class SedaFileIdempotentNoTimeoutIssueTest extends SedaFileIdempotentIssu
                 onException(RuntimeException.class).process(new ShutDown());
 
                 from("file:target/data/inbox?idempotent=true&noop=true&idempotentRepository=#repo&initialDelay=0&delay=10")
-                        .to("log:begin").inOut("seda:process?timeout=-1");
+                        .to("log:begin").to(ExchangePattern.InOut, "seda:process?timeout=-1");
 
                 from("seda:process").throwException(new RuntimeException("Testing with exception"));
             }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentTimeoutIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SedaFileIdempotentTimeoutIssueTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.issues;
 
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 
 /**
@@ -31,7 +32,7 @@ public class SedaFileIdempotentTimeoutIssueTest extends SedaFileIdempotentIssueT
                 onException(RuntimeException.class).process(new ShutDown());
 
                 from("file:target/data/inbox?idempotent=true&noop=true&idempotentRepository=#repo&initialDelay=0&delay=10")
-                        .to("log:begin").inOut("seda:process?timeout=100");
+                        .to("log:begin").to(ExchangePattern.InOut, "seda:process?timeout=100");
 
                 from("seda:process").throwException(new RuntimeException("Testing with exception"));
             }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SetBodyTryCatchIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SetBodyTryCatchIssueTest.java
@@ -55,14 +55,14 @@ public class SetBodyTryCatchIssueTest extends ContextTestSupport {
     public static void doSomething(Exchange exchange) throws Exception {
         Map<String, Object> headers = exchange.getIn().getHeaders();
 
-        exchange.getOut().setBody("Bye World");
+        exchange.getMessage().setBody("Bye World");
         // we copy the headers by mistake by setting it as a reference from the
         // IN
         // but we should ideally do as below instead
         // but we want to let Camel handle this situation as well, otherwise
         // headers may appear as lost
-        // exchange.getOut().getHeaders().putAll(headers);
-        exchange.getOut().setHeaders(headers);
+        // exchange.getMessage().getHeaders().putAll(headers);
+        exchange.getMessage().setHeaders(headers);
 
         throw new IllegalArgumentException("Forced");
     }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SetHeaderInDoCatchIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SetHeaderInDoCatchIssueTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.issues;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -37,7 +38,7 @@ public class SetHeaderInDoCatchIssueTest extends ContextTestSupport {
             }
         });
 
-        assertEquals("CamsResponse", exchange.getOut().getHeader("Status"));
+        assertEquals("CamsResponse", exchange.getMessage().getHeader("Status"));
     }
 
     @Test
@@ -101,7 +102,7 @@ public class SetHeaderInDoCatchIssueTest extends ContextTestSupport {
                 context.setTracing(true);
 
                 from("direct:start").doTry().to("bean:A").setHeader("CamelJmsDestinationName", constant("queue:outQueue"))
-                        .inOut("bean:B").setHeader("Status", constant("CamsResponse"))
+                        .to(ExchangePattern.InOut, "bean:B").setHeader("Status", constant("CamsResponse"))
                         .doCatch(ExchangeTimedOutException.class).setHeader("Status", constant("TimeOut"))
                         .doCatch(Exception.class).setHeader("Status", constant("ExceptionGeneral"))
                         .end().to("bean:C").transform(body());

--- a/core/camel-core/src/test/java/org/apache/camel/language/TokenPairPredicateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/TokenPairPredicateTest.java
@@ -47,7 +47,7 @@ public class TokenPairPredicateTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/pair/hello.xml");
         assertFalse(file.exists(), "File should not exists " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/language/XPathFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/XPathFromFileExceptionTest.java
@@ -48,7 +48,7 @@ public class XPathFromFileExceptionTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/xpath/hello.xml");
         assertFalse(file.exists(), "File should not exists " + file);
@@ -67,7 +67,7 @@ public class XPathFromFileExceptionTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         File file = new File("target/data/xpath/hello2.xml");
         assertFalse(file.exists(), "File should not exists " + file);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/FileRollbackOnCompletionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/FileRollbackOnCompletionTest.java
@@ -97,7 +97,7 @@ public class FileRollbackOnCompletionTest extends ContextTestSupport {
             assertEquals("Simulated fatal error", e.getCause().getMessage());
         }
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // onCompletion is async so we gotta wait a bit for the file to be
         // deleted

--- a/core/camel-core/src/test/java/org/apache/camel/processor/FromToInOutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/FromToInOutTest.java
@@ -43,7 +43,7 @@ public class FromToInOutTest extends ContextTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("direct:start").inOut("direct:foo").to("mock:result");
+                from("direct:start").to(ExchangePattern.InOut, "direct:foo").to("mock:result");
 
                 from("direct:foo").process(new Processor() {
                     public void process(Exchange exchange) throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/LoopWithAggregatorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/LoopWithAggregatorTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.processor;
 import org.apache.camel.AggregationStrategy;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class LoopWithAggregatorTest extends ContextTestSupport {
                         // copy of the input exchange
                         // for each loop iteration, instead of keep using the same
                         // exchange all over
-                        .loop(3).copy().enrich("direct:getTimeStamp", new ExampleAggregationStrategy()).inOnly("mock:loop")
+                        .loop(3).copy().enrich("direct:getTimeStamp", new ExampleAggregationStrategy()).to(ExchangePattern.InOnly,"mock:loop")
                         .end().to("mock:result");
                 // END SNIPPET: e1
 
@@ -69,13 +70,13 @@ public class LoopWithAggregatorTest extends ContextTestSupport {
         @Override
         public Exchange aggregate(Exchange original, Exchange resource) {
             String originalBody = original.getIn().getBody(String.class);
-            if (original.getOut().getBody() != null) {
-                originalBody = original.getOut().getBody(String.class);
+            if (original.getMessage().getBody() != null) {
+                originalBody = original.getMessage().getBody(String.class);
             }
             String resourceResponse = resource.getIn().getBody(String.class);
             String mergeResult = originalBody + resourceResponse;
             if (original.getPattern().isOutCapable()) {
-                original.getOut().setBody(mergeResult);
+                original.getMessage().setBody(mergeResult);
             } else {
                 original.getIn().setBody(mergeResult);
             }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastRedeliverTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastRedeliverTest.java
@@ -119,7 +119,7 @@ public class MulticastRedeliverTest extends ContextTestSupport {
                         assertNull(exchange.getException());
 
                         // mutate OUT body
-                        exchange.getOut().setBody("Bye World");
+                        exchange.getMessage().setBody("Bye World");
 
                         counter++;
                         throw new IllegalArgumentException("Forced");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/PipelineTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/PipelineTest.java
@@ -36,12 +36,12 @@ public class PipelineTest extends ContextTestSupport {
     private static final class InToOut implements Processor {
         @Override
         public void process(Exchange exchange) throws Exception {
-            exchange.getOut().copyFrom(exchange.getIn());
+            exchange.getMessage().copyFrom(exchange.getIn());
             Integer counter = exchange.getIn().getHeader("copy-counter", Integer.class);
             if (counter == null) {
                 counter = 0;
             }
-            exchange.getOut().setHeader("copy-counter", counter + 1);
+            exchange.getMessage().setHeader("copy-counter", counter + 1);
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ProcessorMutateExchangeRedeliverTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ProcessorMutateExchangeRedeliverTest.java
@@ -99,7 +99,7 @@ public class ProcessorMutateExchangeRedeliverTest extends ContextTestSupport {
                         assertNull(exchange.getException());
 
                         // mutate OUT body
-                        exchange.getOut().setBody("Bye World");
+                        exchange.getMessage().setBody("Bye World");
 
                         counter++;
                         throw new IllegalArgumentException("Forced");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RouteContextProcessorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RouteContextProcessorTest.java
@@ -60,7 +60,7 @@ public class RouteContextProcessorTest extends ContextTestSupport {
 
         ProducerTemplate template = context.createProducerTemplate();
         for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
-            template.sendBodyAndHeader("seda:fork", "Test Message: " + i, "seqnum", new Long(i));
+            template.sendBodyAndHeader("seda:fork", "Test Message: " + i, "seqnum", Long.valueOf(i));
         }
 
         long expectedTime = NUMBER_OF_MESSAGES * (RandomSleepProcessor.MAX_PROCESS_TIME + RandomSleepProcessor.MIN_PROCESS_TIME)

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SamplingThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SamplingThrottlerTest.java
@@ -47,7 +47,7 @@ public class SamplingThrottlerTest extends ContextTestSupport {
         List<Exchange> sentExchanges = new ArrayList<>();
         sendExchangesThroughDroppingThrottler(sentExchanges, 15);
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
         mock.assertIsSatisfied();
 
         validateDroppedExchanges(sentExchanges, mock.getReceivedCounter());
@@ -70,7 +70,7 @@ public class SamplingThrottlerTest extends ContextTestSupport {
         // send another 5 now
         sendExchangesThroughDroppingThrottler(sentExchanges, 5);
 
-        notify.matchesMockWaitTime();
+        notify.matchesWaitTime();
         mock.assertIsSatisfied();
 
         validateDroppedExchanges(sentExchanges, mock.getReceivedCounter());
@@ -165,7 +165,7 @@ public class SamplingThrottlerTest extends ContextTestSupport {
 
                 from("direct:sample-configured").sample(1, TimeUnit.SECONDS).to("mock:result");
 
-                from("direct:sample-configured-via-dsl").sample().samplePeriod(1).timeUnits(TimeUnit.SECONDS).to("mock:result");
+                from("direct:sample-configured-via-dsl").sample(1, TimeUnit.SECONDS).to("mock:result");
 
                 from("direct:sample-messageFrequency").sample(10).to("mock:result");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SetExchangePatternTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SetExchangePatternTest.java
@@ -139,10 +139,10 @@ public class SetExchangePatternTest extends ContextTestSupport {
             public void configure() {
                 // START SNIPPET: example
                 // Send to an endpoint using InOut
-                from("direct:testInOut").inOut("mock:result");
+                from("direct:testInOut").to(ExchangePattern.InOut, "mock:result");
 
                 // Send to an endpoint using InOut
-                from("direct:testInOnly").inOnly("mock:result");
+                from("direct:testInOnly").to(ExchangePattern.InOnly, "mock:result");
 
                 // Set the exchange pattern to InOut, then send it from
                 // direct:inOnly to mock:result endpoint

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsRejectedExecutionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThreadsRejectedExecutionTest.java
@@ -120,7 +120,7 @@ public class ThreadsRejectedExecutionTest extends ContextTestSupport {
         }
         assertMockEndpointsSatisfied();
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         int inflight = context.getInflightRepository().size();
         assertEquals(0, inflight);
@@ -146,7 +146,7 @@ public class ThreadsRejectedExecutionTest extends ContextTestSupport {
         }
         assertMockEndpointsSatisfied();
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         int inflight = context.getInflightRepository().size();
         assertEquals(0, inflight);
@@ -172,7 +172,7 @@ public class ThreadsRejectedExecutionTest extends ContextTestSupport {
         }
         assertMockEndpointsSatisfied();
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         int inflight = context.getInflightRepository().size();
         assertEquals(0, inflight);
@@ -198,7 +198,7 @@ public class ThreadsRejectedExecutionTest extends ContextTestSupport {
         }
         assertMockEndpointsSatisfied();
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         int inflight = context.getInflightRepository().size();
         assertEquals(0, inflight);
@@ -230,7 +230,7 @@ public class ThreadsRejectedExecutionTest extends ContextTestSupport {
         }
         assertMockEndpointsSatisfied();
 
-        assertTrue(notify.matchesMockWaitTime());
+        assertTrue(notify.matchesWaitTime());
 
         int inflight = context.getInflightRepository().size();
         assertEquals(0, inflight);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/UnitOfWorkProducerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/UnitOfWorkProducerTest.java
@@ -66,7 +66,7 @@ public class UnitOfWorkProducerTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // there should be 2 completed events
         // one for the producer template, and another for the Camel route
@@ -82,7 +82,7 @@ public class UnitOfWorkProducerTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        oneExchangeDone.matchesMockWaitTime();
+        oneExchangeDone.matchesWaitTime();
 
         // there should be 1 completed events as direct endpoint will be like a
         // direct method call

--- a/core/camel-core/src/test/java/org/apache/camel/processor/UnmarshalProcessorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/UnmarshalProcessorTest.java
@@ -42,7 +42,7 @@ public class UnmarshalProcessorTest extends TestSupport {
 
         processor.process(exchange);
 
-        assertEquals("body", exchange.getOut().getBody(), "UnmarshalProcessor did not copy OUT from IN message");
+        assertEquals("body", exchange.getMessage().getBody(), "UnmarshalProcessor did not copy OUT from IN message");
     }
 
     @Test
@@ -70,8 +70,8 @@ public class UnmarshalProcessorTest extends TestSupport {
         Processor processor = new UnmarshalProcessor(new MyDataFormat(out));
 
         processor.process(exchange);
-        assertSame(out, exchange.getOut(), "UnmarshalProcessor did not make use of the returned OUT message");
-        assertSame(out.getBody(), exchange.getOut().getBody(),
+        assertSame(out, exchange.getMessage(), "UnmarshalProcessor did not make use of the returned OUT message");
+        assertSame(out.getBody(), exchange.getMessage().getBody(),
                 "UnmarshalProcessor did change the body bound to the OUT message");
     }
 
@@ -82,7 +82,7 @@ public class UnmarshalProcessorTest extends TestSupport {
         Processor processor = new UnmarshalProcessor(new MyDataFormat(unmarshalled));
 
         processor.process(exchange);
-        assertSame(unmarshalled, exchange.getOut().getBody(),
+        assertSame(unmarshalled, exchange.getMessage().getBody(),
                 "UnmarshalProcessor did not make use of the returned object being returned while unmarshalling");
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointDelayUoWTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointDelayUoWTest.java
@@ -46,7 +46,7 @@ public class AsyncEndpointDelayUoWTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // wait a bit to ensure UoW has been run
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertFalse(beforeThreadName.equalsIgnoreCase(afterThreadName), "Should use different threads");
         assertEquals(1, sync.isOnComplete());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointUoWFailedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointUoWFailedTest.java
@@ -52,7 +52,7 @@ public class AsyncEndpointUoWFailedTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // wait a bit to ensure UoW has been run
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertFalse(beforeThreadName.equalsIgnoreCase(afterThreadName), "Should use different threads");
         assertEquals(0, sync.isOnComplete());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointUoWTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointUoWTest.java
@@ -46,7 +46,7 @@ public class AsyncEndpointUoWTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // wait a bit to ensure UoW has been run
-        assertTrue(oneExchangeDone.matchesMockWaitTime());
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
         assertFalse(beforeThreadName.equalsIgnoreCase(afterThreadName), "Should use different threads");
         assertEquals(1, sync.isOnComplete());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
@@ -84,7 +84,7 @@ public class PollEnrichFileCustomAggregationStrategyTest extends ContextTestSupp
         public Exchange aggregate(Exchange original, Exchange resource) {
             Object resourceResponse = resource.getIn().getBody();
             if (original.getPattern().isOutCapable()) {
-                original.getOut().setBody(resourceResponse);
+                original.getMessage().setBody(resourceResponse);
                 original.getProperties().putAll(resource.getProperties());
             } else {
                 original.getIn().setBody(resourceResponse);

--- a/core/camel-core/src/test/java/org/apache/camel/support/IntrospectionSupportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/IntrospectionSupportTest.java
@@ -33,17 +33,31 @@ import org.apache.camel.util.AnotherExampleBean;
 import org.apache.camel.util.OtherExampleBean;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.camel.support.IntrospectionSupport.extractProperties;
+import static org.apache.camel.support.IntrospectionSupport.findSetterMethodsOrderedByParameterType;
+import static org.apache.camel.support.IntrospectionSupport.getProperties;
+import static org.apache.camel.support.IntrospectionSupport.getProperty;
+import static org.apache.camel.support.IntrospectionSupport.getPropertyGetter;
+import static org.apache.camel.support.IntrospectionSupport.getPropertySetter;
+import static org.apache.camel.support.IntrospectionSupport.hasProperties;
+import static org.apache.camel.support.IntrospectionSupport.isGetter;
+import static org.apache.camel.support.IntrospectionSupport.isSetter;
+import static org.apache.camel.support.IntrospectionSupport.setProperty;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test for IntrospectionSupport
+ *
+ * The deprecation warnings are a false positive here because this class test IntrospectionSupport (which is, indeed,
+ * deprecated)
  */
+
 public class IntrospectionSupportTest extends ContextTestSupport {
 
     @Test
     public void testOverloadSetterChooseStringSetter() throws Exception {
         MyOverloadedBean overloadedBean = new MyOverloadedBean();
-        IntrospectionSupport.setProperty(context.getTypeConverter(), overloadedBean, "bean", "James");
+        setProperty(context.getTypeConverter(), overloadedBean, "bean", "James");
         assertEquals("James", overloadedBean.getName());
     }
 
@@ -52,7 +66,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         MyOverloadedBean overloadedBean = new MyOverloadedBean();
         ExampleBean bean = new ExampleBean();
         bean.setName("Claus");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), overloadedBean, "bean", bean);
+        setProperty(context.getTypeConverter(), overloadedBean, "bean", bean);
         assertEquals("Claus", overloadedBean.getName());
     }
 
@@ -62,15 +76,15 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         Object value = "Willem".getBytes();
         // should use byte[] -> String type converter and call the
         // setBean(String) setter method
-        IntrospectionSupport.setProperty(context.getTypeConverter(), overloadedBean, "bean", value);
+        setProperty(context.getTypeConverter(), overloadedBean, "bean", value);
         assertEquals("Willem", overloadedBean.getName());
     }
 
     @Test
     public void testPassword() throws Exception {
         MyPasswordBean passwordBean = new MyPasswordBean();
-        IntrospectionSupport.setProperty(context.getTypeConverter(), passwordBean, "oldPassword", "Donald");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), passwordBean, "newPassword", "Duck");
+        setProperty(context.getTypeConverter(), passwordBean, "oldPassword", "Donald");
+        setProperty(context.getTypeConverter(), passwordBean, "newPassword", "Duck");
         assertEquals("Donald", passwordBean.getOldPassword());
         assertEquals("Duck", passwordBean.getNewPassword());
     }
@@ -142,9 +156,9 @@ public class IntrospectionSupportTest extends ContextTestSupport {
     @Test
     public void testBuilderPatternWith() throws Exception {
         MyBuilderPatternWithBean builderBean = new MyBuilderPatternWithBean();
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "name", "Donald");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "age", "33");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "gold-customer", "true");
+        setProperty(context.getTypeConverter(), builderBean, "name", "Donald");
+        setProperty(context.getTypeConverter(), builderBean, "age", "33");
+        setProperty(context.getTypeConverter(), builderBean, "gold-customer", "true");
         assertEquals("Donald", builderBean.getName());
         assertEquals(33, builderBean.getAge());
         assertTrue(builderBean.isGoldCustomer());
@@ -186,9 +200,9 @@ public class IntrospectionSupportTest extends ContextTestSupport {
     @Test
     public void testBuilderPattern() throws Exception {
         MyBuilderPatternBean builderBean = new MyBuilderPatternBean();
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "name", "Goofy");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "age", "34");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), builderBean, "gold-customer", "true");
+        setProperty(context.getTypeConverter(), builderBean, "name", "Goofy");
+        setProperty(context.getTypeConverter(), builderBean, "age", "34");
+        setProperty(context.getTypeConverter(), builderBean, "gold-customer", "true");
         assertEquals("Goofy", builderBean.getName());
         assertEquals(34, builderBean.getAge());
         assertTrue(builderBean.isGoldCustomer());
@@ -233,37 +247,37 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         Method setter2 = MyOtherBuilderBean.class.getMethod("setName", String.class);
         Method setter3 = MyOtherOtherBuilderBean.class.getMethod("setName", String.class);
 
-        assertFalse(IntrospectionSupport.isSetter(setter, false));
-        assertTrue(IntrospectionSupport.isSetter(setter, true));
+        assertFalse(isSetter(setter, false));
+        assertTrue(isSetter(setter, true));
 
-        assertFalse(IntrospectionSupport.isSetter(setter2, false));
-        assertTrue(IntrospectionSupport.isSetter(setter2, true));
+        assertFalse(isSetter(setter2, false));
+        assertTrue(isSetter(setter2, true));
 
-        assertFalse(IntrospectionSupport.isSetter(setter3, false));
-        assertTrue(IntrospectionSupport.isSetter(setter3, true));
+        assertFalse(isSetter(setter3, false));
+        assertTrue(isSetter(setter3, true));
     }
 
     @Test
     public void testHasProperties() throws Exception {
         Map<String, Object> empty = Collections.emptyMap();
-        assertFalse(IntrospectionSupport.hasProperties(empty, null));
-        assertFalse(IntrospectionSupport.hasProperties(empty, ""));
-        assertFalse(IntrospectionSupport.hasProperties(empty, "foo."));
+        assertFalse(hasProperties(empty, null));
+        assertFalse(hasProperties(empty, ""));
+        assertFalse(hasProperties(empty, "foo."));
 
         Map<String, Object> param = new HashMap<>();
-        assertFalse(IntrospectionSupport.hasProperties(param, null));
-        assertFalse(IntrospectionSupport.hasProperties(param, ""));
-        assertFalse(IntrospectionSupport.hasProperties(param, "foo."));
+        assertFalse(hasProperties(param, null));
+        assertFalse(hasProperties(param, ""));
+        assertFalse(hasProperties(param, "foo."));
 
         param.put("name", "Claus");
-        assertTrue(IntrospectionSupport.hasProperties(param, null));
-        assertTrue(IntrospectionSupport.hasProperties(param, ""));
-        assertFalse(IntrospectionSupport.hasProperties(param, "foo."));
+        assertTrue(hasProperties(param, null));
+        assertTrue(hasProperties(param, ""));
+        assertFalse(hasProperties(param, "foo."));
 
         param.put("foo.name", "Hadrian");
-        assertTrue(IntrospectionSupport.hasProperties(param, null));
-        assertTrue(IntrospectionSupport.hasProperties(param, ""));
-        assertTrue(IntrospectionSupport.hasProperties(param, "foo."));
+        assertTrue(hasProperties(param, null));
+        assertTrue(hasProperties(param, ""));
+        assertTrue(hasProperties(param, "foo."));
     }
 
     @Test
@@ -273,7 +287,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setPrice(10.0);
 
         Map<String, Object> map = new HashMap<>();
-        IntrospectionSupport.getProperties(bean, map, null);
+        getProperties(bean, map, null);
         assertEquals(3, map.size());
 
         assertEquals("Claus", map.get("name"));
@@ -297,7 +311,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setChildren(children);
 
         Map<String, Object> map = new HashMap<>();
-        IntrospectionSupport.getProperties(bean, map, null);
+        getProperties(bean, map, null);
         assertEquals(7, map.size());
 
         assertEquals("Claus", map.get("name"));
@@ -318,7 +332,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setId("123");
 
         Map<String, Object> map = new HashMap<>();
-        IntrospectionSupport.getProperties(bean, map, "bean.");
+        getProperties(bean, map, "bean.");
         assertEquals(3, map.size());
 
         assertEquals("Claus", map.get("bean.name"));
@@ -335,7 +349,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setId(null);
 
         Map<String, Object> map = new HashMap<>();
-        IntrospectionSupport.getProperties(bean, map, null, false);
+        getProperties(bean, map, null, false);
         assertEquals(2, map.size());
 
         assertEquals("Claus", map.get("name"));
@@ -350,7 +364,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setName("Claus");
         bean.setPrice(10.0);
 
-        Object name = IntrospectionSupport.getProperty(bean, "name");
+        Object name = getProperty(bean, "name");
         assertEquals("Claus", name);
     }
 
@@ -361,7 +375,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setName("Claus");
         bean.setPrice(10.0);
 
-        IntrospectionSupport.setProperty(context, bean, "name", "James");
+        setProperty(context, bean, "name", "James");
         assertEquals("James", bean.getName());
     }
 
@@ -375,8 +389,8 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setGoldCustomer(true);
         bean.setLittle(true);
 
-        IntrospectionSupport.setProperty(context, bean, "name", "James");
-        IntrospectionSupport.setProperty(context, bean, "gold-customer", "false");
+        setProperty(context, bean, "name", "James");
+        setProperty(context, bean, "gold-customer", "false");
         assertEquals("James", bean.getName());
         assertEquals(false, bean.isGoldCustomer());
     }
@@ -393,13 +407,13 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         Collection<?> children = new ArrayList<>();
         bean.setChildren(children);
 
-        Object name = IntrospectionSupport.getProperty(bean, "name");
+        Object name = getProperty(bean, "name");
         assertEquals("Claus", name);
-        assertSame(date, IntrospectionSupport.getProperty(bean, "date"));
-        assertSame(children, IntrospectionSupport.getProperty(bean, "children"));
-        assertEquals(Boolean.TRUE, IntrospectionSupport.getProperty(bean, "goldCustomer"));
-        assertEquals(Boolean.TRUE, IntrospectionSupport.getProperty(bean, "gold-customer"));
-        assertEquals(Boolean.TRUE, IntrospectionSupport.getProperty(bean, "little"));
+        assertSame(date, getProperty(bean, "date"));
+        assertSame(children, getProperty(bean, "children"));
+        assertEquals(Boolean.TRUE, getProperty(bean, "goldCustomer"));
+        assertEquals(Boolean.TRUE, getProperty(bean, "gold-customer"));
+        assertEquals(Boolean.TRUE, getProperty(bean, "little"));
     }
 
     @Test
@@ -413,9 +427,9 @@ public class IntrospectionSupportTest extends ContextTestSupport {
             bean.setPrice(10.0);
             bean.setId("1");
 
-            Object name = IntrospectionSupport.getProperty(bean, "name");
-            Object id = IntrospectionSupport.getProperty(bean, "id");
-            Object price = IntrospectionSupport.getProperty(bean, "price");
+            Object name = getProperty(bean, "name");
+            Object id = getProperty(bean, "id");
+            Object price = getProperty(bean, "price");
 
             assertEquals("Claus", name);
             assertEquals(10.0, price);
@@ -431,11 +445,11 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setName("Claus");
         bean.setPrice(10.0);
 
-        Method name = IntrospectionSupport.getPropertyGetter(ExampleBean.class, "name");
+        Method name = getPropertyGetter(ExampleBean.class, "name");
         assertEquals("getName", name.getName());
 
         try {
-            IntrospectionSupport.getPropertyGetter(ExampleBean.class, "xxx");
+            getPropertyGetter(ExampleBean.class, "xxx");
             fail("Should have thrown exception");
         } catch (NoSuchMethodException e) {
             assertEquals("org.apache.camel.support.jndi.ExampleBean.getXxx()", e.getMessage());
@@ -448,11 +462,11 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         bean.setName("Claus");
         bean.setPrice(10.0);
 
-        Method name = IntrospectionSupport.getPropertySetter(ExampleBean.class, "name");
+        Method name = getPropertySetter(ExampleBean.class, "name");
         assertEquals("setName", name.getName());
 
         try {
-            IntrospectionSupport.getPropertySetter(ExampleBean.class, "xxx");
+            getPropertySetter(ExampleBean.class, "xxx");
             fail("Should have thrown exception");
         } catch (NoSuchMethodException e) {
             assertEquals("org.apache.camel.support.jndi.ExampleBean.setXxx", e.getMessage());
@@ -464,12 +478,12 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         ExampleBean bean = new ExampleBean();
 
         Method name = bean.getClass().getMethod("getName", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(name));
-        assertEquals(false, IntrospectionSupport.isSetter(name));
+        assertEquals(true, isGetter(name));
+        assertEquals(false, isSetter(name));
 
         Method price = bean.getClass().getMethod("getPrice", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(price));
-        assertEquals(false, IntrospectionSupport.isSetter(price));
+        assertEquals(true, isGetter(price));
+        assertEquals(false, isSetter(price));
     }
 
     @Test
@@ -477,12 +491,12 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         ExampleBean bean = new ExampleBean();
 
         Method name = bean.getClass().getMethod("setName", String.class);
-        assertEquals(false, IntrospectionSupport.isGetter(name));
-        assertEquals(true, IntrospectionSupport.isSetter(name));
+        assertEquals(false, isGetter(name));
+        assertEquals(true, isSetter(name));
 
         Method price = bean.getClass().getMethod("setPrice", double.class);
-        assertEquals(false, IntrospectionSupport.isGetter(price));
-        assertEquals(true, IntrospectionSupport.isSetter(price));
+        assertEquals(false, isGetter(price));
+        assertEquals(true, isSetter(price));
     }
 
     @Test
@@ -490,24 +504,24 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         OtherExampleBean bean = new OtherExampleBean();
 
         Method customerId = bean.getClass().getMethod("getCustomerId", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(customerId));
-        assertEquals(false, IntrospectionSupport.isSetter(customerId));
+        assertEquals(true, isGetter(customerId));
+        assertEquals(false, isSetter(customerId));
 
         Method goldCustomer = bean.getClass().getMethod("isGoldCustomer", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(goldCustomer));
-        assertEquals(false, IntrospectionSupport.isSetter(goldCustomer));
+        assertEquals(true, isGetter(goldCustomer));
+        assertEquals(false, isSetter(goldCustomer));
 
         Method silverCustomer = bean.getClass().getMethod("isSilverCustomer", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(silverCustomer));
-        assertEquals(false, IntrospectionSupport.isSetter(silverCustomer));
+        assertEquals(true, isGetter(silverCustomer));
+        assertEquals(false, isSetter(silverCustomer));
 
         Method company = bean.getClass().getMethod("getCompany", (Class<?>[]) null);
-        assertEquals(true, IntrospectionSupport.isGetter(company));
-        assertEquals(false, IntrospectionSupport.isSetter(company));
+        assertEquals(true, isGetter(company));
+        assertEquals(false, isSetter(company));
 
         Method setupSomething = bean.getClass().getMethod("setupSomething", Object.class);
-        assertEquals(false, IntrospectionSupport.isGetter(setupSomething));
-        assertEquals(false, IntrospectionSupport.isSetter(setupSomething));
+        assertEquals(false, isGetter(setupSomething));
+        assertEquals(false, isSetter(setupSomething));
     }
 
     @Test
@@ -515,24 +529,24 @@ public class IntrospectionSupportTest extends ContextTestSupport {
         OtherExampleBean bean = new OtherExampleBean();
 
         Method customerId = bean.getClass().getMethod("setCustomerId", int.class);
-        assertEquals(false, IntrospectionSupport.isGetter(customerId));
-        assertEquals(true, IntrospectionSupport.isSetter(customerId));
+        assertEquals(false, isGetter(customerId));
+        assertEquals(true, isSetter(customerId));
 
         Method goldCustomer = bean.getClass().getMethod("setGoldCustomer", boolean.class);
-        assertEquals(false, IntrospectionSupport.isGetter(goldCustomer));
-        assertEquals(true, IntrospectionSupport.isSetter(goldCustomer));
+        assertEquals(false, isGetter(goldCustomer));
+        assertEquals(true, isSetter(goldCustomer));
 
         Method silverCustomer = bean.getClass().getMethod("setSilverCustomer", Boolean.class);
-        assertEquals(false, IntrospectionSupport.isGetter(silverCustomer));
-        assertEquals(true, IntrospectionSupport.isSetter(silverCustomer));
+        assertEquals(false, isGetter(silverCustomer));
+        assertEquals(true, isSetter(silverCustomer));
 
         Method company = bean.getClass().getMethod("setCompany", String.class);
-        assertEquals(false, IntrospectionSupport.isGetter(company));
-        assertEquals(true, IntrospectionSupport.isSetter(company));
+        assertEquals(false, isGetter(company));
+        assertEquals(true, isSetter(company));
 
         Method setupSomething = bean.getClass().getMethod("setupSomething", Object.class);
-        assertEquals(false, IntrospectionSupport.isGetter(setupSomething));
-        assertEquals(false, IntrospectionSupport.isSetter(setupSomething));
+        assertEquals(false, isGetter(setupSomething));
+        assertEquals(false, isSetter(setupSomething));
     }
 
     @Test
@@ -544,7 +558,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
 
         // extract all "foo." properties
         // and their keys should have the prefix removed
-        Map<String, Object> foo = IntrospectionSupport.extractProperties(params, "foo.");
+        Map<String, Object> foo = extractProperties(params, "foo.");
         assertEquals(2, foo.size());
         assertEquals("Camel", foo.get("name"));
         assertEquals(5, foo.get("age"));
@@ -556,7 +570,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
 
     @Test
     public void testFindSetterMethodsOrderedByParameterType() throws Exception {
-        List<Method> setters = IntrospectionSupport.findSetterMethodsOrderedByParameterType(MyOverloadedBean.class, "bean",
+        List<Method> setters = findSetterMethodsOrderedByParameterType(MyOverloadedBean.class, "bean",
                 false, false, false);
 
         assertNotNull(setters);
@@ -569,15 +583,15 @@ public class IntrospectionSupportTest extends ContextTestSupport {
     @Test
     public void testArray() throws Exception {
         MyBeanWithArray target = new MyBeanWithArray();
-        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[0]", "James");
-        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[1]", "Claus");
+        setProperty(context.getTypeConverter(), target, "names[0]", "James");
+        setProperty(context.getTypeConverter(), target, "names[1]", "Claus");
         assertEquals("James", target.getNames()[0]);
         assertEquals("Claus", target.getNames()[1]);
 
-        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[0]", "JamesX");
+        setProperty(context.getTypeConverter(), target, "names[0]", "JamesX");
         assertEquals("JamesX", target.getNames()[0]);
 
-        IntrospectionSupport.setProperty(context.getTypeConverter(), target, "names[2]", "Andrea");
+        setProperty(context.getTypeConverter(), target, "names[2]", "Andrea");
         assertEquals("JamesX", target.getNames()[0]);
         assertEquals("Claus", target.getNames()[1]);
         assertEquals("Andrea", target.getNames()[2]);

--- a/core/camel-core/src/test/java/org/apache/camel/util/ExchangeHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/util/ExchangeHelperTest.java
@@ -124,8 +124,8 @@ public class ExchangeHelperTest extends ContextTestSupport {
     @Test
     public void testPopulateVariableMapBodyAndHeaderOnly() throws Exception {
         exchange.setPattern(ExchangePattern.InOut);
-        exchange.getOut().setBody("bar");
-        exchange.getOut().setHeader("quote", "Camel rocks");
+        exchange.getMessage().setBody("bar");
+        exchange.getMessage().setHeader("quote", "Camel rocks");
 
         Map<String, Object> map = new HashMap<>();
         ExchangeHelper.populateVariableMap(exchange, map, false);
@@ -144,8 +144,8 @@ public class ExchangeHelperTest extends ContextTestSupport {
     @Test
     public void testPopulateVariableMap() throws Exception {
         exchange.setPattern(ExchangePattern.InOut);
-        exchange.getOut().setBody("bar");
-        exchange.getOut().setHeader("quote", "Camel rocks");
+        exchange.getMessage().setBody("bar");
+        exchange.getMessage().setHeader("quote", "Camel rocks");
 
         Map<String, Object> map = new HashMap<>();
         ExchangeHelper.populateVariableMap(exchange, map, true);
@@ -154,8 +154,8 @@ public class ExchangeHelperTest extends ContextTestSupport {
         assertSame(exchange, map.get("exchange"));
         assertSame(exchange.getIn(), map.get("in"));
         assertSame(exchange.getIn(), map.get("request"));
-        assertSame(exchange.getOut(), map.get("out"));
-        assertSame(exchange.getOut(), map.get("response"));
+        assertSame(exchange.getMessage(), map.get("out"));
+        assertSame(exchange.getMessage(), map.get("response"));
         assertSame(exchange.getIn().getHeaders(), map.get("headers"));
         assertSame(exchange.getIn().getBody(), map.get("body"));
         assertSame(exchange.getContext(), map.get("camelContext"));
@@ -164,8 +164,8 @@ public class ExchangeHelperTest extends ContextTestSupport {
     @Test
     public void testCreateVariableMap() throws Exception {
         exchange.setPattern(ExchangePattern.InOut);
-        exchange.getOut().setBody("bar");
-        exchange.getOut().setHeader("quote", "Camel rocks");
+        exchange.getMessage().setBody("bar");
+        exchange.getMessage().setHeader("quote", "Camel rocks");
 
         Map<?, ?> map = ExchangeHelper.createVariableMap(exchange, true);
 
@@ -173,8 +173,8 @@ public class ExchangeHelperTest extends ContextTestSupport {
         assertSame(exchange, map.get("exchange"));
         assertSame(exchange.getIn(), map.get("in"));
         assertSame(exchange.getIn(), map.get("request"));
-        assertSame(exchange.getOut(), map.get("out"));
-        assertSame(exchange.getOut(), map.get("response"));
+        assertSame(exchange.getMessage(), map.get("out"));
+        assertSame(exchange.getMessage(), map.get("response"));
         assertSame(exchange.getIn().getHeaders(), map.get("headers"));
         assertSame(exchange.getIn().getBody(), map.get("body"));
         assertSame(exchange.getContext(), map.get("camelContext"));


### PR DESCRIPTION
- fixed most usages of deprecated getOut in test code
- fixed usages of matchesMockWaitTime
- removed usages of clearBody and clearHeaders methods
- added suppress warnings to avoid false positives on IntrospectionSupportTest
- fixed warnings about deprecated Integer constructor
- fixed warnings about deprecated Long constructor
- fixed warnings about usages of inOut and inOnly methods
- fixed usages of deprecated sampling definition methods
- fixed usages of AbstractAppender constructor

A bit bigger than usual, but follows the same steps as the others. Mostly one liners fixing deprecation warnings.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md