### PR TITLE
Backport: avoid NPE on missing event update datetime

### DIFF
--- a/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumer.java
+++ b/components/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumer.java
@@ -88,7 +88,10 @@ public class GoogleCalendarStreamConsumer extends ScheduledBatchPollingConsumer 
             for (Event event : list) {
                 Exchange exchange = getEndpoint().createExchange(getEndpoint().getExchangePattern(), event);
                 answer.add(exchange);
-                dateList.add(new Date(event.getUpdated().getValue()));
+                DateTime updated = event.getUpdated();
+                if (updated != null) {
+                    dateList.add(new Date(updated.getValue()));
+                }
             }
         }
 


### PR DESCRIPTION
Backported #4780 to 3.7.x