### PR TITLE
Replaces the kafka container in camel-kafka test

### DIFF
--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -51,15 +51,27 @@
         <!-- test -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-testcontainers-junit5</artifactId>
+            <artifactId>camel-test-infra-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- Required by the admin client-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-junit5</artifactId>
@@ -92,7 +104,6 @@
             <version>${commons-lang3-version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <profiles>

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/BaseEmbeddedKafkaTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/BaseEmbeddedKafkaTest.java
@@ -19,43 +19,44 @@ package org.apache.camel.component.kafka;
 import java.util.Properties;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.test.infra.services.kafka.KafkaService;
+import org.apache.camel.test.infra.services.kafka.KafkaServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 public abstract class BaseEmbeddedKafkaTest extends CamelTestSupport {
-    protected static AdminClient kafkaAdminClient;
+    @RegisterExtension
+    public static KafkaService service = KafkaServiceFactory.createService();
 
-    private static final String CONFLUENT_PLATFORM_VERSION = "6.0.0";
+    protected static AdminClient kafkaAdminClient;
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseEmbeddedKafkaTest.class);
 
-    protected static KafkaContainer kafkaBroker = new KafkaContainer(CONFLUENT_PLATFORM_VERSION)
-            .withEmbeddedZookeeper()
-            .withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181")
-            .waitingFor(Wait.forListeningPort());
-
-    static {
-        kafkaBroker.start();
-        kafkaAdminClient = createAdminClient();
-    }
-
     @BeforeAll
     public static void beforeClass() {
-        LOG.info("### Embedded Kafka cluster broker list: " + kafkaBroker.getBootstrapServers());
+        LOG.info("### Embedded Kafka cluster broker list: " + service.getBootstrapServers());
+        System.setProperty("bootstrapServers", service.getBootstrapServers());
+    }
+
+    @BeforeEach
+    public void setKafkaAdminClient() {
+        if (kafkaAdminClient == null) {
+            kafkaAdminClient = createAdminClient();
+        }
     }
 
     protected Properties getDefaultProperties() {
-        LOG.info("Connecting to Kafka {}", kafkaBroker.getBootstrapServers());
+        LOG.info("Connecting to Kafka {}", service.getBootstrapServers());
 
         Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker.getBootstrapServers());
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, service.getBootstrapServers());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaConstants.KAFKA_DEFAULT_SERIALIZER);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaConstants.KAFKA_DEFAULT_SERIALIZER);
         props.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, KafkaConstants.KAFKA_DEFAULT_PARTITIONER);
@@ -70,19 +71,20 @@ public abstract class BaseEmbeddedKafkaTest extends CamelTestSupport {
 
         KafkaComponent kafka = new KafkaComponent(context);
         kafka.init();
-        kafka.getConfiguration().setBrokers(kafkaBroker.getBootstrapServers());
+        kafka.getConfiguration().setBrokers(service.getBootstrapServers());
         context.addComponent("kafka", kafka);
 
         return context;
     }
 
+    @Deprecated
     protected static String getBootstrapServers() {
-        return kafkaBroker.getBootstrapServers();
+        return service.getBootstrapServers();
     }
 
     private static AdminClient createAdminClient() {
         final Properties properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker.getBootstrapServers());
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, service.getBootstrapServers());
 
         return KafkaAdminClient.create(properties);
     }

--- a/test-infra/camel-test-infra-kafka/pom.xml
+++ b/test-infra/camel-test-infra-kafka/pom.xml
@@ -43,8 +43,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/KafkaServiceFactory.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/services/kafka/KafkaServiceFactory.java
@@ -30,12 +30,12 @@ public final class KafkaServiceFactory {
     public static KafkaService createService() {
         String kafkaInstanceType = System.getProperty("kafka.instance.type");
 
-        if (kafkaInstanceType.equals("local-strimzi-container")) {
-            return new StrimziService();
+        if (kafkaInstanceType == null || kafkaInstanceType.isEmpty() || kafkaInstanceType.equals("local-kafka-container")) {
+            return new ContainerLocalKafkaService();
         }
 
-        if (kafkaInstanceType.equals("local-kafka-container")) {
-            return new ContainerLocalKafkaService();
+        if (kafkaInstanceType.equals("local-strimzi-container")) {
+            return new StrimziService();
         }
 
         if (kafkaInstanceType.equals("remote")) {


### PR DESCRIPTION
Switches to the infra provided by camel-test-infra-kafka instead of
directly using the KafkaContainer.

This removes the need of camel-testcontainers-junit5 and allows
targetting remote kafka instances as part of the test execution.


- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md