### PR TITLE
Update health-check.adoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/health-check.adoc
+++ b/docs/user-manual/modules/ROOT/pages/health-check.adoc
@@ -37,7 +37,7 @@ you would need to turn off readiness, by overriding the `isReadiness` method and
 [source,java]
 ----
     @Override
-    public boolean isLiveness() {
+    public boolean isReadiness() {
         return false;
     }
 ----


### PR DESCRIPTION
There was a mistake in the documentation. The sample was overriding the method isLiveness when it should instead of isReadiness.