### PR TITLE
CAMEL-15794: don't recreate SSL socket factory for every invocation

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/common/AbstractSslEndpointConfigurer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/common/AbstractSslEndpointConfigurer.java
@@ -27,21 +27,19 @@ import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.transport.http.HTTPConduit;
 
 public class AbstractSslEndpointConfigurer extends AbstractTLSClientParameterConfigurer {
-    protected final SSLContextParameters sslContextParameters;
-    protected final CamelContext camelContext;
+    protected final SSLSocketFactory sslSocketFactory;
 
     public AbstractSslEndpointConfigurer(SSLContextParameters sslContextParameters, CamelContext camelContext) {
-        this.sslContextParameters = sslContextParameters;
-        this.camelContext = camelContext;
+        this.sslSocketFactory = tryToGetSSLSocketFactory(sslContextParameters, camelContext);
     }
 
     protected void setupHttpConduit(HTTPConduit httpConduit) {
         TLSClientParameters tlsClientParameters = tryToGetTLSClientParametersFromConduit(httpConduit);
-        tlsClientParameters.setSSLSocketFactory(tryToGetSSLSocketFactory());
+        tlsClientParameters.setSSLSocketFactory(sslSocketFactory);
         httpConduit.setTlsClientParameters(tlsClientParameters);
     }
 
-    private SSLSocketFactory tryToGetSSLSocketFactory() {
+    private SSLSocketFactory tryToGetSSLSocketFactory(SSLContextParameters sslContextParameters, CamelContext camelContext) {
         try {
             return sslContextParameters.createSSLContext(camelContext)
                     .getSocketFactory();

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsEndpoint.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsEndpoint.java
@@ -75,6 +75,7 @@ public class CxfRsEndpoint extends DefaultEndpoint implements HeaderFilterStrate
     protected Bus bus;
 
     private final InterceptorHolder interceptorHolder = new InterceptorHolder();
+    private CxfRsConfigurer chainedConfigurer;
 
     private Map<String, String> parameters;
     private Map<String, Object> properties;
@@ -223,10 +224,7 @@ public class CxfRsEndpoint extends DefaultEndpoint implements HeaderFilterStrate
     }
 
     public CxfRsConfigurer getChainedCxfRsEndpointConfigurer() {
-        return ChainedCxfRsConfigurer
-                .create(getNullSafeCxfRsEndpointConfigurer(),
-                        SslCxfRsConfigurer.create(sslContextParameters, getCamelContext()))
-                .addChild(HostnameVerifierCxfRsConfigurer.create(hostnameVerifier));
+        return chainedConfigurer;
     }
 
     /**
@@ -761,6 +759,11 @@ public class CxfRsEndpoint extends DefaultEndpoint implements HeaderFilterStrate
                 setProvider(provider);
             }
         }
+
+        chainedConfigurer = ChainedCxfRsConfigurer
+                .create(getNullSafeCxfRsEndpointConfigurer(),
+                        SslCxfRsConfigurer.create(sslContextParameters, getCamelContext()))
+                .addChild(HostnameVerifierCxfRsConfigurer.create(hostnameVerifier));
     }
 
     @Override


### PR DESCRIPTION
Create the configured SSLSocketFactory once  and cache it in the endpoint instead of recreating it on every request.