### PR TITLE
AutomaticRecovery from RabbitMQ Connection Factory doesn't recover from everything

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeoutException;
 
 import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.Consumer;
@@ -39,13 +40,14 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
     private static final Logger LOG = LoggerFactory.getLogger(RabbitConsumer.class);
 
     private final RabbitMQConsumer consumer;
+    private final Semaphore lock = new Semaphore(1);
     private Channel channel;
     private String tag;
-    /** Consumer tag for this consumer. */
+    /**
+     * Consumer tag for this consumer.
+     */
     private volatile String consumerTag;
     private volatile boolean stopping;
-
-    private final Semaphore lock = new Semaphore(1);
 
     /**
      * Constructs a new instance and records its association to the passed-in channel.
@@ -61,122 +63,25 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
         }
     }
 
-    @Override
-    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
-            throws IOException {
-        try {
-            if (!consumer.getEndpoint().isAutoAck()) {
-                lock.acquire();
-            }
-            // Channel might be open because while we were waiting for the lock,
-            // stop() has been succesfully called.
-            if (!channel.isOpen()) {
-                // we could not open the channel so release the lock
-                if (!consumer.getEndpoint().isAutoAck()) {
-                    lock.release();
-                }
-                return;
-            }
-
-            try {
-                doHandleDelivery(consumerTag, envelope, properties, body);
-            } finally {
-                if (!consumer.getEndpoint().isAutoAck()) {
-                    lock.release();
-                }
-            }
-
-        } catch (InterruptedException e) {
-            LOG.warn("Thread Interrupted!");
-        }
-    }
-
-    public void doHandleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
-            throws IOException {
-        Exchange exchange = consumer.getEndpoint().createRabbitExchange(envelope, properties, body);
-        consumer.getEndpoint().getMessageConverter().mergeAmqpProperties(exchange, properties);
-
-        boolean sendReply = properties.getReplyTo() != null;
-        if (sendReply && !exchange.getPattern().isOutCapable()) {
-            LOG.debug("In an inOut capable route");
-            exchange.setPattern(ExchangePattern.InOut);
+    /**
+     * Open channel
+     */
+    private Channel openChannel(Connection conn) throws IOException {
+        LOG.trace("Creating channel...");
+        Channel channel = conn.createChannel();
+        LOG.debug("Created channel: {}", channel);
+        // setup the basicQos
+        if (consumer.getEndpoint().isPrefetchEnabled()) {
+            channel.basicQos(consumer.getEndpoint().getPrefetchSize(), consumer.getEndpoint().getPrefetchCount(),
+                consumer.getEndpoint().isPrefetchGlobal());
         }
 
-        LOG.trace("Created exchange [exchange={}]", exchange);
-        long deliveryTag = envelope.getDeliveryTag();
-        try {
-            consumer.getProcessor().process(exchange);
-        } catch (Exception e) {
-            exchange.setException(e);
+        // This really only needs to be called on the first consumer or on
+        // reconnections.
+        if (consumer.getEndpoint().isDeclare()) {
+            consumer.getEndpoint().declareExchangeAndQueue(channel);
         }
-
-        // obtain the message after processing
-        Message msg;
-        if (exchange.hasOut()) {
-            msg = exchange.getOut();
-        } else {
-            msg = exchange.getIn();
-        }
-
-        if (exchange.getException() != null) {
-            consumer.getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
-        }
-
-        if (!exchange.isFailed()) {
-            // processing success
-            if (sendReply && exchange.getPattern().isOutCapable()) {
-                try {
-                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
-                } catch (RuntimeCamelException e) {
-                    // set the exception on the exchange so it can send the
-                    // exception back to the producer
-                    exchange.setException(e);
-                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
-                }
-            }
-            if (!consumer.getEndpoint().isAutoAck()) {
-                LOG.trace("Acknowledging receipt [delivery_tag={}]", deliveryTag);
-                channel.basicAck(deliveryTag, false);
-            }
-        }
-        // The exchange could have failed when sending the above message
-        if (exchange.isFailed()) {
-            if (consumer.getEndpoint().isTransferException() && exchange.getPattern().isOutCapable()) {
-                // the inOut exchange failed so put the exception in the body
-                // and send back
-                msg.setBody(exchange.getException());
-                exchange.setOut(msg);
-                exchange.getOut().setHeader(RabbitMQConstants.CORRELATIONID,
-                        exchange.getIn().getHeader(RabbitMQConstants.CORRELATIONID));
-                try {
-                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
-                } catch (RuntimeCamelException e) {
-                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
-                }
-
-                if (!consumer.getEndpoint().isAutoAck()) {
-                    LOG.trace("Acknowledging receipt when transferring exception [delivery_tag={}]", deliveryTag);
-                    channel.basicAck(deliveryTag, false);
-                }
-            } else {
-                boolean isRequeueHeaderSet = false;
-                try {
-                    isRequeueHeaderSet = msg.getHeader(RabbitMQConstants.REQUEUE, false, boolean.class);
-                } catch (Exception e) {
-                    // ignore as its an invalid header
-                }
-
-                // processing failed, then reject and handle the exception
-                if (deliveryTag != 0 && !consumer.getEndpoint().isAutoAck()) {
-                    LOG.trace("Rejecting receipt [delivery_tag={}] with requeue={}", deliveryTag, isRequeueHeaderSet);
-                    if (isRequeueHeaderSet) {
-                        channel.basicReject(deliveryTag, true);
-                    } else {
-                        channel.basicReject(deliveryTag, false);
-                    }
-                }
-            }
-        }
+        return channel;
     }
 
     @Override
@@ -185,8 +90,8 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
             throw new IOException("The RabbitMQ channel is not open");
         }
         tag = channel.basicConsume(consumer.getEndpoint().getQueue(), consumer.getEndpoint().isAutoAck(),
-                consumer.getEndpoint().getConsumerTag(), false,
-                consumer.getEndpoint().isExclusiveConsumer(), null, this);
+            consumer.getEndpoint().getConsumerTag(), false,
+            consumer.getEndpoint().isExclusiveConsumer(), null, this);
     }
 
     @Override
@@ -220,15 +125,6 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
     @Override
     public void handleConsumeOk(String consumerTag) {
         this.consumerTag = consumerTag;
-    }
-
-    /**
-     * Retrieve the consumer tag.
-     *
-     * @return the most recently notified consumer tag.
-     */
-    public String getConsumerTag() {
-        return consumerTag;
     }
 
     /**
@@ -283,14 +179,14 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
                     connected = true;
                 } catch (Exception e) {
                     LOG.warn(
-                            "Unable to obtain a RabbitMQ channel. Will try again. Caused by: {}. Stacktrace logged at DEBUG logging level.",
-                            e.getMessage());
+                        "Unable to obtain a RabbitMQ channel. Will try again. Caused by: {}. Stacktrace logged at DEBUG logging level.",
+                        e.getMessage());
                     // include stacktrace in DEBUG logging
                     LOG.debug(e.getMessage(), e);
 
                     Integer networkRecoveryInterval = consumer.getEndpoint().getNetworkRecoveryInterval();
                     final long connectionRetryInterval
-                            = networkRecoveryInterval != null && networkRecoveryInterval > 0 ? networkRecoveryInterval : 100L;
+                        = networkRecoveryInterval != null && networkRecoveryInterval > 0 ? networkRecoveryInterval : 100L;
                     try {
                         Thread.sleep(connectionRetryInterval);
                     } catch (InterruptedException e1) {
@@ -308,6 +204,137 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
     public void handleRecoverOk(String consumerTag) {
         // no work to do
         LOG.debug("Received recover ok signal on the rabbitMQ channel");
+    }
+
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
+        throws IOException {
+        try {
+            if (!consumer.getEndpoint().isAutoAck()) {
+                lock.acquire();
+            }
+            // Channel might be open because while we were waiting for the lock,
+            // stop() has been succesfully called.
+            if (!channel.isOpen()) {
+                // we could not open the channel so release the lock
+                if (!consumer.getEndpoint().isAutoAck()) {
+                    lock.release();
+                }
+                return;
+            }
+
+            try {
+                doHandleDelivery(consumerTag, envelope, properties, body);
+            } finally {
+                if (!consumer.getEndpoint().isAutoAck()) {
+                    lock.release();
+                }
+            }
+
+        } catch (InterruptedException e) {
+            LOG.warn("Thread Interrupted!");
+        }
+    }
+
+    public void doHandleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
+        throws IOException {
+        Exchange exchange = consumer.getEndpoint().createRabbitExchange(envelope, properties, body);
+        consumer.getEndpoint().getMessageConverter().mergeAmqpProperties(exchange, properties);
+
+        boolean sendReply = properties.getReplyTo() != null;
+        if (sendReply && !exchange.getPattern().isOutCapable()) {
+            LOG.debug("In an inOut capable route");
+            exchange.setPattern(ExchangePattern.InOut);
+        }
+
+        LOG.trace("Created exchange [exchange={}]", exchange);
+        long deliveryTag = envelope.getDeliveryTag();
+        try {
+            consumer.getProcessor().process(exchange);
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+
+        // obtain the message after processing
+        Message msg;
+        if (exchange.hasOut()) {
+            msg = exchange.getOut();
+        } else {
+            msg = exchange.getIn();
+        }
+
+        if (exchange.getException() != null) {
+            consumer.getExceptionHandler().handleException("Error processing exchange", exchange, exchange.getException());
+        }
+
+        if (!exchange.isFailed()) {
+            // processing success
+            if (sendReply && exchange.getPattern().isOutCapable()) {
+                try {
+                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
+                } catch (AlreadyClosedException alreadyClosedException) {
+                    LOG.warn("Connection or channel closed during reply to exchange {} for correlationId {}. Will reconnect and try again.", exchange.getExchangeId(), properties.getCorrelationId());
+                    // RPC call could not be responded because channel (or connection has been closed during the processing ...
+                    // will try to reconnect
+                    try {
+                        reconnect();
+                        LOG.debug("Sending again the reply to exchange {} for correlationId {}", exchange.getExchangeId(), properties.getCorrelationId());
+                        consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
+                    } catch (Exception e) {
+                        LOG.error("Couldn't sending again the reply to exchange {} for correlationId {}", exchange.getExchangeId(), properties.getCorrelationId());
+                        exchange.setException(e);
+                        consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                    }
+                } catch (RuntimeCamelException e) {
+                    // set the exception on the exchange so it can send the
+                    // exception back to the producer
+                    exchange.setException(e);
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                }
+            }
+            if (!consumer.getEndpoint().isAutoAck()) {
+                LOG.trace("Acknowledging receipt [delivery_tag={}]", deliveryTag);
+                channel.basicAck(deliveryTag, false);
+            }
+        }
+        // The exchange could have failed when sending the above message
+        if (exchange.isFailed()) {
+            if (consumer.getEndpoint().isTransferException() && exchange.getPattern().isOutCapable()) {
+                // the inOut exchange failed so put the exception in the body
+                // and send back
+                msg.setBody(exchange.getException());
+                exchange.setOut(msg);
+                exchange.getOut().setHeader(RabbitMQConstants.CORRELATIONID,
+                    exchange.getIn().getHeader(RabbitMQConstants.CORRELATIONID));
+                try {
+                    consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
+                } catch (RuntimeCamelException e) {
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
+                }
+
+                if (!consumer.getEndpoint().isAutoAck()) {
+                    LOG.trace("Acknowledging receipt when transferring exception [delivery_tag={}]", deliveryTag);
+                    channel.basicAck(deliveryTag, false);
+                }
+            } else {
+                boolean isRequeueHeaderSet = false;
+                try {
+                    isRequeueHeaderSet = msg.getHeader(RabbitMQConstants.REQUEUE, false, boolean.class);
+                } catch (Exception e) {
+                    // ignore as its an invalid header
+                }
+
+                // processing failed, then reject and handle the exception
+                if (deliveryTag != 0 && !consumer.getEndpoint().isAutoAck()) {
+                    LOG.trace("Rejecting receipt [delivery_tag={}] with requeue={}", deliveryTag, isRequeueHeaderSet);
+                    if (isRequeueHeaderSet) {
+                        channel.basicReject(deliveryTag, true);
+                    } else {
+                        channel.basicReject(deliveryTag, false);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -336,34 +363,22 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
         }
     }
 
-    private boolean isAutomaticRecoveryEnabled() {
-        return this.consumer.getEndpoint().getAutomaticRecoveryEnabled() != null
-                && this.consumer.getEndpoint().getAutomaticRecoveryEnabled();
-    }
-
     private boolean isChannelOpen() {
         return channel != null && channel.isOpen();
     }
 
-    /**
-     * Open channel
-     */
-    private Channel openChannel(Connection conn) throws IOException {
-        LOG.trace("Creating channel...");
-        Channel channel = conn.createChannel();
-        LOG.debug("Created channel: {}", channel);
-        // setup the basicQos
-        if (consumer.getEndpoint().isPrefetchEnabled()) {
-            channel.basicQos(consumer.getEndpoint().getPrefetchSize(), consumer.getEndpoint().getPrefetchCount(),
-                    consumer.getEndpoint().isPrefetchGlobal());
-        }
+    private boolean isAutomaticRecoveryEnabled() {
+        return this.consumer.getEndpoint().getAutomaticRecoveryEnabled() != null
+            && this.consumer.getEndpoint().getAutomaticRecoveryEnabled();
+    }
 
-        // This really only needs to be called on the first consumer or on
-        // reconnections.
-        if (consumer.getEndpoint().isDeclare()) {
-            consumer.getEndpoint().declareExchangeAndQueue(channel);
-        }
-        return channel;
+    /**
+     * Retrieve the consumer tag.
+     *
+     * @return the most recently notified consumer tag.
+     */
+    public String getConsumerTag() {
+        return consumerTag;
     }
 
 }

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -326,9 +326,13 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
         } else if (channel == null || !isAutomaticRecoveryEnabled()) {
             LOG.info("Attempting to open a new rabbitMQ channel");
             Connection conn = consumer.getConnection();
-            channel = openChannel(conn);
-            // Register the channel to the tag
-            start();
+            try {
+                stop();
+            } finally {
+                channel = openChannel(conn);
+                // Register the channel to the tag
+                start();
+            }
         }
     }
 

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitConsumer.java
@@ -73,7 +73,7 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
         // setup the basicQos
         if (consumer.getEndpoint().isPrefetchEnabled()) {
             channel.basicQos(consumer.getEndpoint().getPrefetchSize(), consumer.getEndpoint().getPrefetchCount(),
-                consumer.getEndpoint().isPrefetchGlobal());
+                    consumer.getEndpoint().isPrefetchGlobal());
         }
 
         // This really only needs to be called on the first consumer or on
@@ -90,8 +90,8 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
             throw new IOException("The RabbitMQ channel is not open");
         }
         tag = channel.basicConsume(consumer.getEndpoint().getQueue(), consumer.getEndpoint().isAutoAck(),
-            consumer.getEndpoint().getConsumerTag(), false,
-            consumer.getEndpoint().isExclusiveConsumer(), null, this);
+                consumer.getEndpoint().getConsumerTag(), false,
+                consumer.getEndpoint().isExclusiveConsumer(), null, this);
     }
 
     @Override
@@ -179,14 +179,14 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
                     connected = true;
                 } catch (Exception e) {
                     LOG.warn(
-                        "Unable to obtain a RabbitMQ channel. Will try again. Caused by: {}. Stacktrace logged at DEBUG logging level.",
-                        e.getMessage());
+                            "Unable to obtain a RabbitMQ channel. Will try again. Caused by: {}. Stacktrace logged at DEBUG logging level.",
+                            e.getMessage());
                     // include stacktrace in DEBUG logging
                     LOG.debug(e.getMessage(), e);
 
                     Integer networkRecoveryInterval = consumer.getEndpoint().getNetworkRecoveryInterval();
                     final long connectionRetryInterval
-                        = networkRecoveryInterval != null && networkRecoveryInterval > 0 ? networkRecoveryInterval : 100L;
+                            = networkRecoveryInterval != null && networkRecoveryInterval > 0 ? networkRecoveryInterval : 100L;
                     try {
                         Thread.sleep(connectionRetryInterval);
                     } catch (InterruptedException e1) {
@@ -208,7 +208,7 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
 
     @Override
     public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
-        throws IOException {
+            throws IOException {
         try {
             if (!consumer.getEndpoint().isAutoAck()) {
                 lock.acquire();
@@ -237,7 +237,7 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
     }
 
     public void doHandleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
-        throws IOException {
+            throws IOException {
         Exchange exchange = consumer.getEndpoint().createRabbitExchange(envelope, properties, body);
         consumer.getEndpoint().getMessageConverter().mergeAmqpProperties(exchange, properties);
 
@@ -273,15 +273,19 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
                 try {
                     consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
                 } catch (AlreadyClosedException alreadyClosedException) {
-                    LOG.warn("Connection or channel closed during reply to exchange {} for correlationId {}. Will reconnect and try again.", exchange.getExchangeId(), properties.getCorrelationId());
+                    LOG.warn(
+                            "Connection or channel closed during reply to exchange {} for correlationId {}. Will reconnect and try again.",
+                            exchange.getExchangeId(), properties.getCorrelationId());
                     // RPC call could not be responded because channel (or connection has been closed during the processing ...
                     // will try to reconnect
                     try {
                         reconnect();
-                        LOG.debug("Sending again the reply to exchange {} for correlationId {}", exchange.getExchangeId(), properties.getCorrelationId());
+                        LOG.debug("Sending again the reply to exchange {} for correlationId {}", exchange.getExchangeId(),
+                                properties.getCorrelationId());
                         consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
                     } catch (Exception e) {
-                        LOG.error("Couldn't sending again the reply to exchange {} for correlationId {}", exchange.getExchangeId(), properties.getCorrelationId());
+                        LOG.error("Couldn't sending again the reply to exchange {} for correlationId {}",
+                                exchange.getExchangeId(), properties.getCorrelationId());
                         exchange.setException(e);
                         consumer.getExceptionHandler().handleException("Error processing exchange", exchange, e);
                     }
@@ -305,7 +309,7 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
                 msg.setBody(exchange.getException());
                 exchange.setOut(msg);
                 exchange.getOut().setHeader(RabbitMQConstants.CORRELATIONID,
-                    exchange.getIn().getHeader(RabbitMQConstants.CORRELATIONID));
+                        exchange.getIn().getHeader(RabbitMQConstants.CORRELATIONID));
                 try {
                     consumer.getEndpoint().publishExchangeToChannel(exchange, channel, properties.getReplyTo());
                 } catch (RuntimeCamelException e) {
@@ -369,7 +373,7 @@ class RabbitConsumer extends ServiceSupport implements com.rabbitmq.client.Consu
 
     private boolean isAutomaticRecoveryEnabled() {
         return this.consumer.getEndpoint().getAutomaticRecoveryEnabled() != null
-            && this.consumer.getEndpoint().getAutomaticRecoveryEnabled();
+                && this.consumer.getEndpoint().getAutomaticRecoveryEnabled();
     }
 
     /**

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -74,13 +74,11 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
      * Returns the exiting open connection or opens a new one
      */
     protected synchronized Connection getConnection() throws IOException, TimeoutException {
-        if (this.conn == null) {
+        if (this.conn == null || !this.conn.isOpen()) {
+            LOG.debug("The existing connection is closed or not opened yet.");
             openConnection();
             return this.conn;
-        } else if (this.conn.isOpen() || (!this.conn.isOpen() && isAutomaticRecoveryEnabled())) {
-            return this.conn;
         } else {
-            LOG.debug("The existing connection is closed");
             openConnection();
             return this.conn;
         }

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/RabbitMQProducerTest.java
@@ -51,6 +51,7 @@ public class RabbitMQProducerTest {
         RabbitMQMessageConverter converter = new RabbitMQMessageConverter();
         converter.setAllowCustomHeaders(true);
         Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getMessage()).thenReturn(message);
         Mockito.when(endpoint.connect(any(ExecutorService.class))).thenReturn(conn);
         Mockito.when(conn.createChannel()).thenReturn(null);
         Mockito.when(endpoint.getMessageConverter()).thenReturn(converter);


### PR DESCRIPTION
Hi,

We met a condition in production where the Connection Factory of Rabbitmq won't recover (when isAutomaticRecoveryEnabled is set to true). It's easily reproducible by calling the ".close()" method on it. 
It's explained here : https://www.rabbitmq.com/api-guide.html#recovery

The current code would always returns the same connection, not re-establishing it, if isAutomaticRecoveryEnabled is enabled.

Our solution, based on the fact we just have "isOpen" to check the state of the channel/connection was to re-establish the connection in the RabbitMQConsumer even if "isAutomaticRecoveryEnabled" is enabled.

What's your thought about it ?