### PR TITLE
[CAMEL-15588] Updated swagger-core to 1.6.2

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -292,7 +292,7 @@
     <jackrabbit-version>2.21.3</jackrabbit-version>
     <jackson-spark-version>2.10.5</jackson-spark-version>
     <jackson-version>1.9.12</jackson-version>
-    <jackson2-version>2.10.5</jackson2-version>
+    <jackson2-version>2.11.2</jackson2-version>
     <jain-sip-ri-bundle-version>1.2.154_2</jain-sip-ri-bundle-version>
     <jakarta-api-version>2.1.5</jakarta-api-version>
     <jakarta-jaxb-version>2.3.3</jakarta-jaxb-version>

--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -544,8 +544,8 @@
     <stompjms-version>1.19</stompjms-version>
     <stringtemplate-version>4.3</stringtemplate-version>
     <swagger-java-guava-version>27.1-jre</swagger-java-guava-version>
-    <swagger-java-parser-version>1.0.47</swagger-java-parser-version>
-    <swagger-java-version>1.5.24</swagger-java-version>
+    <swagger-java-parser-version>1.0.51</swagger-java-parser-version>
+    <swagger-java-version>1.6.2</swagger-java-version>
     <tagsoup-version>1.2.1</tagsoup-version>
     <templating-maven-plugin-version>1.0.0</templating-maven-plugin-version>
     <testcontainers-version>1.14.3</testcontainers-version>

--- a/components/camel-jackson/pom.xml
+++ b/components/camel-jackson/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.import.before.defaults>
-            com.fasterxml.jackson.*;version="[2.9,3)"
+            com.fasterxml.jackson.*;version="[2.11,3)"
         </camel.osgi.import.before.defaults>
     </properties>
 

--- a/components/camel-jacksonxml/pom.xml
+++ b/components/camel-jacksonxml/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <camel.osgi.import.before.defaults>
-            com.fasterxml.jackson.*;version="[2.9,3)"
+            com.fasterxml.jackson.*;version="[2.11,3)"
         </camel.osgi.import.before.defaults>
     </properties>
 

--- a/components/camel-openapi-java/pom.xml
+++ b/components/camel-openapi-java/pom.xml
@@ -38,7 +38,7 @@
         <label>rest,api</label>
 
         <camel.osgi.import.before.defaults>
-            com.fasterxml.jackson.*;version="[2.9,3)",
+            com.fasterxml.jackson.*;version="[2.11,3)",
             io.apicurio.datamodels*
         </camel.osgi.import.before.defaults>
     </properties>

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -37,7 +37,7 @@
         <firstVersion>3.1.0</firstVersion>
         <label>rest,api,http</label>
         <camel.osgi.import.before.defaults>
-            com.fasterxml.jackson.*;version="[2.9,3)",
+            com.fasterxml.jackson.*;version="[2.11,3)",
             io.apicurio.datamodels*
         </camel.osgi.import.before.defaults>
     </properties>

--- a/components/camel-swagger-java/pom.xml
+++ b/components/camel-swagger-java/pom.xml
@@ -37,7 +37,7 @@
         <label>rest,api</label>
 
         <camel.osgi.import.before.defaults>
-            com.fasterxml.jackson.*;version="[2.9,3)"
+            com.fasterxml.jackson.*;version="[2.11,3)"
         </camel.osgi.import.before.defaults>
     </properties>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -528,8 +528,8 @@
         <squareup-okio-version>1.17.2</squareup-okio-version>
         <sshd-version>2.0.0</sshd-version>
         <stompjms-version>1.19</stompjms-version>
-        <swagger-java-version>1.5.24</swagger-java-version>
-        <swagger-java-parser-version>1.0.47</swagger-java-parser-version>
+        <swagger-java-version>1.6.2</swagger-java-version>
+        <swagger-java-parser-version>1.0.51</swagger-java-parser-version>
         <swagger-java-guava-version>27.1-jre</swagger-java-guava-version>
         <apicurio-version>1.0.16.Final</apicurio-version>
         <stax-api-version>1.0.1</stax-api-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -271,7 +271,7 @@
         <ivy-version>2.5.0</ivy-version>
         <jackson-version>1.9.12</jackson-version>
         <jackson-spark-version>2.10.5</jackson-spark-version>
-        <jackson2-version>2.10.5</jackson2-version>
+        <jackson2-version>2.11.2</jackson2-version>
         <jackrabbit-version>2.21.3</jackrabbit-version>
         <jain-sip-ri-bundle-version>1.2.154_2</jain-sip-ri-bundle-version>
         <jasminb-jsonapi-version>0.10</jasminb-jsonapi-version>


### PR DESCRIPTION
Updated swagger-core to 1.6.2
Updated swagger-parser to 1.0.51

This is to address a NoSuchMethod exception when upgrading to latest jackson. See https://github.com/swagger-api/swagger-core/issues/3554 for details.