### PR TITLE
CAMEL-15678: camel-aws2-s3 multipart upload multiplies file by number of parts

### DIFF
--- a/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -71,7 +71,6 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
  * A Producer which sends messages to the Amazon Web Service Simple Storage Service
  * <a href="http://aws.amazon.com/s3/">AWS S3</a>
  *
- * @author Kiril Nugmanov
  */
 public class AWS2S3Producer extends DefaultProducer {
 


### PR DESCRIPTION
CAMEL-15678: camel-aws2-s3 multipart upload multiplies file by number of parts
Camel AWS2 S3 incorectly defines upload part content on multipart upload:
`org.apache.camel.component.aws2.s3.AWS2S3Producer:193`

```
for (int part = 1; filePosition < contentLength; part++) {
    ... 
    ...
    String etag = getEndpoint().getS3Client().uploadPart(uploadRequest, RequestBody.fromFile(filePayload)).eTag();
 ...

}
``` 

`filePayload` - is whole file to be uploaded. 

In case when file size is bigger than `partSize` (which by default is 25MB) - uploaded amount of content to S3 will be `file.size * number_of_parts`