### PR TITLE
Fix not waiting for the compaction completeness on Pulsar tests

### DIFF
--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerReadCompactedTest.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/PulsarConsumerReadCompactedTest.java
@@ -99,7 +99,7 @@ public class PulsarConsumerReadCompactedTest extends PulsarTestSupport {
         final Topics topics = givenPulsarAdmin().topics();
 
         topics.triggerCompaction(TOPIC_URI);
-        while (!topics.compactionStatus(TOPIC_URI).status.equals(LongRunningProcessStatus.Status.RUNNING)) {
+        while (topics.compactionStatus(TOPIC_URI).status.equals(LongRunningProcessStatus.Status.RUNNING)) {
             LOGGER.info("Waiting for compaction completeness...");
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
It seems a bit hard to spot this one unless compaction is slow. In such case, it could throw a "Compaction already in progress" exception.

This change ensures it does wait for the compaction to finish.


- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md