### PR TITLE
CAMEL-15917: Resilience4j Property Component doesn't work for configu…

### DIFF
--- a/components/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceReifier.java
+++ b/components/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceReifier.java
@@ -146,7 +146,7 @@ public class FaultToleranceReifier extends ProcessorReifier<CircuitBreakerDefini
         // Extract properties from referenced configuration, the one configured
         // on camel context takes the precedence over those in the registry
         if (definition.getConfigurationRef() != null) {
-            final String ref = definition.getConfigurationRef();
+            final String ref = parseString(definition.getConfigurationRef());
 
             loadProperties(properties, Suppliers.firstNotNull(
                 () -> camelContext.getExtension(Model.class).getFaultToleranceConfiguration(ref),

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceReifier.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceReifier.java
@@ -176,7 +176,7 @@ public class ResilienceReifier extends ProcessorReifier<CircuitBreakerDefinition
         // Extract properties from referenced configuration, the one configured
         // on camel context takes the precedence over those in the registry
         if (definition.getConfigurationRef() != null) {
-            final String ref = definition.getConfigurationRef();
+            final String ref = parseString(definition.getConfigurationRef());
 
             loadProperties(properties, Suppliers.firstNotNull(
                 () -> camelContext.getExtension(Model.class).getResilience4jConfiguration(ref),


### PR DESCRIPTION
[CAMEL-15917] Resilience4j Property Component doesn't work for configurationRef

Add support of property placeholder for resilience4j circuit breaker configurationRef in routes definitions.
Before  for `<circuitBreaker configurationRef="{{myName}}">`, 
`{{myName}}` property was not resolved based on configuration files.
Now it will lookup in configuration. If there is no property configured, value will be used as is.