### PR TITLE
CAMEL-15608: Add support for multipart uploads to platform-http-vertx

### DIFF
--- a/components/camel-attachments/src/main/java/org/apache/camel/attachment/CamelFileDataSource.java
+++ b/components/camel-attachments/src/main/java/org/apache/camel/attachment/CamelFileDataSource.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.http.common;
+package org.apache.camel.attachment;
 
 import java.io.File;
 

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpBinding.java
@@ -46,6 +46,7 @@ import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.StreamCache;
 import org.apache.camel.attachment.AttachmentMessage;
+import org.apache.camel.attachment.CamelFileDataSource;
 import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.support.ExchangeHelper;

--- a/components/camel-platform-http-vertx/pom.xml
+++ b/components/camel-platform-http-vertx/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>camel-platform-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-attachments</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
             <version>${vertx-version}</version>

--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngine.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngine.java
@@ -28,7 +28,6 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.platform.http.PlatformHttpConstants;
 import org.apache.camel.component.platform.http.PlatformHttpEndpoint;
 import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
-import org.apache.camel.component.platform.http.spi.UploadAttacher;
 import org.apache.camel.spi.annotations.JdkService;
 import org.apache.camel.support.service.ServiceSupport;
 
@@ -39,7 +38,6 @@ import org.apache.camel.support.service.ServiceSupport;
 @JdkService(PlatformHttpConstants.PLATFORM_HTTP_ENGINE_FACTORY)
 public class VertxPlatformHttpEngine extends ServiceSupport implements PlatformHttpEngine {
     private List<Handler<RoutingContext>> handlers;
-    private UploadAttacher uploadAttacher;
 
     public VertxPlatformHttpEngine() {
         this.handlers = Collections.emptyList();
@@ -53,14 +51,6 @@ public class VertxPlatformHttpEngine extends ServiceSupport implements PlatformH
         if (handlers != null) {
             this.handlers = new ArrayList<>(handlers);
         }
-    }
-
-    public UploadAttacher getUploadAttacher() {
-        return uploadAttacher;
-    }
-
-    public void setUploadAttacher(UploadAttacher uploadAttacher) {
-        this.uploadAttacher = uploadAttacher;
     }
 
     @Override
@@ -78,7 +68,6 @@ public class VertxPlatformHttpEngine extends ServiceSupport implements PlatformH
         return new VertxPlatformHttpConsumer(
                 endpoint,
                 processor,
-                handlers,
-                uploadAttacher);
+                handlers);
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_6.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_6.adoc
@@ -158,3 +158,9 @@ Should eb replaced by:
 === Camel Karaf
 
 The following features has been removed due they become not compatible with OSGi: `camel-atmosphere-websocket`.
+
+=== CamelFileDataSource
+
+Class `CamelFileDataSource` has moved from `camel-http-common` in package `org.apache.camel.http.common` to `camel-attachments` package `org.apache.camel.attachment.CamelFileDataSource`.
+
+If your code directly depends on this class, you will need to update the package reference to the new location.


### PR DESCRIPTION
Note: I moved `CamelFileDataSource` out of `camel-http-common` and into `camel-attachments`, as it's a bit friendlier for camel-quarkus to not have to deal with `servlet-api` and other stuff that `camel-http-common` depends on.