### PR TITLE
camel-salesforce: Change default API version to 50.

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceEndpointConfig.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceEndpointConfig.java
@@ -41,7 +41,7 @@ import org.apache.camel.spi.UriParams;
 public class SalesforceEndpointConfig implements Cloneable {
 
     // default API version
-    public static final String DEFAULT_VERSION = "34.0";
+    public static final String DEFAULT_VERSION = "50.0";
 
     // general parameter
     public static final String API_VERSION = "apiVersion";

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_7.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_7.adoc
@@ -258,3 +258,8 @@ In this context, it wasn't having any sense to maintain the autodiscoverClient o
 
 The camel-aws2-athena has now support for autowiring the amazonAthenaClient option with AthenaClient instance coming from the registry.
 In this context, it wasn't having any sense to maintain the autodiscoverClient option, which has been now removed.
+
+=== camel-salesforce
+
+The default API version for camel-salesforce has been updated to 50.0. Older versions are still supported and can be set via the `apiVersion`
+component option.


### PR DESCRIPTION
Current default is 34, which is ancient and causes issues that either don't have a good error message, or the underlying error message from salesforce never makes it to the user.