### PR TITLE
CAMEL-15661: use Testcontainers and Azurite at integration tests

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/azure-storage-blob-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/azure-storage-blob-component.adoc
@@ -685,8 +685,10 @@ from("direct:start")
 
 
 === Development Notes (Important)
-When developing on this component, you will need to obtain your Azure accessKey in order to run the integration tests. In addition to the mocked unit tests
-you *will need to run the integration tests with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
+All integration tests use [Testcontainers](https://www.testcontainers.org/) and run by default.
+Obtaining of Azure accessKey and accountName is needed to be able to run all integration tests using Azure services.
+In addition to the mocked unit tests you *will need to run the integration tests
+with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
 To run the integration tests, on this component directory, run the following maven command:
 ----
 mvn verify -PfullTests -DaccountName=myacc -DaccessKey=mykey

--- a/components/camel-azure-storage-blob/pom.xml
+++ b/components/camel-azure-storage-blob/pom.xml
@@ -81,34 +81,17 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>fullTests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven-surefire-plugin-version}</version>
-                        <executions>
-                            <execution>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <excludes>
-                                        <exclude>none</exclude>
-                                    </excludes>
-                                    <includes>
-                                        <include>**/*IT</include>
-                                    </includes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/components/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
+++ b/components/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
@@ -685,8 +685,10 @@ from("direct:start")
 
 
 === Development Notes (Important)
-When developing on this component, you will need to obtain your Azure accessKey in order to run the integration tests. In addition to the mocked unit tests
-you *will need to run the integration tests with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
+All integration tests use [Testcontainers](https://www.testcontainers.org/) and run by default.
+Obtaining of Azure accessKey and accountName is needed to be able to run all integration tests using Azure services.
+In addition to the mocked unit tests you *will need to run the integration tests
+with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
 To run the integration tests, on this component directory, run the following maven command:
 ----
 mvn verify -PfullTests -DaccountName=myacc -DaccessKey=mykey

--- a/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/BlobTestUtils.java
+++ b/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/BlobTestUtils.java
@@ -26,26 +26,18 @@ public final class BlobTestUtils {
     private BlobTestUtils() {
     }
 
-    public static Properties loadAzurePropertiesFile() throws IOException {
+    public static Properties getAzuriteProperties() {
         final Properties properties = new Properties();
-        final String fileName = "azure_key.properties";
+        final String fileName = "azurite.properties";
 
         final InputStream inputStream
                 = Objects.requireNonNull(BlobTestUtils.class.getClassLoader().getResourceAsStream(fileName));
 
-        properties.load(inputStream);
-
-        return properties;
-    }
-
-    public static Properties loadAzureAccessFromJvmEnv() throws Exception {
-        final Properties properties = new Properties();
-        if (System.getProperty("accountName") == null || System.getProperty("accessKey") == null) {
-            throw new Exception(
-                    "Make sure to supply azure accessKey or accountName, e.g:  mvn verify -PfullTests -DaccountName=myacc -DaccessKey=mykey");
+        try {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not initialize Azurite properties", e);
         }
-        properties.setProperty("account_name", System.getProperty("accountName"));
-        properties.setProperty("access_key", System.getProperty("accessKey"));
 
         return properties;
     }

--- a/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BaseIT.java
+++ b/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BaseIT.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.storage.blob.integration;
+
+import java.util.Properties;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.azure.storage.blob.BlobConfiguration;
+import org.apache.camel.component.azure.storage.blob.BlobTestUtils;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BaseIT extends CamelTestSupport {
+    private static final String ACCESS_KEY = "accessKey";
+    private static final String ACCOUNT_NAME = "accountName";
+    private static final String AZURITE_IMAGE_NAME = "mcr.microsoft.com/azure-storage/azurite:3.9.0";
+    private static final int AZURITE_EXPOSED_PORT = 10000;
+    private static String accountName;
+    private static String accessKey;
+    private static String endpoint;
+
+    protected BlobServiceClient serviceClient;
+    protected BlobConfiguration configuration;
+    protected String containerName;
+
+    static {
+        // Start testcontainers as a singleton if needed
+        initEndpoint();
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.getRegistry().bind("serviceClient", serviceClient);
+        return context;
+    }
+
+    static void initEndpoint() {
+        accountName = System.getProperty(ACCOUNT_NAME);
+        accessKey = System.getProperty(ACCESS_KEY);
+        endpoint = String.format("https://%s.blob.core.windows.net", accountName);
+
+        // If everything is set, do not start Azurite
+        if (StringUtils.isNotEmpty(accountName) && StringUtils.isNotEmpty(accessKey)) {
+            return;
+        }
+
+        if ((StringUtils.isEmpty(accountName) && StringUtils.isNotEmpty(accessKey)) ||
+                (StringUtils.isNotEmpty(accountName) && StringUtils.isEmpty(accessKey))) {
+            throw new IllegalArgumentException(
+                    "Make sure to supply both azure accessKey and accountName," +
+                                               " e.g:  mvn verify -DaccountName=myacc -DaccessKey=mykey");
+        }
+
+        final GenericContainer<?> azurite = new GenericContainer<>(AZURITE_IMAGE_NAME)
+                .withExposedPorts(AZURITE_EXPOSED_PORT);
+        azurite.start();
+        Properties azuriteProperties = BlobTestUtils.getAzuriteProperties();
+        accountName = azuriteProperties.getProperty(ACCOUNT_NAME);
+        accessKey = azuriteProperties.getProperty(ACCESS_KEY);
+        endpoint = String.format("http://%s:%d/%s", azurite.getContainerIpAddress(),
+                azurite.getMappedPort(AZURITE_EXPOSED_PORT), accountName);
+    }
+
+    @BeforeAll
+    void initProperties() {
+        containerName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+
+        configuration = new BlobConfiguration();
+        configuration.setCredentials(new StorageSharedKeyCredential(accountName, accessKey));
+        configuration.setContainerName(containerName);
+
+        serviceClient = new BlobServiceClientBuilder()
+                .credential(configuration.getCredentials())
+                .endpoint(endpoint)
+                .buildClient();
+    }
+}

--- a/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobContainerOperationsITTest.java
+++ b/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobContainerOperationsITTest.java
@@ -14,47 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.azure.storage.blob.operations;
+package org.apache.camel.component.azure.storage.blob.integration;
 
 import java.util.Collections;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.PublicAccessType;
 import org.apache.camel.Exchange;
-import org.apache.camel.component.azure.storage.blob.BlobConfiguration;
 import org.apache.camel.component.azure.storage.blob.BlobConstants;
-import org.apache.camel.component.azure.storage.blob.BlobTestUtils;
-import org.apache.camel.component.azure.storage.blob.client.BlobClientFactory;
 import org.apache.camel.component.azure.storage.blob.client.BlobContainerClientWrapper;
 import org.apache.camel.component.azure.storage.blob.client.BlobServiceClientWrapper;
+import org.apache.camel.component.azure.storage.blob.operations.BlobContainerOperations;
+import org.apache.camel.component.azure.storage.blob.operations.BlobOperationResponse;
 import org.apache.camel.support.DefaultExchange;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class BlobContainerOperationsIT extends CamelTestSupport {
+class BlobContainerOperationsITTest extends BaseIT {
 
-    private BlobConfiguration configuration;
     private BlobServiceClientWrapper blobServiceClientWrapper;
 
     @BeforeAll
-    public void setup() throws Exception {
-        final Properties properties = BlobTestUtils.loadAzureAccessFromJvmEnv();
-
-        configuration = new BlobConfiguration();
-        configuration.setAccountName(properties.getProperty("account_name"));
-        configuration.setAccessKey(properties.getProperty("access_key"));
-
-        blobServiceClientWrapper = new BlobServiceClientWrapper(BlobClientFactory.createBlobServiceClient(configuration));
+    public void setup() {
+        blobServiceClientWrapper = new BlobServiceClientWrapper(serviceClient);
     }
 
     @Test

--- a/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobOperationsITTest.java
+++ b/components/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobOperationsITTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.azure.storage.blob.operations;
+package org.apache.camel.component.azure.storage.blob.integration;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.Random;
 
 import com.azure.storage.blob.models.PageList;
@@ -37,51 +36,37 @@ import com.azure.storage.blob.models.PageRange;
 import com.azure.storage.blob.specialized.BlobInputStream;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.azure.storage.blob.BlobBlock;
-import org.apache.camel.component.azure.storage.blob.BlobConfiguration;
 import org.apache.camel.component.azure.storage.blob.BlobConstants;
-import org.apache.camel.component.azure.storage.blob.BlobTestUtils;
 import org.apache.camel.component.azure.storage.blob.BlobUtils;
-import org.apache.camel.component.azure.storage.blob.client.BlobClientFactory;
 import org.apache.camel.component.azure.storage.blob.client.BlobClientWrapper;
 import org.apache.camel.component.azure.storage.blob.client.BlobContainerClientWrapper;
 import org.apache.camel.component.azure.storage.blob.client.BlobServiceClientWrapper;
+import org.apache.camel.component.azure.storage.blob.operations.BlobOperationResponse;
+import org.apache.camel.component.azure.storage.blob.operations.BlobOperations;
 import org.apache.camel.support.DefaultExchange;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class BlobOperationsIT extends CamelTestSupport {
+class BlobOperationsITTest extends BaseIT {
 
-    private BlobConfiguration configuration;
     private BlobContainerClientWrapper blobContainerClientWrapper;
 
     private String randomBlobName;
-    private String randomContainerName;
 
     @BeforeAll
     public void setup() throws Exception {
-        final Properties properties = BlobTestUtils.loadAzureAccessFromJvmEnv();
-
-        randomContainerName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
         randomBlobName = RandomStringUtils.randomAlphabetic(10);
 
-        configuration = new BlobConfiguration();
-        configuration.setAccountName(properties.getProperty("account_name"));
-        configuration.setAccessKey(properties.getProperty("access_key"));
-        configuration.setContainerName(randomContainerName);
-
-        blobContainerClientWrapper = new BlobServiceClientWrapper(BlobClientFactory.createBlobServiceClient(configuration))
+        blobContainerClientWrapper = new BlobServiceClientWrapper(serviceClient)
                 .getBlobContainerClientWrapper(configuration.getContainerName());
 
         // create test container

--- a/components/camel-azure-storage-blob/src/test/resources/azurite.properties
+++ b/components/camel-azure-storage-blob/src/test/resources/azurite.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Default Azurite properties
+accountName=devstoreaccount1
+accessKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==

--- a/docs/components/modules/ROOT/pages/azure-storage-blob-component.adoc
+++ b/docs/components/modules/ROOT/pages/azure-storage-blob-component.adoc
@@ -687,8 +687,10 @@ from("direct:start")
 
 
 === Development Notes (Important)
-When developing on this component, you will need to obtain your Azure accessKey in order to run the integration tests. In addition to the mocked unit tests
-you *will need to run the integration tests with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
+All integration tests use [Testcontainers](https://www.testcontainers.org/) and run by default.
+Obtaining of Azure accessKey and accountName is needed to be able to run all integration tests using Azure services.
+In addition to the mocked unit tests you *will need to run the integration tests
+with every change you make or even client upgrade as the Azure client can break things even on minor versions upgrade.*
 To run the integration tests, on this component directory, run the following maven command:
 ----
 mvn verify -PfullTests -DaccountName=myacc -DaccessKey=mykey


### PR DESCRIPTION
Integration tests now run by default using Azurite.
There is a bug at integration test, that was introduced recently #4480
Disabled that integration test. Created a ticket CAMEL-15747.