### PR TITLE
camel-cxf: fixed several warnings about usage of deprecated methods

### DIFF
--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/AbstractCxfWsdlFirstTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/AbstractCxfWsdlFirstTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractCxfWsdlFirstTest extends CamelSpringTestSupport {
     public void testInvokingServiceWithCamelProducer() throws Exception {
         Exchange exchange = sendJaxWsMessageWithHolders("hello");
         assertEquals(false, exchange.isFailed(), "The request should be handled sucessfully");
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         List<Object> result = out.getBody(List.class);
         assertEquals(4, result.size(), "The result list should not be empty");
         Holder<String> name = (Holder<String>) result.get(3);

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerContinuationTimeoutTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerContinuationTimeoutTest.java
@@ -90,9 +90,9 @@ public class CxfConsumerContinuationTimeoutTest extends CamelTestSupport {
                         } else {
                             // Send the response message back
                             if (request.indexOf(ECHO_METHOD) > 0) {
-                                exchange.getOut().setBody(ECHO_RESPONSE);
+                                exchange.getMessage().setBody(ECHO_RESPONSE);
                             } else { // echoBoolean call
-                                exchange.getOut().setBody(ECHO_BOOLEAN_RESPONSE);
+                                exchange.getMessage().setBody(ECHO_BOOLEAN_RESPONSE);
                             }
                         }
                         asyncCallback.done(true);

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerFaultTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerFaultTest.java
@@ -39,7 +39,7 @@ public class CxfConsumerFaultTest extends CxfConsumerPayloadFaultTest {
                                 = new org.apache.camel.wsdl_first.types.UnknownPersonFault();
                         faultDetail.setPersonId("");
                         UnknownPersonFault fault = new UnknownPersonFault("Get the null value of person name", faultDetail);
-                        exchange.getOut().setBody(fault);
+                        exchange.getMessage().setBody(fault);
                     }
                 });
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerMessageTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerMessageTest.java
@@ -66,9 +66,9 @@ public class CxfConsumerMessageTest extends CamelTestSupport {
                         String request = in.getBody(String.class);
                         // Send the response message back
                         if (request.indexOf(ECHO_METHOD) > 0) {
-                            exchange.getOut().setBody(ECHO_RESPONSE);
+                            exchange.getMessage().setBody(ECHO_RESPONSE);
                         } else { // echoBoolean call
-                            exchange.getOut().setBody(ECHO_BOOLEAN_RESPONSE);
+                            exchange.getMessage().setBody(ECHO_BOOLEAN_RESPONSE);
                         }
 
                     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadConvertorTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadConvertorTest.java
@@ -56,7 +56,7 @@ public class CxfConsumerPayLoadConvertorTest extends CxfConsumerPayloadTest {
                             checkRequest("ECHO_REQUEST", request);
                         }
                         // just set the documentString into to the message body
-                        exchange.getOut().setBody(documentString);
+                        exchange.getMessage().setBody(documentString);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadFaultMessageTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadFaultMessageTest.java
@@ -46,7 +46,7 @@ public class CxfConsumerPayLoadFaultMessageTest extends CxfConsumerPayloadFaultT
                         List<Element> outElements = new ArrayList<>();
                         outElements.add(details);
                         CxfPayload<SoapHeader> responsePayload = new CxfPayload<>(null, outElements);
-                        exchange.getOut().setBody(responsePayload);
+                        exchange.getMessage().setBody(responsePayload);
                     }
                 });
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadMarshalFaultTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayLoadMarshalFaultTest.java
@@ -48,7 +48,7 @@ public class CxfConsumerPayLoadMarshalFaultTest extends CxfConsumerPayloadFaultT
                         unknowPersonFault.setPersonId("");
                         context.createMarshaller().marshal(unknowPersonFault, details);
                         fault.setDetail(details);
-                        exchange.getOut().setBody(fault);
+                        exchange.getMessage().setBody(fault);
                     }
                 });
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadTest.java
@@ -93,7 +93,7 @@ public class CxfConsumerPayloadTest extends CxfConsumerMessageTest {
                         outElements.add(new DOMSource(outDocument.getDocumentElement()));
                         // set the payload header with null
                         CxfPayload<SoapHeader> responsePayload = new CxfPayload<>(null, outElements, null);
-                        exchange.getOut().setBody(responsePayload);
+                        exchange.getMessage().setBody(responsePayload);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadXPathClientServerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadXPathClientServerTest.java
@@ -100,7 +100,7 @@ public class CxfConsumerPayloadXPathClientServerTest extends CamelTestSupport {
                         outElements.add(new DOMSource(outDocument.getDocumentElement()));
                         // set the payload header with null
                         CxfPayload<SoapHeader> responsePayload = new CxfPayload<>(null, outElements, null);
-                        exchange.getOut().setBody(responsePayload);
+                        exchange.getMessage().setBody(responsePayload);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadXPathTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerPayloadXPathTest.java
@@ -137,8 +137,8 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
             Object obj = exchange.getIn().getBody();
             //xpath expression directly results in a: String  
             String content = (String) XPathBuilder.xpath("//xml/text()").stringResult().evaluate(context, obj, Object.class);
-            exchange.getOut().setBody(content);
-            exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+            exchange.getMessage().setBody(content);
+            exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
         }
     }
 
@@ -150,8 +150,8 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
             //xpath expression results in a: net.sf.saxon.dom.DOMNodeList
             //after which it is converted to a String
             String content = XPathBuilder.xpath("//xml/text()").evaluate(context, obj, String.class);
-            exchange.getOut().setBody(content);
-            exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+            exchange.getMessage().setBody(content);
+            exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
         }
     }
 
@@ -164,8 +164,8 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
             CxfPayload<SoapHeader> payload = (CxfPayload<SoapHeader>) obj;
             Element el = payload.getBody().get(0);
             Text textnode = (Text) el.getFirstChild();
-            exchange.getOut().setBody(textnode.getNodeValue());
-            exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+            exchange.getMessage().setBody(textnode.getNodeValue());
+            exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
         }
     }
 
@@ -187,8 +187,8 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
                 textnode = (Text) textnode.getNextSibling();
             }
 
-            exchange.getOut().setBody(b.toString());
-            exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+            exchange.getMessage().setBody(b.toString());
+            exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
         }
     }
 
@@ -198,9 +198,9 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
             Object obj = exchange.getIn().getBody();
             String content = (String) obj;
             String msgOut = constructSoapMessage(content);
-            exchange.getOut().setBody(msgOut);
-            exchange.getOut().setHeaders(exchange.getIn().getHeaders());
-            exchange.getOut().setHeader(HEADER_SIZE, "" + content.length());
+            exchange.getMessage().setBody(msgOut);
+            exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
+            exchange.getMessage().setHeader(HEADER_SIZE, "" + content.length());
         }
     }
 
@@ -220,11 +220,11 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
         Exchange exchgOut = template.send(builder.getTestAddress(), exchgIn);
 
         //Verify
-        String result = exchgOut.getOut().getBody(String.class);
+        String result = exchgOut.getMessage().getBody(String.class);
         assertNotNull(result, "response on http call");
 
         //check for data loss in received input (after xpath)
-        String headerSize = exchgOut.getOut().getHeader(HEADER_SIZE, String.class);
+        String headerSize = exchgOut.getMessage().getHeader(HEADER_SIZE, String.class);
         assertEquals("" + repeat, headerSize);
 
         assertTrue(result.length() > repeat, "dataloss in output occurred");

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerProviderTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerProviderTest.java
@@ -62,7 +62,7 @@ public class CxfConsumerProviderTest extends CamelTestSupport {
                         assertNotNull(node);
                         XmlConverter xmlConverter = new XmlConverter();
                         // Put the result back
-                        exchange.getOut().setBody(xmlConverter.toSource(RESPONSE));
+                        exchange.getMessage().setBody(xmlConverter.toSource(RESPONSE));
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerResponseTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerResponseTest.java
@@ -92,7 +92,7 @@ public class CxfConsumerResponseTest extends CamelTestSupport {
                                 // Get the parameter list
                                 List<?> parameter = in.getBody(List.class);
                                 // Put the result back
-                                exchange.getOut().setBody(parameter.get(0));
+                                exchange.getMessage().setBody(parameter.get(0));
                             }
                         })
                         .when(header(CxfConstants.OPERATION_NAME).isEqualTo(PING_OPERATION)).process(new Processor() {

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerStreamCacheTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerStreamCacheTest.java
@@ -70,7 +70,7 @@ public class CxfConsumerStreamCacheTest extends CamelTestSupport {
                         CachedOutputStream cos = new CachedOutputStream(exchange);
                         cos.write(RESPONSE.getBytes("UTF-8"));
                         cos.close();
-                        exchange.getOut().setBody(cos.newStreamCache());
+                        exchange.getMessage().setBody(cos.newStreamCache());
 
                         exchange.adapt(ExtendedExchange.class).addOnCompletion(new Synchronization() {
                             @Override

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerTest.java
@@ -83,11 +83,11 @@ public class CxfConsumerTest extends CamelTestSupport {
                                 String operation = (String) in.getHeader(CxfConstants.OPERATION_NAME);
                                 Object result = operation + " " + (String) parameter.get(0);
                                 // Put the result back
-                                exchange.getOut().setBody(result);
+                                exchange.getMessage().setBody(result);
                                 // set up the response context which force start document
                                 Map<String, Object> map = new HashMap<>();
                                 map.put("org.apache.cxf.stax.force-start-document", Boolean.TRUE);
-                                exchange.getOut().setHeader(Client.RESPONSE_CONTEXT, map);
+                                exchange.getMessage().setHeader(Client.RESPONSE_CONTEXT, map);
                             }
                         })
                         .when(header(CxfConstants.OPERATION_NAME).isEqualTo(ECHO_BOOLEAN_OPERATION)).process(new Processor() {
@@ -96,7 +96,7 @@ public class CxfConsumerTest extends CamelTestSupport {
                                 // Get the parameter list
                                 List<?> parameter = in.getBody(List.class);
                                 // Put the result back
-                                exchange.getOut().setBody(parameter.get(0));
+                                exchange.getMessage().setBody(parameter.get(0));
                             }
                         });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerWithTryCatchTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfConsumerWithTryCatchTest.java
@@ -47,7 +47,7 @@ public class CxfConsumerWithTryCatchTest extends CxfConsumerTest {
                                 String operation = (String) in.getHeader(CxfConstants.OPERATION_NAME);
                                 Object result = operation + " " + (String) parameter.get(0);
                                 // Put the result back
-                                exchange.getOut().setBody(result);
+                                exchange.getMessage().setBody(result);
                             }
                         })
                         .when(header(CxfConstants.OPERATION_NAME).isEqualTo(ECHO_BOOLEAN_OPERATION))
@@ -65,7 +65,7 @@ public class CxfConsumerWithTryCatchTest extends CxfConsumerTest {
                                 // Get the parameter list
                                 List<?> parameter = in.getBody(List.class);
                                 // Put the result back
-                                exchange.getOut().setBody(parameter.get(0));
+                                exchange.getMessage().setBody(parameter.get(0));
                             }
                         })
                         .end();

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfCustomizedExceptionTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfCustomizedExceptionTest.java
@@ -102,7 +102,7 @@ public class CxfCustomizedExceptionTest extends CamelTestSupport {
                         .process(new Processor() {
                             public void process(Exchange exchange) throws Exception {
                                 SoapFault fault = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, SoapFault.class);
-                                exchange.getOut().setBody(fault);
+                                exchange.getMessage().setBody(fault);
                             }
 
                         })

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfJavaOnlyCamelContextAwareTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfJavaOnlyCamelContextAwareTest.java
@@ -85,7 +85,7 @@ public class CxfJavaOnlyCamelContextAwareTest extends CamelTestSupport {
                                    + "</GetPersonResponse>";
 
                         Document xml = context.getTypeConverter().convertTo(Document.class, s);
-                        exchange.getOut().setBody(xml);
+                        exchange.getMessage().setBody(xml);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfJavaOnlyPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfJavaOnlyPayloadModeTest.java
@@ -75,7 +75,7 @@ public class CxfJavaOnlyPayloadModeTest extends CamelTestSupport {
                                    + "</GetPersonResponse>";
 
                         Document xml = context.getTypeConverter().convertTo(Document.class, s);
-                        exchange.getOut().setBody(xml);
+                        exchange.getMessage().setBody(xml);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfMessageStreamExceptionTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfMessageStreamExceptionTest.java
@@ -34,7 +34,7 @@ public class CxfMessageStreamExceptionTest extends CxfMessageCustomizedException
                             public void process(Exchange exchange) throws Exception {
                                 SoapFault fault = exchange
                                         .getProperty(Exchange.EXCEPTION_CAUGHT, SoapFault.class);
-                                exchange.getOut().setBody(fault);
+                                exchange.getMessage().setBody(fault);
                             }
 
                         }).end().to(serviceURI);
@@ -43,11 +43,11 @@ public class CxfMessageStreamExceptionTest extends CxfMessageCustomizedException
                 from(routerEndpointURI).process(new Processor() {
 
                     public void process(Exchange exchange) throws Exception {
-                        Message out = exchange.getOut();
+                        Message out = exchange.getMessage();
                         // Set the message body with the 
                         out.setBody(this.getClass().getResourceAsStream("SoapFaultMessage.xml"));
                         // Set the response code here
-                        out.setHeader(org.apache.cxf.message.Message.RESPONSE_CODE, new Integer(500));
+                        out.setHeader(org.apache.cxf.message.Message.RESPONSE_CODE, Integer.valueOf(500));
                     }
 
                 });

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEITest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfPayloadWsdlWithoutSEITest.java
@@ -50,7 +50,7 @@ public class CxfPayloadWsdlWithoutSEITest extends AbstractCxfWsdlFirstTest {
     public void testInvokingServiceWithCamelProducer() {
         Exchange exchange = sendJaxWsMessage("hello");
         assertEquals(false, exchange.isFailed(), "The request should be handled sucessfully");
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String result = out.getBody(String.class);
         assertStringContains(result, "Bonjour");
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerOperationTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerOperationTest.java
@@ -99,7 +99,7 @@ public class CxfProducerOperationTest extends CxfProducerTest {
             throw exchange.getException();
         }
 
-        assertEquals("param:para1para2", exchange.getOut().getBody(String.class), "Get a wrong response.");
+        assertEquals("param:para1para2", exchange.getMessage().getBody(String.class), "Get a wrong response.");
 
     }
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerProtocalHeaderTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerProtocalHeaderTest.java
@@ -50,10 +50,10 @@ public class CxfProducerProtocalHeaderTest extends CamelTestSupport {
                                 assertNull(exchange.getIn().getHeader("CamelCxfTest"), "We should not get this header");
                                 assertNull(exchange.getIn().getHeader("Transfer-Encoding"), "We should not get this header");
                                 //check the headers
-                                exchange.getOut().setHeader("Content-Type", "text/xml");
-                                exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+                                exchange.getMessage().setHeader("Content-Type", "text/xml");
+                                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
                                 //send the response back 
-                                exchange.getOut().setBody(RESPONSE);
+                                exchange.getMessage().setBody(RESPONSE);
                             }
                         });
             }
@@ -82,7 +82,7 @@ public class CxfProducerProtocalHeaderTest extends CamelTestSupport {
         Exchange exchange = sendSimpleMessage("cxf://http://localhost:" + port
                                               + "/CxfProducerProtocalHeaderTest/user"
                                               + "?serviceClass=org.apache.camel.component.cxf.HelloService");
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String result = out.getBody(String.class);
         assertEquals("echo " + "Hello World!", result, "reply body on Camel");
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerRouterTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerRouterTest.java
@@ -124,7 +124,7 @@ public class CxfProducerRouterTest extends CamelTestSupport {
 
         Exchange exchange = template.send("direct:EndpointA", senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         // The response message's body is an MessageContentsList which first element is the return value of the operation,
         // If there are some holder parameters, the holder parameter will be filled in the reset of List.
         // The result will be extract from the MessageContentsList with the String class type
@@ -144,7 +144,7 @@ public class CxfProducerRouterTest extends CamelTestSupport {
         senderExchange.getIn().setBody(REQUEST_MESSAGE);
         Exchange exchange = template.send("direct:EndpointB", senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String response = out.getBody(String.class);
         assertTrue(response.indexOf("echo " + TEST_MESSAGE) > 0, "It should has the echo message");
         assertTrue(response.indexOf("echoResponse") > 0, "It should has the echoResponse tag");
@@ -159,7 +159,7 @@ public class CxfProducerRouterTest extends CamelTestSupport {
         senderExchange.getIn().setHeader(CxfConstants.OPERATION_NAME, "echo");
         Exchange exchange = template.send("direct:EndpointC", senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String response = out.getBody(String.class);
         assertTrue(response.indexOf("echo " + TEST_MESSAGE) > 0, "It should has the echo message");
         assertTrue(response.indexOf("echoResponse") > 0, "It should has the echoResponse tag");

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerSoapFaultTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerSoapFaultTest.java
@@ -87,7 +87,7 @@ public class CxfProducerSoapFaultTest {
         assertNotNull(exception, "except to get the exception");
         assertTrue(exception instanceof BadRecordLitFault, "Get a wrong soap fault");
         // check out the message header which is copied from in message
-        String fileName = exchange.getOut().getHeader(Exchange.FILE_NAME, String.class);
+        String fileName = exchange.getMessage().getHeader(Exchange.FILE_NAME, String.class);
         assertEquals("testFile", fileName, "Should get the file name from out message header");
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfProducerTest.java
@@ -113,7 +113,7 @@ public class CxfProducerTest {
     public void testInvokingSimpleServerWithParams() throws Exception {
         Exchange exchange = sendSimpleMessage();
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String result = out.getBody(String.class);
         LOG.info("Received output text: " + result);
         Map<String, Object> responseContext = CastUtils.cast((Map<?, ?>) out.getHeader(Client.RESPONSE_CONTEXT));
@@ -152,7 +152,7 @@ public class CxfProducerTest {
     public void testInvokingJaxWsServerWithParams() throws Exception {
         Exchange exchange = sendJaxWsMessage();
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         String result = out.getBody(String.class);
         LOG.info("Received output text: " + result);
         Map<String, Object> responseContext = CastUtils.cast((Map<?, ?>) out.getHeader(Client.RESPONSE_CONTEXT));

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfRawMessageRouterTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfRawMessageRouterTest.java
@@ -80,10 +80,10 @@ public class CxfRawMessageRouterTest extends CxfSimpleRouterTest {
             }
 
         });
-        assertNotNull(MessageHelper.getContentType(exchange.getOut()), "We should get the Content-Type here");
-        assertTrue(MessageHelper.getContentType(exchange.getOut()).startsWith("text/xml"), "Get wrong content type");
-        assertNotNull(exchange.getOut().getHeader("content-type"), "We should get the content-type here");
-        String response = exchange.getOut().getBody(String.class);
+        assertNotNull(MessageHelper.getContentType(exchange.getMessage()), "We should get the Content-Type here");
+        assertTrue(MessageHelper.getContentType(exchange.getMessage()).startsWith("text/xml"), "Get wrong content type");
+        assertNotNull(exchange.getMessage().getHeader("content-type"), "We should get the content-type here");
+        String response = exchange.getMessage().getBody(String.class);
         assertNotNull(response, "Response should not be null");
         assertTrue(response.indexOf("echo hello world") > 0, "We should get right return result");
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
@@ -77,7 +77,7 @@ public class CxfTimeoutTest extends CamelSpringTestSupport {
         Exchange reply = sendJaxWsMessage("cxf://bean:springEndpoint?cxfConfigurer=#myConfigurer");
         // we don't expect the exception here
         assertFalse(reply.isFailed(), "We don't expect the exception here");
-        assertEquals("Greet Hello World!", reply.getOut().getBody(String.class), "Get a wrong response");
+        assertEquals("Greet Hello World!", reply.getMessage().getBody(String.class), "Get a wrong response");
     }
 
     @Test

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/DefaultCxfBindingTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/DefaultCxfBindingTest.java
@@ -254,7 +254,7 @@ public class DefaultCxfBindingTest {
 
         cxfBinding.populateExchangeFromCxfResponse(exchange, cxfExchange, responseContext);
 
-        Map<String, Object> camelHeaders = exchange.getOut().getHeaders();
+        Map<String, Object> camelHeaders = exchange.getMessage().getHeaders();
         assertNotNull(camelHeaders);
         assertEquals(responseContext, camelHeaders.get(Client.RESPONSE_CONTEXT));
 
@@ -281,7 +281,7 @@ public class DefaultCxfBindingTest {
 
         cxfBinding.populateExchangeFromCxfResponse(exchange, cxfExchange, responseContext);
 
-        CxfPayload<?> cxfPayload = exchange.getOut().getBody(CxfPayload.class);
+        CxfPayload<?> cxfPayload = exchange.getMessage().getBody(CxfPayload.class);
 
         assertNotNull(cxfPayload);
         List<?> body = cxfPayload.getBody();

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/RouteBuilderCxfTracer.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/RouteBuilderCxfTracer.java
@@ -41,14 +41,14 @@ public class RouteBuilderCxfTracer extends RouteBuilder {
     private static class DoSomethingProcessor implements Processor {
         @Override
         public void process(Exchange exchange) throws Exception {
-            exchange.getOut().setBody(exchange.getIn().getBody() + " world!");
+            exchange.getMessage().setBody(exchange.getIn().getBody() + " world!");
         }
     }
 
     private static class DoNothingProcessor implements Processor {
         @Override
         public void process(Exchange exchange) throws Exception {
-            exchange.getOut().setBody(exchange.getIn().getBody());
+            exchange.getMessage().setBody(exchange.getIn().getBody());
         }
     }
 
@@ -70,7 +70,7 @@ public class RouteBuilderCxfTracer extends RouteBuilder {
 
             MessageContentsList mclOut = new MessageContentsList();
             mclOut.set(0, gpr);
-            e.getOut().setBody(mclOut, MessageContentsList.class);
+            e.getMessage().setBody(mclOut, MessageContentsList.class);
         }
     }
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/converter/PayLoadConvertToPOJOTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/converter/PayLoadConvertToPOJOTest.java
@@ -101,7 +101,7 @@ public class PayLoadConvertToPOJOTest extends CamelTestSupport {
 
                         GetPersonResponse reply = new GetPersonResponse();
                         reply.setPersonId(request.getPersonId());
-                        exchange.getOut().setBody(reply);
+                        exchange.getMessage().setBody(reply);
                     }
 
                 });

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/holder/MyProcessor.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/holder/MyProcessor.java
@@ -39,7 +39,7 @@ public class MyProcessor implements Processor {
             }
             parameters.add(0, "Ordered ammount " + amount);
             //reuse the MessageContentList at this time to test CAMEL-4113
-            exchange.getOut().setBody(parameters);
+            exchange.getMessage().setBody(parameters);
         } else {
             List<Object> parameters = in.getBody(List.class);
             int amount = (Integer) parameters.remove(0);
@@ -47,7 +47,7 @@ public class MyProcessor implements Processor {
             securityOrder.value = "secureParts";
             parameters.add(0, "Ordered ammount " + amount);
             //reuse the MessageContentList at this time to test CAMEL-4113
-            exchange.getOut().setBody(parameters);
+            exchange.getMessage().setBody(parameters);
         }
     }
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerSessionTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerSessionTest.java
@@ -50,45 +50,45 @@ public class CxfRsAsyncProducerSessionTest extends CamelSpringTestSupport {
 
     @Test
     public void testNoSessionProxy() {
-        String response = sendMessage("direct://proxy", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxy", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
-        response = sendMessage("direct://proxy", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxy", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
     }
 
     @Test
     public void testExchangeSessionProxy() {
-        String response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
     }
 
     @Test
     public void testInstanceSession() {
-        String response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old Old World", response);
         // we do the instance tests for proxy and http in one test because order
         // matters here
-        response = sendMessage("direct://httpinstance", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://httpinstance", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old Old World", response);
     }
 
     @Test
     public void testNoSessionHttp() {
-        String response = sendMessage("direct://http", "World", Boolean.TRUE).getOut().getBody(String.class);
+        String response = sendMessage("direct://http", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
-        response = sendMessage("direct://http", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://http", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
     }
 
     @Test
     public void testExchangeSessionHttp() {
-        String response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getOut().getBody(String.class);
+        String response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerTest.java
@@ -59,7 +59,7 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         public void process(Exchange exchange) throws Exception {
             // check the query
             Message inMessage = exchange.getIn();
-            exchange.getOut().setBody(inMessage.getHeader(Exchange.HTTP_QUERY, String.class));
+            exchange.getMessage().setBody(inMessage.getHeader(Exchange.HTTP_QUERY, String.class));
         }
     }
 
@@ -98,13 +98,13 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
         // END SNIPPET: ProxyExample     
     }
 
@@ -122,12 +122,12 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        List<Customer> response = CastUtils.cast((List<?>) exchange.getOut().getBody());
+        List<Customer> response = CastUtils.cast((List<?>) exchange.getMessage().getBody());
 
         assertNotNull(response, "The response should not be null");
         assertTrue(response.contains(new Customer(113, "Dan")), "Dan is missing!");
         assertTrue(response.contains(new Customer(123, "John")), "John is missing!");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -150,12 +150,12 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        List<Customer> response = CastUtils.cast((List<?>) exchange.getOut().getBody());
+        List<Customer> response = CastUtils.cast((List<?>) exchange.getMessage().getBody());
 
         assertNotNull(response, "The response should not be null");
         assertTrue(response.contains(new Customer(113, "Dan")), "Dan is missing!");
         assertTrue(response.contains(new Customer(123, "John")), "John is missing!");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -178,13 +178,13 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
     }
 
     @Test
@@ -208,7 +208,7 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
 
         // we should get the exception here 
         assertNull(exchange.getException(), "Don't expect the exception here");
-        Message result = exchange.getOut();
+        Message result = exchange.getMessage();
         assertEquals(406, result.getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong http status code.");
 
     }
@@ -259,11 +259,11 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -286,11 +286,11 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                 });
 
         // get the response message
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -313,13 +313,13 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertNotNull(response.getEntity(), "The response entity should not be null");
         // check the response code
         assertEquals(201, response.getStatus(), "Get a wrong response code");
         // check the response code from message header
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -342,13 +342,13 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertNotNull(response.getEntity(), "The response entity should not be null");
         // check the response code
         assertEquals(201, response.getStatus(), "Get a wrong response code");
         // check the response code from message header
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -375,11 +375,11 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertTrue(response.getId() != 8888, "Get a wrong customer id");
         assertEquals("Willem", response.getName(), "Get a wrong customer name");
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -396,7 +396,7 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                 });
 
         // get the response message 
-        String response = exchange.getOut().getBody(String.class);
+        String response = exchange.getMessage().getBody(String.class);
         assertNotNull(response, "The response should not be null");
         assertEquals("q1=12&q2=13", response, "The response value is wrong");
     }
@@ -422,7 +422,7 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
                 });
 
         // get the response message 
-        String response = exchange.getOut().getBody(String.class);
+        String response = exchange.getMessage().getBody(String.class);
         assertNotNull(response, "The response should not be null");
         assertEquals("q1=new&q2=world", response, "The response value is wrong");
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsConsumerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsConsumerTest.java
@@ -237,7 +237,7 @@ public class CxfRsConsumerTest extends CamelTestSupport {
                 customer.setId(Long.parseLong(id));
                 customer.setName("Willem");
                 // We just put the response Object into the out message body
-                exchange.getOut().setBody(customer);
+                exchange.getMessage().setBody(customer);
             } else {
                 if ("/customerservice/customers/400".equals(path)) {
                     // We return the remote client IP address this time
@@ -247,13 +247,13 @@ public class CxfRsConsumerTest extends CamelTestSupport {
                     // Just make sure the request object is not null
                     assertNotNull(request, "The request object should not be null");
                     Response r = Response.status(200).entity("The remoteAddress is 127.0.0.1").build();
-                    exchange.getOut().setBody(r);
+                    exchange.getMessage().setBody(r);
                     return;
                 }
                 if ("/customerservice/customers/123".equals(path)) {
                     // send a customer response back
                     Response r = Response.status(200).entity("customer response back!").build();
-                    exchange.getOut().setBody(r);
+                    exchange.getMessage().setBody(r);
                     return;
                 }
                 if ("/customerservice/customers/456".equals(path)) {
@@ -263,11 +263,11 @@ public class CxfRsConsumerTest extends CamelTestSupport {
                 } else if ("/customerservice/customers/234".equals(path)) {
                     Response r = Response.status(404).entity("Can't found the customer with uri " + path)
                             .header("Content-Type", "text/plain").build();
-                    exchange.getOut().setBody(r);
+                    exchange.getMessage().setBody(r);
                 } else if ("/customerservice/customers/789".equals(path)) {
-                    exchange.getOut().setBody("Can't found the customer with uri " + path);
-                    exchange.getOut().setHeader(Exchange.CONTENT_TYPE, "text/plain");
-                    exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, "404");
+                    exchange.getMessage().setBody("Can't found the customer with uri " + path);
+                    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                    exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, "404");
                 } else {
                     throw new RuntimeCamelException("Can't found the customer with uri " + path);
                 }
@@ -293,7 +293,7 @@ public class CxfRsConsumerTest extends CamelTestSupport {
                 // Now you can do what you want on the customer object
                 assertEquals("Mary", customer.getName(), "Get a wrong customer name.");
                 // set the response back
-                exchange.getOut().setBody(Response.ok().build());
+                exchange.getMessage().setBody(Response.ok().build());
             }
 
         }
@@ -312,7 +312,7 @@ public class CxfRsConsumerTest extends CamelTestSupport {
                     processGetCustomer(exchange);
                 } else if (HttpMethod.POST.equals(httpMethod)) {
                     InputStream inBody = exchange.getIn().getBody(InputStream.class);
-                    exchange.getOut().setBody(Response.ok(inBody).build());
+                    exchange.getMessage().setBody(Response.ok(inBody).build());
                 }
             }
         }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsGlobalSslProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsGlobalSslProducerTest.java
@@ -67,13 +67,13 @@ public class CxfRsGlobalSslProducerTest extends CamelSpringTestSupport {
         Exchange exchange = template.send("direct://trust", new CxfRsGlobalSslProducerTest.MyProcessor());
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals("123", String.valueOf(response.getId()), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
     }
 
     @Test

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerAddressOverrideTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerAddressOverrideTest.java
@@ -72,7 +72,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
@@ -98,7 +98,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
@@ -123,7 +123,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
@@ -150,7 +150,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         });
 
         // get the response message
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
@@ -163,7 +163,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         Exchange exchange = template.send("direct://http",
                 new SendProcessor("http://localhost:" + getPort1() + "/CxfRsProducerAddressOverrideTest"));
         // get the response message
-        Customer response = exchange.getOut().getBody(Customer.class);
+        Customer response = exchange.getMessage().getBody(Customer.class);
         assertNotNull(response, "The response should not be null");
 
         // Second call with override url
@@ -174,7 +174,7 @@ public class CxfRsProducerAddressOverrideTest extends CamelSpringTestSupport {
         exchange = template.send("direct://http",
                 new SendProcessor("http://localhost:" + getPort1() + "/CxfRsProducerAddressOverrideTest"));
         // get the response message
-        response = exchange.getOut().getBody(Customer.class);
+        response = exchange.getMessage().getBody(Customer.class);
         assertNotNull(response, "The response should not be null");
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerClientFactoryCacheTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerClientFactoryCacheTest.java
@@ -87,12 +87,12 @@ public class CxfRsProducerClientFactoryCacheTest {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals("123", String.valueOf(response.getId()), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     public int getPort1() {

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerHeaderTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerHeaderTest.java
@@ -70,12 +70,12 @@ public class CxfRsProducerHeaderTest {
         });
 
         // verify the out message is a Response object by default
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertEquals(200, response.getStatus());
 
         // test converter (from Response to InputStream)
-        assertEquals(RESPONSE, CxfUtils.getStringFromInputStream(exchange.getOut().getBody(InputStream.class)));
+        assertEquals(RESPONSE, CxfUtils.getStringFromInputStream(exchange.getMessage().getBody(InputStream.class)));
     }
 
     @Test
@@ -96,13 +96,13 @@ public class CxfRsProducerHeaderTest {
         });
 
         // get the response message 
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
 
         // check the response code on the Response object as set by the "HttpProcess"
         assertEquals(200, response.getStatus());
 
         // get out message
-        Message outMessage = exchange.getOut();
+        Message outMessage = exchange.getMessage();
 
         // verify the content-type header sent by the "HttpProcess"
         assertEquals("text/xml", outMessage.getHeader(Exchange.CONTENT_TYPE));
@@ -125,7 +125,7 @@ public class CxfRsProducerHeaderTest {
         @Override
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
-            Message out = exchange.getOut();
+            Message out = exchange.getMessage();
 
             if (in.getHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API) != null) {
                 // this should have been filtered
@@ -135,8 +135,8 @@ public class CxfRsProducerHeaderTest {
             out.setHeader("echo-accept", in.getHeader("Accept"));
             out.setHeader("echo-my-user-defined-header", in.getHeader("my-user-defined-header"));
 
-            exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
-            exchange.getOut().setHeader(Exchange.CONTENT_TYPE, "text/xml");
+            exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+            exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/xml");
 
         }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerSessionTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerSessionTest.java
@@ -54,45 +54,45 @@ public class CxfRsProducerSessionTest extends CamelSpringTestSupport {
 
     @Test
     public void testNoSessionProxy() {
-        String response = sendMessage("direct://proxy", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxy", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
-        response = sendMessage("direct://proxy", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxy", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
     }
 
     @Test
     public void testExchangeSessionProxy() {
-        String response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxyexchange", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
     }
 
     @Test
     public void testInstanceSession() {
-        String response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getOut().getBody(String.class);
+        String response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getOut().getBody(String.class);
+        response = sendMessage("direct://proxyinstance", "World", Boolean.FALSE).getMessage().getBody(String.class);
         assertEquals("Old Old World", response);
         // we do the instance tests for proxy and http in one test because order
         // matters here
-        response = sendMessage("direct://httpinstance", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://httpinstance", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old Old World", response);
     }
 
     @Test
     public void testNoSessionHttp() {
-        String response = sendMessage("direct://http", "World", Boolean.TRUE).getOut().getBody(String.class);
+        String response = sendMessage("direct://http", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
-        response = sendMessage("direct://http", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://http", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("New New World", response);
     }
 
     @Test
     public void testExchangeSessionHttp() {
-        String response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getOut().getBody(String.class);
+        String response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
-        response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getOut().getBody(String.class);
+        response = sendMessage("direct://httpexchange", "World", Boolean.TRUE).getMessage().getBody(String.class);
         assertEquals("Old New World", response);
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerTest.java
@@ -58,7 +58,7 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
         public void process(Exchange exchange) throws Exception {
             // check the query
             Message inMessage = exchange.getIn();
-            exchange.getOut().setBody(inMessage.getHeader(Exchange.HTTP_QUERY, String.class));
+            exchange.getMessage().setBody(inMessage.getHeader(Exchange.HTTP_QUERY, String.class));
         }
     }
 
@@ -101,13 +101,13 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
         // END SNIPPET: ProxyExample     
     }
 
@@ -128,12 +128,12 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        List<Customer> response = CastUtils.cast((List<?>) exchange.getOut().getBody());
+        List<Customer> response = CastUtils.cast((List<?>) exchange.getMessage().getBody());
 
         assertNotNull(response, "The response should not be null");
         assertTrue(response.contains(new Customer(113, "Dan")), "Dan is missing!");
         assertTrue(response.contains(new Customer(123, "John")), "John is missing!");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -159,13 +159,13 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
         // END SNIPPET: HttpExample 
     }
 
@@ -192,7 +192,7 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
 
         // we should get the exception here 
         assertNull(exchange.getException(), "Don't expect the exception here");
-        Message result = exchange.getOut();
+        Message result = exchange.getMessage();
         assertEquals(406, result.getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong http status code.");
 
     }
@@ -247,11 +247,11 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -276,11 +276,11 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
                 });
 
         // get the response message
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertEquals(123, response.getId(), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -305,13 +305,13 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertNotNull(response.getEntity(), "The response entity should not be null");
         // check the response code
         assertEquals(201, response.getStatus(), "Get a wrong response code");
         // check the response code from message header
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -334,13 +334,13 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
         });
 
         // get the response message 
-        Response response = (Response) exchange.getOut().getBody();
+        Response response = (Response) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertNotNull(response.getEntity(), "The response entity should not be null");
         // check the response code
         assertEquals(201, response.getStatus(), "Get a wrong response code");
         // check the response code from message header
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
 
     }
 
@@ -368,11 +368,11 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
                         });
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
         assertNotNull(response, "The response should not be null");
         assertTrue(response.getId() != 8888, "Get a wrong customer id");
         assertEquals("Willem", response.getName(), "Get a wrong customer name");
-        assertEquals(201, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals(201, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
     }
 
     @Test
@@ -392,7 +392,7 @@ public class CxfRsProducerTest extends CamelSpringTestSupport {
                 });
 
         // get the response message 
-        String response = exchange.getOut().getBody(String.class);
+        String response = exchange.getMessage().getBody(String.class);
         assertNotNull(response, "The response should not be null");
         assertEquals("q1=12&q2=13", response, "The response value is wrong");
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSslProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSslProducerTest.java
@@ -55,13 +55,13 @@ public class CxfRsSslProducerTest extends CamelSpringTestSupport {
         Exchange exchange = template.send("direct://trust", new MyProcessor());
 
         // get the response message 
-        Customer response = (Customer) exchange.getOut().getBody();
+        Customer response = (Customer) exchange.getMessage().getBody();
 
         assertNotNull(response, "The response should not be null");
         assertEquals("123", String.valueOf(response.getId()), "Get a wrong customer id");
         assertEquals("John", response.getName(), "Get a wrong customer name");
-        assertEquals(200, exchange.getOut().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
-        assertEquals("value", exchange.getOut().getHeader("key"), "Get a wrong header value");
+        assertEquals(200, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE), "Get a wrong response code");
+        assertEquals("value", exchange.getMessage().getHeader("key"), "Get a wrong header value");
     }
 
     @Test

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/CxfRsConsumerSimpleBindingImplTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/CxfRsConsumerSimpleBindingImplTest.java
@@ -80,8 +80,8 @@ public class CxfRsConsumerSimpleBindingImplTest extends CamelTestSupport {
                     @Override
                     public void process(Exchange exchange) throws Exception {
                         assertEquals("123", exchange.getIn().getHeader("id"));
-                        exchange.getOut().setBody(new Customer(123, "Raul"));
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+                        exchange.getMessage().setBody(new Customer(123, "Raul"));
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
                     }
                 });
 
@@ -92,7 +92,7 @@ public class CxfRsConsumerSimpleBindingImplTest extends CamelTestSupport {
                         assertNotNull(c);
                         assertEquals(123, c.getId());
                         assertEquals(12, exchange.getIn().getHeader("age"));
-                        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+                        exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/CxfRsConsumerSimpleBindingTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/CxfRsConsumerSimpleBindingTest.java
@@ -101,10 +101,10 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         if (id == 123) {
                             assertEquals("123", exchange.getIn().getHeader("id"));
                             assertEquals(MessageContentsList.class, exchange.getIn().getBody().getClass());
-                            exchange.getOut().setBody(new Customer(123, "Raul"));
-                            exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+                            exchange.getMessage().setBody(new Customer(123, "Raul"));
+                            exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
                         } else if (id == 456) {
-                            exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                            exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
                         } else {
                             fail();
                         }
@@ -138,7 +138,7 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         list.add(new Customer(123, "Raul"));
                         list.add(new Customer(456, "Raul2"));
                         response.setCustomers(list);
-                        exchange.getOut().setBody(response);
+                        exchange.getMessage().setBody(response);
                     }
                 });
 
@@ -166,7 +166,7 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         assertTrue(InputStream.class.isAssignableFrom(exchange.getIn().getBody().getClass()));
                         InputStream is = exchange.getIn().getBody(InputStream.class);
                         is.close();
-                        exchange.getOut().setBody(null);
+                        exchange.getMessage().setBody(null);
                     }
                 });
 
@@ -178,7 +178,7 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         DataHandler dh = exchange.getIn().getBody(DataHandler.class);
                         assertEquals("image/jpeg", dh.getContentType());
                         dh.getInputStream().close();
-                        exchange.getOut().setBody(null);
+                        exchange.getMessage().setBody(null);
                     }
                 });
 
@@ -191,7 +191,7 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         assertNull(exchange.getIn().getHeader("part1"));
                         assertNull(exchange.getIn().getHeader("part2"));
                         assertEquals(Customer.class, exchange.getIn().getHeader("body").getClass());
-                        exchange.getOut().setBody(null);
+                        exchange.getMessage().setBody(null);
                     }
                 });
 
@@ -202,7 +202,7 @@ public class CxfRsConsumerSimpleBindingTest extends CamelTestSupport {
                         assertNull(exchange.getIn().getHeader("part1"));
                         assertNull(exchange.getIn().getHeader("part2"));
                         assertEquals(Customer.class, exchange.getIn().getHeader("body").getClass());
-                        exchange.getOut().setBody(null);
+                        exchange.getMessage().setBody(null);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/testbean/Order.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/simplebinding/testbean/Order.java
@@ -53,7 +53,7 @@ public class Order {
     @GET
     @Path("products/{productId}/")
     public Product getProduct(@PathParam("productId") int productId) {
-        Product p = products.get(new Long(productId));
+        Product p = products.get(Long.valueOf(productId));
         return p;
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jms/CxfEndpointJMSConsumerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jms/CxfEndpointJMSConsumerTest.java
@@ -71,7 +71,7 @@ public class CxfEndpointJMSConsumerTest extends CamelTestSupport {
                     public void process(Exchange exchange) throws Exception {
                         // just set the response for greetme operation here
                         String me = exchange.getIn().getBody(String.class);
-                        exchange.getOut().setBody("Hello " + me);
+                        exchange.getMessage().setBody("Hello " + me);
                     }
                 });
             }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfJavaMtomProducerPayloadTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfJavaMtomProducerPayloadTest.java
@@ -59,7 +59,7 @@ public class CxfJavaMtomProducerPayloadTest extends CxfMtomConsumerTest {
         // Make sure we don't put the attachement into out message
         assertEquals(0, exchange.getOut(AttachmentMessage.class).getAttachments().size(), "The attachement size should be 0");
 
-        Object[] result = exchange.getOut().getBody(Object[].class);
+        Object[] result = exchange.getMessage().getBody(Object[].class);
 
         Holder<byte[]> photo1 = (Holder<byte[]>) result[1];
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerPayloadModeTest.java
@@ -135,7 +135,7 @@ public class CxfMtomConsumerPayloadModeTest {
             CxfPayload<SoapHeader> sbody = new CxfPayload<>(
                     new ArrayList<SoapHeader>(),
                     elements, null);
-            exchange.getOut().setBody(sbody);
+            exchange.getMessage().setBody(sbody);
             exchange.getOut(AttachmentMessage.class).addAttachment(MtomTestHelper.RESP_PHOTO_CID,
                     new DataHandler(new ByteArrayDataSource(MtomTestHelper.RESP_PHOTO_DATA, "application/octet-stream")));
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerTest.java
@@ -73,7 +73,7 @@ public class CxfMtomConsumerTest extends CamelTestSupport {
                         Holder<Image> image = (Holder<Image>) parameter.get(1);
                         assertNotNull(image.value, "We should get the image here");
                         // set the holder message back    
-                        exchange.getOut().setBody(new Object[] { null, photo, image });
+                        exchange.getMessage().setBody(new Object[] { null, photo, image });
 
                     }
                 });

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledConsumerPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledConsumerPayloadModeTest.java
@@ -76,7 +76,7 @@ public class CxfMtomDisabledConsumerPayloadModeTest extends CxfMtomConsumerPaylo
             CxfPayload<SoapHeader> body = new CxfPayload<>(
                     new ArrayList<SoapHeader>(),
                     elements, null);
-            exchange.getOut().setBody(body);
+            exchange.getMessage().setBody(body);
             exchange.getOut(AttachmentMessage.class).addAttachment(MtomTestHelper.RESP_PHOTO_CID,
                     new DataHandler(new ByteArrayDataSource(MtomTestHelper.RESP_PHOTO_DATA, "application/octet-stream")));
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledProducerPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledProducerPayloadModeTest.java
@@ -107,7 +107,7 @@ public class CxfMtomDisabledProducerPayloadModeTest extends CxfMtomProducerPaylo
 
         // process response - verify response attachments
 
-        CxfPayload<?> out = exchange.getOut().getBody(CxfPayload.class);
+        CxfPayload<?> out = exchange.getMessage().getBody(CxfPayload.class);
         assertEquals(1, out.getBody().size());
 
         DataHandler dr = exchange.getOut(AttachmentMessage.class).getAttachment(MtomTestHelper.RESP_PHOTO_CID);

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomPOJOProducerTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomPOJOProducerTest.java
@@ -95,7 +95,7 @@ public class CxfMtomPOJOProducerTest {
 
         assertEquals(2, exchange.getOut(AttachmentMessage.class).getAttachments().size(), "The attachement size should be 2");
 
-        Object[] result = exchange.getOut().getBody(Object[].class);
+        Object[] result = exchange.getMessage().getBody(Object[].class);
         Holder<byte[]> photo1 = (Holder<byte[]>) result[1];
         assertArrayEquals(MtomTestHelper.RESP_PHOTO_DATA, photo1.value);
         Holder<Image> image1 = (Holder<Image>) result[2];

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomProducerPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomProducerPayloadModeTest.java
@@ -122,7 +122,7 @@ public class CxfMtomProducerPayloadModeTest {
 
         // process response 
 
-        CxfPayload<SoapHeader> out = exchange.getOut().getBody(CxfPayload.class);
+        CxfPayload<SoapHeader> out = exchange.getMessage().getBody(CxfPayload.class);
         assertEquals(1, out.getBody().size());
 
         Map<String, String> ns = new HashMap<>();

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
@@ -437,7 +437,7 @@ public class CxfMessageHeadersRelayTest {
 
         });
 
-        CxfPayload<?> out = exchange.getOut().getBody(CxfPayload.class);
+        CxfPayload<?> out = exchange.getMessage().getBody(CxfPayload.class);
         assertEquals(1, out.getBodySources().size());
 
         assertTrue(out.getBodySources().get(0) instanceof DOMSource);
@@ -516,7 +516,7 @@ public class CxfMessageHeadersRelayTest {
 
         Exchange exchange = template.send(producerUri, senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         MessageContentsList result = (MessageContentsList) out.getBody();
         Map<String, Object> responseContext = CastUtils.cast((Map<?, ?>) out.getHeader(Client.RESPONSE_CONTEXT));
         assertNotNull(responseContext);
@@ -539,7 +539,7 @@ public class CxfMessageHeadersRelayTest {
 
         Exchange exchange = template.send(producerUri, senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         MessageContentsList result = (MessageContentsList) out.getBody();
         assertTrue(result.get(0) != null && ((Me) result.get(0)).getFirstName().equals("pass"),
                 "Expected the out of band header to propagate but it didn't");
@@ -567,7 +567,7 @@ public class CxfMessageHeadersRelayTest {
 
         Exchange exchange = template.send(producerUri, senderExchange);
 
-        org.apache.camel.Message out = exchange.getOut();
+        org.apache.camel.Message out = exchange.getMessage();
         MessageContentsList result = (MessageContentsList) out.getBody();
         assertTrue(result.get(0) != null && ((Me) result.get(0)).getFirstName().equals("pass"),
                 "Expected the out of band header to propagate but it didn't");

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/spring/MyProcessor.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/spring/MyProcessor.java
@@ -37,7 +37,7 @@ public class MyProcessor implements Processor {
         // Get the operation name
         String operation = (String) in.getHeader(CxfConstants.OPERATION_NAME);
         Object result = operation + " " + (String) parameter.get(0);
-        exchange.getOut().setBody(result);
+        exchange.getMessage().setBody(result);
     }
 
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/util/SplitterWithXqureyTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/util/SplitterWithXqureyTest.java
@@ -62,7 +62,7 @@ public class SplitterWithXqureyTest extends CamelTestSupport {
                             public void process(Exchange exchange) throws Exception {
                                 Element element = (Element) exchange.getIn().getBody();
                                 String message = CxfUtilsTestHelper.elementToString(element);
-                                exchange.getOut().setBody(message);
+                                exchange.getMessage().setBody(message);
                             }
                         })
                         .to("mock:result");

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/wsrm/MyProcessor.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/wsrm/MyProcessor.java
@@ -31,7 +31,7 @@ public class MyProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         logger.info("***** Entering Processor *******");
         String name = exchange.getIn().getBody(String.class);
-        exchange.getOut().setBody("Hello " + name);
+        exchange.getMessage().setBody("Hello " + name);
         logger.info("***** Leaving Processor *******");
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/non_wrapper/PersonProcessor.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/non_wrapper/PersonProcessor.java
@@ -50,7 +50,7 @@ public class PersonProcessor implements Processor {
             personFault.setPersonId("");
             org.apache.camel.non_wrapper.UnknownPersonFault fault
                     = new org.apache.camel.non_wrapper.UnknownPersonFault("Get the null value of person name", personFault);
-            exchange.getOut().setBody(fault);
+            exchange.getMessage().setBody(fault);
             return;
         }
         response.setPersonId(personId);
@@ -59,7 +59,7 @@ public class PersonProcessor implements Processor {
         LOG.info("setting Bonjour as the response");
         // Set the response message, first element is the return value of the operation,
         // the others are the holders of method parameters
-        exchange.getOut().setBody(new Object[] { response });
+        exchange.getMessage().setBody(new Object[] { response });
     }
 
 }

--- a/components/camel-cxf/src/test/java/org/apache/camel/wsdl_first/PersonProcessor.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/wsdl_first/PersonProcessor.java
@@ -53,7 +53,7 @@ public class PersonProcessor implements Processor {
             personFault.setPersonId("");
             org.apache.camel.wsdl_first.UnknownPersonFault fault
                     = new org.apache.camel.wsdl_first.UnknownPersonFault("Get the null value of person name", personFault);
-            exchange.getOut().setBody(fault);
+            exchange.getMessage().setBody(fault);
             return;
         }
 
@@ -62,7 +62,7 @@ public class PersonProcessor implements Processor {
         LOG.info("setting Bonjour as the response");
         // Set the response message, first element is the return value of the operation,
         // the others are the holders of method parameters
-        exchange.getOut().setBody(new Object[] { null, personId, ssn, name });
+        exchange.getMessage().setBody(new Object[] { null, personId, ssn, name });
     }
 
 }


### PR DESCRIPTION
Includes:
- replaced calls to deprecated getOut with getMessage in test code
- fixed usages of deprecated wrapper contructors

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md