### PR TITLE
CAMEL-15556: Create automated PR for regen

### DIFF
--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         java: [ '1.8' ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
@@ -41,12 +41,20 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: mvn sourcecheck
         run: ./mvnw -V --no-transfer-progress -Psourcecheck -Dcheckstyle.failOnViolation=true -DskipTests checkstyle:checkstyle verify
-      - name: Check if there are uncommited changes
-        id: changes
-        uses: bedlaj/has-changes-action@camel
-      - name: Fail if git tree is dirty
-        if: steps.changes.outputs.changed == 1
-        run: |
-          echo "Maven build will override some files, which are not commited as part of this PR. Please run maven build and commit generated sources."
-          echo "${{ steps.changes.outputs.changes }}"
-          exit 1
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Regen for commit ${{ github.sha }}"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: true
+          branch: regen_bot
+          title: "Generated sources regen"
+          body: |
+            Regen bot :robot: found some uncommited changes after running build on :camel: master.
+            Please do not delete `regen_bot` branch after merge/rebase.
+          labels: |
+            regen
+            automated pr
+          assignees: oscerd


### PR DESCRIPTION
Result can be seen here https://github.com/bedlaj/test-github-bot/pull/3

Please do not delete branch `regen_bot`. Github forbids modifying workflow from github action authenticated by `GITHUB_TOKEN`, so it would fail. If this will be limiting, we would need to create personal access token secret - probably with INFRA, or can we do this for repo?

[ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful subject line and body.
[ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
[ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md