### PR TITLE
[CAMEL-15748] nullify mqtt client on producer and consumer stop

### DIFF
--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConsumer.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConsumer.java
@@ -126,8 +126,8 @@ public class PahoConsumer extends DefaultConsumer {
             }
             LOG.debug("Disconnecting client: {} from broker: {}", clientId, getEndpoint().getConfiguration().getBrokerUrl());
             client.disconnect();
-            client = null;
         }
+        client = null;
     }
 
     @Override

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoProducer.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoProducer.java
@@ -92,8 +92,8 @@ public class PahoProducer extends DefaultProducer {
         if (stopClient && client != null && client.isConnected()) {
             LOG.debug("Disconnecting client: {} from broker: {}", clientId, getEndpoint().getConfiguration().getBrokerUrl());
             client.disconnect();
-            client = null;
         }
+        client = null;
     }
 
 }

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoReconnectAfterFailureTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoReconnectAfterFailureTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.paho;
 
 import java.util.concurrent.CountDownLatch;

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoReconnectAfterFailureTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoReconnectAfterFailureTest.java
@@ -1,0 +1,128 @@
+package org.apache.camel.component.paho;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.broker.BrokerService;
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Route;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.spi.RouteController;
+import org.apache.camel.spi.SupervisingRouteController;
+import org.apache.camel.support.RoutePolicySupport;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.After;
+import org.junit.Test;
+
+public class PahoReconnectAfterFailureTest extends CamelTestSupport {
+
+    public static final String TESTING_ROUTE_ID = "testingRoute";
+    BrokerService broker;
+
+    int mqttPort = AvailablePortFinder.getNextAvailable();
+    CountDownLatch routeStartedLatch = new CountDownLatch(1);
+
+    @EndpointInject("mock:test")
+    MockEndpoint mock;
+
+    @Override
+    protected boolean useJmx() {
+        return false;
+    }
+
+    @Override
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+        broker = new BrokerService();
+        broker.setPersistent(false);
+        broker.addConnector("mqtt://localhost:" + mqttPort);
+        // Broker will be started later, after camel context is started,
+        // to ensure first consumer connection fails
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        // Setup supervisor to restart routes because paho consumer 
+        // is not able to recover automatically on startup
+        SupervisingRouteController supervising = context.getRouteController().supervising();
+        supervising.setBackOffDelay(500);
+        supervising.setIncludeRoutes("paho:*");
+        return context;
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        broker.stop();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                from("direct:test").to("paho:queue?lazyStartProducer=true&brokerUrl=tcp://localhost:" + mqttPort);
+                from("paho:queue?brokerUrl=tcp://localhost:" + mqttPort)
+                    .id(TESTING_ROUTE_ID)
+                    .routePolicy(new RoutePolicySupport() {
+                        @Override
+                        public void onStart(Route route) {
+                            routeStartedLatch.countDown();
+                        }
+                    })
+                    .to("mock:test");
+            }
+        };
+    }
+
+
+    @Test
+    public void startConsumerShouldReconnectMqttClientAfterFailures() throws Exception {
+        RouteController routeController = context.getRouteController();
+
+        assertNotEquals("Broker down, expecting  route not to be started", ServiceStatus.Started, routeController.getRouteStatus(TESTING_ROUTE_ID));
+
+        // Start broker and wait for supervisor to restart route
+        // consumer should now connect
+        broker.start();
+        routeStartedLatch.await(5, TimeUnit.SECONDS);
+        assertEquals("Expecting consumer connected to broker and route started", ServiceStatus.Started, routeController.getRouteStatus(TESTING_ROUTE_ID));
+
+        // Given
+        String msg = "msg";
+        mock.expectedBodiesReceived(msg);
+
+        // When
+        template.sendBody("paho:queue?lazyStartProducer=true&brokerUrl=tcp://localhost:" + mqttPort, msg);
+
+        // Then
+        mock.assertIsSatisfied();
+
+    }
+
+    @Test
+    public void startProducerShouldReconnectMqttClientAfterFailures() throws Exception {
+        String msg = "msg";
+        mock.expectedBodiesReceived(msg);
+
+        try {
+            template.sendBody("direct:test", "notSentMessage");
+            fail("Broker is down, paho producer should fail");
+        }catch (Exception e) {
+            // ignore
+        }
+
+        broker.start();
+
+        template.sendBody("direct:test", msg);
+
+        mock.assertIsSatisfied();
+    }
+}


### PR DESCRIPTION
When restarting a route with a paho consumer or using a paho producer
after a connection failure to the broker the mqtt client was not
reconnected. This patch sets consumer and producer internl mqtt  client
instance to null os stop, so that a restart will create a new instance
and connect to the broker again.

- [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
- [X] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md