### PR TITLE
CAMEL-15769: add camel-jsonpath tests for new 'false' tokenizer

### DIFF
--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,18 @@ public class JsonPathSplitTest extends CamelTestSupport {
                         .split().jsonpath("$.store.book[*]")
                         .to("mock:authors")
                         .convertBodyTo(String.class);
+
+                from("direct:start-1")
+                        .split(jsonpath("text.div", String.class), "false")
+                        .to("mock:result-1");
+
+                from("direct:start-2")
+                        .split(jsonpath("text.div", String.class))
+                        .to("mock:result-2");
+
+                from("direct:start-3")
+                        .split(jsonpath("text.div", String.class), "#")
+                        .to("mock:result-3");
             }
         };
     }
@@ -64,6 +77,39 @@ public class JsonPathSplitTest extends CamelTestSupport {
         assertTrue(out.contains("\"price\": 8.95"));
         assertTrue(out.contains("\"title\": \"Sword of Honour\""));
         assertTrue(out.contains("\"price\": 12.99,"));
+    }
+
+    @Test
+    public void testJsonPathSplitDelimiterDisable() throws Exception {
+        // CAMEL-15769
+        String json = "{ \"text\": { \"div\": \"some , text\" } }";
+        MockEndpoint m = getMockEndpoint("mock:result-1");
+        m.expectedPropertyReceived("CamelSplitSize", 1);
+        m.expectedBodiesReceived("some , text");
+        template.sendBody("direct:start-1", json);
+        m.assertIsSatisfied();
+    }
+
+    @Test
+    public void testJsonPathSplitDelimiterDefault() throws Exception {
+        // CAMEL-15769
+        String json = "{ \"text\": { \"div\": \"some , text\" } }";
+        MockEndpoint m = getMockEndpoint("mock:result-2");
+        m.expectedPropertyReceived("CamelSplitSize", 2);
+        m.expectedBodiesReceived("some ", " text");
+        template.sendBody("direct:start-2", json);
+        m.assertIsSatisfied();
+    }
+
+    @Test
+    public void testJsonPathSplitDelimiter() throws Exception {
+        // CAMEL-15769
+        String json = "{ \"text\": { \"div\": \"some ,# text\" } }";
+        MockEndpoint m = getMockEndpoint("mock:result-3");
+        m.expectedPropertyReceived("CamelSplitSize", 2);
+        m.expectedBodiesReceived("some ,", " text");
+        template.sendBody("direct:start-3", json);
+        m.assertIsSatisfied();
     }
 
 }


### PR DESCRIPTION
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md

This PR addresses a request in CAMEL-15769 to add test cases within camel-jsonpath for the new 'false' split delimiter.
https://issues.apache.org/jira/browse/CAMEL-15769?focusedCommentId=17230827&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17230827

I appended test cases to an existing test file, but I'd be happy to break them out into a separate test file if that's preferred.
Thanks