### PR TITLE
[CAMEL-15797] Update isIncludeFolders check in AWS2S3Consumer to cover folders with charset

### DIFF
--- a/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
+++ b/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
@@ -218,7 +218,8 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
             return true;
         } else {
             // Config says to ignore folders/directories
-            return !"application/x-directory".equalsIgnoreCase(s3Object.response().contentType());
+            return !Optional.of(((GetObjectResponse) s3Object.response()).contentType()).orElse("")
+                    .toLowerCase().startsWith("application/x-directory");
         }
     }
 

--- a/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
+++ b/components/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 
 import org.apache.camel.AsyncCallback;


### PR DESCRIPTION
covers cases where the s3Object contentType is coming from s3 as "application/x-directory; charset=UTF-8"