### PR TITLE
Use isEmpty for checking whether collections are empty since it runs in constant time

### DIFF
--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
@@ -267,7 +267,7 @@ public final class CamelJavaParserHelper {
             if ("fromF".equals(name)) {
                 List args = mi.arguments();
                 // the first argument is where the uri is
-                if (args != null && args.size() >= 1) {
+                if (args != null && !args.isEmpty()) {
                     Object arg = args.get(0);
                     if (isValidArgument(name, arg)) {
                         extractEndpointUriFromArgument(name, clazz, block, uris, arg, strings, fields);
@@ -277,7 +277,7 @@ public final class CamelJavaParserHelper {
             if ("interceptFrom".equals(name)) {
                 List args = mi.arguments();
                 // the first argument is where the uri is
-                if (args != null && args.size() >= 1) {
+                if (args != null && !args.isEmpty()) {
                     Object arg = args.get(0);
                     if (isValidArgument(name, arg)) {
                         extractEndpointUriFromArgument(name, clazz, block, uris, arg, strings, fields);
@@ -287,7 +287,7 @@ public final class CamelJavaParserHelper {
             if ("pollEnrich".equals(name)) {
                 List args = mi.arguments();
                 // the first argument is where the uri is
-                if (args != null && args.size() >= 1) {
+                if (args != null && !args.isEmpty()) {
                     Object arg = args.get(0);
                     if (isValidArgument(name, arg)) {
                         extractEndpointUriFromArgument(name, clazz, block, uris, arg, strings, fields);
@@ -311,7 +311,7 @@ public final class CamelJavaParserHelper {
             if ("toF".equals(name)) {
                 List args = mi.arguments();
                 // the first argument is where the uri is
-                if (args != null && args.size() >= 1) {
+                if (args != null && !args.isEmpty()) {
                     Object arg = args.get(0);
                     if (isValidArgument(name, arg)) {
                         extractEndpointUriFromArgument(name, clazz, block, uris, arg, strings, fields);
@@ -321,7 +321,7 @@ public final class CamelJavaParserHelper {
             if ("enrich".equals(name) || "wireTap".equals(name)) {
                 List args = mi.arguments();
                 // the first argument is where the uri is
-                if (args != null && args.size() >= 1) {
+                if (args != null && !args.isEmpty()) {
                     Object arg = args.get(0);
                     if (isValidArgument(name, arg)) {
                         extractEndpointUriFromArgument(name, clazz, block, uris, arg, strings, fields);
@@ -463,7 +463,7 @@ public final class CamelJavaParserHelper {
         if ("simple".equals(name)) {
             List args = mi.arguments();
             // the first argument is a string parameter for the simple expression
-            if (args != null && args.size() >= 1) {
+            if (args != null && !args.isEmpty()) {
                 // it is a String type
                 Object arg = args.get(0);
                 String simple = getLiteralValue(clazz, block, (Expression) arg);

--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaRestDslParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaRestDslParserHelper.java
@@ -446,7 +446,7 @@ public final class CamelJavaRestDslParserHelper {
 
     private static String extractValueFromFirstArgument(JavaClassSource clazz, Block block, MethodInvocation mi) {
         List args = mi.arguments();
-        if (args != null && args.size() > 0) {
+        if (args != null && !args.isEmpty()) {
             Expression exp = (Expression) args.get(0);
             return getLiteralValue(clazz, block, exp);
         }
@@ -583,7 +583,7 @@ public final class CamelJavaRestDslParserHelper {
                     if (expression instanceof MethodInvocation) {
                         MethodInvocation mi = (MethodInvocation) expression;
                         List args = mi.arguments();
-                        if (args != null && args.size() > 0) {
+                        if (args != null && !args.isEmpty()) {
                             // the first argument has the endpoint uri
                             expression = (Expression) args.get(0);
                             return getLiteralValue(clazz, block, expression);

--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaTreeParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaTreeParserHelper.java
@@ -261,7 +261,7 @@ public final class CamelJavaTreeParserHelper {
             if ("routeId".equals(name)) {
                 // grab the route id
                 List args = mi.arguments();
-                if (args != null && args.size() > 0) {
+                if (args != null && !args.isEmpty()) {
                     // the first argument has the route id
                     Expression exp = (Expression) args.get(0);
                     String routeId = getLiteralValue(clazz, block, exp);
@@ -406,7 +406,7 @@ public final class CamelJavaTreeParserHelper {
                     if (expression instanceof MethodInvocation) {
                         MethodInvocation mi = (MethodInvocation) expression;
                         List args = mi.arguments();
-                        if (args != null && args.size() > 0) {
+                        if (args != null && !args.isEmpty()) {
                             // the first argument has the endpoint uri
                             expression = (Expression) args.get(0);
                             return getLiteralValue(clazz, block, expression);

--- a/components/camel-aws-kinesis/src/main/java/org/apache/camel/component/aws/kinesis/KinesisConsumer.java
+++ b/components/camel-aws-kinesis/src/main/java/org/apache/camel/component/aws/kinesis/KinesisConsumer.java
@@ -149,7 +149,7 @@ public class KinesisConsumer extends ScheduledBatchPollingConsumer {
 
                 List<Shard> shards = res1.getStreamDescription().getShards();
 
-                if (shards.size() == 0) {
+                if (shards.isEmpty()) {
                     LOG.warn("There are no shards in the stream");
                     // NOTE: Should we also set isShardClosed to true?
                     return null;

--- a/components/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
+++ b/components/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
@@ -150,7 +150,7 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer {
 
                 List<Shard> shards = res1.streamDescription().shards();
 
-                if (shards.size() == 0) {
+                if (shards.isEmpty()) {
                     LOG.warn("There are no shards in the stream");
                     return null;
                 }

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/DefaultBeanProcessorFactory.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/DefaultBeanProcessorFactory.java
@@ -108,7 +108,7 @@ public final class DefaultBeanProcessorFactory extends ServiceSupport
                 if (scope == BeanScope.Singleton && clazz != null) {
                     // attempt to lookup in registry by type to favour using it (like bean ref would do to lookup in registry)
                     Set<?> beans = camelContext.getRegistry().findByType(clazz);
-                    if (beans.size() > 0) {
+                    if (!beans.isEmpty()) {
                         if (beans.size() == 1) {
                             LOG.debug("Exactly one instance of type: {} in registry found.", clazz);
                             bean = beans.iterator().next();

--- a/components/camel-bean/src/main/java/org/apache/camel/language/bean/BeanExpression.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/language/bean/BeanExpression.java
@@ -521,7 +521,7 @@ public class BeanExpression implements Expression, Predicate {
                         }
                     }
                 }
-                if (num != null && num >= 0 && list.size() > num - 1 && list.size() > 0) {
+                if (num != null && num >= 0 && !list.isEmpty() && list.size() > num - 1) {
                     return list.get(num);
                 }
                 if (!nullSafe) {

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
@@ -276,7 +276,7 @@ public class BindyKeyValuePairFactory extends BindyAbstractFactory implements Bi
                 } else {
 
                     // Data have been retrieved from message
-                    if (values.size() >= 1) {
+                    if (!values.isEmpty()) {
 
                         if (obj != null) {
 

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/fixed/BindyFixedLengthDataFormat.java
@@ -158,7 +158,7 @@ public class BindyFixedLengthDataFormat extends BindyAbstractDataFormat {
     private boolean isPreparedList(Object object) {
         if (List.class.isAssignableFrom(object.getClass())) {
             List<?> list = (List<?>) object;
-            if (list.size() > 0) {
+            if (!list.isEmpty()) {
                 // Check first entry, should be enough
                 Object entry = list.get(0);
                 if (Map.class.isAssignableFrom(entry.getClass())) {

--- a/components/camel-bonita/src/main/java/org/apache/camel/component/bonita/api/BonitaAPI.java
+++ b/components/camel-bonita/src/main/java/org/apache/camel/component/bonita/api/BonitaAPI.java
@@ -55,7 +55,7 @@ public class BonitaAPI {
         List<ProcessDefinitionResponse> listProcess = resource.request().accept(MediaType.APPLICATION_JSON)
                 .get(new GenericType<List<ProcessDefinitionResponse>>() {
                 });
-        if (listProcess.size() > 0) {
+        if (!listProcess.isEmpty()) {
             return listProcess.get(0);
         } else {
             throw new RuntimeException(

--- a/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/CMComponent.java
+++ b/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/CMComponent.java
@@ -55,7 +55,7 @@ public class CMComponent extends DefaultComponent {
         // Validate configuration
         final Set<ConstraintViolation<CMConfiguration>> constraintViolations
                 = getValidator().validate(endpoint.getConfiguration());
-        if (constraintViolations.size() > 0) {
+        if (!constraintViolations.isEmpty()) {
             final StringBuffer msg = new StringBuffer();
             for (final ConstraintViolation<CMConfiguration> cv : constraintViolations) {
                 msg.append(String.format("- Invalid value for %s: %s",

--- a/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/CMProducer.java
+++ b/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/CMProducer.java
@@ -63,7 +63,7 @@ public class CMProducer extends DefaultProducer {
         // Validates Payload - SMSMessage
         LOG.trace("Validating SMSMessage instance provided: {}", smsMessage);
         final Set<ConstraintViolation<SMSMessage>> constraintViolations = getValidator().validate(smsMessage);
-        if (constraintViolations.size() > 0) {
+        if (!constraintViolations.isEmpty()) {
             final StringBuffer msg = new StringBuffer();
             for (final ConstraintViolation<SMSMessage> cv : constraintViolations) {
                 msg.append(String.format("- Invalid value for %s: %s", cv.getPropertyPath().toString(), cv.getMessage()));

--- a/components/camel-crypto-cms/src/main/java/org/apache/camel/component/crypto/cms/crypt/EnvelopedDataDecryptor.java
+++ b/components/camel-crypto-cms/src/main/java/org/apache/camel/component/crypto/cms/crypt/EnvelopedDataDecryptor.java
@@ -175,7 +175,7 @@ public class EnvelopedDataDecryptor extends CryptoCmsUnmarshaller {
             @SuppressWarnings("unchecked")
             Store<X509CertificateHolder> certStore = originatorInfo.getCertificates();
             Collection<X509CertificateHolder> certs = certStore.getMatches(null);
-            if (certs != null && certs.size() > 0) {
+            if (certs != null && !certs.isEmpty()) {
                 LOG.debug("Certificates in the originator information:");
                 for (X509CertificateHolder cert : certs) {
                     LOG.debug("    subject={}, issuer={}, serial number={}",
@@ -185,7 +185,7 @@ public class EnvelopedDataDecryptor extends CryptoCmsUnmarshaller {
             @SuppressWarnings("unchecked")
             Store<X509CRLHolder> crlsStore = originatorInfo.getCRLs();
             Collection<X509CRLHolder> crls = crlsStore.getMatches(null);
-            if (crls != null && crls.size() > 0) {
+            if (crls != null && !crls.isEmpty()) {
                 LOG.debug("CRLs in the originator information:");
                 for (X509CRLHolder crl : crls) {
                     LOG.debug("    CRL issuer={}", crl.getIssuer());

--- a/components/camel-crypto-cms/src/main/java/org/apache/camel/component/crypto/cms/crypt/EnvelopedDataEncryptorConfiguration.java
+++ b/components/camel-crypto-cms/src/main/java/org/apache/camel/component/crypto/cms/crypt/EnvelopedDataEncryptorConfiguration.java
@@ -192,7 +192,7 @@ public class EnvelopedDataEncryptorConfiguration extends CryptoCmsMarshallerConf
     }
 
     public void init() throws CryptoCmsException {
-        if (recipient.size() == 0) {
+        if (recipient.isEmpty()) {
             logErrorAndThrow(LOG, "No recipient configured.");
         }
         checkEncryptionAlgorithmAndSecretKeyLength();

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/converter/CachedCxfPayload.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/converter/CachedCxfPayload.java
@@ -151,7 +151,7 @@ public class CachedCxfPayload<T> extends CxfPayload<T> implements StreamCache {
     @Override
     public void writeTo(OutputStream os) throws IOException {
         // no body no write
-        if (getBodySources().size() == 0) {
+        if (getBodySources().isEmpty()) {
             return;
         }
         Source body = getBodySources().get(0);

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/converter/CxfPayloadConverter.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/converter/CxfPayloadConverter.java
@@ -97,7 +97,7 @@ public final class CxfPayloadConverter {
     public static <T> Node cxfPayLoadToNode(CxfPayload<T> payload, Exchange exchange) {
         List<Element> payloadBodyElements = payload.getBody();
 
-        if (payloadBodyElements.size() > 0) {
+        if (!payloadBodyElements.isEmpty()) {
             return payloadBodyElements.get(0);
         }
         return null;
@@ -107,7 +107,7 @@ public final class CxfPayloadConverter {
     public static <T> Source cxfPayLoadToSource(CxfPayload<T> payload, Exchange exchange) {
         List<Source> payloadBody = payload.getBodySources();
 
-        if (payloadBody.size() > 0) {
+        if (!payloadBody.isEmpty()) {
             return payloadBody.get(0);
         }
         return null;

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
@@ -407,7 +407,7 @@ public class CxfRsProducer extends DefaultAsyncProducer {
         if (cookieHandler != null) {
             for (Map.Entry<String, List<String>> cookie : cookieHandler.loadCookies(exchange, client.getCurrentURI())
                     .entrySet()) {
-                if (cookie.getValue().size() > 0) {
+                if (!cookie.getValue().isEmpty()) {
                     client.header(cookie.getKey(), cookie.getValue());
                 }
             }

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanBlockStoragesProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanBlockStoragesProducer.java
@@ -138,7 +138,7 @@ public class DigitalOceanBlockStoragesProducer extends DigitalOceanProducer {
             }
 
             List<Volume> volumes = getEndpoint().getDigitalOceanClient().getVolumeInfo(name, region).getVolumes();
-            if (volumes.size() > 0) {
+            if (!volumes.isEmpty()) {
                 volume = volumes.get(1);
             }
         } else {

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/CustomMapper.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/CustomMapper.java
@@ -231,6 +231,6 @@ public class CustomMapper extends BaseConverter {
             }
         }
 
-        return methods.size() > 0 ? methods.get(0) : null;
+        return !methods.isEmpty() ? methods.get(0) : null;
     }
 }

--- a/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerEndpoint.java
+++ b/components/camel-dozer/src/main/java/org/apache/camel/component/dozer/DozerEndpoint.java
@@ -143,7 +143,7 @@ public class DozerEndpoint extends DefaultEndpoint {
 
                 // if bean mapping builders have been defined skip loading the "default" mapping file.
                 if (isNullOrEmpty(configuration.getMappingConfiguration().getBeanMappingBuilders())) {
-                    if (config.getMappingFiles() == null || config.getMappingFiles().size() <= 0) {
+                    if (config.getMappingFiles() == null || config.getMappingFiles().isEmpty()) {
                         URL url = ResourceHelper.resolveMandatoryResourceAsUrl(getCamelContext().getClassResolver(),
                                 configuration.getMappingFile());
                         config.setMappingFiles(Arrays.asList(url.toString()));

--- a/components/camel-flink/src/main/java/org/apache/camel/component/flink/annotations/AnnotatedDataSetCallback.java
+++ b/components/camel-flink/src/main/java/org/apache/camel/component/flink/annotations/AnnotatedDataSetCallback.java
@@ -44,7 +44,7 @@ public class AnnotatedDataSetCallback implements org.apache.camel.component.flin
         this.objectWithCallback = objectWithCallback;
         this.camelContext = camelContext;
         this.dataSetCallbacks = findMethodsWithAnnotation(objectWithCallback.getClass(), DataSetCallback.class);
-        if (dataSetCallbacks.size() == 0) {
+        if (dataSetCallbacks.isEmpty()) {
             throw new UnsupportedOperationException("Can't find methods annotated with @DataSetCallback");
         }
     }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpUtils.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpUtils.java
@@ -104,7 +104,7 @@ public final class FtpUtils {
             }
         }
 
-        if (endsWithSlash && stack.size() > 0) {
+        if (endsWithSlash && !stack.isEmpty()) {
             sb.append(File.separator);
         }
 

--- a/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/PullRequestConsumer.java
+++ b/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/PullRequestConsumer.java
@@ -52,7 +52,7 @@ public class PullRequestConsumer extends AbstractGitHubConsumer {
 
         LOG.info("GitHub PullRequestConsumer: Indexing current pull requests...");
         List<PullRequest> pullRequests = pullRequestService.getPullRequests(getRepository(), "open");
-        if (pullRequests.size() > 0) {
+        if (!pullRequests.isEmpty()) {
             lastOpenPullRequest = pullRequests.get(0).getNumber();
         }
     }
@@ -70,7 +70,7 @@ public class PullRequestConsumer extends AbstractGitHubConsumer {
             }
         }
 
-        if (newPullRequests.size() > 0) {
+        if (!newPullRequests.isEmpty()) {
             lastOpenPullRequest = openPullRequests.get(0).getNumber();
         }
 

--- a/components/camel-hbase/src/main/java/org/apache/camel/component/hbase/HBaseConsumer.java
+++ b/components/camel-hbase/src/main/java/org/apache/camel/component/hbase/HBaseConsumer.java
@@ -109,7 +109,7 @@ public class HBaseConsumer extends ScheduledBatchPollingConsumer {
                 List<Cell> cells = result.listCells();
                 if (cells != null) {
                     Set<HBaseCell> cellModels = rowModel.getCells();
-                    if (cellModels.size() > 0) {
+                    if (!cellModels.isEmpty()) {
                         for (HBaseCell modelCell : cellModels) {
                             HBaseCell resultCell = new HBaseCell();
                             String family = modelCell.getFamily();

--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -224,7 +224,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
         if (!filterInitParameters.isEmpty()) {
             endpoint.setFilterInitParameters(filterInitParameters);
         }
-        if (handlerList.size() > 0) {
+        if (!handlerList.isEmpty()) {
             endpoint.setHandlers(handlerList);
         }
         // prefer to use endpoint configured over component configured
@@ -376,7 +376,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
                 enableMultipartFilter(endpoint, connectorRef.server, connectorKey);
             }
 
-            if (endpoint.getFilters() != null && endpoint.getFilters().size() > 0) {
+            if (endpoint.getFilters() != null && !endpoint.getFilters().isEmpty()) {
                 setFilters(endpoint, connectorRef.server, connectorKey);
             }
             connectorRef.servlet.connect(consumer);

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewIssuesConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewIssuesConsumer.java
@@ -46,7 +46,7 @@ public class NewIssuesConsumer extends AbstractJiraConsumer {
         // grab only the top
         List<Issue> issues = getIssues(jql, 0, 1, 1);
         // in case there aren't any issues...
-        if (issues.size() >= 1) {
+        if (!issues.isEmpty()) {
             latestIssueId = issues.get(0).getId();
         }
     }
@@ -74,7 +74,7 @@ public class NewIssuesConsumer extends AbstractJiraConsumer {
         // search only for issues created after the latest id
         String jqlFilter = "id > " + latestIssueId + " AND " + jql;
         List<Issue> issues = getIssues(jqlFilter, 0, 50, ((JiraEndpoint) getEndpoint()).getMaxResults());
-        if (issues.size() > 0) {
+        if (!issues.isEmpty()) {
             latestIssueId = issues.get(0).getId();
         }
         return issues;

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/AddIssueProducer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/AddIssueProducer.java
@@ -86,7 +86,7 @@ public class AddIssueProducer extends DefaultProducer {
         IssueInputBuilder builder = new IssueInputBuilder(projectKey, issueTypeId);
         builder.setDescription(exchange.getIn().getBody(String.class));
         builder.setSummary(summary);
-        if (components != null && components.size() > 0) {
+        if (components != null && !components.isEmpty()) {
             builder.setComponentsNames(components);
         }
         if (priorityId != null) {
@@ -99,7 +99,7 @@ public class AddIssueProducer extends DefaultProducer {
         IssueRestClient issueClient = client.getIssueClient();
         BasicIssue issueCreated = issueClient.createIssue(builder.build()).claim();
         Issue issue = issueClient.getIssue(issueCreated.getKey()).claim();
-        if (watchers != null && watchers.size() > 0) {
+        if (watchers != null && !watchers.isEmpty()) {
             for (String watcher : watchers) {
                 issueClient.addWatcher(issue.getWatchers().getSelf(), watcher);
             }

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/UpdateIssueProducer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/UpdateIssueProducer.java
@@ -79,7 +79,7 @@ public class UpdateIssueProducer extends DefaultProducer {
         if (description != null) {
             builder.setDescription(description);
         }
-        if (components != null && components.size() > 0) {
+        if (components != null && !components.isEmpty()) {
             builder.setComponentsNames(components);
         }
         if (priorityId != null) {

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/WatcherProducer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/producer/WatcherProducer.java
@@ -45,8 +45,8 @@ public class WatcherProducer extends DefaultProducer {
                     "Missing exchange input header named \'IssueKey\', it should specify the issue key to add/remove watchers to.");
         }
         JiraRestClient client = ((JiraEndpoint) getEndpoint()).getClient();
-        boolean hasWatchersToAdd = watchersAdd != null && watchersAdd.size() > 0;
-        boolean hasWatchersToRemove = watchersRemove != null && watchersRemove.size() > 0;
+        boolean hasWatchersToAdd = watchersAdd != null && !watchersAdd.isEmpty();
+        boolean hasWatchersToRemove = watchersRemove != null && !watchersRemove.isEmpty();
         if (hasWatchersToAdd || hasWatchersToRemove) {
             IssueRestClient issueClient = client.getIssueClient();
             Issue issue = issueClient.getIssue(issueKey).claim();

--- a/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
+++ b/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
@@ -117,7 +117,7 @@ public class JsonValidatorEndpoint extends ResourceEndpoint {
                 }
                 Set<ValidationMessage> errors = localSchema.validate(node);
 
-                if (errors.size() > 0) {
+                if (!errors.isEmpty()) {
                     this.log.debug("Validated JSON has {} errors", errors.size());
                     this.errorHandler.handleErrors(exchange, schema, errors);
                 } else {

--- a/components/camel-leveldb/src/main/java/org/apache/camel/component/leveldb/LevelDBAggregationRepository.java
+++ b/components/camel-leveldb/src/main/java/org/apache/camel/component/leveldb/LevelDBAggregationRepository.java
@@ -264,7 +264,7 @@ public class LevelDBAggregationRepository extends ServiceSupport implements Reco
             IOHelper.close(it);
         }
 
-        if (answer.size() == 0) {
+        if (answer.isEmpty()) {
             LOG.trace("Scanned and found no exchange to recover.");
         } else {
             if (LOG.isDebugEnabled()) {

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
@@ -248,7 +248,7 @@ public final class MailConverters {
                 result.add(SortTerm.TO);
             }
         }
-        if (result.size() > 0) {
+        if (!result.isEmpty()) {
             return result.toArray(new SortTerm[result.size()]);
         } else {
             return null;

--- a/components/camel-mina/src/main/java/org/apache/camel/component/mina/MinaConsumer.java
+++ b/components/camel-mina/src/main/java/org/apache/camel/component/mina/MinaConsumer.java
@@ -353,7 +353,7 @@ public class MinaConsumer extends DefaultConsumer {
     }
 
     private void appendIoFiltersToChain(List<IoFilter> filters, DefaultIoFilterChainBuilder filterChain) {
-        if (filters != null && filters.size() > 0) {
+        if (filters != null && !filters.isEmpty()) {
             for (IoFilter ioFilter : filters) {
                 filterChain.addLast(ioFilter.getClass().getCanonicalName(), ioFilter);
             }

--- a/components/camel-mina/src/main/java/org/apache/camel/component/mina/MinaProducer.java
+++ b/components/camel-mina/src/main/java/org/apache/camel/component/mina/MinaProducer.java
@@ -445,7 +445,7 @@ public class MinaProducer extends DefaultProducer {
     }
 
     private void appendIoFiltersToChain(List<IoFilter> filters, DefaultIoFilterChainBuilder filterChain) {
-        if (filters != null && filters.size() > 0) {
+        if (filters != null && !filters.isEmpty()) {
             for (IoFilter ioFilter : filters) {
                 filterChain.addLast(ioFilter.getClass().getCanonicalName(), ioFilter);
             }

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpProducer.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpProducer.java
@@ -86,7 +86,7 @@ public class NettyHttpProducer extends NettyProducer {
             Map<String, List<String>> cookieHeaders = cookieHandler.loadCookies(exchange, u);
             for (Map.Entry<String, List<String>> entry : cookieHeaders.entrySet()) {
                 String key = entry.getKey();
-                if (entry.getValue().size() > 0) {
+                if (!entry.getValue().isEmpty()) {
                     request.headers().add(key, entry.getValue());
                 }
             }

--- a/components/camel-optaplanner/src/main/java/org/apache/camel/component/optaplanner/OptaPlannerEndpoint.java
+++ b/components/camel-optaplanner/src/main/java/org/apache/camel/component/optaplanner/OptaPlannerEndpoint.java
@@ -124,7 +124,7 @@ public class OptaPlannerEndpoint extends DefaultEndpoint {
     protected synchronized void removeSolutionEventListener(Long problemId, OptaplannerSolutionEventListener listener) {
         Set<OptaplannerSolutionEventListener> listeners = SOLUTION_LISTENER.get(problemId);
         listeners.remove(listener);
-        if (listeners.size() == 0) {
+        if (listeners.isEmpty()) {
             SOLUTION_LISTENER.remove(problemId);
         }
     }

--- a/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/ReactiveStreamsBackpressureStrategy.java
+++ b/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/ReactiveStreamsBackpressureStrategy.java
@@ -44,7 +44,7 @@ public enum ReactiveStreamsBackpressureStrategy {
     OLDEST {
         @Override
         public <T> Collection<T> update(Deque<T> buffer, T newItem) {
-            if (buffer.size() > 0) {
+            if (!buffer.isEmpty()) {
                 // the buffer has another item, so discarding the incoming one
                 return Collections.singletonList(newItem);
             } else {
@@ -63,7 +63,7 @@ public enum ReactiveStreamsBackpressureStrategy {
         @Override
         public <T> Collection<T> update(Deque<T> buffer, T newItem) {
             Collection<T> discarded = Collections.emptySet();
-            if (buffer.size() > 0) {
+            if (!buffer.isEmpty()) {
                 // there should be an item in the buffer,
                 // so removing it to overwrite
                 discarded = Collections.singletonList(buffer.removeFirst());

--- a/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/util/UnwrapStreamProcessor.java
+++ b/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/util/UnwrapStreamProcessor.java
@@ -66,7 +66,7 @@ public class UnwrapStreamProcessor extends AsyncProcessorSupport {
 
                 private void addData() {
                     Object body;
-                    if (data.size() == 0) {
+                    if (data.isEmpty()) {
                         body = null;
                     } else if (data.size() == 1) {
                         body = data.get(0);

--- a/components/camel-saxon/src/main/java/org/apache/camel/converter/saxon/SaxonConverter.java
+++ b/components/camel-saxon/src/main/java/org/apache/camel/converter/saxon/SaxonConverter.java
@@ -108,7 +108,7 @@ public final class SaxonConverter {
                         lion.add((NodeInfo) o);
                     }
                 }
-                if (lion.size() > 0) {
+                if (!lion.isEmpty()) {
                     NodeList nl = toDOMNodeList(lion);
                     return tc.convertTo(type, exchange, nl);
                 }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
@@ -87,7 +87,7 @@ public final class QueueReference {
 
     public synchronized boolean hasConsumers() {
         for (SedaEndpoint endpoint : endpoints) {
-            if (endpoint.getConsumers().size() > 0) {
+            if (!endpoint.getConsumers().isEmpty()) {
                 return true;
             }
         }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
@@ -271,7 +271,7 @@ public class SedaComponent extends DefaultComponent {
         // we need to remove the endpoint from the reference counter
         String key = getQueueKey(endpoint.getEndpointUri());
         QueueReference ref = getQueues().get(key);
-        if (ref != null && endpoint.getConsumers().size() == 0) {
+        if (ref != null && endpoint.getConsumers().isEmpty()) {
             // only remove the endpoint when the consumers are removed
             ref.removeReference(endpoint);
             if (ref.getCount() <= 0) {

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -511,7 +511,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     }
 
     public boolean hasConsumers() {
-        return this.consumers.size() > 0;
+        return !this.consumers.isEmpty();
     }
 
     @Override

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap11DataFormatAdapter.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap11DataFormatAdapter.java
@@ -97,7 +97,7 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
             header.getAny().add(elem);
         }
         Envelope envelope = new Envelope();
-        if (headerContent.size() > 0) {
+        if (!headerContent.isEmpty()) {
             envelope.setHeader(header);
         }
         envelope.setBody(body);
@@ -165,7 +165,7 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
         }
 
         List<Object> anyElement = envelope.getBody().getAny();
-        if (anyElement.size() == 0) {
+        if (anyElement.isEmpty()) {
             // No parameter so return null
             return null;
 
@@ -193,7 +193,7 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
         String message = fault.getFaultstring();
 
         Detail faultDetail = fault.getDetail();
-        if (faultDetail == null || faultDetail.getAny().size() == 0) {
+        if (faultDetail == null || faultDetail.getAny().isEmpty()) {
             try {
                 return new SOAPFaultException(SOAPFactory.newInstance().createFault(message, fault.getFaultcode()));
             } catch (SOAPException e) {

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap12DataFormatAdapter.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap12DataFormatAdapter.java
@@ -100,7 +100,7 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
             header.getAny().add(elem);
         }
         Envelope envelope = new Envelope();
-        if (headerContent.size() > 0) {
+        if (!headerContent.isEmpty()) {
             envelope.setHeader(header);
         }
         envelope.setBody(body);
@@ -176,7 +176,7 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
         }
 
         List<Object> anyElement = envelope.getBody().getAny();
-        if (anyElement.size() == 0) {
+        if (anyElement.isEmpty()) {
             // No parameter so return null
             return null;
 
@@ -208,7 +208,7 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
         String message = sb.toString();
 
         Detail faultDetail = fault.getDetail();
-        if (faultDetail == null || faultDetail.getAny().size() == 0) {
+        if (faultDetail == null || faultDetail.getAny().isEmpty()) {
             try {
                 return new SOAPFaultException(SOAPFactory.newInstance().createFault(message, fault.getCode().getValue()));
             } catch (SOAPException e) {

--- a/components/camel-spark/src/main/java/org/apache/camel/component/spark/annotations/AnnotatedRddCallbackProxy.java
+++ b/components/camel-spark/src/main/java/org/apache/camel/component/spark/annotations/AnnotatedRddCallbackProxy.java
@@ -42,7 +42,7 @@ class AnnotatedRddCallbackProxy implements RddCallback {
         this.camelContext = camelContext;
         this.rddCallbacks = findMethodsWithAnnotation(objectWithCallback.getClass(),
                 org.apache.camel.component.spark.annotations.RddCallback.class);
-        if (rddCallbacks.size() == 0) {
+        if (rddCallbacks.isEmpty()) {
             throw new UnsupportedOperationException("Can't find methods annotated with @RddCallback.");
         }
     }

--- a/components/camel-spring-redis/src/main/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepository.java
+++ b/components/camel-spring-redis/src/main/java/org/apache/camel/component/redis/processor/idempotent/RedisStringIdempotentRepository.java
@@ -78,7 +78,7 @@ public class RedisStringIdempotentRepository extends RedisIdempotentRepository {
                     byte[] key = cursor.next();
                     binaryKeys.add(key);
                 }
-                if (binaryKeys.size() > 0) {
+                if (!binaryKeys.isEmpty()) {
                     connection.del(binaryKeys.toArray(new byte[][] {}));
                 }
                 return binaryKeys;

--- a/components/camel-spring-security/src/main/java/org/apache/camel/component/spring/security/DefaultAuthenticationAdapter.java
+++ b/components/camel-spring-security/src/main/java/org/apache/camel/component/spring/security/DefaultAuthenticationAdapter.java
@@ -26,11 +26,11 @@ public class DefaultAuthenticationAdapter implements AuthenticationAdapter {
 
     @Override
     public Authentication toAuthentication(Subject subject) {
-        if (subject == null || subject.getPrincipals().size() == 0) {
+        if (subject == null || subject.getPrincipals().isEmpty()) {
             return null;
         }
         Set<Authentication> authentications = subject.getPrincipals(Authentication.class);
-        if (authentications.size() > 0) {
+        if (!authentications.isEmpty()) {
             // just return the first one 
             return authentications.iterator().next();
         } else {

--- a/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/directmessage/DirectMessageConsumerHandler.java
+++ b/components/camel-twitter/src/main/java/org/apache/camel/component/twitter/directmessage/DirectMessageConsumerHandler.java
@@ -40,7 +40,7 @@ public class DirectMessageConsumerHandler extends AbstractTwitterConsumerHandler
     public List<Exchange> pollConsume() throws TwitterException {
         // the first call doesn't require any cursor as parameters
         DirectMessageList directMessages = directMessages(null, null);
-        if (directMessages.size() > 0) {
+        if (!directMessages.isEmpty()) {
             // the DM response list is in reverse chronological order, so the last id is the first element.
             setLastId(directMessages.get(0).getId());
         }

--- a/components/camel-weather/src/main/java/org/apache/camel/component/weather/WeatherQuery.java
+++ b/components/camel-weather/src/main/java/org/apache/camel/component/weather/WeatherQuery.java
@@ -49,7 +49,7 @@ public class WeatherQuery {
                        + weatherConfiguration.getZoom() + "&cluster=yes";
         } else if (!isEmpty(weatherConfiguration.getZip())) {
             location = "zip=" + weatherConfiguration.getZip();
-        } else if (weatherConfiguration.getIds() != null && weatherConfiguration.getIds().size() > 0) {
+        } else if (weatherConfiguration.getIds() != null && !weatherConfiguration.getIds().isEmpty()) {
             location = "id=" + String.join(",", weatherConfiguration.getIds());
         } else if (isEmpty(location) || "current".equals(location)) {
             GeoLocation geoLocation = getCurrentGeoLocation();
@@ -103,7 +103,7 @@ public class WeatherQuery {
             } else {
                 answer = "find?";
             }
-        } else if (weatherConfiguration.getIds() != null && weatherConfiguration.getIds().size() > 0) {
+        } else if (weatherConfiguration.getIds() != null && !weatherConfiguration.getIds().isEmpty()) {
             if (weatherConfiguration.getIds().size() == 1) {
                 if (!isEmpty(weatherConfiguration.getPeriod())) {
                     if (weatherConfiguration.getWeatherApi() == WeatherApi.Hourly) {

--- a/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/api/DefaultXmlSignature2Message.java
+++ b/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/api/DefaultXmlSignature2Message.java
@@ -420,7 +420,7 @@ public class DefaultXmlSignature2Message implements XmlSignature2Message {
 
         @SuppressWarnings("unchecked")
         List<XMLStructure> structures = referencedObjects.get(0).getContent();
-        if (structures.size() == 0) {
+        if (structures.isEmpty()) {
             throw new XmlSignatureException(
                     "Unsupported XML signature: XML signature is not enveloping; content not found in XML signature: structure list is empty.");
         }

--- a/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/api/XAdESSignatureProperties.java
+++ b/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/api/XAdESSignatureProperties.java
@@ -803,7 +803,7 @@ public class XAdESSignatureProperties implements XmlSignatureProperties {
     }
 
     protected boolean isAddSignerRole() {
-        return getSignerClaimedRoles().size() > 0 || getSignerCertifiedRoles().size() > 0;
+        return !getSignerClaimedRoles().isEmpty() || !getSignerCertifiedRoles().isEmpty();
     }
 
     protected void addSignatureProductionPlace(Document doc, Element signedSignatureProperties, Input input) {

--- a/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/processor/XmlSignerProcessor.java
+++ b/components/camel-xmlsecurity/src/main/java/org/apache/camel/component/xmlsecurity/processor/XmlSignerProcessor.java
@@ -331,7 +331,7 @@ public class XmlSignerProcessor extends XmlSignatureProcessor {
 
         boolean isEnveloped = getConfiguration().getParentLocalName() != null || getConfiguration().getParentXpath() != null;
 
-        boolean isDetached = getXpathToIdAttributes(message).size() > 0;
+        boolean isDetached = !getXpathToIdAttributes(message).isEmpty();
 
         if (isEnveloped && isDetached) {
             if (getConfiguration().getParentLocalName() != null) {
@@ -754,7 +754,7 @@ public class XmlSignerProcessor extends XmlSignatureProcessor {
                 }
             }
         }
-        if (result.size() == 0) {
+        if (result.isEmpty()) {
             throw new XmlSignatureException(
                     "No element to sign found in the detached case. No node found for the configured xpath expressions "
                                             + toString(xpathsToIdAttributes)
@@ -790,7 +790,7 @@ public class XmlSignerProcessor extends XmlSignatureProcessor {
             List<AlgorithmMethod> configuredTrafos = getConfiguration().getTransformMethods();
             if (SignatureType.enveloped == sigType) {
                 // add enveloped transform if necessary
-                if (configuredTrafos.size() > 0) {
+                if (!configuredTrafos.isEmpty()) {
                     if (!containsEnvelopedTransform(configuredTrafos)) {
                         configuredTrafos = new ArrayList<>(configuredTrafos.size() + 1);
                         configuredTrafos.add(XmlSignatureHelper.getEnvelopedTransform());

--- a/core/camel-base/src/main/java/org/apache/camel/impl/scan/AssignableToPackageScanFilter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/scan/AssignableToPackageScanFilter.java
@@ -57,7 +57,7 @@ public class AssignableToPackageScanFilter implements PackageScanFilter {
 
     @Override
     public boolean matches(Class<?> type) {
-        if (parents.size() > 0) {
+        if (!parents.isEmpty()) {
             for (Class<?> parent : parents) {
                 if (parent.isAssignableFrom(type)) {
                     if (includeAbstract) {

--- a/core/camel-base/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyBeanInfo.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyBeanInfo.java
@@ -74,7 +74,7 @@ public class AggregationStrategyBeanInfo {
 
         for (int i = 0; i < size / 2; i++) {
             Class<?> oldType = parameterTypes[i];
-            if (oldParameters.size() == 0) {
+            if (oldParameters.isEmpty()) {
                 // the first parameter is the body
                 Expression oldBody = ExpressionBuilder.mandatoryBodyExpression(oldType);
                 AggregationStrategyParameterInfo info = new AggregationStrategyParameterInfo(i, oldType, oldBody);
@@ -94,7 +94,7 @@ public class AggregationStrategyBeanInfo {
 
         for (int i = size / 2; i < size; i++) {
             Class<?> newType = parameterTypes[i];
-            if (newParameters.size() == 0) {
+            if (newParameters.isEmpty()) {
                 // the first parameter is the body
                 Expression newBody = ExpressionBuilder.mandatoryBodyExpression(newType);
                 AggregationStrategyParameterInfo info = new AggregationStrategyParameterInfo(i, newType, newBody);

--- a/core/camel-base/src/main/java/org/apache/camel/processor/resequencer/ResequencerEngine.java
+++ b/core/camel-base/src/main/java/org/apache/camel/processor/resequencer/ResequencerEngine.java
@@ -244,7 +244,7 @@ public class ResequencerEngine<E> {
      *
      */
     public boolean deliverNext() throws Exception {
-        if (sequence.size() == 0) {
+        if (sequence.isEmpty()) {
             return false;
         }
         // inspect element with lowest sequence value

--- a/core/camel-core-engine/src/main/java/org/apache/camel/model/InterceptDefinition.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/model/InterceptDefinition.java
@@ -96,7 +96,7 @@ public class InterceptDefinition extends OutputDefinition<InterceptDefinition> {
      * we have to do a bit of magic logic to fixup to handle predicates with or without proceed/stop set as well.
      */
     public void afterPropertiesSet() {
-        if (getOutputs().size() == 0) {
+        if (getOutputs().isEmpty()) {
             // no outputs
             return;
         }

--- a/core/camel-core-engine/src/main/java/org/apache/camel/model/InterceptSendToEndpointDefinition.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/model/InterceptSendToEndpointDefinition.java
@@ -127,7 +127,7 @@ public class InterceptSendToEndpointDefinition extends OutputDefinition<Intercep
         // interceptors
         // so we must fix the route definition yet again
 
-        if (getOutputs().size() == 0) {
+        if (getOutputs().isEmpty()) {
             // no outputs
             return;
         }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/PatternBasedPackageScanFilter.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/PatternBasedPackageScanFilter.java
@@ -91,13 +91,13 @@ public class PatternBasedPackageScanFilter implements PackageScanFilter {
         String candidate = candidateClass.getName();
         if (includePatterns != null || excludePatterns != null) {
 
-            if (excludePatterns != null && excludePatterns.size() > 0) {
+            if (excludePatterns != null && !excludePatterns.isEmpty()) {
                 if (matchesAny(excludePatterns, candidate)) {
                     return false;
                 }
             }
 
-            if (includePatterns != null && includePatterns.size() > 0) {
+            if (includePatterns != null && !includePatterns.isEmpty()) {
                 return matchesAny(includePatterns, candidate);
             }
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBrowsableEndpoint.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBrowsableEndpoint.java
@@ -117,7 +117,7 @@ public class ManagedBrowsableEndpoint extends ManagedEndpoint implements Managed
         }
 
         List<Exchange> exchanges = getEndpoint().getExchanges();
-        if (exchanges.size() == 0) {
+        if (exchanges.isEmpty()) {
             return null;
         }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultScheduledPollConsumerScheduler.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultScheduledPollConsumerScheduler.java
@@ -163,7 +163,7 @@ public class DefaultScheduledPollConsumerScheduler extends ServiceSupport implem
             currentDelay = delay;
         }
 
-        if (futures.size() == 0) {
+        if (futures.isEmpty()) {
             if (isUseFixedDelay()) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Scheduling poll (fixed delay) with initialDelay: {}, delay: {} ({}) for: {}",
@@ -190,7 +190,7 @@ public class DefaultScheduledPollConsumerScheduler extends ServiceSupport implem
 
     @Override
     public boolean isSchedulerStarted() {
-        return futures != null && futures.size() > 0;
+        return futures != null && !futures.isEmpty();
     }
 
     @Override

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -334,7 +334,7 @@ public final class FileUtil {
             }
         }
 
-        if (endsWithSlash && stack.size() > 0) {
+        if (endsWithSlash && !stack.isEmpty()) {
             sb.append(separator);
         }
 

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -896,7 +896,7 @@ public class XmlConverter {
                 }
             }
         }
-        if (features.size() > 0) {
+        if (!features.isEmpty()) {
             StringBuilder featureString = new StringBuilder();
             // just log the configured feature
             for (String feature : features) {

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIterator.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIterator.java
@@ -304,7 +304,7 @@ public class XMLTokenExpressionIterator extends ExpressionAdapter implements Nam
 
         private void pushNamespaces(XMLStreamReader reader) {
             Map<String, String> m = new HashMap<>();
-            if (namespaces.size() > 0) {
+            if (!namespaces.isEmpty()) {
                 m.putAll(namespaces.get(namespaces.size() - 1));
             }
             for (int i = 0; i < reader.getNamespaceCount(); i++) {
@@ -503,7 +503,7 @@ public class XMLTokenExpressionIterator extends ExpressionAdapter implements Nam
                         break;
                     case XMLStreamConstants.END_ELEMENT:
                         if ((backtrack || (trackdepth > 0 && depth == trackdepth))
-                                && (mode == 'w' && group > 1 && tokens.size() > 0)) {
+                                && (mode == 'w' && group > 1 && !tokens.isEmpty())) {
                             // flush the left over using the current context
                             code = XMLStreamConstants.END_ELEMENT;
                             return getGroupedToken();
@@ -546,7 +546,7 @@ public class XMLTokenExpressionIterator extends ExpressionAdapter implements Nam
                         break;
                     case XMLStreamConstants.END_DOCUMENT:
                         LOG.trace("depth={}", depth);
-                        if (group > 1 && tokens.size() > 0) {
+                        if (group > 1 && !tokens.isEmpty()) {
                             // flush the left over before really going EoD
                             code = XMLStreamConstants.END_DOCUMENT;
                             return getGroupedToken();

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
@@ -260,7 +260,7 @@ public class XMLConverterHelper {
                 }
             }
         }
-        if (features.size() > 0) {
+        if (!features.isEmpty()) {
             StringBuilder featureString = new StringBuilder();
             // just log the configured feature
             for (String feature : features) {

--- a/init/camel-format-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/init/camel-format-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -77,7 +77,7 @@ public class ValidateMojo extends FormatterMojo {
                 sb.append("Type:\t").append(delta.getType()).append(NL);
                 if (delta.getSource() != null) {
                     sb.append("Line:\t").append(delta.getSource().getPosition()).append(NL);
-                    if (delta.getSource().getLines().size() > 0) {
+                    if (!delta.getSource().getLines().isEmpty()) {
                         sb.append("Source:").append(NL);
                         for (String line : delta.getSource().getLines()) {
                             sb.append(line).append(NL);
@@ -85,7 +85,7 @@ public class ValidateMojo extends FormatterMojo {
                     }
                 }
 
-                if (delta.getTarget() != null && delta.getTarget().getLines().size() > 0) {
+                if (delta.getTarget() != null && !delta.getTarget().getLines().isEmpty()) {
                     sb.append("Target:").append(NL);
                     for (String line : delta.getTarget().getLines()) {
                         sb.append(line).append(NL);

--- a/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/Jsoner.java
+++ b/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/Jsoner.java
@@ -554,7 +554,7 @@ public final class Jsoner {
      * @return            a state for deserialization context so it knows how to consume the next token.
      */
     private static States popNextState(final LinkedList<States> stateStack) {
-        if (stateStack.size() > 0) {
+        if (!stateStack.isEmpty()) {
             return stateStack.removeLast();
         } else {
             return States.PARSED_ERROR;

--- a/tooling/maven/camel-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/tooling/maven/camel-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -2056,7 +2056,7 @@ public abstract class AbstractJavadocMojo
         arguments.addAll( javadocArguments );
         arguments.addAll( standardDocletArguments );
 
-        if ( arguments.size() > 0 )
+        if ( !arguments.isEmpty() )
         {
             addCommandLineOptions( cmd, arguments, javadocOutputDirectory );
         }
@@ -2778,7 +2778,7 @@ public abstract class AbstractJavadocMojo
                         (List<Toolchain>) getToolchainsMethod.invoke( toolchainManager, session, "jdk",
                                 jdkToolchain );
 
-                if ( tcs != null && tcs.size() > 0 )
+                if ( tcs != null && !tcs.isEmpty())
                 {
                     tc = tcs.get( 0 );
                 }


### PR DESCRIPTION
A minor cleanup, but potentially positive: replaces calls to Collections.size() with Collections.isEmpty(). The reason is that isEmpty provides constant time whereas size (usually) runs in linear time. 

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md