### PR TITLE
[CAMEL-15891]ByteArrayBodyGenerator for String body

### DIFF
--- a/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/DefaultAhcBinding.java
+++ b/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/DefaultAhcBinding.java
@@ -48,6 +48,7 @@ import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.request.body.generator.BodyGenerator;
+import org.asynchttpclient.request.body.generator.ByteArrayBodyGenerator;
 import org.asynchttpclient.request.body.generator.FileBodyGenerator;
 import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
 import org.slf4j.Logger;
@@ -169,7 +170,7 @@ public class DefaultAhcBinding implements AhcBinding {
                         ByteArrayOutputStream bos = new ByteArrayOutputStream(endpoint.getBufferSize());
                         AhcHelper.writeObjectToStream(bos, obj);
                         byte[] bytes = bos.toByteArray();
-                        body = new InputStreamBodyGenerator(new ByteArrayInputStream(bytes));
+                        body = new ByteArrayBodyGenerator(bytes);
                         IOHelper.close(bos);
                     } else if (data instanceof File || data instanceof GenericFile) {
                         // file based (could potentially also be a FTP file etc)
@@ -183,9 +184,9 @@ public class DefaultAhcBinding implements AhcBinding {
                         // do not fallback to use the default charset as it can influence the request
                         // (for example application/x-www-form-urlencoded forms being sent)
                         if (charset != null) {
-                            body = new InputStreamBodyGenerator(new ByteArrayInputStream(((String) data).getBytes(charset)));
+                            body = new ByteArrayBodyGenerator(((String) data).getBytes(charset));
                         } else {
-                            body = new InputStreamBodyGenerator(new ByteArrayInputStream(((String) data).getBytes()));
+                            body = new ByteArrayBodyGenerator(((String) data).getBytes());
                         }
                     }
                     // fallback as input stream


### PR DESCRIPTION
The issue is due to a mistake done by async-http-client team.

Commit : AsyncHttpClient/async-http-client@d47c56e#diff-5247ce5d437efdde629533d6239bf0c24358bdf0157fa204050e908c48a8c1f3

They made the ByteArrayBodyGenerator constructor package level.
Due to this change, camel had to adapt and for String type of body, they changed their implementation from ByteArrayBodyGenerator to InputStreamBodyGenerator.
In InputStreamBodyGenerator, the content length is by default set to -1.
Since, content length was less than 0, NettyRequestFactory in async-http-client was using Transfer-Encoding header instead of Content-Length header.

Solution :

Async-http-client team corrected their mistake in the following commit :
AsyncHttpClient/async-http-client@4469c30#diff-208f8952b67ba2a28d2cb2d6881485f8fc1b2b5df53a841d4a4a48b2ed8aded0

However, the change was not reverted in camel, and hence, this regression has happened.
The change needs to be reverted in camel as well. This is causing regression when we are migrating from lower camel versions to higher versions.

The change to inputStreamBodyGenerator was introduced with the following commit.
684ef57#diff-4d41a9fe212a88af9bc5cddb7e348f8031f39ceaf2263d7275fc4b6dd09e0867