### PR TITLE
CAMEL-15619 camel-shiro: allow custom implementation of serialization

### DIFF
--- a/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityHelper.java
+++ b/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityHelper.java
@@ -16,39 +16,45 @@
  */
 package org.apache.camel.component.shiro.security;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.apache.camel.util.IOHelper;
 import org.apache.shiro.crypto.CipherService;
 import org.apache.shiro.util.ByteSource;
 
 public final class ShiroSecurityHelper {
 
+    private static Pattern pattern = Pattern.compile("(\\d+):(.+)");
+
     private ShiroSecurityHelper() {
     }
 
-    public static ByteSource encrypt(ShiroSecurityToken securityToken, byte[] passPhrase, CipherService cipherService)
-            throws Exception {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        ObjectOutput serialStream = new ObjectOutputStream(stream);
-        try {
-            serialStream.writeObject(securityToken);
-            return cipherService.encrypt(stream.toByteArray(), passPhrase);
-        } finally {
-            close(serialStream);
-            IOHelper.close(stream);
-        }
+    public static ByteSource encrypt(
+            ShiroSecurityToken securityToken, byte[] passPhrase, CipherService cipherService) {
+        byte[] data = serialize(securityToken);
+        return cipherService.encrypt(data, passPhrase);
     }
 
-    private static void close(ObjectOutput output) {
-        try {
-            output.close();
-        } catch (IOException e) {
-            // ignore
-        }
+    static byte[] serialize(ShiroSecurityToken token) {
+        StringBuilder sb = new StringBuilder().append(token.getUsername().length())
+                .append(":")
+                .append(token.getUsername())
+                .append(token.getPassword() != null ? token.getPassword() : "");
+        return sb.toString().getBytes();
     }
 
+    public static ShiroSecurityToken deserialize(byte[] data) {
+        String text = new String(data);
+
+        Matcher matcher = pattern.matcher(text);
+        if (!matcher.matches()) {
+            throw new IllegalStateException("Can not deserialize security token - token is probably corrupted.");
+        }
+        int length = Integer.parseInt(matcher.group(1));
+
+        String username = matcher.group(2).substring(0, length);
+        String password = matcher.group(2).substring(length);
+
+        return new ShiroSecurityToken(username, password);
+    }
 }

--- a/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityTokenInjector.java
+++ b/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityTokenInjector.java
@@ -93,5 +93,4 @@ public class ShiroSecurityTokenInjector implements Processor {
     public void setBase64(boolean base64) {
         this.base64 = base64;
     }
-
 }

--- a/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroSecurityHelperTest.java
+++ b/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroSecurityHelperTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.shiro.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ShiroSecurityHelperTest {
+
+    @Test
+    public void testSerializeAndDeserialize() {
+        test("user", "password");
+    }
+
+    @Test
+    public void testSerializeAndDeserializeEmptyPassword() {
+        test("user", "");
+        test("user", null);
+    }
+
+    private void test(String username, String password) {
+        ShiroSecurityToken token = new ShiroSecurityToken(username, password);
+
+        byte[] data = ShiroSecurityHelper.serialize(token);
+        ShiroSecurityToken deserializedToken = ShiroSecurityHelper.deserialize(data);
+
+        assertEquals(token.getUsername(), deserializedToken.getUsername());
+        assertEquals(token.getPassword() != null ? token.getPassword() : "", deserializedToken.getPassword());
+    }
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-15619

I'm replacing serialization of `ShiroSecurityToken` with custom written serialization. (without `ObjectOutputStream.writeObject()`).
This change allows creation of camel-quarkus extension for this component (because serialization is not possible in native, see https://github.com/oracle/graal/issues/460)

- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md