### PR TITLE
Update how-do-i-configure-endpoints.adoc to display ampersand correctly

### DIFF
--- a/docs/user-manual/modules/faq/pages/how-do-i-configure-endpoints.adoc
+++ b/docs/user-manual/modules/faq/pages/how-do-i-configure-endpoints.adoc
@@ -344,7 +344,7 @@ shown below:
 </route>
 ----
 
-Notice that it still requires escaping `&` as `&amp;` in XML. Also you
+Notice that it still requires escaping `&` as `&amp;amp;` in XML. Also you
 can have multiple options in one line, eg this is the same:
 
 [source,xml]


### PR DESCRIPTION
Escape ampersand twice so that it is displayed as &amp;amp; in the browser