### PR TITLE
CAMEL-15919: map java.io.File to swagger response schema type 'file'

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
@@ -36,7 +36,10 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30SchemaDefinition;
 public class RestModelConverters {
 
     public List<? extends OasSchema> readClass(OasDocument oasDocument, Class<?> clazz) {
-        if (oasDocument instanceof Oas20Document) {
+        if (clazz.equals(java.io.File.class)) {
+            // File is a special type in OAS2 / OAS3 (no model)
+            return null;
+        } else if (oasDocument instanceof Oas20Document) {
             return readClassOas20((Oas20Document) oasDocument, clazz);
         } else if (oasDocument instanceof Oas30Document) {
             return readClassOas30((Oas30Document) oasDocument, clazz);

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
@@ -1256,6 +1256,13 @@ public class RestOpenApiReader {
             } else if ("boolean".equals(typeName) || "java.lang.Boolean".equals(typeName)) {
                 prop.format = "boolean";
                 prop.type = "number";
+            } else if ("file".equals(typeName) || "java.io.File".equals(typeName)) {
+                if (openApi instanceof Oas20Document) {
+                    prop.type = "file";
+                } else if (openApi instanceof Oas30Document) {
+                    prop.type = "string";
+                    prop.format = "binary";
+                }
             } else {
                 prop.type = "string";
             }

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.apicurio.datamodels.openapi.v2.models.Oas20Info;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Info;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.engine.DefaultClassResolver;
+import org.apache.camel.model.rest.RestParamType;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RestOpenApiReaderFileResponseModelTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestOpenApiReaderFileResponseModelTest.class);
+
+    @BindToRegistry("dummy-rest")
+    private DummyRestConsumerFactory factory = new DummyRestConsumerFactory();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                rest("/hello").consumes("application/json").produces("application/octet-stream").get("/pdf/{name}").description("Saying hi").param().name("name")
+                    .type(RestParamType.path).dataType("string").description("Who is it").example("Donald Duck").endParam().responseMessage().code(200)
+                    .message("A document as reply").responseModel(java.io.File.class).endResponseMessage().to("log:hi");
+            }
+        };
+    }
+
+    @Test
+    public void testReaderRead() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        Oas20Info info = new Oas20Info();
+        config.setInfo(info);
+        config.setVersion("2.0");
+        RestOpenApiReader reader = new RestOpenApiReader();
+
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+                new DefaultClassResolver());
+        assertNotNull(openApi);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Object dump = Library.writeNode(openApi);
+        String json = mapper.writeValueAsString(dump);
+
+        LOG.info(json);
+        assertTrue(json.contains("\"type\" : \"file\""));
+
+        context.stop();
+    }
+
+    @Test
+    public void testReaderReadV3() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        Oas30Info info = new Oas30Info();
+        config.setInfo(info);
+        RestOpenApiReader reader = new RestOpenApiReader();
+
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+                new DefaultClassResolver());
+        assertNotNull(openApi);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Object dump = Library.writeNode(openApi);
+        String json = mapper.writeValueAsString(dump);
+
+        LOG.info(json);
+        assertTrue(json.contains("\"format\" : \"binary\""));
+        assertTrue(json.contains("\"type\" : \"string\""));
+
+        context.stop();
+    }
+
+}

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -53,6 +53,7 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.ByteArrayProperty;
 import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FileProperty;
 import io.swagger.models.properties.FloatProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.LongProperty;
@@ -739,6 +740,8 @@ public class RestSwaggerReader {
                 prop = new DoubleProperty();
             } else if ("boolean".equals(typeName) || "java.lang.Boolean".equals(typeName)) {
                 prop = new BooleanProperty();
+            } else if ("file".equals(typeName) || "java.io.File".equals(typeName)) {
+                prop = new FileProperty();
             } else {
                 prop = new StringProperty(typeName);
             }

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderFileResponseModelTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderFileResponseModelTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.swagger;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.Swagger;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.engine.DefaultClassResolver;
+import org.apache.camel.model.rest.RestParamType;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RestSwaggerReaderFileResponseModelTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestSwaggerReaderFileResponseModelTest.class);
+
+    @BindToRegistry("dummy-rest")
+    private DummyRestConsumerFactory factory = new DummyRestConsumerFactory();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                rest("/hello").consumes("application/json").produces("application/octet-stream").get("/pdf/{name}")
+                        .description("Saying hi").param().name("name").type(RestParamType.path)
+                        .dataType("string").description("Who is it").example("Donald Duck").endParam()
+                        .responseMessage().code(200).message("A document as reply").responseModel(java.io.File.class).endResponseMessage()
+                        .to("log:hi");
+            }
+        };
+    }
+
+    @Test
+    public void testReaderRead() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        RestSwaggerReader reader = new RestSwaggerReader();
+
+        Swagger swagger
+                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+        assertNotNull(swagger);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String json = mapper.writeValueAsString(swagger);
+
+        LOG.info(json);
+
+        assertTrue(json.contains("\"type\" : \"file\""));
+
+        context.stop();
+    }
+
+}


### PR DESCRIPTION
Fixes CAMEL-15919 by setting schema type to 'file' if responseMessage class is 'java.io.File'.