### PR TITLE
Throttles strimzi startup to prevent resource reuse errors

### DIFF
--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/StrimziContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/StrimziContainer.java
@@ -17,8 +17,6 @@
 
 package org.apache.camel.test.infra.services.kafka;
 
-import java.util.function.Consumer;
-
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -28,24 +26,17 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
     private static final String STRIMZI_CONTAINER = System.getProperty("itest.strimzi.container.image");
     private static final int KAFKA_PORT = 9092;
 
-    public StrimziContainer(Network network, String name) {
+    public StrimziContainer(Network network, String name, String zookeeperInstanceName) {
         super(STRIMZI_CONTAINER);
 
         withEnv("LOG_DIR", "/tmp/logs");
         withExposedPorts(KAFKA_PORT);
         withEnv("KAFKA_ADVERTISED_LISTENERS", String.format("PLAINTEXT://%s:9092", getContainerIpAddress()));
         withEnv("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:9092");
-        withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181");
+        withEnv("KAFKA_ZOOKEEPER_CONNECT", zookeeperInstanceName + ":2181");
         withNetwork(network);
 
-        withCreateContainerCmdModifier(
-                new Consumer<CreateContainerCmd>() {
-                    @Override
-                    public void accept(CreateContainerCmd createContainerCmd) {
-                        createContainerCmd.withHostName(name);
-                        createContainerCmd.withName(name);
-                    }
-                });
+        withCreateContainerCmdModifier(createContainerCmd -> setupContainer(name, createContainerCmd));
 
         withCommand("sh", "-c",
                 "bin/kafka-server-start.sh config/server.properties "
@@ -54,6 +45,11 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
                                 + "--override zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT}");
 
         waitingFor(Wait.forListeningPort());
+    }
+
+    private void setupContainer(String name, CreateContainerCmd createContainerCmd) {
+        createContainerCmd.withHostName(name);
+        createContainerCmd.withName(name);
     }
 
     public int getKafkaPort() {

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/ZookeeperContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/ZookeeperContainer.java
@@ -17,8 +17,6 @@
 
 package org.apache.camel.test.infra.services.kafka;
 
-import java.util.function.Consumer;
-
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -34,19 +32,18 @@ public class ZookeeperContainer extends GenericContainer<ZookeeperContainer> {
         withEnv("LOG_DIR", "/tmp/logs");
         withExposedPorts(ZOOKEEPER_PORT);
         withNetwork(network);
-        withCreateContainerCmdModifier(
-                new Consumer<CreateContainerCmd>() {
-                    @Override
-                    public void accept(CreateContainerCmd createContainerCmd) {
-                        createContainerCmd.withHostName(name);
-                        createContainerCmd.withName(name);
-                    }
-                });
+
+        withCreateContainerCmdModifier(createContainerCmd -> setupContainer(name, createContainerCmd));
 
         withCommand("sh", "-c",
                 "bin/zookeeper-server-start.sh config/zookeeper.properties");
 
         waitingFor(Wait.forListeningPort());
+    }
+
+    private void setupContainer(String name, CreateContainerCmd createContainerCmd) {
+        createContainerCmd.withHostName(name);
+        createContainerCmd.withName(name);
     }
 
     public int getZookeeperPort() {


### PR DESCRIPTION
This works around sporadic errors raised by docker during the tear
up/down cycle of the tests. This seems to happen because, although the
containers are reportedly terminated, some of their resources may still
be utilized at the time of the start of the new test.

This is likely a problem elsewhere, but this patch adds a work-around
for this.

---

Obs.: it sourcecheck seems to complain about StrimziService class formatting without giving much details about the failure. I tried reformating it several times without success. I am trying a PR in the hope it is a problem w/ the check and not w/ the file formatting itself.


- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md