### PR TITLE
CAMEL-15575: prevent stack traces from being printed directly to stdout

### DIFF
--- a/components/camel-activemq/src/test/java/org/apache/camel/component/activemq/JmsJdbcXATest.java
+++ b/components/camel-activemq/src/test/java/org/apache/camel/component/activemq/JmsJdbcXATest.java
@@ -189,7 +189,7 @@ public class JmsJdbcXATest extends CamelSpringTestSupport {
                                 try {
                                     broker.stop();
                                 } catch (Exception e) {
-                                    e.printStackTrace();
+                                    LOG.warn("Failed to stop the broker: {}", e.getMessage(), e);
                                 }
                             }
                         });

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
@@ -165,8 +165,7 @@ public class AS2ServerConnection {
             } catch (final IOException ex) {
                 LOG.error("I/O error: {}", ex.getMessage());
             } catch (final HttpException ex) {
-                ex.printStackTrace();
-                LOG.error("Unrecoverable HTTP protocol violation: {}", ex.getMessage());
+                LOG.error("Unrecoverable HTTP protocol violation: {}", ex.getMessage(), ex);
             } finally {
                 try {
                     this.serverConnection.shutdown();

--- a/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/AmazonS3ClientMock.java
+++ b/components/camel-aws-s3/src/test/java/org/apache/camel/component/aws/s3/AmazonS3ClientMock.java
@@ -76,10 +76,13 @@ import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.model.VersionListing;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AmazonS3ClientMock extends AbstractAmazonS3 {
+    private static final Logger LOG = LoggerFactory.getLogger(AmazonS3ClientMock.class);
 
     List<S3Object> objects = new CopyOnWriteArrayList<>();
     List<PutObjectRequest> putObjectRequests = new CopyOnWriteArrayList<>();
@@ -471,7 +474,7 @@ public class AmazonS3ClientMock extends AbstractAmazonS3 {
         try {
             url = new URL("http://aws.amazonas.s3/file.zip");
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            LOG.warn("Invalid URL: {}", e.getMessage(), e);
         }
         return url;
     }

--- a/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptBot.java
+++ b/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptBot.java
@@ -73,8 +73,7 @@ public class ChatScriptBot {
             resp = in.readLine();
             echoSocket.close();
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new Exception("Unable to send message to ChatScript Server. Reason:" + e.getMessage());
+            throw new Exception("Unable to send message to ChatScript Server. Reason:" + e.getMessage(), e);
         }
 
         return resp;

--- a/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptProducer.java
+++ b/components/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptProducer.java
@@ -66,8 +66,7 @@ public class ChatScriptProducer extends DefaultProducer {
         try {
             ret = mapper.readValue(message, ChatScriptMessage.class);
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new Exception("Unable to parse the input message. Error Message" + e.getMessage());
+            throw new Exception("Unable to parse the input message. Error Message" + e.getMessage(), e);
         }
         return ret;
     }

--- a/components/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentTest.java
+++ b/components/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentTest.java
@@ -24,8 +24,11 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.language.SimpleExpression;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ChatScriptComponentTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(ChatScriptComponentTest.class);
 
     @Test
     public void testChatScript() throws Exception {
@@ -51,7 +54,7 @@ public class ChatScriptComponentTest extends CamelTestSupport {
                     rq2 = new ObjectMapper().writeValueAsString(rq2Msg);
                     rq3 = new ObjectMapper().writeValueAsString(rq3Msg);
                 } catch (JsonProcessingException e) {
-                    e.printStackTrace();
+                    LOG.warn("Failed processing JSON: {}", e.getMessage(), e);
                 }
                 from("timer://foo?repeatCount=1")
                         .setBody(new SimpleExpression(rq))

--- a/components/camel-corda/src/test/java/org/apache/camel/component/corda/CordaProducerIntegrationTest.java
+++ b/components/camel-corda/src/test/java/org/apache/camel/component/corda/CordaProducerIntegrationTest.java
@@ -49,6 +49,8 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static net.corda.core.node.services.vault.QueryCriteriaUtils.DEFAULT_PAGE_NUM;
 import static net.corda.core.node.services.vault.QueryCriteriaUtils.MAX_PAGE_SIZE;
@@ -58,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CordaProducerIntegrationTest extends CordaTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(CordaProducerIntegrationTest.class);
     private static final SecureHash.SHA256 TEST_SHA_256
             = SecureHash.parse("6D1687C143DF792A011A1E80670A4E4E0C25D0D87A39514409B1ABFC2043581F");
 
@@ -442,7 +445,7 @@ public class CordaProducerIntegrationTest extends CordaTestSupport {
             zos.write(in.getBytes());
             zos.closeEntry();
         } catch (IOException ioe) {
-            ioe.printStackTrace();
+            LOG.warn("I/O error while trying to compress stream: {}", ioe.getMessage(), ioe);
         }
 
         return new ByteArrayInputStream(baos.toByteArray());

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelConduitTest.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelConduitTest.java
@@ -34,11 +34,14 @@ import org.apache.cxf.bus.spring.SpringBusFactory;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CamelConduitTest extends CamelTransportTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelConduitTest.class);
 
     @Override
     protected RouteBuilder createRouteBuilder() {
@@ -113,7 +116,7 @@ public class CamelConduitTest extends CamelTransportTestSupport {
         try {
             conduit.prepare(message);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error preparing the message: {}", ex.getMessage(), ex);
         }
         verifyMessageContent(message);
     }
@@ -156,7 +159,7 @@ public class CamelConduitTest extends CamelTransportTestSupport {
         try {
             bis.read(bytes);
         } catch (IOException ex) {
-            ex.printStackTrace();
+            LOG.warn("I/O error receiving messages: {}", ex.getMessage(), ex);
         }
         String reponse = new String(bytes);
         assertEquals(content, reponse, "The reponse date should be equals");

--- a/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
+++ b/components/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
@@ -48,6 +48,8 @@ import org.apache.cxf.transport.ConduitInitiator;
 import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.MessageObserver;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,6 +60,7 @@ import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 
 public class CamelDestinationTest extends CamelTransportTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelDestinationTest.class);
     private Message destMessage;
 
     @Override
@@ -136,8 +139,8 @@ public class CamelDestinationTest extends CamelTransportTestSupport {
             destination = setupCamelDestination(endpointInfo, true);
             // destination.activate();
         } catch (IOException e) {
+            LOG.warn("I/O error setting up destination: {}", e.getMessage(), e);
             fail("The CamelDestination activate should not through exception ");
-            e.printStackTrace();
         }
         sendoutMessage(conduit, outMessage, true, "HelloWorld");
 

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpointUtils.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpointUtils.java
@@ -48,7 +48,7 @@ public final class CxfEndpointUtils {
             try {
                 qName = QName.valueOf(name);
             } catch (Exception ex) {
-                ex.printStackTrace();
+                LOG.warn("Cannot create QName: {}", ex.getMessage(), ex);
             }
         }
         return qName;

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/JaxWsWebFaultAnnotationToFaultTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/JaxWsWebFaultAnnotationToFaultTest.java
@@ -25,6 +25,8 @@ import org.apache.cxf.greeter_control.Greeter;
 import org.apache.cxf.greeter_control.PingMeFault;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -33,13 +35,14 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Test for throwing an exception with a JAX-WS WebFault annotation from Camel CXF consumer
  */
 public class JaxWsWebFaultAnnotationToFaultTest extends CamelTestSupport {
-
     protected static final String ROUTER_ADDRESS = "http://localhost:" + CXFTestSupport.getPort1()
                                                    + "/JaxWsWebFaultAnnotationToFaultTest/router";
     protected static final String SERVICE_CLASS = "serviceClass=org.apache.cxf.greeter_control.Greeter";
     protected static final String SERVICE_URI = "cxf://" + ROUTER_ADDRESS + "?" + SERVICE_CLASS;
 
     protected static final String MESSAGE = "this is our test message for the exception";
+
+    private static final Logger LOG = LoggerFactory.getLogger(JaxWsWebFaultAnnotationToFaultTest.class);
 
     @Override
     protected RouteBuilder createRouteBuilder() {
@@ -70,7 +73,7 @@ public class JaxWsWebFaultAnnotationToFaultTest extends CamelTestSupport {
         } catch (PingMeFault expected) {
             assertEquals(MESSAGE, expected.getMessage());
         } catch (Throwable t) {
-            t.printStackTrace();
+            LOG.warn("The CXF client did not manage to map the client exception: {}", t.getMessage(), t);
             fail("The CXF client did not manage to map the client exception "
                  + t.getClass().getName() + " to a " + PingMeFault.class.getName()
                  + ": " + t.getMessage());

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/SoapTargetBean.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/SoapTargetBean.java
@@ -27,8 +27,11 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import org.apache.cxf.staxutils.StaxUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SoapTargetBean {
+    private static final Logger LOG = LoggerFactory.getLogger(SoapTargetBean.class);
     private static QName sayHi = new QName("http://apache.org/hello_world_soap_http/types", "sayHi");
     private static QName greetMe = new QName("http://apache.org/hello_world_soap_http/types", "greetMe");
     private SOAPMessage sayHiResponse;
@@ -45,7 +48,7 @@ public class SoapTargetBean {
             greetMeResponse = factory.createMessage(null, is);
             is.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Failed to initialize SoapTargetBean: {}", ex.getMessage(), ex);
         }
     }
 
@@ -74,7 +77,7 @@ public class SoapTargetBean {
                 response = greetMeResponse;
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Failed to invoke soap message: {}", ex.getMessage(), ex);
         }
         return response;
     }
@@ -93,7 +96,7 @@ public class SoapTargetBean {
                 response = greetMeResponse;
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Failed to invoke stream: {}", ex.getMessage(), ex);
         }
         return response;
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledProducerPayloadModeTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomDisabledProducerPayloadModeTest.java
@@ -142,7 +142,7 @@ public class CxfMtomDisabledProducerPayloadModeTest extends CxfMtomProducerPaylo
             try {
                 bytes = IOUtils.readBytesFromStream(dh.getInputStream());
             } catch (IOException e) {
-                e.printStackTrace();
+                LOG.warn("I/O error reading bytes from stream: {}", e.getMessage(), e);
             }
             assertArrayEquals(MtomTestHelper.REQ_PHOTO_DATA, bytes);
 
@@ -154,7 +154,7 @@ public class CxfMtomDisabledProducerPayloadModeTest extends CxfMtomProducerPaylo
                 bufferedImage = ImageIO.read(dh.getInputStream());
 
             } catch (IOException e) {
-                e.printStackTrace();
+                LOG.warn("I/O error reading bytes from stream: {}", e.getMessage(), e);
             }
             assertNotNull(bufferedImage);
             assertEquals(41, bufferedImage.getWidth());
@@ -168,7 +168,7 @@ public class CxfMtomDisabledProducerPayloadModeTest extends CxfMtomProducerPaylo
                 map.put(MtomTestHelper.RESP_IMAGE_CID, new DataHandler(ds));
 
             } catch (IOException e) {
-                e.printStackTrace();
+                LOG.warn("I/O error: {}", e.getMessage(), e);
             }
 
             try {
@@ -178,7 +178,7 @@ public class CxfMtomDisabledProducerPayloadModeTest extends CxfMtomProducerPaylo
                 map.put(MtomTestHelper.RESP_PHOTO_CID, new DataHandler(ds));
 
             } catch (IOException e) {
-                e.printStackTrace();
+                LOG.warn("I/O error: {}", e.getMessage(), e);
             }
 
         }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/MtomTestHelper.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/mtom/MtomTestHelper.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.cxf.mtom;
 import java.io.IOException;
 
 import org.apache.cxf.helpers.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -26,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Package local test helper
  */
 public final class MtomTestHelper {
-
     static final String SERVICE_TYPES_NS = "http://apache.org/camel/cxf/mtom_feature/types";
     static final String XOP_NS = "http://www.w3.org/2004/08/xop/include";
     static final byte[] REQ_PHOTO_DATA = { 1, 0, -1, 34, 23, 3, 23, 55, 33 };
@@ -65,13 +66,14 @@ public final class MtomTestHelper {
     static byte[] requestJpeg;
     static byte[] responseJpeg;
 
+    private static final Logger LOG = LoggerFactory.getLogger(MtomTestHelper.class);
+
     static {
         try {
             requestJpeg = IOUtils.readBytesFromStream(CxfMtomConsumerPayloadModeTest.class.getResourceAsStream("/java.jpg"));
             responseJpeg = IOUtils.readBytesFromStream(CxfMtomConsumerPayloadModeTest.class.getResourceAsStream("/Splash.jpg"));
         } catch (IOException e) {
-
-            e.printStackTrace();
+            LOG.warn("I/O error reading bytes from stream: {}", e.getMessage(), e);
         }
     }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/multipart/MultiPartInvokeImpl.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/multipart/MultiPartInvokeImpl.java
@@ -44,7 +44,7 @@ public class MultiPartInvokeImpl implements MultiPartInvoke {
             InE out1Value = in1;
             out1.value = out1Value;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("I/O error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
@@ -61,6 +61,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -81,6 +83,8 @@ public class CxfMessageHeadersRelayTest {
     static int portE3 = CXFTestSupport.getPort("CxfMessageHeadersRelayTest.3");
     static int portE4 = CXFTestSupport.getPort("CxfMessageHeadersRelayTest.4");
     static int portE5 = CXFTestSupport.getPort("CxfMessageHeadersRelayTest.5");
+
+    private static final Logger LOG = LoggerFactory.getLogger(CxfMessageHeadersRelayTest.class);
 
     @Autowired
     protected CamelContext context;
@@ -620,7 +624,7 @@ public class CxfMessageHeadersRelayTest {
                             .createUnmarshaller().unmarshal((Node) hdr1.getObject());
                     hdrToTest = (OutofBandHeader) job.getValue();
                 } catch (JAXBException ex) {
-                    ex.printStackTrace();
+                    LOG.warn("JAXB error: {}", ex.getMessage(), ex);
                 }
             }
         }
@@ -677,7 +681,7 @@ public class CxfMessageHeadersRelayTest {
                             .createUnmarshaller().unmarshal((Node) hdr1.getObject());
                     hdrToTest.add((OutofBandHeader) job.getValue());
                 } catch (JAXBException ex) {
-                    ex.printStackTrace();
+                    LOG.warn("JAXB error: {}", ex.getMessage(), ex);
                 }
             }
         }

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/HeaderTesterImpl.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/soap/headers/HeaderTesterImpl.java
@@ -34,12 +34,15 @@ import org.apache.cxf.headers.Header;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.jaxb.JAXBDataBinding;
 import org.apache.cxf.outofband.header.OutofBandHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @javax.jws.WebService(serviceName = "HeaderService",
                       targetNamespace = "http://apache.org/camel/cxf/soap/headers",
                       endpointInterface = "org.apache.camel.component.cxf.soap.headers.HeaderTester")
 
 public class HeaderTesterImpl implements HeaderTester {
+    private static final Logger LOG = LoggerFactory.getLogger(HeaderTesterImpl.class);
 
     @Resource
     protected WebServiceContext context;
@@ -59,7 +62,6 @@ public class HeaderTesterImpl implements HeaderTester {
             theResponse.value = theResponseValue;
             headerInfo.value = Constants.OUT_HEADER_DATA;
         } catch (Exception ex) {
-            ex.printStackTrace();
             throw new RuntimeException(ex);
         }
     }
@@ -80,7 +82,7 @@ public class HeaderTesterImpl implements HeaderTester {
             }
             return result;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }
@@ -102,7 +104,7 @@ public class HeaderTesterImpl implements HeaderTester {
             headerInfo.value = Constants.IN_OUT_RESPONSE_HEADER_DATA;
             return result;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }
@@ -117,7 +119,7 @@ public class HeaderTesterImpl implements HeaderTester {
             }
             return result;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }
@@ -133,7 +135,7 @@ public class HeaderTesterImpl implements HeaderTester {
             }
             return result;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }
@@ -145,7 +147,7 @@ public class HeaderTesterImpl implements HeaderTester {
             addReplyOutOfBandHeader();
             return result;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
     }
@@ -169,7 +171,7 @@ public class HeaderTesterImpl implements HeaderTester {
                     List<Header> hdrList = CastUtils.cast((List<?>) ctx.get(Header.HEADER_LIST));
                     hdrList.add(hdr);
                 } catch (Exception ex) {
-                    ex.printStackTrace();
+                    LOG.warn("Unexpected error: {}", ex.getMessage(), ex);
                 }
             }
         }
@@ -216,7 +218,7 @@ public class HeaderTesterImpl implements HeaderTester {
                             throw new RuntimeException("test failed");
                         }
                     } catch (JAXBException ex) {
-                        ex.printStackTrace();
+                        LOG.warn("JAXB error: {}", ex.getMessage(), ex);
                     }
                 }
             }

--- a/components/camel-digitalocean/src/test/java/org/apache/camel/component/digitalocean/integration/DigitalOceanTestSupport.java
+++ b/components/camel-digitalocean/src/test/java/org/apache/camel/component/digitalocean/integration/DigitalOceanTestSupport.java
@@ -22,8 +22,11 @@ import java.net.URL;
 import java.util.Properties;
 
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DigitalOceanTestSupport extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(DigitalOceanTestSupport.class);
 
     protected final Properties properties;
 
@@ -34,7 +37,7 @@ public class DigitalOceanTestSupport extends CamelTestSupport {
         try {
             inStream = url.openStream();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("I/O error opening the stream: {}", e.getMessage(), e);
             throw new IllegalAccessError("test-options.properties could not be found");
         }
 
@@ -42,7 +45,7 @@ public class DigitalOceanTestSupport extends CamelTestSupport {
         try {
             properties.load(inStream);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("I/O error reading the stream: {}", e.getMessage(), e);
             throw new IllegalAccessError("test-options.properties could not be found");
         }
     }

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/AttachContainerCmdHeaderTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.component.docker.DockerOperation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
  * Validates Attach Container Request headers are applied properly
  */
 public class AttachContainerCmdHeaderTest extends BaseDockerHeaderTest<AttachContainerCmd> {
+    private static final Logger LOG = LoggerFactory.getLogger(AttachContainerCmdHeaderTest.class);
 
     @Mock
     private AttachContainerCmd mockObject;
@@ -77,7 +80,7 @@ public class AttachContainerCmdHeaderTest extends BaseDockerHeaderTest<AttachCon
         try {
             Mockito.when(callback.awaitCompletion()).thenReturn(callback);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.warn("Interrupted while setting up mocks", e);
         }
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecStartCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/ExecStartCmdHeaderTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.component.docker.DockerOperation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
  * Validates Exec Start Request headers are parsed properly
  */
 public class ExecStartCmdHeaderTest extends BaseDockerHeaderTest<ExecStartCmd> {
+    private static final Logger LOG = LoggerFactory.getLogger(ExecStartCmdHeaderTest.class);
 
     @Mock
     private ExecStartCmd mockObject;
@@ -65,7 +68,7 @@ public class ExecStartCmdHeaderTest extends BaseDockerHeaderTest<ExecStartCmd> {
         try {
             Mockito.when(callback.awaitCompletion()).thenReturn(callback);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.warn("Interrupted while setting up mocks", e);
         }
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/LogContainerCmdHeaderTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.component.docker.DockerOperation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
  * Validates Log Container Request headers are applied properly
  */
 public class LogContainerCmdHeaderTest extends BaseDockerHeaderTest<LogContainerCmd> {
+    private static final Logger LOG = LoggerFactory.getLogger(LogContainerCmdHeaderTest.class);
 
     @Mock
     private LogContainerCmd mockObject;
@@ -80,7 +83,7 @@ public class LogContainerCmdHeaderTest extends BaseDockerHeaderTest<LogContainer
         try {
             Mockito.when(callback.awaitCompletion()).thenReturn(callback);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.warn("Interrupted while setting up mocks", e);
         }
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PullImageCmdHeaderTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.component.docker.DockerOperation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
  * Validates Pull Image Request headers are applied properly
  */
 public class PullImageCmdHeaderTest extends BaseDockerHeaderTest<PullImageCmd> {
+    private static final Logger LOG = LoggerFactory.getLogger(PullImageCmdHeaderTest.class);
 
     @Mock
     private PullImageCmd mockObject;
@@ -68,7 +71,7 @@ public class PullImageCmdHeaderTest extends BaseDockerHeaderTest<PullImageCmd> {
         try {
             Mockito.when(callback.awaitCompletion()).thenReturn(callback);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.warn("Interrupted while setting up mocks", e);
         }
     }
 

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/headers/PushImageCmdHeaderTest.java
@@ -26,6 +26,8 @@ import org.apache.camel.component.docker.DockerOperation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.anyString;
  * Validates Push Image Request headers are applied properly
  */
 public class PushImageCmdHeaderTest extends BaseDockerHeaderTest<PushImageCmd> {
+    private static final Logger LOG = LoggerFactory.getLogger(PushImageCmdHeaderTest.class);
 
     @Mock
     private PushImageCmd mockObject;
@@ -73,7 +76,7 @@ public class PushImageCmdHeaderTest extends BaseDockerHeaderTest<PushImageCmd> {
         try {
             Mockito.when(callback.awaitCompletion()).thenReturn(callback);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.warn("Interrupted while setting up mocks", e);
         }
     }
 

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/util/DropboxPropertyManager.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/util/DropboxPropertyManager.java
@@ -47,15 +47,13 @@ public final class DropboxPropertyManager {
         try {
             inStream = url.openStream();
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new DropboxException("dropbox.properties could not be found");
+            throw new DropboxException("dropbox.properties could not be found", e);
         }
         properties = new Properties();
         try {
             properties.load(inStream);
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new DropboxException("dropbox.properties can't be read");
+            throw new DropboxException("dropbox.properties can't be read", e);
         }
         return properties;
     }

--- a/components/camel-dropbox/src/test/java/org/apache/camel/component/dropbox/integration/DropboxTestSupport.java
+++ b/components/camel-dropbox/src/test/java/org/apache/camel/component/dropbox/integration/DropboxTestSupport.java
@@ -46,7 +46,7 @@ public class DropboxTestSupport extends CamelTestSupport {
         try (InputStream inStream = getClass().getResourceAsStream("/test-options.properties")) {
             properties.load(inStream);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("I/O error: reading test-options.properties: {}", e.getMessage(), e);
             throw new IllegalAccessError("test-options.properties could not be found");
         }
 

--- a/components/camel-elytron/src/test/java/org/apache/camel/component/elytron/ElytronBearerTokenTest.java
+++ b/components/camel-elytron/src/test/java/org/apache/camel/component/elytron/ElytronBearerTokenTest.java
@@ -122,7 +122,7 @@ public class ElytronBearerTokenTest extends BaseElytronTest {
         try {
             signedJWT.sign(new RSASSASigner(signingKey));
         } catch (JOSEException e) {
-            e.printStackTrace();
+            LOG.warn("Cannot sign object: {}", e.getMessage(), e);
         }
 
         return signedJWT.serialize();

--- a/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
+++ b/components/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
@@ -110,7 +110,7 @@ public class GoogleBigQuerySQLProducer extends DefaultProducer {
             try {
                 headers.putAll(message.getBody(Map.class));
             } catch (ClassCastException e) {
-                e.printStackTrace();
+                LOG.warn("Unable to perform cast while extracting header parameters: {}", e.getMessage(), e);
             }
         }
 

--- a/components/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/CalendarCalendarsIntegrationTest.java
+++ b/components/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/CalendarCalendarsIntegrationTest.java
@@ -24,6 +24,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.calendar.internal.CalendarCalendarsApiMethod;
 import org.apache.camel.component.google.calendar.internal.GoogleCalendarApiCollection;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -32,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Test class for {@link com.google.api.services.calendar.Calendar$Calendars} APIs.
  */
 public class CalendarCalendarsIntegrationTest extends AbstractGoogleCalendarTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(CalendarCalendarsIntegrationTest.class);
 
     private static final String PATH_PREFIX
             = GoogleCalendarApiCollection.getCollection().getApiName(CalendarCalendarsApiMethod.class).getName();
@@ -56,7 +59,8 @@ public class CalendarCalendarsIntegrationTest extends AbstractGoogleCalendarTest
             calendarFromGet = requestBody("direct://GET", calendar.getId());
             fail("Should have not found deleted calendar.");
         } catch (Exception e) {
-            e.printStackTrace();
+            // Likely safe to ignore in this context
+            LOG.debug("Unhandled exception (probably safe to ignore): {}", e.getMessage(), e);
         }
     }
 

--- a/components/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveCommentsIntegrationTest.java
+++ b/components/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveCommentsIntegrationTest.java
@@ -100,7 +100,8 @@ public class DriveCommentsIntegrationTest extends AbstractGoogleDriveTestSupport
             final com.google.api.services.drive.model.Comment result4 = requestBodyAndHeaders("direct://GET", null, headers);
             fail("Should have thrown an exception.");
         } catch (Exception e) {
-            e.printStackTrace();
+            // Likely safe to ignore in this context
+            LOG.debug("Unhandled exception (probably safe to ignore): {}", e.getMessage(), e);
         }
     }
 

--- a/components/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveFilesIntegrationTest.java
+++ b/components/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveFilesIntegrationTest.java
@@ -82,7 +82,8 @@ public class DriveFilesIntegrationTest extends AbstractGoogleDriveTestSupport {
             final File result = requestBody("direct://GET", fileId);
             fail("Should have not found deleted file.");
         } catch (Exception e) {
-            e.printStackTrace();
+            // Likely safe to ignore in this context
+            LOG.debug("Unhandled exception (probably safe to ignore): {}", e.getMessage(), e);
         }
     }
 

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
@@ -81,7 +81,7 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
                 try {
                     latch.await(5, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOG.debug("Unhandled exception (probably safe to ignore): {}", e.getMessage(), e);
                 }
 
                 PongResponse pongResponse = responseObserver.getPongResponse();
@@ -122,7 +122,7 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
                 try {
                     latch.await(5, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOG.debug("Interrupted while waiting for the response", e);
                 }
 
                 PongResponse pongResponse = responseObserver.getPongResponse();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HazelcastQueueConsumerPollTest extends HazelcastCamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(HazelcastQueueConsumerPollTest.class);
 
     @Mock
     private IQueue<String> queue;
@@ -48,7 +51,7 @@ public class HazelcastQueueConsumerPollTest extends HazelcastCamelTestSupport {
         try {
             verify(queue, atLeast(1)).poll(10000, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.debug("Interrupted during test execution", e);
         }
     }
 

--- a/components/camel-irc/src/test/java/org/apache/camel/component/irc/CodehausIrcChat.java
+++ b/components/camel-irc/src/test/java/org/apache/camel/component/irc/CodehausIrcChat.java
@@ -106,7 +106,7 @@ public final class CodehausIrcChat {
         try {
             conn.connect();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.debug("I/O error while connecting: {}", e.getMessage(), e);
         }
         // while (!conn.isConnected()) {
         // Thread.sleep(1000);

--- a/components/camel-jira/src/test/java/org/apache/camel/component/jira/Utils.java
+++ b/components/camel-jira/src/test/java/org/apache/camel/component/jira/Utils.java
@@ -42,20 +42,21 @@ import com.atlassian.jira.rest.client.api.domain.Worklog;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.slf4j.LoggerFactory;
 
 import static com.atlassian.jira.rest.client.api.domain.User.S48_48;
 import static org.apache.camel.component.jira.JiraTestConstants.KEY;
 import static org.apache.camel.component.jira.JiraTestConstants.TEST_JIRA_URL;
 
 public final class Utils {
-
     public static User userAssignee;
     static {
         try {
             userAssignee = new User(
                     null, "user-test", "User Test", "user@test", true, null, buildUserAvatarUris("user-test", 10082L), null);
         } catch (Exception e) {
-            e.printStackTrace();
+
+            LoggerFactory.getLogger(Utils.class).debug("Failed to build test user: {}", e.getMessage(), e);
         }
     }
     private static IssueType issueType = new IssueType(null, 1L, "Bug", false, "Bug", null);

--- a/components/camel-ldap/src/test/java/org/apache/directory/server/core/integ5/ServerAnnotationProcessor.java
+++ b/components/camel-ldap/src/test/java/org/apache/directory/server/core/integ5/ServerAnnotationProcessor.java
@@ -51,6 +51,8 @@ import org.apache.directory.server.ldap.replication.consumer.ReplicationConsumer
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.directory.server.protocol.shared.transport.Transport;
 import org.apache.directory.server.protocol.shared.transport.UdpTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Annotation processor for creating LDAP and Kerberos servers.
@@ -58,6 +60,7 @@ import org.apache.directory.server.protocol.shared.transport.UdpTransport;
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
 public final class ServerAnnotationProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerAnnotationProcessor.class);
 
     private ServerAnnotationProcessor() {
     }
@@ -260,7 +263,7 @@ public final class ServerAnnotationProcessor {
         try {
             ldapServer.start();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to start the LDAP server: {}", e.getMessage(), e);
         }
 
         return ldapServer;
@@ -380,7 +383,7 @@ public final class ServerAnnotationProcessor {
         try {
             kdcServer.start();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to start the KDC server: {}", e.getMessage(), e);
         }
 
         return kdcServer;

--- a/components/camel-ldif/src/test/java/org/apache/directory/server/core/integ5/ServerAnnotationProcessor.java
+++ b/components/camel-ldif/src/test/java/org/apache/directory/server/core/integ5/ServerAnnotationProcessor.java
@@ -51,6 +51,8 @@ import org.apache.directory.server.ldap.replication.consumer.ReplicationConsumer
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.directory.server.protocol.shared.transport.Transport;
 import org.apache.directory.server.protocol.shared.transport.UdpTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Annotation processor for creating LDAP and Kerberos servers.
@@ -58,6 +60,7 @@ import org.apache.directory.server.protocol.shared.transport.UdpTransport;
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
 public final class ServerAnnotationProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerAnnotationProcessor.class);
 
     private ServerAnnotationProcessor() {
     }
@@ -260,7 +263,7 @@ public final class ServerAnnotationProcessor {
         try {
             ldapServer.start();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to start the LDAP server: {}", e.getMessage(), e);
         }
 
         return ldapServer;
@@ -380,7 +383,7 @@ public final class ServerAnnotationProcessor {
         try {
             kdcServer.start();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to start the KDC server: {}", e.getMessage(), e);
         }
 
         return kdcServer;

--- a/components/camel-lucene/src/test/java/org/apache/camel/processor/lucene/LuceneQueryProcessorTest.java
+++ b/components/camel-lucene/src/test/java/org/apache/camel/processor/lucene/LuceneQueryProcessorTest.java
@@ -62,7 +62,7 @@ public class LuceneQueryProcessorTest extends CamelTestSupport {
                     from("direct:start").setHeader("QUERY", constant("Rodney Dangerfield"))
                             .process(new LuceneQueryProcessor("target/stdindexDir", analyzer, null, 20, 20)).to("direct:next");
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOG.warn("Unhandled exception: {}", e.getMessage(), e);
                 }
 
                 from("direct:next").process(new Processor() {
@@ -105,7 +105,7 @@ public class LuceneQueryProcessorTest extends CamelTestSupport {
                             .process(new LuceneQueryProcessor("target/simpleindexDir", analyzer, null, 20, 20))
                             .to("direct:next");
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOG.warn("Unhandled exception: {}", e.getMessage(), e);
                 }
 
                 from("direct:next").process(new Processor() {

--- a/components/camel-mina/src/test/java/org/apache/camel/component/mina/MinaReverseProtocolHandler.java
+++ b/components/camel-mina/src/test/java/org/apache/camel/component/mina/MinaReverseProtocolHandler.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.mina;
 import org.apache.mina.core.service.IoHandler;
 import org.apache.mina.core.service.IoHandlerAdapter;
 import org.apache.mina.core.session.IoSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 
@@ -27,10 +29,11 @@ import static org.apache.camel.test.junit5.TestSupport.isPlatform;
  *
  */
 public class MinaReverseProtocolHandler extends IoHandlerAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(MinaReverseProtocolHandler.class);
 
     @Override
     public void exceptionCaught(IoSession session, Throwable cause) {
-        cause.printStackTrace();
+        LOG.warn("Unhandled exception: {}", cause.getMessage(), cause);
         // Close connection when unexpected exception is caught.
         session.closeNow();
     }

--- a/components/camel-minio/src/test/java/org/apache/camel/component/minio/integration/MinioTestContainerSupport.java
+++ b/components/camel-minio/src/test/java/org/apache/camel/component/minio/integration/MinioTestContainerSupport.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import org.apache.camel.component.minio.MinioTestUtils;
 import org.apache.camel.test.testcontainers.junit5.ContainerAwareTestSupport;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
@@ -32,7 +33,8 @@ class MinioTestContainerSupport extends ContainerAwareTestSupport {
         try {
             properties = MinioTestUtils.loadMinioPropertiesFile();
         } catch (IOException e) {
-            e.printStackTrace();
+            LoggerFactory.getLogger(MinioTestContainerSupport.class)
+                    .warn("I/O exception loading minio properties file: {}", e.getMessage(), e);
         }
     }
 

--- a/components/camel-mllp/src/test/java/org/apache/camel/test/junit/rule/mllp/MllpServerResource.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/test/junit/rule/mllp/MllpServerResource.java
@@ -790,7 +790,7 @@ public class MllpServerResource implements BeforeEachCallback, AfterEachCallback
             try {
                 serverSocket.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                log.warn("I/O exception closing the server socket: {}", e.getMessage(), e);
             }
             log.info("Closed TCP Listener on port {}", serverSocket.getLocalPort());
         }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerThrowExceptionOnFailureTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerThrowExceptionOnFailureTest.java
@@ -19,11 +19,14 @@ package org.apache.camel.component.netty.http;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class NettyHttpProducerThrowExceptionOnFailureTest extends BaseNettyTest {
+    private static final Logger LOG = LoggerFactory.getLogger(NettyHttpProducerThrowExceptionOnFailureTest.class);
 
     @Test
     public void testFailWithoutException() throws Exception {
@@ -32,7 +35,7 @@ public class NettyHttpProducerThrowExceptionOnFailureTest extends BaseNettyTest 
                     String.class);
             assertEquals("Fail", out);
         } catch (Throwable t) {
-            t.printStackTrace();
+            LOG.error("Unexpected exception: {}", t.getMessage(), t);
             fail("Should not throw an exception");
         }
     }

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeReconnectTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeReconnectTest.java
@@ -138,7 +138,7 @@ public class NettyConsumerClientModeReconnectTest extends BaseNettyTest {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            cause.printStackTrace();
+            LOG.warn("Unhandled exception caught: {}", cause.getMessage(), cause);
             ctx.close();
         }
 

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeReuseChannelTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeReuseChannelTest.java
@@ -39,11 +39,14 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NettyConsumerClientModeReuseChannelTest extends BaseNettyTest {
+    private static final Logger LOG = LoggerFactory.getLogger(NettyConsumerClientModeReuseChannelTest.class);
 
     private final List<Channel> channels = new ArrayList<>();
 
@@ -139,7 +142,7 @@ public class NettyConsumerClientModeReuseChannelTest extends BaseNettyTest {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            cause.printStackTrace();
+            LOG.warn("Unhandled exception caught: {}", cause.getMessage(), cause);
             ctx.close();
         }
 

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyConsumerClientModeTest.java
@@ -36,8 +36,11 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NettyConsumerClientModeTest extends BaseNettyTest {
+    private static final Logger LOG = LoggerFactory.getLogger(NettyConsumerClientModeTest.class);
     private MyServer server;
 
     public void startNettyServer() throws Exception {
@@ -123,7 +126,7 @@ public class NettyConsumerClientModeTest extends BaseNettyTest {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            cause.printStackTrace();
+            LOG.warn("Unhandled exception caught: {}", cause.getMessage(), cause);
             ctx.close();
         }
 

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettySSLConsumerClientModeTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettySSLConsumerClientModeTest.java
@@ -54,8 +54,11 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NettySSLConsumerClientModeTest extends BaseNettyTest {
+    private static final Logger LOG = LoggerFactory.getLogger(NettySSLConsumerClientModeTest.class);
     private MyServer server;
 
     public void startNettyServer() throws Exception {
@@ -151,7 +154,7 @@ public class NettySSLConsumerClientModeTest extends BaseNettyTest {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            cause.printStackTrace();
+            LOG.warn("Unhandled exception caught: {}", cause.getMessage(), cause);
             ctx.close();
         }
 
@@ -195,7 +198,7 @@ public class NettySSLConsumerClientModeTest extends BaseNettyTest {
                 sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
             } catch (NoSuchAlgorithmException | KeyStoreException | CertificateException | IOException
                      | UnrecoverableKeyException | KeyManagementException e) {
-                e.printStackTrace();
+                LOG.warn("Failed to initialize server: {}", e.getMessage(), e);
             }
         }
 

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/integration/spring/AbstractRabbitMQSpringIntTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/integration/spring/AbstractRabbitMQSpringIntTest.java
@@ -22,15 +22,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.camel.test.testcontainers.junit5.Containers;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.testcontainers.containers.GenericContainer;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractRabbitMQSpringIntTest extends CamelSpringTestSupport {
-
     // Container starts once per test class
     protected static GenericContainer container;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractRabbitMQSpringIntTest.class);
 
     protected List<GenericContainer<?>> containers = new CopyOnWriteArrayList();
 
@@ -43,7 +46,7 @@ public abstract class AbstractRabbitMQSpringIntTest extends CamelSpringTestSuppo
         try {
             Containers.start(this.containers, null, 10);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error("Failed to start RabbitMQ Container: {}", e.getMessage(), e);
         }
 
         ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(getConfigLocation());

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltDTDTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltDTDTest.java
@@ -28,10 +28,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SaxonXsltDTDTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(SaxonXsltDTDTest.class);
 
     private static final String MESSAGE
             = "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc//user//test\">]><task><name>&xxe;</name></task>";
@@ -76,7 +79,7 @@ public class SaxonXsltDTDTest extends CamelTestSupport {
             xml = exchange.getIn().getBody(String.class);
             assertTrue(xml.indexOf("<transformed subject=\"\">") > 0, "Get a wrong transformed message");
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.warn("Exception thrown during test (likely safe to ignore): {}", ex.getMessage(), ex);
             // expect an exception here
             assertTrue(ex instanceof CamelExecutionException, "Get a wrong exception");
             // the file could not be found

--- a/components/camel-soroush/src/test/java/org/apache/camel/component/soroushbot/support/SoroushMockServer.java
+++ b/components/camel-soroush/src/test/java/org/apache/camel/component/soroushbot/support/SoroushMockServer.java
@@ -19,8 +19,11 @@ package org.apache.camel.component.soroushbot.support;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SoroushMockServer extends Thread {
+    private static final Logger LOG = LoggerFactory.getLogger(SoroushMockServer.class);
 
     private Server jettyServer;
     private Integer port = 8080;
@@ -51,7 +54,7 @@ public class SoroushMockServer extends Thread {
                 jettyServer.start();
                 port = jettyServer.getURI().getPort();
             } catch (Exception e) {
-                e.printStackTrace();
+                LOG.warn("Failed to start the Jetty server: {}", e.getMessage(), e);
             }
         }
     }

--- a/components/camel-soroush/src/test/java/org/apache/camel/component/soroushbot/utils/MultiQueueWithTopicThreadPoolTest.java
+++ b/components/camel-soroush/src/test/java/org/apache/camel/component/soroushbot/utils/MultiQueueWithTopicThreadPoolTest.java
@@ -19,11 +19,15 @@ package org.apache.camel.component.soroushbot.utils;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiQueueWithTopicThreadPoolTest {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiQueueWithTopicThreadPoolTest.class);
+
     @Test
     public void singleThreadSuccessful() throws InterruptedException {
         LinkedBlockingQueue<Integer> finalResultsOrder = new LinkedBlockingQueue<>();
@@ -40,7 +44,7 @@ public class MultiQueueWithTopicThreadPoolTest {
                     Thread.sleep((capacity - finalI) * 100);
                     finalResultsOrder.add(finalI);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOG.warn("Interrupted while running the test", e);
                 }
             });
         }
@@ -58,7 +62,7 @@ public class MultiQueueWithTopicThreadPoolTest {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        LOG.warn("Interrupted while running the test", e);
                     }
                 });
             }
@@ -87,7 +91,7 @@ public class MultiQueueWithTopicThreadPoolTest {
                     Thread.sleep((mod3 == 0 ? 1 : mod3 == 1 ? 4 : 13) * 10);
                     finalResultsOrder.add(finalI);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOG.warn("Interrupted while running the test", e);
                 }
             });
         }
@@ -116,7 +120,7 @@ public class MultiQueueWithTopicThreadPoolTest {
                     finalResultsOrder.add(finalI);
                     Thread.sleep((mod3 == 0 ? 1 : mod3 == 1 ? 4 : 13) * 10);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOG.warn("Interrupted while running the test", e);
                 }
             });
         }
@@ -140,7 +144,7 @@ public class MultiQueueWithTopicThreadPoolTest {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        LOG.warn("Interrupted while running the test", e);
                     }
                 });
             }

--- a/components/camel-stomp/src/test/java/org/apache/camel/component/stomp/StompProducerTest.java
+++ b/components/camel-stomp/src/test/java/org/apache/camel/component/stomp/StompProducerTest.java
@@ -28,6 +28,8 @@ import org.fusesource.stomp.client.BlockingConnection;
 import org.fusesource.stomp.client.Stomp;
 import org.fusesource.stomp.codec.StompFrame;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.fusesource.stomp.client.Constants.DESTINATION;
 import static org.fusesource.stomp.client.Constants.ID;
@@ -36,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StompProducerTest extends StompBaseTest {
+    private static final Logger LOG = LoggerFactory.getLogger(StompProducerTest.class);
 
     private static final String HEADER = "testheader1";
     private static final String HEADER_VALUE = "testheader1";
@@ -68,7 +71,7 @@ public class StompProducerTest extends StompBaseTest {
                         assertTrue(frame.getHeader(new AsciiBuffer(HEADER)).ascii().toString().startsWith(HEADER_VALUE));
                         latch.countDown();
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LOG.warn("Unhandled exception receiving STOMP data: {}", e.getMessage(), e);
                         break;
                     }
                 }

--- a/components/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/AsyncSendMockTest.java
+++ b/components/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/AsyncSendMockTest.java
@@ -19,10 +19,14 @@ package org.apache.camel.test.junit5.patterns;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AsyncSendMockTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncSendMockTest.class);
+
     @Override
     public String isMockEndpoints() {
         return "seda*";
@@ -40,7 +44,7 @@ public class AsyncSendMockTest extends CamelTestSupport {
             template.asyncSend("seda:start", dfex);
             assertMockEndpointsSatisfied();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to make async call to api: {}", e.getMessage(), e);
             assertTrue(false, "Failed to make async call to api");
         }
     }

--- a/components/camel-test/src/test/java/org/apache/camel/test/patterns/AsyncSendMockTest.java
+++ b/components/camel-test/src/test/java/org/apache/camel/test/patterns/AsyncSendMockTest.java
@@ -19,8 +19,12 @@ package org.apache.camel.test.patterns;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AsyncSendMockTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncSendMockTest.class);
+
     @Override
     public String isMockEndpoints() {
         return "seda*";
@@ -38,7 +42,7 @@ public class AsyncSendMockTest extends CamelTestSupport {
             template.asyncSend("seda:start", dfex);
             assertMockEndpointsSatisfied();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.warn("Failed to make async call to api: {}", e.getMessage(), e);
             assertTrue("Failed to make async call to api", false);
         }
     }

--- a/components/camel-twitter/src/test/java/org/apache/camel/component/twitter/CamelTwitterTestSupport.java
+++ b/components/camel-twitter/src/test/java/org/apache/camel/component/twitter/CamelTwitterTestSupport.java
@@ -56,7 +56,7 @@ public class CamelTwitterTestSupport extends CamelTestSupport {
             try (InputStream inStream = url.openStream()) {
                 properties.load(inStream);
             } catch (IOException e) {
-                e.printStackTrace();
+                log.warn("I/O exception loading test-options.properties: {}", e.getMessage(), e);
                 throw new IllegalAccessError("test-options.properties could not be found");
             }
         }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpStreamingTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpStreamingTest.java
@@ -32,10 +32,13 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UndertowHttpStreamingTest extends BaseUndertowTest {
+    private static final Logger LOG = LoggerFactory.getLogger(UndertowHttpStreamingTest.class);
 
     private static final String LINE = String.join("", Collections.nCopies(100, "0123456789"));
     private static final long COUNT = 1000; // approx. 1MB
@@ -89,7 +92,7 @@ public class UndertowHttpStreamingTest extends BaseUndertowTest {
                     }
                 });
             } catch (IOException e) {
-                e.printStackTrace();
+                LOG.warn("I/O exception: {}", e.getMessage(), e);
             }
         }).start();
     }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
@@ -46,6 +46,8 @@ import org.asynchttpclient.ws.WebSocket;
 import org.asynchttpclient.ws.WebSocketListener;
 import org.asynchttpclient.ws.WebSocketUpgradeHandler;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
+    private static final Logger LOG = LoggerFactory.getLogger(UndertowWsConsumerRouteTest.class);
 
     private static final String CONNECTED_PREFIX = "connected ";
     private static final String BROADCAST_MESSAGE_PREFIX = "broadcast ";
@@ -79,7 +82,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                 }).build()).get();
@@ -118,7 +121,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                 }).build()).get();
@@ -159,7 +162,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                     @Override
@@ -202,7 +205,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                 }).build()).get();
@@ -249,7 +252,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                 }).build()).get();
@@ -273,7 +276,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
 
                 }).build()).get();

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsProducerRouteRestartTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsProducerRouteRestartTest.java
@@ -94,7 +94,7 @@ public class UndertowWsProducerRouteRestartTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
                 }).build()).get();
 

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsProducerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsProducerRouteTest.java
@@ -73,7 +73,7 @@ public class UndertowWsProducerRouteTest extends BaseUndertowTest {
 
                     @Override
                     public void onError(Throwable t) {
-                        t.printStackTrace();
+                        LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                     }
                 }).build()).get();
 

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesTest.java
@@ -67,7 +67,7 @@ public class UndertowWsTwoRoutesTest extends BaseUndertowTest {
 
                                 @Override
                                 public void onError(Throwable t) {
-                                    t.printStackTrace();
+                                    LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                                 }
                             }).build())
                     .get();
@@ -107,7 +107,7 @@ public class UndertowWsTwoRoutesTest extends BaseUndertowTest {
 
                                 @Override
                                 public void onError(Throwable t) {
-                                    t.printStackTrace();
+                                    LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                                 }
                             }).build())
                     .get();

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesToSameEndpointSendToAllHeaderTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesToSameEndpointSendToAllHeaderTest.java
@@ -68,7 +68,7 @@ public class UndertowWsTwoRoutesToSameEndpointSendToAllHeaderTest extends BaseUn
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
                         }).build())
                 .get();

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesToSameEndpointTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsTwoRoutesToSameEndpointTest.java
@@ -67,7 +67,7 @@ public class UndertowWsTwoRoutesToSameEndpointTest extends BaseUndertowTest {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
                         }).build())
                 .get();

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWssRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWssRouteTest.java
@@ -143,7 +143,7 @@ public class UndertowWssRouteTest extends BaseUndertowTest {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
                         }).build())
                 .get();

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketClientCamelRouteTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketClientCamelRouteTest.java
@@ -71,7 +71,7 @@ public class WebsocketClientCamelRouteTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketComponentRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketComponentRouteExampleTest.java
@@ -70,7 +70,7 @@ public class WebsocketComponentRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketConsumerRouteTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketConsumerRouteTest.java
@@ -27,8 +27,11 @@ import org.asynchttpclient.ws.WebSocketListener;
 import org.asynchttpclient.ws.WebSocketUpgradeHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WebsocketConsumerRouteTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(WebsocketConsumerRouteTest.class);
 
     private int port;
 
@@ -57,7 +60,7 @@ public class WebsocketConsumerRouteTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override
@@ -110,7 +113,7 @@ public class WebsocketConsumerRouteTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                LOG.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketProducerRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketProducerRouteExampleTest.java
@@ -79,7 +79,7 @@ public class WebsocketProducerRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketProducerRouteRestartTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketProducerRouteRestartTest.java
@@ -99,7 +99,7 @@ public class WebsocketProducerRouteRestartTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketRouteExampleTest.java
@@ -70,7 +70,7 @@ public class WebsocketRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLClientAuthRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLClientAuthRouteExampleTest.java
@@ -146,7 +146,7 @@ public class WebsocketSSLClientAuthRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLContextGlobalRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLContextGlobalRouteExampleTest.java
@@ -145,7 +145,7 @@ public class WebsocketSSLContextGlobalRouteExampleTest extends CamelTestSupport 
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLContextInUriRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLContextInUriRouteExampleTest.java
@@ -144,7 +144,7 @@ public class WebsocketSSLContextInUriRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLRouteExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketSSLRouteExampleTest.java
@@ -141,7 +141,7 @@ public class WebsocketSSLRouteExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketStaticTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketStaticTest.java
@@ -71,7 +71,7 @@ public class WebsocketStaticTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesExampleTest.java
@@ -76,7 +76,7 @@ public class WebsocketTwoRoutesExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override
@@ -132,7 +132,7 @@ public class WebsocketTwoRoutesExampleTest extends CamelTestSupport {
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesToSIndividualAndBroadcastEndpointExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesToSIndividualAndBroadcastEndpointExampleTest.java
@@ -75,7 +75,7 @@ public class WebsocketTwoRoutesToSIndividualAndBroadcastEndpointExampleTest exte
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesToSameEndpointExampleTest.java
+++ b/components/camel-websocket/src/test/java/org/apache/camel/component/websocket/WebsocketTwoRoutesToSameEndpointExampleTest.java
@@ -74,7 +74,7 @@ public class WebsocketTwoRoutesToSameEndpointExampleTest extends CamelTestSuppor
 
                             @Override
                             public void onError(Throwable t) {
-                                t.printStackTrace();
+                                log.warn("Unhandled exception: {}", t.getMessage(), t);
                             }
 
                             @Override

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/TestHelper.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/TestHelper.java
@@ -44,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHelper {
-
     protected static final String NS_XML_FRAGMENT
             = "<ns1:cheesesites xmlns:ns1=\"http://cheese.xmlsecurity.camel.apache.org/\">"
               + "<netherlands>"
@@ -77,6 +76,7 @@ public class TestHelper {
                                                  + "</cheesesites>";
 
     static final boolean HAS_3DES;
+
     static {
         boolean ok = false;
         try {
@@ -84,7 +84,7 @@ public class TestHelper {
             XMLCipher.getInstance(XMLCipher.TRIPLEDES_KeyWrap);
             ok = true;
         } catch (XMLEncryptionException e) {
-            e.printStackTrace();
+            LoggerFactory.getLogger(TestHelper.class).warn("XML encryption exception: {}", e.getMessage(), e);
         }
         HAS_3DES = ok;
     }

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppDeferredConnectionTest.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppDeferredConnectionTest.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test to verify that the XMPP producer and consumer will create deferred / lazy connections to the XMPP server when
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
  */
 
 public class XmppDeferredConnectionTest extends XmppBaseTest {
+    private static final Logger LOG = LoggerFactory.getLogger(XmppDeferredConnectionTest.class);
 
     /**
      * Ensures that the XMPP server instance is created and 'stopped' before the camel routes are initialized
@@ -39,7 +42,7 @@ public class XmppDeferredConnectionTest extends XmppBaseTest {
         try {
             xmppServer.stopXmppEndpoint();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.warn("Failed to stop XMPP endpoint: {}", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This ensures that stacktraces are always handled by the logging
mechanism. Basically replaces all instances of calls to
printStackTrace() with a call to the logger handler.

I put the list of affected components in the ticket. A bit large patch, but in general the patch is simple: it just adds the calls to the logger and adds a logger to the class if needed.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md