### PR TITLE
Remove explicit zeroing of AtomicInteger and AtomicLong object at ins…

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/csv/BindyCsvDataFormat.java
@@ -158,7 +158,7 @@ public class BindyCsvDataFormat extends BindyAbstractDataFormat {
             org.apache.camel.util.ObjectHelper.notNull(separator,
                     "The separator has not been defined in the annotation @CsvRecord or not instantiated during initModel.");
             Boolean removeQuotes = factory.getRemoveQuotes();
-            AtomicInteger count = new AtomicInteger(0);
+            AtomicInteger count = new AtomicInteger();
 
             // Use a Stream to stream a file across.
             try (Stream<String> lines = new BufferedReader(in).lines()) {

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
@@ -195,7 +195,7 @@ public class BindyFixedLengthDataFormat extends BindyAbstractDataFormat {
             isEolSet = true;
         }
 
-        AtomicInteger count = new AtomicInteger(0);
+        AtomicInteger count = new AtomicInteger();
 
         try {
 

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/kvp/BindyKeyValuePairDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/kvp/BindyKeyValuePairDataFormat.java
@@ -108,7 +108,7 @@ public class BindyKeyValuePairDataFormat extends BindyAbstractDataFormat {
             org.apache.camel.util.ObjectHelper.notNull(factory.getPairSeparator(),
                     "The pair separator property of the annotation @Message");
             String separator = factory.getPairSeparator();
-            AtomicInteger count = new AtomicInteger(0);
+            AtomicInteger count = new AtomicInteger();
 
             try {
                 lines.forEachOrdered(line -> {

--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelContextNameStrategy.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelContextNameStrategy.java
@@ -34,7 +34,7 @@ import org.apache.camel.spi.CamelContextNameStrategy;
 @Vetoed
 final class CdiCamelContextNameStrategy extends DefaultCamelContextNameStrategy implements CamelContextNameStrategy {
 
-    private static final AtomicInteger CONTEXT_COUNTER = new AtomicInteger(0);
+    private static final AtomicInteger CONTEXT_COUNTER = new AtomicInteger();
 
     @Override
     public String getNextName() {

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/MultipleConsumerSynchronizedExchange.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/MultipleConsumerSynchronizedExchange.java
@@ -30,7 +30,7 @@ public class MultipleConsumerSynchronizedExchange extends AbstractSynchronizedEx
 
     private final int expectedConsumers;
 
-    private final AtomicInteger processedConsumers = new AtomicInteger(0);
+    private final AtomicInteger processedConsumers = new AtomicInteger();
 
     private final AtomicBoolean resultHandled = new AtomicBoolean(false);
 

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/cloud/EtcdWatchServiceDiscovery.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/cloud/EtcdWatchServiceDiscovery.java
@@ -47,7 +47,7 @@ public class EtcdWatchServiceDiscovery
         super(configuration);
 
         this.serversRef = new AtomicReference<>();
-        this.index = new AtomicLong(0);
+        this.index = new AtomicLong();
         this.servicePath = ObjectHelper.notNull(configuration.getServicePath(), "servicePath");
     }
 

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
@@ -50,7 +50,7 @@ public class EtcdRoutePolicy extends RoutePolicySupport
     private final Object lock = new Object();
     private final AtomicBoolean leader = new AtomicBoolean(false);
     private final Set<Route> suspendedRoutes = new HashSet<>();
-    private final AtomicLong index = new AtomicLong(0);
+    private final AtomicLong index = new AtomicLong();
 
     private int ttl = 60;
     private int watchTimeout = 60 / 3;

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsConsumer.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsConsumer.java
@@ -137,7 +137,7 @@ public final class HdfsConsumer extends ScheduledPollConsumer {
     }
 
     private int processFileStatuses(HdfsInfo info, FileStatus[] fileStatuses) {
-        final AtomicInteger totalMessageCount = new AtomicInteger(0);
+        final AtomicInteger totalMessageCount = new AtomicInteger();
 
         List<HdfsInputStream> hdfsFiles = Arrays.stream(fileStatuses)
                 .filter(status -> normalFileIsDirectoryHasSuccessFile(status, info))
@@ -164,7 +164,7 @@ public final class HdfsConsumer extends ScheduledPollConsumer {
     }
 
     private int processHdfsInputStream(HdfsInputStream hdfsFile, AtomicInteger totalMessageCount) {
-        final AtomicInteger messageCount = new AtomicInteger(0);
+        final AtomicInteger messageCount = new AtomicInteger();
         Holder<Object> currentKey = new Holder<>();
         Holder<Object> currentValue = new Holder<>();
 

--- a/components/camel-jgroups-raft/src/main/java/org/apache/camel/component/jgroups/raft/JGroupsRaftEndpoint.java
+++ b/components/camel-jgroups-raft/src/main/java/org/apache/camel/component/jgroups/raft/JGroupsRaftEndpoint.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class JGroupsRaftEndpoint extends DefaultEndpoint {
     private static final Logger LOG = LoggerFactory.getLogger(JGroupsRaftEndpoint.class);
 
-    private AtomicInteger connectCount = new AtomicInteger(0);
+    private AtomicInteger connectCount = new AtomicInteger();
 
     private RaftHandle raftHandle;
     private RaftHandle resolvedRaftHandle;

--- a/components/camel-jgroups/src/main/java/org/apache/camel/component/jgroups/JGroupsEndpoint.java
+++ b/components/camel-jgroups/src/main/java/org/apache/camel/component/jgroups/JGroupsEndpoint.java
@@ -48,7 +48,7 @@ public class JGroupsEndpoint extends DefaultEndpoint {
     public static final String HEADER_JGROUPS_CHANNEL_ADDRESS = "JGROUPS_CHANNEL_ADDRESS";
 
     private static final Logger LOG = LoggerFactory.getLogger(JGroupsEndpoint.class);
-    private AtomicInteger connectCount = new AtomicInteger(0);
+    private AtomicInteger connectCount = new AtomicInteger();
 
     private JChannel channel;
     private JChannel resolvedChannel;

--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
@@ -75,7 +75,7 @@ public class KafkaIdempotentRepository extends ServiceSupport implements Idempot
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    private final AtomicLong duplicateCount = new AtomicLong(0);
+    private final AtomicLong duplicateCount = new AtomicLong();
 
     // configurable
     private String topic;

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
@@ -78,7 +78,7 @@ public class SubscriptionManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(SubscriptionManager.class);
 
-    private final AtomicLong clientHandleCounter = new AtomicLong(0);
+    private final AtomicLong clientHandleCounter = new AtomicLong();
 
     private final class SubscriptionListenerImpl implements SubscriptionListener {
         @Override

--- a/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzComponent.java
+++ b/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzComponent.java
@@ -477,7 +477,7 @@ public class QuartzComponent extends DefaultComponent implements ExtendedStartup
         // that has not completed yet, and the last one with job counts to zero will eventually shutdown.
         AtomicInteger number = (AtomicInteger) quartzContext.get(QuartzConstants.QUARTZ_CAMEL_JOBS_COUNT);
         if (number == null) {
-            number = new AtomicInteger(0);
+            number = new AtomicInteger();
             quartzContext.put(QuartzConstants.QUARTZ_CAMEL_JOBS_COUNT, number);
         }
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/Counter.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/dto/composite/Counter.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Counter implements ReferenceGenerator {
 
-    private final AtomicInteger counter = new AtomicInteger(0);
+    private final AtomicInteger counter = new AtomicInteger();
 
     @Override
     public String nextReferenceFor(final Object object) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -99,7 +99,7 @@ public class SubscriptionHelper extends ServiceSupport {
 
         this.listenerMap = new ConcurrentHashMap<>();
 
-        restartBackoff = new AtomicLong(0);
+        restartBackoff = new AtomicLong();
         backoffIncrement = component.getConfig().getBackoffIncrement();
         maxBackoff = component.getConfig().getMaxBackoff();
     }

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
@@ -284,7 +284,7 @@ public class GenerateMojo extends AbstractSalesforceMojo {
 
             AtomicInteger counter = varNames.get(base);
             if (counter == null) {
-                counter = new AtomicInteger(0);
+                counter = new AtomicInteger();
                 varNames.put(base, counter);
             }
 

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/tx/BatchTransactionCommitStrategy.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/tx/BatchTransactionCommitStrategy.java
@@ -27,7 +27,7 @@ import org.apache.camel.component.sjms.TransactionCommitStrategy;
 @Deprecated
 public class BatchTransactionCommitStrategy implements TransactionCommitStrategy {
 
-    private final AtomicInteger current = new AtomicInteger(0);
+    private final AtomicInteger current = new AtomicInteger();
     private final int count;
 
     public BatchTransactionCommitStrategy(int count) {

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextNameStrategy.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextNameStrategy.java
@@ -25,7 +25,7 @@ import org.apache.camel.spi.CamelContextNameStrategy;
  */
 public class DefaultCamelContextNameStrategy implements CamelContextNameStrategy {
 
-    private static final AtomicInteger CONTEXT_COUNTER = new AtomicInteger(0);
+    private static final AtomicInteger CONTEXT_COUNTER = new AtomicInteger();
     private final String prefix;
     private String name;
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultNodeIdFactory.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultNodeIdFactory.java
@@ -40,7 +40,7 @@ public class DefaultNodeIdFactory implements NodeIdFactory {
      * Returns the counter for the given node key, lazily creating one if necessary
      */
     protected static AtomicInteger getNodeCounter(String key) {
-        return nodeCounters.computeIfAbsent(key, k -> new AtomicInteger(0));
+        return nodeCounters.computeIfAbsent(key, k -> new AtomicInteger());
     }
 
     /**

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
@@ -89,7 +89,7 @@ public class DefaultSupervisingRouteController extends DefaultRouteController im
     public DefaultSupervisingRouteController() {
         this.lock = new Object();
         this.contextStarted = new AtomicBoolean(false);
-        this.routeCount = new AtomicInteger(0);
+        this.routeCount = new AtomicInteger();
         this.routes = new TreeSet<>();
         this.nonSupervisedRoutes = new HashSet<>();
         this.routeManager = new RouteManager();

--- a/core/camel-base/src/main/java/org/apache/camel/processor/DelayProcessorSupport.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/DelayProcessorSupport.java
@@ -44,7 +44,7 @@ public abstract class DelayProcessorSupport extends DelegateAsyncProcessor {
     private final boolean shutdownExecutorService;
     private boolean asyncDelayed = true;
     private boolean callerRunsWhenRejected = true;
-    private final AtomicInteger delayedCount = new AtomicInteger(0);
+    private final AtomicInteger delayedCount = new AtomicInteger();
 
     private final class ProcessCall implements Runnable {
         private final Exchange exchange;

--- a/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/BacklogDebugger.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/BacklogDebugger.java
@@ -67,7 +67,7 @@ public final class BacklogDebugger extends ServiceSupport {
     private LoggingLevel loggingLevel = LoggingLevel.INFO;
     private final CamelLogger logger = new CamelLogger(LOG, loggingLevel);
     private final AtomicBoolean enabled = new AtomicBoolean();
-    private final AtomicLong debugCounter = new AtomicLong(0);
+    private final AtomicLong debugCounter = new AtomicLong();
     private final Debugger debugger;
     private final ConcurrentMap<String, NodeBreakpoint> breakpoints = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, SuspendedExchange> suspendedBreakpoints = new ConcurrentHashMap<>();

--- a/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/BacklogTracer.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/interceptor/BacklogTracer.java
@@ -45,7 +45,7 @@ public final class BacklogTracer extends ServiceSupport {
     public static final int MAX_BACKLOG_SIZE = 10 * 1000;
     private final CamelContext camelContext;
     private boolean enabled;
-    private final AtomicLong traceCounter = new AtomicLong(0);
+    private final AtomicLong traceCounter = new AtomicLong();
     // use a queue with a upper limit to avoid storing too many messages
     private final Queue<BacklogTracerEventMessage> queue = new LinkedBlockingQueue<>(MAX_BACKLOG_SIZE);
     // how many of the last messages to keep in the backlog at total

--- a/core/camel-main/src/main/java/org/apache/camel/main/MainDurationEventNotifier.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/MainDurationEventNotifier.java
@@ -55,7 +55,7 @@ public class MainDurationEventNotifier extends EventNotifierSupport {
         this.maxIdleSeconds = maxIdleSeconds;
         this.shutdownStrategy = shutdownStrategy;
         this.stopCamelContext = stopCamelContext;
-        this.doneMessages = new AtomicInteger(0);
+        this.doneMessages = new AtomicInteger();
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticCounter.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticCounter.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class StatisticCounter extends Statistic {
 
-    private final AtomicLong value = new AtomicLong(0);
+    private final AtomicLong value = new AtomicLong();
 
     @Override
     public void updateValue(long newValue) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
@@ -48,7 +48,7 @@ import static org.apache.camel.util.StringHelper.after;
 public final class EndpointHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(EndpointHelper.class);
-    private static final AtomicLong ENDPOINT_COUNTER = new AtomicLong(0);
+    private static final AtomicLong ENDPOINT_COUNTER = new AtomicLong();
 
     private EndpointHelper() {
         //Utility Class

--- a/core/camel-util/src/main/java/org/apache/camel/util/ReferenceCount.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ReferenceCount.java
@@ -24,7 +24,7 @@ public final class ReferenceCount {
     private final Runnable onRelease;
 
     private ReferenceCount(Runnable onFirst, Runnable onRelease) {
-        this.count = new AtomicLong(0);
+        this.count = new AtomicLong();
         this.onFirst = ObjectHelper.notNull(onFirst, "onFirst");
         this.onRelease = ObjectHelper.notNull(onRelease, "onRelease");
     }

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/DirectToOperationId.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/DirectToOperationId.java
@@ -23,7 +23,7 @@ import io.apicurio.datamodels.openapi.models.OasOperation;
 
 public final class DirectToOperationId implements DestinationGenerator {
 
-    private final AtomicInteger directRouteCount = new AtomicInteger(0);
+    private final AtomicInteger directRouteCount = new AtomicInteger();
 
     @Override
     public String generateDestinationFor(final OasOperation operation) {

--- a/tooling/swagger-rest-dsl-generator/src/main/java/org/apache/camel/generator/swagger/DirectToOperationId.java
+++ b/tooling/swagger-rest-dsl-generator/src/main/java/org/apache/camel/generator/swagger/DirectToOperationId.java
@@ -23,7 +23,7 @@ import io.swagger.models.Operation;
 
 public final class DirectToOperationId implements DestinationGenerator {
 
-    private final AtomicInteger directRouteCount = new AtomicInteger(0);
+    private final AtomicInteger directRouteCount = new AtomicInteger();
 
     @Override
     public String generateDestinationFor(final Operation operation) {


### PR DESCRIPTION
…tantiation time, which is redundant and slower than relying on default values.

Similar to https://github.com/spring-projects/spring-framework/pull/25846 (see jhm benchmark of this pull request).

Not sure if this is worth it.