### PR TITLE
CAMEL-15484 - UPDATE Documentation for Camel 3.x

### DIFF
--- a/components/camel-mail/src/main/docs/mail-component.adoc
+++ b/components/camel-mail/src/main/docs/mail-component.adoc
@@ -544,7 +544,8 @@ mail from java code:
 ---------------------------------------------------------------------------------
 public void process(Exchange exchange) throws Exception {
     // the API is a bit clunky so we need to loop
-    Map<String, DataHandler> attachments = exchange.getIn().getAttachments();
+    AttachmentMessage attachmentMessage = exchange.getMessage(AttachmentMessage.class);
+    Map<String, DataHandler> attachments = attachmentMessage.getAttachments();
     if (attachments.size() > 0) {
         for (String name : attachments.keySet()) {
             DataHandler dh = attachments.get(name);

--- a/docs/components/modules/ROOT/pages/mail-component.adoc
+++ b/docs/components/modules/ROOT/pages/mail-component.adoc
@@ -546,7 +546,8 @@ mail from java code:
 ---------------------------------------------------------------------------------
 public void process(Exchange exchange) throws Exception {
     // the API is a bit clunky so we need to loop
-    Map<String, DataHandler> attachments = exchange.getIn().getAttachments();
+    AttachmentMessage attachmentMessage = exchange.getMessage(AttachmentMessage.class);
+    Map<String, DataHandler> attachments = attachmentMessage.getAttachments();
     if (attachments.size() > 0) {
         for (String name : attachments.keySet()) {
             DataHandler dh = attachments.get(name);


### PR DESCRIPTION


Update documentation for camel 3.x related to attachments as there is no exchange.getIn().getAttachments() method anymore.

Fix for the Issue [CAMEL-15484](https://issues.apache.org/jira/browse/CAMEL-15484?filter=12348073)