### PR TITLE
Set FTPClient default socket timeout to avoid permanent hang during implicit TLS handshake

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
@@ -112,6 +112,10 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
             client.configure(clientConfig);
         }
 
+        if (endpoint.getSoTimeout() > 0) {
+            client.setDefaultTimeout(endpoint.getSoTimeout());
+        }
+
         if (log.isTraceEnabled()) {
             log.trace("Connecting to {} using connection timeout: {}", configuration.remoteServerInformation(),
                     client.getConnectTimeout());


### PR DESCRIPTION
Set the FTPClient default socket timeout to allow it to, in turn, set a socket timeout before starting the implicit TLS handshake which can currently hang permanently.

Related commons-net fix: https://github.com/apache/commons-net/pull/70

This solves a problem where our routes hang permanently because an FTPS provider intermittently hangs during the TLS handshake, and no socket timeout is set yet.

Let me know if this needs a Jira ticket. :) 