### PR TITLE
CAMEL-15787 NettyConfiguration.java default client socket lifetime ex…

### DIFF
--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyConfiguration.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyConfiguration.java
@@ -93,8 +93,8 @@ public class NettyConfiguration extends NettyServerBootstrapConfiguration implem
     private int producerPoolMinIdle;
     @UriParam(label = "producer,advanced", defaultValue = "100")
     private int producerPoolMaxIdle = 100;
-    @UriParam(label = "producer,advanced", defaultValue = "" + 5 * 60 * 1000L)
-    private long producerPoolMinEvictableIdle = 5 * 60 * 1000L;
+    @UriParam(label = "producer,advanced", defaultValue = "" + 365 * 24 * 60 * 60 * 1000L)
+    private long producerPoolMinEvictableIdle = 365 * 24 * 60 * 60 * 1000L;
     @UriParam(label = "producer,advanced", defaultValue = "true")
     private boolean producerPoolEnabled = true;
     @UriParam(label = "producer,advanced")


### PR DESCRIPTION
When using netty in client mode (create pool of connections) and do not send any requests, all sockets in pool recreate every 5 minutes.

It is strange  private long producerPoolMinEvictableIdle = 5 * 60 * 1000L config for apache common pool. Default value must be bigger and do not recreate all sockets every 5 minutes