### PR TITLE
CAMEL-15552: Print dirty files in workflow step

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -43,7 +43,10 @@ jobs:
       run: ./mvnw -V --no-transfer-progress -Psourcecheck -Dcheckstyle.failOnViolation=true -DskipTests checkstyle:checkstyle verify
     - name: Check if there are uncommited changes
       id: changes
-      uses: UnicornGlobal/has-changes-action@v1.0.11
+      uses: bedlaj/has-changes-action@camel
     - name: Fail if git tree is dirty
       if: steps.changes.outputs.changed == 1
-      run: echo "Maven build will override some files, which are not commited as part of this PR. Please run maven build and commit generated sources." && exit 1
+      run: |
+        echo "Maven build will override some files, which are not commited as part of this PR. Please run maven build and commit generated sources."
+        echo "${{ steps.changes.outputs.changes }}"
+        exit 1

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -43,7 +43,10 @@ jobs:
         run: ./mvnw -V --no-transfer-progress -Psourcecheck -Dcheckstyle.failOnViolation=true -DskipTests checkstyle:checkstyle verify
       - name: Check if there are uncommited changes
         id: changes
-        uses: UnicornGlobal/has-changes-action@v1.0.11
+        uses: bedlaj/has-changes-action@camel
       - name: Fail if git tree is dirty
         if: steps.changes.outputs.changed == 1
-        run: echo "Maven build will override some files, which are not commited yet. Please run maven build and commit generated sources." && exit 1
+        run: |
+          echo "Maven build will override some files, which are not commited as part of this PR. Please run maven build and commit generated sources."
+          echo "${{ steps.changes.outputs.changes }}"
+          exit 1


### PR DESCRIPTION
If this step fails, it is currently missing information about the reason. Switched to my fork of has-changes-action temporarilly until https://github.com/UnicornGlobal/has-changes-action/pull/2 gets merged. 

Sample output - https://github.com/bedlaj/camel/runs/1134623405 :
```
Maven build will override some files, which are not commited as part of this PR. Please run maven build and commit generated sources.
 M catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/box-component.adoc
 M catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/twilio-component.adoc
 M catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/microprofile-fault-tolerance.json
 M components/camel-box/camel-box-component/src/generated/resources/org/apache/camel/component/box/box.json
 M components/camel-box/camel-box-component/src/main/docs/box-component.adoc
 M components/camel-twilio/src/generated/resources/org/apache/camel/component/twilio/twilio.json
 M components/camel-twilio/src/main/docs/twilio-component.adoc
 M docs/components/modules/ROOT/pages/box-component.adoc
 M docs/components/modules/ROOT/pages/twilio-component.adoc
##[error]Process completed with exit code 1.
```

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md