### PR TITLE
Update camel-3-migration-guide.adoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -610,7 +610,7 @@ However its even easier using lambda style with `AdviceWithRouteBuilder` directl
 
 [source,java]
 ----
-AdviceWithRouteBuilder.adviceWith(context, "myRoute", a -> {
+AdviceWith.adviceWith(context, "myRoute", a -> {
   a.replaceFromWith("direct:start");
 }
 ----


### PR DESCRIPTION
`AdviceWithRouteBuilder.adviceWith` is deprecated, corrected with the replacement.