### PR TITLE
CAMEL-15718: Camel lumberjack server component not thread safe

### DIFF
--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentGlobalSSLTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentGlobalSSLTest.java
@@ -67,17 +67,19 @@ public class LumberjackComponentGlobalSSLTest extends CamelTestSupport {
 
         // We're expecting 25 messages with Maps
         MockEndpoint mock = getMockEndpoint("mock:output");
-        mock.expectedMessageCount(25);
+        mock.expectedMessageCount(60);
         mock.allMessages().body().isInstanceOf(Map.class);
 
+        List<Integer> windows = Arrays.asList(15, 10, 15, 10, 10);
+
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port, createClientSSLContextParameters());
+        List<Integer> responses = LumberjackUtil.sendMessages(port, createClientSSLContextParameters(), windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();
 
         // And we should have replied with 2 acknowledgments for each window frame
-        assertEquals(Arrays.asList(10, 15), responses);
+        assertEquals(windows, responses);
     }
 
     /**

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentSSLTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentSSLTest.java
@@ -58,17 +58,18 @@ public class LumberjackComponentSSLTest extends CamelTestSupport {
     public void shouldListenToMessagesOverSSL() throws Exception {
         // We're expecting 25 messages with Maps
         MockEndpoint mock = getMockEndpoint("mock:output");
-        mock.expectedMessageCount(25);
+        mock.expectedMessageCount(60);
         mock.allMessages().body().isInstanceOf(Map.class);
+        List<Integer> windows = Arrays.asList(15, 10, 15, 10, 10);
 
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port, createClientSSLContextParameters());
+        List<Integer> responses = LumberjackUtil.sendMessages(port, createClientSSLContextParameters(), windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();
 
         // And we should have replied with 2 acknowledgments for each window frame
-        assertEquals(Arrays.asList(10, 15), responses);
+        assertEquals(windows, responses);
     }
 
     /**

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.lumberjack;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -56,8 +57,10 @@ public class LumberjackDisconnectionTest extends CamelTestSupport {
         mock.expectedMessageCount(3);
         mock.allMessages().body().isInstanceOf(Map.class);
 
+        List<Integer> windows = Arrays.asList(15, 10);
+
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port, null);
+        List<Integer> responses = LumberjackUtil.sendMessages(port, null, windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.component.lumberjack;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -29,7 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class LumberjackComponentTest extends CamelTestSupport {
+public class LumberjackMultiThreadTest extends CamelTestSupport {
+
     private static int port;
 
     @BeforeAll
@@ -51,13 +54,20 @@ public class LumberjackComponentTest extends CamelTestSupport {
     public void shouldListenToMessages() throws Exception {
         // We're expecting 25 messages with Maps
         MockEndpoint mock = getMockEndpoint("mock:output");
-        mock.expectedMessageCount(60);
+        mock.expectedMessageCount(125);
         mock.allMessages().body().isInstanceOf(Map.class);
 
-        List<Integer> windows = Arrays.asList(15, 10, 15, 10, 10);
-
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port, null, windows);
+        List<Integer> windows = Arrays.asList(15, 10);
+
+        // create 5 threads
+        List<LumberjackThreadTest> threads = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            threads.add(new LumberjackThreadTest());
+        }
+
+        // sending messages on 5 parallel sessions
+        threads.stream().forEach(thread -> thread.start());
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();
@@ -68,7 +78,23 @@ public class LumberjackComponentTest extends CamelTestSupport {
         assertEquals("/home/qatest/collectNetwork/log/data-integration/00000000-f000-0000-1541-8da26f200001/absorption.log",
                 first.get("source"));
 
-        // And we should have replied with 2 acknowledgments for each window frame
-        assertEquals(windows, responses);
+        TimeUnit.MILLISECONDS.sleep(2000);
+
+        // And we should have replied with 2 acknowledgments for each session frame
+        threads.stream().forEach(thread -> assertEquals(windows, thread.responses));
+    }
+
+    class LumberjackThreadTest extends Thread {
+        private List<Integer> responses;
+
+        @Override
+        public void run() {
+            try {
+                this.responses = LumberjackUtil.sendMessages(port, null, Arrays.asList(15, 10));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
     }
 }

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
@@ -44,7 +44,8 @@ final class LumberjackUtil {
     private LumberjackUtil() {
     }
 
-    static List<Integer> sendMessages(int port, SSLContextParameters sslContextParameters) throws InterruptedException {
+    static List<Integer> sendMessages(int port, SSLContextParameters sslContextParameters, List<Integer> windows)
+            throws InterruptedException {
         NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup();
         try {
             // This list will hold the acknowledgment response sequence numbers
@@ -82,11 +83,8 @@ final class LumberjackUtil {
                     .handler(initializer)                         //
                     .connect("127.0.0.1", port).sync().channel(); //
 
-            // Send the 2 window frames
-            TimeUnit.MILLISECONDS.sleep(500);
-            channel.writeAndFlush(readSample("io/window10"));
-            TimeUnit.MILLISECONDS.sleep(500);
-            channel.writeAndFlush(readSample("io/window15"));
+            // send 5 frame windows, without pausing
+            windows.stream().forEach(window -> channel.writeAndFlush(readSample(String.format("io/window%s", window))));
             TimeUnit.MILLISECONDS.sleep(500);
 
             channel.close();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/io/LumberjackChannelInitializerTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/io/LumberjackChannelInitializerTest.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -45,6 +46,14 @@ public class LumberjackChannelInitializerTest {
         // It contains 2 windows with compressed messages
         writeResourceBytePerByte(channel, "window10");
         writeResourceBytePerByte(channel, "window15");
+
+        // EmbeddedChannel is no "real" Channel implementation and mainly use-able for testing and embedded ChannelHandlers
+        // since now we are executing scheduled writeAndFlush for parallel messages within a single session
+        // we need to use runPendingTasks for this type of Channel
+        // this is use case for internal camel code test only : other unit tests use production like channels and don't need
+        // adding runPendingTasks()
+        TimeUnit.MILLISECONDS.sleep(2000);
+        channel.runPendingTasks();
 
         // Then we must have 25 messages with only maps
         assertEquals(25, messages.size());


### PR DESCRIPTION
PR to resolve the problem of wrong ACKs or incomplete while processing multiple parallel windows within the same session. 
Each channel/session is thread safe in Netty. However, while using lumberjack component, one single session can process multiple windows in parallel, and that causes mess while updating session data.
My solution to that : for each Lumberjack session, a new window to process has to wait the ACK sent from the previous one, if exists. In that way, we can assure that session data are not changed by another process.     
