### PR TITLE
CAMEL-15687: Upgrade to Deep Java Library 0.8.0

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -170,10 +170,10 @@
     <digitalocean-api-client-version>2.17</digitalocean-api-client-version>
     <directory-watcher-version>0.10.1</directory-watcher-version>
     <disruptor-version>3.4.2</disruptor-version>
-    <djl-mxnet-native-version>1.7.0-b</djl-mxnet-native-version>
-    <djl-pytorch-native-version>1.5.0</djl-pytorch-native-version>
-    <djl-tensorflow-native-version>2.2.0</djl-tensorflow-native-version>
-    <djl-version>0.6.0</djl-version>
+    <djl-mxnet-native-version>1.7.0-backport</djl-mxnet-native-version>
+    <djl-pytorch-native-version>1.6.0</djl-pytorch-native-version>
+    <djl-tensorflow-native-version>2.3.0</djl-tensorflow-native-version>
+    <djl-version>0.8.0</djl-version>
     <dnsjava-version>3.2.2</dnsjava-version>
     <docker-java-version>3.2.5</docker-java-version>
     <dozer-version>6.5.0</dozer-version>

--- a/components/camel-djl/src/test/java/org/apache/camel/component/djl/training/MnistTraining.java
+++ b/components/camel-djl/src/test/java/org/apache/camel/component/djl/training/MnistTraining.java
@@ -36,6 +36,7 @@ import ai.djl.training.evaluator.Accuracy;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
+import ai.djl.translate.TranslateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,7 @@ public final class MnistTraining {
         // No-op; won't be called
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, TranslateException {
         // Construct neural network
         Block block = new Mlp(Mnist.IMAGE_HEIGHT * Mnist.IMAGE_WIDTH, Mnist.NUM_CLASSES, new int[] { 128, 64 });
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -150,10 +150,10 @@
         <directory-watcher-version>0.10.1</directory-watcher-version>
         <disruptor-version>3.4.2</disruptor-version>
         <dnsjava-version>3.2.2</dnsjava-version>
-        <djl-version>0.6.0</djl-version>
-        <djl-mxnet-native-version>1.7.0-b</djl-mxnet-native-version>
-        <djl-pytorch-native-version>1.5.0</djl-pytorch-native-version>
-        <djl-tensorflow-native-version>2.2.0</djl-tensorflow-native-version>
+        <djl-version>0.8.0</djl-version>
+        <djl-mxnet-native-version>1.7.0-backport</djl-mxnet-native-version>
+        <djl-pytorch-native-version>1.6.0</djl-pytorch-native-version>
+        <djl-tensorflow-native-version>2.3.0</djl-tensorflow-native-version>
         <docker-java-version>3.2.5</docker-java-version>
         <dozer-version>6.5.0</dozer-version>
         <drools-version>7.43.1.Final</drools-version>


### PR DESCRIPTION
Implementation of https://issues.apache.org/jira/browse/CAMEL-15687
Upgrade Deep Java Library to the latest version (0.8.0)