### PR TITLE
Update typo in jsonpath language documentation

### DIFF
--- a/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
+++ b/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
@@ -183,7 +183,7 @@ And in XML DSL:
 
 This option is also available on the `@JsonPath` annotation.
 
-== Inline Simple exceptions
+== Inline Simple expressions
 
 *Since Camel 2.18*
 

--- a/docs/components/modules/languages/pages/jsonpath-language.adoc
+++ b/docs/components/modules/languages/pages/jsonpath-language.adoc
@@ -185,7 +185,7 @@ And in XML DSL:
 
 This option is also available on the `@JsonPath` annotation.
 
-== Inline Simple exceptions
+== Inline Simple expressions
 
 *Since Camel 2.18*
 

--- a/docs/components/modules/languages/pages/jsonpath-language.adoc
+++ b/docs/components/modules/languages/pages/jsonpath-language.adoc
@@ -185,7 +185,7 @@ And in XML DSL:
 
 This option is also available on the `@JsonPath` annotation.
 
-== Inline Simple expressions
+== Inline Simple exceptions
 
 *Since Camel 2.18*
 


### PR DESCRIPTION
typo error, should be expressions instead of exceptions