### PR TITLE
Avoid explicit initialization of AtomicBoolean with its default value

### DIFF
--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/cluster/ConsulClusterView.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/cluster/ConsulClusterView.java
@@ -137,7 +137,7 @@ final class ConsulClusterView extends AbstractCamelClusterView {
     // ***********************************************
 
     private final class ConsulLocalMember implements CamelClusterMember {
-        private AtomicBoolean master = new AtomicBoolean(false);
+        private AtomicBoolean master = new AtomicBoolean();
 
         void setMaster(boolean master) {
             if (master && this.master.compareAndSet(false, true)) {

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpoint.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/CxfEndpoint.java
@@ -130,7 +130,7 @@ public class CxfEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
     protected Bus bus;
 
     protected volatile boolean createBus;
-    private final AtomicBoolean getBusHasBeenCalled = new AtomicBoolean(false);
+    private final AtomicBoolean getBusHasBeenCalled = new AtomicBoolean();
 
     private BindingConfiguration bindingConfig;
     private DataBinding dataBinding;

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/MultipleConsumerSynchronizedExchange.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/MultipleConsumerSynchronizedExchange.java
@@ -32,7 +32,7 @@ public class MultipleConsumerSynchronizedExchange extends AbstractSynchronizedEx
 
     private final AtomicInteger processedConsumers = new AtomicInteger();
 
-    private final AtomicBoolean resultHandled = new AtomicBoolean(false);
+    private final AtomicBoolean resultHandled = new AtomicBoolean();
 
     public MultipleConsumerSynchronizedExchange(Exchange exchange, int expectedConsumers) {
         super(exchange);

--- a/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
+++ b/components/camel-etcd/src/main/java/org/apache/camel/component/etcd/policy/EtcdRoutePolicy.java
@@ -48,7 +48,7 @@ public class EtcdRoutePolicy extends RoutePolicySupport
     private static final Logger LOGGER = LoggerFactory.getLogger(EtcdRoutePolicy.class);
 
     private final Object lock = new Object();
-    private final AtomicBoolean leader = new AtomicBoolean(false);
+    private final AtomicBoolean leader = new AtomicBoolean();
     private final Set<Route> suspendedRoutes = new HashSet<>();
     private final AtomicLong index = new AtomicLong();
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicy.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicy.java
@@ -69,7 +69,7 @@ public class HazelcastRoutePolicy extends RoutePolicySupport implements CamelCon
         this.instance = instance;
         this.managedInstance = managedInstance;
         this.suspendedRoutes = new HashSet<>();
-        this.leader = new AtomicBoolean(false);
+        this.leader = new AtomicBoolean();
         this.lockMapName = null;
         this.lockKey = null;
         this.lockValue = null;

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsOutputStream.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsOutputStream.java
@@ -37,7 +37,7 @@ public class HdfsOutputStream implements Closeable {
     private final AtomicLong numOfWrittenBytes = new AtomicLong(0L);
     private final AtomicLong numOfWrittenMessages = new AtomicLong(0L);
     private final AtomicLong lastAccess = new AtomicLong(Long.MAX_VALUE);
-    private final AtomicBoolean busy = new AtomicBoolean(false);
+    private final AtomicBoolean busy = new AtomicBoolean();
 
     protected HdfsOutputStream() {
     }

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsProducer.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsProducer.java
@@ -40,7 +40,7 @@ public class HdfsProducer extends DefaultProducer {
 
     private final HdfsConfiguration config;
     private final StringBuilder hdfsPath;
-    private final AtomicBoolean idle = new AtomicBoolean(false);
+    private final AtomicBoolean idle = new AtomicBoolean();
     private volatile ScheduledExecutorService scheduler;
     private volatile HdfsOutputStream oStream;
 

--- a/components/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/policy/InfinispanRoutePolicy.java
+++ b/components/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/policy/InfinispanRoutePolicy.java
@@ -87,7 +87,7 @@ public class InfinispanRoutePolicy extends RoutePolicySupport implements CamelCo
         this.manager = manager;
         this.stoppeddRoutes = new HashSet<>();
         this.startedRoutes = new HashSet<>();
-        this.leader = new AtomicBoolean(false);
+        this.leader = new AtomicBoolean();
         this.shouldStopRoute = true;
         this.lockKey = lockKey;
         this.lockValue = lockValue;

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumer.java
@@ -72,7 +72,7 @@ public class WatchUpdatesConsumer extends AbstractJiraConsumer {
 
     private void checkIfIssueChanged(Issue issue) throws Exception {
         Issue original = watchedIssues.get(issue.getId());
-        AtomicBoolean issueChanged = new AtomicBoolean(false);
+        AtomicBoolean issueChanged = new AtomicBoolean();
         if (original != null) {
             for (String field : this.watchedFieldsList) {
                 if (hasFieldChanged(issue, original, field)) {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
@@ -58,7 +58,7 @@ public class JmsProducer extends DefaultAsyncProducer {
 
     private static final String GENERATED_CORRELATION_ID_PREFIX = "Camel-";
     private final JmsEndpoint endpoint;
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean started = new AtomicBoolean();
     private JmsOperations inOnlyTemplate;
     private JmsOperations inOutTemplate;
     private UuidGenerator uuidGenerator;

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/TemporaryQueueReplyManager.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/TemporaryQueueReplyManager.java
@@ -200,7 +200,7 @@ public class TemporaryQueueReplyManager extends ReplyManagerSupport {
 
     private final class TemporaryReplyQueueDestinationResolver implements DestinationResolver {
         private TemporaryQueue queue;
-        private final AtomicBoolean refreshWanted = new AtomicBoolean(false);
+        private final AtomicBoolean refreshWanted = new AtomicBoolean();
 
         @Override
         public Destination resolveDestinationName(Session session, String destinationName, boolean pubSubDomain)

--- a/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzEndpoint.java
+++ b/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzEndpoint.java
@@ -68,8 +68,8 @@ public class QuartzEndpoint extends DefaultEndpoint {
     private volatile AsyncProcessor processor;
 
     // An internal variables to track whether a job has been in scheduler or not, and has it paused or not.
-    private final AtomicBoolean jobAdded = new AtomicBoolean(false);
-    private final AtomicBoolean jobPaused = new AtomicBoolean(false);
+    private final AtomicBoolean jobAdded = new AtomicBoolean();
+    private final AtomicBoolean jobPaused = new AtomicBoolean();
 
     @UriPath(description = "The quartz group name to use. The combination of group name and trigger name should be unique.",
              defaultValue = "Camel")

--- a/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/QuickfixjEngine.java
+++ b/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/QuickfixjEngine.java
@@ -98,7 +98,7 @@ public class QuickfixjEngine extends ServiceSupport {
     private ObjectName acceptorObjectName;
     private ObjectName initiatorObjectName;
     private final SessionSettings settings;
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final AtomicBoolean initialized = new AtomicBoolean();
     private boolean lazy;
 
     public enum ThreadModel {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
@@ -50,7 +50,7 @@ public class RabbitMQProducer extends DefaultAsyncProducer {
     private ObjectPool<Channel> channelPool;
     private ExecutorService executorService;
     private int closeTimeout = 30 * 1000;
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean started = new AtomicBoolean();
 
     private ReplyManager replyManager;
 

--- a/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/engine/DelayedMonoPublisher.java
+++ b/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/engine/DelayedMonoPublisher.java
@@ -40,7 +40,7 @@ public class DelayedMonoPublisher<T> implements Publisher<T> {
 
     private final List<MonoSubscription> subscriptions = new CopyOnWriteArrayList<>();
 
-    private final AtomicBoolean flushing = new AtomicBoolean(false);
+    private final AtomicBoolean flushing = new AtomicBoolean();
 
     private volatile T data;
 

--- a/components/camel-saxon/src/main/java/org/apache/camel/component/xquery/XQueryBuilder.java
+++ b/components/camel-saxon/src/main/java/org/apache/camel/component/xquery/XQueryBuilder.java
@@ -95,7 +95,7 @@ public abstract class XQueryBuilder implements Expression, Predicate, NamespaceA
     private ResultFormat resultsFormat = ResultFormat.DOM;
     private Properties properties = new Properties();
     private Class<?> resultType;
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final AtomicBoolean initialized = new AtomicBoolean();
     private boolean stripsAllWhiteSpace = true;
     private ModuleURIResolver moduleURIResolver;
     private boolean allowStAX;

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/batch/SjmsBatchConsumer.java
@@ -75,7 +75,7 @@ public class SjmsBatchConsumer extends DefaultConsumer {
     private final ConnectionFactory connectionFactory;
     private final String destinationName;
     private ExecutorService jmsConsumerExecutors;
-    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean running = new AtomicBoolean();
     private final AtomicReference<CountDownLatch> consumersShutdownLatchRef = new AtomicReference<>();
     private volatile Connection connection;
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -540,7 +540,7 @@ public abstract class AbstractCamelContext extends BaseService
 
         try {
             // Flag used to mark a component of being created.
-            final AtomicBoolean created = new AtomicBoolean(false);
+            final AtomicBoolean created = new AtomicBoolean();
 
             // atomic operation to get/create a component. Avoid global locks.
             final Component component = components.computeIfAbsent(name, new Function<String, Component>() {

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
@@ -88,7 +88,7 @@ public class DefaultSupervisingRouteController extends DefaultRouteController im
 
     public DefaultSupervisingRouteController() {
         this.lock = new Object();
-        this.contextStarted = new AtomicBoolean(false);
+        this.contextStarted = new AtomicBoolean();
         this.routeCount = new AtomicInteger();
         this.routes = new TreeSet<>();
         this.nonSupervisedRoutes = new HashSet<>();
@@ -280,7 +280,7 @@ public class DefaultSupervisingRouteController extends DefaultRouteController im
             // from super class.
             return super.stopRoute(routeId, timeout, timeUnit, abortAfterTimeout);
         } else {
-            final AtomicBoolean result = new AtomicBoolean(false);
+            final AtomicBoolean result = new AtomicBoolean();
 
             doStopRoute(route.get(), true, r -> result.set(super.stopRoute(r.getId(), timeout, timeUnit, abortAfterTimeout)));
             return result.get();

--- a/core/camel-base/src/main/java/org/apache/camel/impl/engine/RouteService.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/engine/RouteService.java
@@ -60,8 +60,8 @@ public class RouteService extends ChildServiceSupport {
     private final Route route;
     private boolean removingRoutes;
     private final Map<Route, Consumer> inputs = new HashMap<>();
-    private final AtomicBoolean warmUpDone = new AtomicBoolean(false);
-    private final AtomicBoolean endpointDone = new AtomicBoolean(false);
+    private final AtomicBoolean warmUpDone = new AtomicBoolean();
+    private final AtomicBoolean endpointDone = new AtomicBoolean();
 
     public RouteService(Route route) {
         this.route = route;

--- a/core/camel-base/src/main/java/org/apache/camel/throttling/ThrottlingExceptionRoutePolicy.java
+++ b/core/camel-base/src/main/java/org/apache/camel/throttling/ThrottlingExceptionRoutePolicy.java
@@ -71,7 +71,7 @@ public class ThrottlingExceptionRoutePolicy extends RoutePolicySupport implement
     // stateful information
     private final AtomicInteger failures = new AtomicInteger();
     private final AtomicInteger state = new AtomicInteger(STATE_CLOSED);
-    private final AtomicBoolean keepOpen = new AtomicBoolean(false);
+    private final AtomicBoolean keepOpen = new AtomicBoolean();
     private volatile Timer halfOpenTimer;
     private volatile long lastFailure;
     private volatile long openedAt;

--- a/core/camel-cluster/src/main/java/org/apache/camel/impl/cluster/ClusteredRoutePolicy.java
+++ b/core/camel-cluster/src/main/java/org/apache/camel/impl/cluster/ClusteredRoutePolicy.java
@@ -84,8 +84,8 @@ public final class ClusteredRoutePolicy extends RoutePolicySupport implements Ca
 
         this.stoppedRoutes = new HashSet<>();
         this.startedRoutes = new HashSet<>();
-        this.leader = new AtomicBoolean(false);
-        this.contextStarted = new AtomicBoolean(false);
+        this.leader = new AtomicBoolean();
+        this.contextStarted = new AtomicBoolean();
         this.initialDelay = Duration.ofMillis(0);
 
         try {

--- a/core/camel-core-engine/src/main/java/org/apache/camel/builder/RouteBuilder.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/builder/RouteBuilder.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class RouteBuilder extends BuilderSupport implements RoutesBuilder, Ordered {
     protected Logger log = LoggerFactory.getLogger(getClass());
-    private AtomicBoolean initialized = new AtomicBoolean(false);
+    private AtomicBoolean initialized = new AtomicBoolean();
     private RestsDefinition restCollection = new RestsDefinition();
     private RestConfigurationDefinition restConfiguration;
     private List<TransformerBuilder> transformerBuilders = new ArrayList<>();

--- a/core/camel-core-engine/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -54,7 +54,7 @@ import org.apache.camel.spi.RoutePolicy;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 // must use XmlAccessType.PROPERTY as there is some custom logic needed to be executed in the setter methods
 public class RouteDefinition extends OutputDefinition<RouteDefinition> implements NamedRoute {
-    private final AtomicBoolean prepared = new AtomicBoolean(false);
+    private final AtomicBoolean prepared = new AtomicBoolean();
     private FromDefinition input;
     private String group;
     private String streamCache;

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
@@ -152,9 +152,9 @@ public class SimplePredicateParser extends BaseSimpleParser {
         SimpleNode lastSingle = null;
         SimpleNode lastDouble = null;
         SimpleNode lastFunction = null;
-        AtomicBoolean startSingle = new AtomicBoolean(false);
-        AtomicBoolean startDouble = new AtomicBoolean(false);
-        AtomicBoolean startFunction = new AtomicBoolean(false);
+        AtomicBoolean startSingle = new AtomicBoolean();
+        AtomicBoolean startDouble = new AtomicBoolean();
+        AtomicBoolean startFunction = new AtomicBoolean();
 
         LiteralNode imageToken = null;
         for (SimpleToken token : tokens) {

--- a/core/camel-main/src/main/java/org/apache/camel/main/SimpleMainShutdownStrategy.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/SimpleMainShutdownStrategy.java
@@ -33,7 +33,7 @@ public class SimpleMainShutdownStrategy implements MainShutdownStrategy {
     private final CountDownLatch latch;
 
     public SimpleMainShutdownStrategy() {
-        this.completed = new AtomicBoolean(false);
+        this.completed = new AtomicBoolean();
         this.latch = new CountDownLatch(1);
     }
 


### PR DESCRIPTION
The constructor new AtomicBoolean(false) causes a volatile write that can be saved as the constructor parameter is the default value.

This saves a volatile write but makes the code (a bit) less readable. Not sure if this is worth it.