### PR TITLE
Fix SimpleMain oversight on doStop method (master)

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/SimpleMain.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/SimpleMain.java
@@ -53,7 +53,7 @@ public class SimpleMain extends BaseMainSupport {
             listener.beforeStop(this);
         }
 
-        super.doStart();
+        super.doStop();
 
         getCamelContext().stop();
 


### PR DESCRIPTION
SimpleMain is used in CamelKafkaConnector and this oversight could cause problems in case we decide to implement doStop or doStart in BaseMainSupport.