### PR TITLE
Update loadBalance-eip.adoc

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/loadBalance-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/loadBalance-eip.adoc
@@ -14,7 +14,7 @@ Camel provides the following policies out-of-the-box:
 [width="100%",cols="3,6",options="header"]
 |=======================================================================
 | Policy | Description
-| Round Robin | The exchanges are selected from in a round robin fashion. This is a well known and classic policy, which spreads the load evenly.
+| Round Robin | The exchanges are selected in a round robin fashion. This is a well known and classic policy, which spreads the load evenly.
 | Random | A random endpoint is selected for each exchange.
 | Sticky | Sticky load balancing using an Expression to calculate a correlation key to perform the sticky load balancing; rather like jsessionid in the web or JMSXGroupID in JMS.
 | Topic | Topic which sends to all destinations (rather like JMS Topics)


### PR DESCRIPTION
Corrected wording for Round Robin load balancer description (removed unnecessary 'from')