### PR TITLE
[CAMEL-15899] Hazelcast consumer listeners not removed after use

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListConsumer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.list;
 
+import java.util.UUID;
+
 import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
 import org.apache.camel.Consumer;
@@ -29,12 +31,35 @@ import org.apache.camel.component.hazelcast.listener.CamelItemListener;
  */
 public class HazelcastListConsumer extends HazelcastDefaultConsumer {
 
+    private final IList<Object> queue;
+
+    private UUID listener;
+
     public HazelcastListConsumer(HazelcastInstance hazelcastInstance, Endpoint endpoint, Processor processor,
                                  String cacheName) {
         super(hazelcastInstance, endpoint, processor, cacheName);
 
-        IList<Object> queue = hazelcastInstance.getList(cacheName);
-        queue.addItemListener(new CamelItemListener(this, cacheName), true);
+        queue = hazelcastInstance.getList(cacheName);
+    }
+
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStart()
+     */
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        listener = queue.addItemListener(new CamelItemListener(this, cacheName), true);
+    }
+
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStop()
+     */
+    @Override
+    protected void doStop() throws Exception {
+        queue.removeItemListener(listener);
+
+        super.doStop();
     }
 
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapConsumer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.map;
 
+import java.util.UUID;
+
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.camel.Endpoint;
@@ -23,12 +25,36 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 import org.apache.camel.component.hazelcast.listener.CamelMapListener;
 
+
 public class HazelcastMapConsumer extends HazelcastDefaultConsumer {
+
+    private final IMap<Object, Object> cache;
+
+    private UUID listener;
 
     public HazelcastMapConsumer(HazelcastInstance hazelcastInstance, Endpoint endpoint, Processor processor, String cacheName) {
         super(hazelcastInstance, endpoint, processor, cacheName);
 
-        IMap<Object, Object> cache = hazelcastInstance.getMap(cacheName);
-        cache.addEntryListener(new CamelMapListener(this, cacheName), true);
+        cache = hazelcastInstance.getMap(cacheName);
+    }
+
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStart()
+     */
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        listener = cache.addEntryListener(new CamelMapListener(this, cacheName), true);
+    }
+
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStop()
+     */
+    @Override
+    protected void doStop() throws Exception {
+        cache.removeEntryListener(listener);
+
+        super.doStop();
     }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapConsumer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.multimap;
 
+import java.util.UUID;
+
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.multimap.MultiMap;
 import org.apache.camel.Endpoint;
@@ -25,12 +27,34 @@ import org.apache.camel.component.hazelcast.listener.CamelEntryListener;
 
 public class HazelcastMultimapConsumer extends HazelcastDefaultConsumer {
 
+    private final MultiMap<Object, Object> cache;
+
+    private UUID listener;
+
     public HazelcastMultimapConsumer(HazelcastInstance hazelcastInstance, Endpoint endpoint, Processor processor,
                                      String cacheName) {
         super(hazelcastInstance, endpoint, processor, cacheName);
 
-        MultiMap<Object, Object> cache = hazelcastInstance.getMultiMap(cacheName);
-        cache.addEntryListener(new CamelEntryListener(this, cacheName), true);
+        cache = hazelcastInstance.getMultiMap(cacheName);
     }
 
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStart()
+     */
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        listener = cache.addEntryListener(new CamelEntryListener(this, cacheName), true);
+    }
+
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStop()
+     */
+    @Override
+    protected void doStop() throws Exception {
+        cache.removeEntryListener(listener);
+
+        super.doStop();
+    }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/topic/HazelcastTopicConsumer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.hazelcast.topic;
 
+import java.util.UUID;
+
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
 import org.apache.camel.Endpoint;
@@ -23,21 +25,39 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.hazelcast.HazelcastDefaultConsumer;
 import org.apache.camel.component.hazelcast.listener.CamelMessageListener;
 
+
 /**
  *
  */
 public class HazelcastTopicConsumer extends HazelcastDefaultConsumer {
 
+    private ITopic<Object> topic;
+
+    private UUID listener;
+
     public HazelcastTopicConsumer(HazelcastInstance hazelcastInstance, Endpoint endpoint, Processor processor, String cacheName,
                                   boolean reliable) {
         super(hazelcastInstance, endpoint, processor, cacheName);
-        ITopic<Object> topic;
         if (!reliable) {
             topic = hazelcastInstance.getTopic(cacheName);
         } else {
             topic = hazelcastInstance.getReliableTopic(cacheName);
         }
-        topic.addMessageListener(new CamelMessageListener(this, cacheName));
     }
 
+    /**
+     * @see org.apache.camel.support.DefaultConsumer#doStart()
+     */
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        listener = topic.addMessageListener(new CamelMessageListener(this, cacheName));
+    }
+
+    protected void doStop() throws Exception {
+        topic.removeMessageListener(listener);
+
+        super.doStop();
+    }
 }


### PR DESCRIPTION
The following exception occurs if the camelroute with a hazel cast topic is restarted  

```
WARNUNG: Error processing exchange for hazelcast consumer on object 'null' in cache 'server.trace.event'.. Exchange[ID-1605875260724-0-338]. Caused by: [java.util.concurrent.RejectedExecutionException - null]
java.util.concurrent.RejectedExecutionException
at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:435)
at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
at org.apache.camel.processor.DelegateAsyncProcessor.process(DelegateAsyncProcessor.java:97)
at org.apache.camel.component.hazelcast.listener.CamelListener.sendExchange(CamelListener.java:48)
at org.apache.camel.component.hazelcast.listener.CamelMessageListener.onMessage(CamelMessageListener.java:34)
at com.hazelcast.topic.impl.TopicService.dispatchEvent(TopicService.java:138)
at com.hazelcast.spi.impl.eventservice.impl.LocalEventDispatcher.run(LocalEventDispatcher.java:64)
at com.hazelcast.util.executor.StripedExecutor$Worker.process(StripedExecutor.java:244)
at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:227)
```

Solution
Register listeners in doStart and remove them in doStop

As requested:
> acosentino Andrea Cosentino added a comment - 25 minutes ago
> We'll release 3.7.0 as second LTS, the other LTS is 3.4.x, so we'll need a PR on 3.4.x branch only