### PR TITLE
Avoid NPE on missing event update datetime [google-calendar-stream]

### DIFF
--- a/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumer.java
+++ b/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumer.java
@@ -88,7 +88,10 @@ public class GoogleCalendarStreamConsumer extends ScheduledBatchPollingConsumer 
             for (Event event : list) {
                 Exchange exchange = getEndpoint().createExchange(getEndpoint().getExchangePattern(), event);
                 answer.add(exchange);
-                dateList.add(new Date(event.getUpdated().getValue()));
+                DateTime updated = event.getUpdated();
+                if (updated != null) {
+                    dateList.add(new Date(updated.getValue()));
+                }
             }
         }
 


### PR DESCRIPTION
Added a simple null check to prevent `NullPointerException` in case event update datetime is missing. 
```
[2020-12-09 11:14:19,110] WARN Consumer Consumer[google-calendar-stream://gcalstream?accessToken=xxxxxx] failed polling endpoint: google-calendar-stream://gcalstream?accessToken=xxxxxx. Will try again at next poll. Caused by: [java.lang.NullPointerException - null] (org.apache.camel.component.google.calendar.stream.GoogleCalendarStreamConsumer)
java.lang.NullPointerException
	at org.apache.camel.component.google.calendar.stream.GoogleCalendarStreamConsumer.poll(GoogleCalendarStreamConsumer.java:91)
	at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:190)
	at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:107)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```