### PR TITLE
CAMEL-15624 : Refactoring camel-wordpress Configuration class name to avoid conflict with camel-workpress-starter Configuration

### DIFF
--- a/components/camel-wordpress/src/generated/java/org/apache/camel/component/wordpress/WordpressComponentConfigurer.java
+++ b/components/camel-wordpress/src/generated/java/org/apache/camel/component/wordpress/WordpressComponentConfigurer.java
@@ -29,13 +29,13 @@ public class WordpressComponentConfigurer extends PropertyConfigurerSupport impl
         map.put("bridgeErrorHandler", boolean.class);
         map.put("lazyStartProducer", boolean.class);
         map.put("basicPropertyBinding", boolean.class);
-        map.put("configuration", org.apache.camel.component.wordpress.WordpressComponentConfiguration.class);
+        map.put("configuration", org.apache.camel.component.wordpress.WordpressConfiguration.class);
         ALL_OPTIONS = map;
     }
 
-    private org.apache.camel.component.wordpress.WordpressComponentConfiguration getOrCreateConfiguration(WordpressComponent target) {
+    private org.apache.camel.component.wordpress.WordpressConfiguration getOrCreateConfiguration(WordpressComponent target) {
         if (target.getConfiguration() == null) {
-            target.setConfiguration(new org.apache.camel.component.wordpress.WordpressComponentConfiguration());
+            target.setConfiguration(new org.apache.camel.component.wordpress.WordpressConfiguration());
         }
         return target.getConfiguration();
     }
@@ -50,7 +50,7 @@ public class WordpressComponentConfigurer extends PropertyConfigurerSupport impl
         case "basicPropertyBinding": target.setBasicPropertyBinding(property(camelContext, boolean.class, value)); return true;
         case "bridgeerrorhandler":
         case "bridgeErrorHandler": target.setBridgeErrorHandler(property(camelContext, boolean.class, value)); return true;
-        case "configuration": target.setConfiguration(property(camelContext, org.apache.camel.component.wordpress.WordpressComponentConfiguration.class, value)); return true;
+        case "configuration": target.setConfiguration(property(camelContext, org.apache.camel.component.wordpress.WordpressConfiguration.class, value)); return true;
         case "criteria": getOrCreateConfiguration(target).setCriteria(property(camelContext, java.util.Map.class, value)); return true;
         case "force": getOrCreateConfiguration(target).setForce(property(camelContext, boolean.class, value)); return true;
         case "id": getOrCreateConfiguration(target).setId(property(camelContext, java.lang.Integer.class, value)); return true;

--- a/components/camel-wordpress/src/main/docs/wordpress-component.adoc
+++ b/components/camel-wordpress/src/main/docs/wordpress-component.adoc
@@ -37,7 +37,7 @@ The Wordpress component supports 12 options, which are listed below.
 | *bridgeErrorHandler* (consumer) | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | boolean
 | *lazyStartProducer* (producer) | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. | false | boolean
 | *basicPropertyBinding* (advanced) | *Deprecated* Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | boolean
-| *configuration* (advanced) | Wordpress component configuration |  | WordpressComponentConfiguration
+| *configuration* (advanced) | Wordpress component configuration |  | WordpressConfiguration
 |===
 // component options: END
 
@@ -100,7 +100,7 @@ The `WordpressConfiguration` class can be used to set initial properties configu
 ----
 public void configure() {
     final WordpressConfiguration configuration = new WordpressConfiguration();
-    final WordpressComponentConfiguration component = new WordpressComponentConfiguration();
+    final WordpressComponent component = new WordpressComponent();
     configuration.setApiVersion("2");
     configuration.setUrl("http://yoursite.com/wp-json/");
     component.setConfiguration(configuration);

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressComponent.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressComponent.java
@@ -36,26 +36,26 @@ public class WordpressComponent extends DefaultComponent {
     private static final String OP_SEPARATOR = ":";
 
     @Metadata(label = "advanced", description = "Wordpress component configuration")
-    private WordpressComponentConfiguration configuration;
+    private WordpressConfiguration configuration;
 
     public WordpressComponent() {
-        this(new WordpressComponentConfiguration());
+        this(new WordpressConfiguration());
     }
 
-    public WordpressComponent(WordpressComponentConfiguration configuration) {
+    public WordpressComponent(WordpressConfiguration configuration) {
         this.configuration = configuration;
     }
 
     public WordpressComponent(CamelContext camelContext) {
         super(camelContext);
-        this.configuration = new WordpressComponentConfiguration();
+        this.configuration = new WordpressConfiguration();
     }
 
-    public WordpressComponentConfiguration getConfiguration() {
+    public WordpressConfiguration getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(WordpressComponentConfiguration configuration) {
+    public void setConfiguration(WordpressConfiguration configuration) {
         this.configuration = configuration;
     }
 
@@ -67,7 +67,7 @@ public class WordpressComponent extends DefaultComponent {
             beanIntrospection.getProperties(configuration, properties, null, false);
             properties.forEach(parameters::putIfAbsent);
         }
-        WordpressComponentConfiguration config = new WordpressComponentConfiguration();
+        WordpressConfiguration config = new WordpressConfiguration();
         WordpressEndpoint endpoint = new WordpressEndpoint(uri, this, config);
         discoverOperations(endpoint, remaining);
         setProperties(endpoint, parameters);

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressConfiguration.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressConfiguration.java
@@ -28,7 +28,7 @@ import org.apache.camel.spi.UriParams;
 import org.apache.camel.util.StringHelper;
 
 @UriParams
-public class WordpressComponentConfiguration {
+public class WordpressConfiguration {
 
     private URI uri;
 

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressEndpoint.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/WordpressEndpoint.java
@@ -60,14 +60,14 @@ public class WordpressEndpoint extends DefaultEndpoint {
     private String operationDetail;
 
     @UriParam
-    private WordpressComponentConfiguration configuration;
+    private WordpressConfiguration configuration;
 
-    public WordpressEndpoint(String uri, WordpressComponent component, WordpressComponentConfiguration configuration) {
+    public WordpressEndpoint(String uri, WordpressComponent component, WordpressConfiguration configuration) {
         super(uri, component);
         this.configuration = configuration;
     }
 
-    public WordpressComponentConfiguration getConfiguration() {
+    public WordpressConfiguration getConfiguration() {
         return configuration;
     }
 
@@ -120,7 +120,7 @@ public class WordpressEndpoint extends DefaultEndpoint {
         // set configuration properties first
         try {
             if (configuration == null) {
-                configuration = new WordpressComponentConfiguration();
+                configuration = new WordpressConfiguration();
             }
             PropertyBindingSupport.bindProperties(getCamelContext(), configuration, options);
 

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/consumer/AbstractWordpressConsumer.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/consumer/AbstractWordpressConsumer.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.component.wordpress.WordpressComponentConfiguration;
+import org.apache.camel.component.wordpress.WordpressConfiguration;
 import org.apache.camel.component.wordpress.WordpressEndpoint;
 import org.apache.camel.support.ScheduledPollConsumer;
 import org.slf4j.Logger;
@@ -30,7 +30,7 @@ public abstract class AbstractWordpressConsumer extends ScheduledPollConsumer {
 
     protected static final Logger LOG = LoggerFactory.getLogger(AbstractWordpressConsumer.class);
 
-    private WordpressComponentConfiguration configuration;
+    private WordpressConfiguration configuration;
 
     public AbstractWordpressConsumer(WordpressEndpoint endpoint, Processor processor) {
         super(endpoint, processor);
@@ -45,7 +45,7 @@ public abstract class AbstractWordpressConsumer extends ScheduledPollConsumer {
         this.initConsumer();
     }
 
-    public WordpressComponentConfiguration getConfiguration() {
+    public WordpressConfiguration getConfiguration() {
         return configuration;
     }
 
@@ -63,7 +63,7 @@ public abstract class AbstractWordpressConsumer extends ScheduledPollConsumer {
      * 
      * @param configuration the endpoint configuration
      */
-    protected void configureService(WordpressComponentConfiguration configuration) {
+    protected void configureService(WordpressConfiguration configuration) {
 
     }
 

--- a/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/producer/AbstractWordpressProducer.java
+++ b/components/camel-wordpress/src/main/java/org/apache/camel/component/wordpress/producer/AbstractWordpressProducer.java
@@ -17,7 +17,7 @@
 package org.apache.camel.component.wordpress.producer;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.component.wordpress.WordpressComponentConfiguration;
+import org.apache.camel.component.wordpress.WordpressConfiguration;
 import org.apache.camel.component.wordpress.WordpressEndpoint;
 import org.apache.camel.component.wordpress.api.WordpressServiceProvider;
 import org.apache.camel.support.DefaultProducer;
@@ -28,7 +28,7 @@ public abstract class AbstractWordpressProducer<T> extends DefaultProducer {
 
     protected static final Logger LOG = LoggerFactory.getLogger(WordpressPostProducer.class);
 
-    private WordpressComponentConfiguration configuration;
+    private WordpressConfiguration configuration;
 
     public AbstractWordpressProducer(WordpressEndpoint endpoint) {
         super(endpoint);
@@ -39,7 +39,7 @@ public abstract class AbstractWordpressProducer<T> extends DefaultProducer {
         }
     }
 
-    public WordpressComponentConfiguration getConfiguration() {
+    public WordpressConfiguration getConfiguration() {
         return configuration;
     }
 

--- a/components/camel-wordpress/src/test/java/org/apache/camel/component/wordpress/WordpressPostOperationTest.java
+++ b/components/camel-wordpress/src/test/java/org/apache/camel/component/wordpress/WordpressPostOperationTest.java
@@ -100,7 +100,7 @@ public class WordpressPostOperationTest extends WordpressComponentTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                final WordpressComponentConfiguration configuration = new WordpressComponentConfiguration();
+                final WordpressConfiguration configuration = new WordpressConfiguration();
                 final WordpressComponent component = new WordpressComponent();
                 configuration.setApiVersion(WordpressConstants.API_VERSION);
                 configuration.setUrl(getServerBaseUrl());

--- a/components/camel-wordpress/src/test/java/org/apache/camel/component/wordpress/WordpressUserOperationTest.java
+++ b/components/camel-wordpress/src/test/java/org/apache/camel/component/wordpress/WordpressUserOperationTest.java
@@ -97,7 +97,7 @@ public class WordpressUserOperationTest extends WordpressComponentTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                final WordpressComponentConfiguration configuration = new WordpressComponentConfiguration();
+                final WordpressConfiguration configuration = new WordpressConfiguration();
                 final WordpressComponent component = new WordpressComponent();
                 configuration.setUrl(getServerBaseUrl());
                 component.setConfiguration(configuration);


### PR DESCRIPTION
Refactoring WordpressComponentConfiguration.java to WordpressConfiguration.java
This name is conflicted with auto generated camel-wordpress-starter
component configuration. By current document,
WordpressConfiguration should be correct name and it resolves the
conflicting issue on starter module. I updated doc accordingly.