### PR TITLE
[CAMEL-15935] Update Properties docs (Spring -> Camel bridge examples)

### DIFF
--- a/components/camel-spring/src/test/resources/org/apache/camel/component/properties/CamelSpringPropertyPlaceholderConfigurerTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/component/properties/CamelSpringPropertyPlaceholderConfigurerTest.xml
@@ -23,6 +23,7 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <!-- START SNIPPET: e1 -->
+  <!-- tag::e1[] -->
 
   <!-- bridge spring property placeholder with Camel -->
   <!-- you must NOT use the <context:property-placeholder at the same time, only this bridge bean -->
@@ -30,9 +31,11 @@
     <property name="location" value="classpath:org/apache/camel/component/properties/cheese.properties"/>
   </bean>
 
+  <!-- end::e1[] -->
   <!-- END SNIPPET: e1 -->
 
   <!-- START SNIPPET: e2 -->
+  <!-- tag::e2[] -->
 
   <!-- a bean that uses Spring property placeholder -->
   <!-- the ${hi} is a spring property placeholder -->
@@ -49,6 +52,7 @@
     </route>
   </camelContext>
 
+  <!-- end::e2[] -->
   <!-- END SNIPPET: e2 -->
 
 </beans>

--- a/core/camel-base/src/main/docs/properties-component.adoc
+++ b/core/camel-base/src/main/docs/properties-component.adoc
@@ -611,16 +611,22 @@ type.
 
 To bridge Spring and Camel you must define a single bean as shown below:
 
-*Bridging Spring and Camel property placeholders*
+[source,xml]
+----
+include::{examplesdir}/components/camel-spring/src/test/resources/org/apache/camel/components/properties/CamelSpringPropertyPlaceholderConfigurerTest.xml[tags=e1]
+----
 
-You *must not* use the spring <context:property-placeholder> namespace
+You *must not* use the spring `<context:property-placeholder>` namespace
 at the same time; this is not possible.
 
 After declaring this bean, you can define property placeholders using
-both the Spring style, and the Camel style within the <camelContext> tag
+both the Spring style, and the Camel style within the `<camelContext>` tag
 as shown below:
 
-*Using bridge property placeholders*
+[source,xml]
+----
+include::{examplesdir}/components/camel-spring/src/test/resources/org/apache/camel/components/properties/CamelSpringPropertyPlaceholderConfigurerTest.xml[tags=e2]
+----
 
 Notice how the hello bean is using pure Spring property placeholders
 using the `${ }` notation. And in the Camel routes we use the Camel


### PR DESCRIPTION
Re-adds missing bean configuration examples for spring to camel properties bridge.


I did not run `mvn clean install -Psourcecheck` as it fails on OSX with
```
[ERROR] Unrecognized VM option 'ExitOnOutOfMemoryError'
[ERROR] Did you mean 'OnOutOfMemoryError=<value>'?
[ERROR] Error: Could not create the Java Virtual Machine.
[ERROR] Error: A fatal exception has occurred. Program will exit.
``` 

The [working example page](https://camel.apache.org/manual/latest/using-propertyplaceholder.html#UsingPropertyPlaceholder-BridgingSpringandCamelPropertyPlaceholders-1) actually embeds the snippet, which seems like more prone to becoming out of date. 

But I did not verify that the tags work in XML on the website as building the camel website fails on OSX.
```
➤ YN0000: [17:18:49] Starting 'build'...
➤ YN0000: [17:18:50] 'build' errored after 682 ms
➤ YN0000: [17:18:50] Error in plugin "gulp-imagemin"
➤ YN0000: Message:
➤ YN0000:     Command failed: /Users/whikloj/www/camel-website/antora-ui-camel/.yarn/unplugged/optipng-bin-npm-6.0.0-3aa5f04a3e/node_modules/optipng-bin/vendor/optipng -strip all -clobber -o 3 -out /private/var/folders/w3/9tw0brpn0xg9gr2q6ct9zty80000gp/T/74954000-fa6d-4b0f-b943-f26a9fd5efe4 -fix /private/var/folders/w3/9tw0brpn0xg9gr2q6ct9zty80000gp/T/c636ec0d-dc33-4dd1-aa58-21fdf1c86b1e
➤ YN0000: /Users/whikloj/www/camel-website/antora-ui-camel/.yarn/unplugged/optipng-bin-npm-6.0.0-3aa5f04a3e/node_modules/optipng-bin/vendor/optipng: /Users/whikloj/www/camel-website/antora-ui-camel/.yarn/unplugged/optipng-bin-npm-6.0.0-3aa5f04a3e/node_modules/optipng-bin/vendor/optipng: cannot execute binary file
```