### PR TITLE
revert CAMEL-15710

### DIFF
--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -30,6 +30,11 @@ messages that matches the pattern. The content is a Set<String> where the key is
 uses the rules from Intercept.
 |encoding |false| Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean.
 Dashes need for instances to be encoded for JMS property keys.
+|setTracingStrategy | NoopTracingStrategy | Allows a custom Camel `InterceptStrategy` to be provided in order to
+augment the default Spans with data from each processor in a route. `OpenTracingTracingStrategy` will create spans for each
+processor, except for Camel log and OpenTracing processors, and activate a Scope in order to enable third-party instrumentation
+in processors through the default ScopeManager. Processor spans can be excluded through the exludePatterns set, these
+will be matched using the processor's ID.
 
 |=======================================================================
 

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
@@ -19,8 +19,6 @@ package org.apache.camel.opentracing;
 import java.util.EnumMap;
 import java.util.Map;
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
 import io.opentracing.tag.AbstractTag;
 import io.opentracing.tag.Tags;
 import org.apache.camel.tracing.SpanAdapter;
@@ -43,19 +41,13 @@ public class OpenTracingSpanAdapter implements SpanAdapter {
     }
 
     private io.opentracing.Span span;
-    private Scope scope;
 
-    OpenTracingSpanAdapter(Span span, Scope scope) {
+    OpenTracingSpanAdapter(io.opentracing.Span span) {
         this.span = span;
-        this.scope = scope;
     }
 
     public io.opentracing.Span getOpenTracingSpan() {
         return this.span;
-    }
-
-    public Scope getOpenTracingScope() {
-        return scope;
     }
 
     @Override

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
@@ -104,8 +104,7 @@ public class OpenTracingTracer extends org.apache.camel.tracing.Tracer {
             io.opentracing.Span parentSpan = ((OpenTracingSpanAdapter) parent).getOpenTracingSpan();
             spanBuilder.asChildOf(parentSpan);
         }
-        Span span = spanBuilder.start();
-        return new OpenTracingSpanAdapter(span, tracer.scopeManager().activate(span, false));
+        return new OpenTracingSpanAdapter(spanBuilder.start());
     }
 
     @Override
@@ -131,8 +130,7 @@ public class OpenTracingTracer extends org.apache.camel.tracing.Tracer {
             }
         }
 
-        Span span = builder.start();
-        return new OpenTracingSpanAdapter(span, tracer.scopeManager().activate(span, false));
+        return new OpenTracingSpanAdapter(builder.start());
     }
 
     public Tracer getTracer() {
@@ -146,7 +144,6 @@ public class OpenTracingTracer extends org.apache.camel.tracing.Tracer {
     protected void finishSpan(SpanAdapter span) {
         OpenTracingSpanAdapter openTracingSpanWrapper = (OpenTracingSpanAdapter) span;
         openTracingSpanWrapper.getOpenTracingSpan().finish();
-        openTracingSpanWrapper.getOpenTracingScope().close();
     }
 
     protected void inject(SpanAdapter span, InjectAdapter adapter) {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracingStrategy.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracingStrategy.java
@@ -72,11 +72,11 @@ public class OpenTracingTracingStrategy implements InterceptStrategy {
                     || target instanceof GetBaggageProcessor
                     || target instanceof SetBaggageProcessor);
 
-            try (Scope scope = tracer.getTracer().scopeManager().activate(processorSpan, true)) {
-                if (activateExchange) {
-                    ActiveSpanManager.activate(exchange, new OpenTracingSpanAdapter(processorSpan, scope));
-                }
+            if (activateExchange) {
+                ActiveSpanManager.activate(exchange, new OpenTracingSpanAdapter(processorSpan));
+            }
 
+            try (Scope scope = tracer.getTracer().scopeManager().activate(processorSpan, false)) {
                 target.process(exchange);
             } catch (Exception ex) {
                 processorSpan.log(errorLogs(ex));

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ThirdPartyInstrumentationIntegrationTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ThirdPartyInstrumentationIntegrationTest.java
@@ -58,7 +58,7 @@ public class ThirdPartyInstrumentationIntegrationTest extends CamelTestSupport {
 
         OpenTracingTracer openTracingTracer = new OpenTracingTracer();
         openTracingTracer.setTracer(tracer);
-        openTracingTracer.setTracingStrategy(new NoopTracingStrategy());
+        openTracingTracer.setTracingStrategy(new OpenTracingTracingStrategy(openTracingTracer));
         openTracingTracer.init(context);
         return context;
     }
@@ -68,7 +68,7 @@ public class ThirdPartyInstrumentationIntegrationTest extends CamelTestSupport {
         template.requestBody("direct:DirectProcessor", "");
 
         List<MockSpan> actualSpans = tracer.finishedSpans();
-        assertEquals(2, actualSpans.size(), "Unexpected spans registered");
+        assertEquals(3, actualSpans.size(), "Unexpected spans registered");
 
         Set<Long> traceIds = getTraceIds(actualSpans);
         assertEquals(1, traceIds.size(), () -> "Expected all spans belonging to the same trace, but got: " + traceIds);
@@ -81,7 +81,7 @@ public class ThirdPartyInstrumentationIntegrationTest extends CamelTestSupport {
         template.requestBody("direct:DirectProcessor", "");
 
         List<MockSpan> actualSpans = tracer.finishedSpans();
-        assertEquals(4, actualSpans.size(), "Unexpected spans registered");
+        assertEquals(6, actualSpans.size(), "Unexpected spans registered");
 
         Set<Long> traceIds = getTraceIds(actualSpans);
         assertEquals(2, traceIds.size(), () -> "Expected all spans belonging to two traces, but got: " + traceIds);
@@ -92,7 +92,7 @@ public class ThirdPartyInstrumentationIntegrationTest extends CamelTestSupport {
         executeInThirdPartySpan(() -> template.requestBody("direct:DirectProcessor", ""));
 
         List<MockSpan> actualSpans = tracer.finishedSpans();
-        assertEquals(3, actualSpans.size(), "Unexpected spans registered");
+        assertEquals(4, actualSpans.size(), "Unexpected spans registered");
 
         Set<Long> traceIds = getTraceIds(actualSpans);
         assertEquals(1, traceIds.size(), "Expected all spans belonging to the same trace, but got: " + traceIds);


### PR DESCRIPTION
In order to enable extending camel-created spans in processors, PR https://github.com/apache/camel/pull/4497 introduced functionality that was already present through a configurable `InterceptStrategy` though it was undocumented (my fault).This PR takes care of reverting those changes and adds documentation, while preserving the added test in order to prove the functionality is the same.

@orange-buffalo please take a look. You'll notice that the only modification to the test is that now we have one extra span for each route execution, this is the span for the single processor in the route.

@oscerd I know you guys are preparing the 3.7 release, I'm hoping we can squeeze in this fix. 