### PR TITLE
CAMEL-15928: TimeoutException does not trigger Resilience4j circuit breaker

### DIFF
--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
@@ -353,30 +353,60 @@ public class ResilienceProcessor extends AsyncProcessorSupport implements CamelC
         // Camel error handler
         exchange.setProperty(Exchange.TRY_ROUTE_BLOCK, true);
 
-        Callable<Exchange> task = CircuitBreaker.decorateCallable(circuitBreaker, new CircuitBreakerTask(processor, exchange));
-        Function<Throwable, Exchange> fallbackTask = new CircuitBreakerFallbackTask(fallback, exchange);
+        Callable<Exchange> task;
+
+        if (timeLimiterConfig != null) {
+            // timeout handling is more complex with thread-pools
+
+            TimeLimiter tl = TimeLimiter.of(id, timeLimiterConfig);
+            Supplier<CompletableFuture<Exchange>> futureSupplier;
+            if (executorService == null) {
+                futureSupplier = () -> CompletableFuture.supplyAsync(() -> processInCopy(exchange));
+            } else {
+                futureSupplier = () -> CompletableFuture.supplyAsync(() -> processInCopy(exchange), executorService);
+            }
+            task = TimeLimiter.decorateFutureSupplier (tl, futureSupplier);
+        } else {
+            task = new CircuitBreakerTask(() -> processInCopy(exchange));
+        }
+
         if (bulkheadConfig != null) {
             Bulkhead bh = Bulkhead.of(id, bulkheadConfig);
             task = Bulkhead.decorateCallable(bh, task);
         }
 
-        if (timeLimiterConfig != null) {
-            // timeout handling is more complex with thread-pools
-            final CircuitBreakerTimeoutTask timeoutTask = new CircuitBreakerTimeoutTask(task, exchange);
-            Supplier<CompletableFuture<Exchange>> futureSupplier;
-            if (executorService == null) {
-                futureSupplier = () -> CompletableFuture.supplyAsync(timeoutTask::get);
-            } else {
-                futureSupplier = () -> CompletableFuture.supplyAsync(timeoutTask::get, executorService);
-            }
+        task = CircuitBreaker.decorateCallable(circuitBreaker, task);
 
-            TimeLimiter tl = TimeLimiter.of(id, timeLimiterConfig);
-            task = TimeLimiter.decorateFutureSupplier(tl, futureSupplier);
-        }
-
+        Function<Throwable, Exchange> fallbackTask = new CircuitBreakerFallbackTask(this.fallback, exchange);
         Try.ofCallable(task).recover(fallbackTask).andFinally(() -> callback.done(false)).get();
-
         return false;
+    }
+
+    private Exchange processInCopy(Exchange exchange) {
+        try {
+            LOG.debug("Running processor: {} with exchange: {}", processor, exchange);
+            // prepare a copy of exchange so downstream processors don't
+            // cause side-effects if they mutate the exchange
+            // in case timeout processing and continue with the fallback etc
+            Exchange copy = ExchangeHelper.createCorrelatedCopy(exchange, false, false);
+            // process the processor until its fully done
+            processor.process(copy);
+            if (copy.getException() != null) {
+                exchange.setException(copy.getException());
+            } else {
+                // copy the result as its regarded as success
+                ExchangeHelper.copyResults(exchange, copy);
+                exchange.setProperty(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
+                exchange.setProperty(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
+            }
+        } catch (Throwable e) {
+            exchange.setException(e);
+        }
+        if (exchange.getException() != null) {
+            // throw exception so resilient4j know it was a failure
+            throw RuntimeExchangeException.wrapRuntimeException(exchange.getException());
+        }
+        return exchange;
     }
 
     @Override
@@ -396,40 +426,15 @@ public class ResilienceProcessor extends AsyncProcessorSupport implements CamelC
 
     private static final class CircuitBreakerTask implements Callable<Exchange> {
 
-        private final Processor processor;
-        private final Exchange exchange;
+        Supplier<Exchange> supplier;
 
-        private CircuitBreakerTask(Processor processor, Exchange exchange) {
-            this.processor = processor;
-            this.exchange = exchange;
+        public CircuitBreakerTask(Supplier<Exchange> supplier) {
+            this.supplier = supplier;
         }
 
         @Override
         public Exchange call() throws Exception {
-            try {
-                LOG.debug("Running processor: {} with exchange: {}", processor, exchange);
-                // prepare a copy of exchange so downstream processors don't
-                // cause side-effects if they mutate the exchange
-                // in case timeout processing and continue with the fallback etc
-                Exchange copy = ExchangeHelper.createCorrelatedCopy(exchange, false, false);
-                // process the processor until its fully done
-                processor.process(copy);
-                if (copy.getException() != null) {
-                    exchange.setException(copy.getException());
-                } else {
-                    // copy the result as its regarded as success
-                    ExchangeHelper.copyResults(exchange, copy);
-                    exchange.setProperty(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
-                    exchange.setProperty(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
-                }
-            } catch (Throwable e) {
-                exchange.setException(e);
-            }
-            if (exchange.getException() != null) {
-                // throw exception so resilient4j know it was a failure
-                throw RuntimeExchangeException.wrapRuntimeException(exchange.getException());
-            }
-            return exchange;
+            return supplier.get();
         }
     }
 
@@ -461,7 +466,7 @@ public class ResilienceProcessor extends AsyncProcessorSupport implements CamelC
                     exchange.setProperty(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
                     exchange.setProperty(CircuitBreakerConstants.RESPONSE_SHORT_CIRCUITED, true);
                     exchange.setProperty(CircuitBreakerConstants.RESPONSE_REJECTED, true);
-                    return exchange;
+                    throw RuntimeExchangeException.wrapRuntimeException(throwable);
                 } else {
                     // throw exception so resilient4j know it was a failure
                     throw RuntimeExchangeException.wrapRuntimeException(throwable);
@@ -498,26 +503,4 @@ public class ResilienceProcessor extends AsyncProcessorSupport implements CamelC
             return exchange;
         }
     }
-
-    private static final class CircuitBreakerTimeoutTask implements Supplier<Exchange> {
-
-        private final Callable<Exchange> future;
-        private final Exchange exchange;
-
-        private CircuitBreakerTimeoutTask(Callable<Exchange> future, Exchange exchange) {
-            this.future = future;
-            this.exchange = exchange;
-        }
-
-        @Override
-        public Exchange get() {
-            try {
-                return future.call();
-            } catch (Exception e) {
-                exchange.setException(e);
-            }
-            return exchange;
-        }
-    }
-
 }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceExistingCircuitBreakerTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceExistingCircuitBreakerTest.java
@@ -32,11 +32,20 @@ public class ResilienceExistingCircuitBreakerTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws InterruptedException {
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
 
@@ -54,6 +63,10 @@ public class ResilienceExistingCircuitBreakerTest extends CamelTestSupport {
             public void configure() throws Exception {
                 from("direct:start").to("log:start").circuitBreaker().resilience4jConfiguration().circuitBreakerRef("myCircuitBreaker").end()
                     .throwException(new IllegalArgumentException("Forced")).onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration().circuitBreakerRef("myCircuitBreaker")
+                        .timeoutEnabled(true).timeoutDuration(2000).end()
+                        .throwException(new IllegalArgumentException("Forced")).onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
             }
         };
     }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceInheritErrorHandlerTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceInheritErrorHandlerTest.java
@@ -24,11 +24,20 @@ public class ResilienceInheritErrorHandlerTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws InterruptedException {
         getMockEndpoint("mock:a").expectedMessageCount(3 + 1);
         getMockEndpoint("mock:dead").expectedMessageCount(1);
         getMockEndpoint("mock:result").expectedMessageCount(0);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -44,6 +53,13 @@ public class ResilienceInheritErrorHandlerTest extends CamelTestSupport {
                     // turn on Camel's error handler on hystrix so it can do
                     // redeliveries
                     .circuitBreaker().inheritErrorHandler(true).to("mock:a").throwException(new IllegalArgumentException("Forced")).end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:start.with.timeout.enabled")
+                        // turn on Camel's error handler on hystrix so it can do
+                        // redeliveries
+                        .circuitBreaker().inheritErrorHandler(true).resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("mock:a").throwException(new IllegalArgumentException("Forced")).end().to("log:result").to("mock:result");
+
             }
         };
     }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteOkTest.java
@@ -47,13 +47,22 @@ public class ResilienceRouteOkTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         assertEquals(0, bi.getInvokedCounter());
 
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
 
@@ -66,6 +75,8 @@ public class ResilienceRouteOkTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").circuitBreaker().to("direct:foo").to("log:foo").onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end().to("direct:foo").to("log:foo").onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
 
                 from("direct:foo").transform().constant("Bye World");
             }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteRejectedTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteRejectedTest.java
@@ -36,6 +36,15 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start", "myResilience");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled", "myResilienceWithTimeout");
+    }
+
+    private void test(String endPointUri, String circuitBreakerName) throws Exception {
         // look inside jmx
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
@@ -43,7 +52,7 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
         // context name
         String name = context.getManagementName();
 
-        ObjectName on = ObjectName.getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"myResilience\"");
+        ObjectName on = ObjectName.getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"" + circuitBreakerName + "\"");
 
         // force it into open state
         mbeanServer.invoke(on, "transitionToForcedOpenState", null, null);
@@ -53,7 +62,7 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
         // send message which should get rejected, so the message is not changed
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -64,6 +73,8 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").circuitBreaker().id("myResilience").to("direct:foo").to("log:foo").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end().id("myResilienceWithTimeout").to("direct:foo").to("log:foo").end().to("log:result").to("mock:result");
 
                 from("direct:foo").transform().constant("Bye World");
             }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.java
@@ -33,11 +33,21 @@ public class SpringResilienceRouteFallbackTest extends CamelSpringTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
+        // look inside jmx
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.java
@@ -33,11 +33,20 @@ public class SpringResilienceRouteOkTest extends CamelSpringTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.xml
+++ b/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.xml
@@ -37,6 +37,23 @@
       <to uri="mock:result"/>
     </route>
 
+    <route>
+      <from uri="direct:start.with.timeout.enabled"/>
+      <circuitBreaker>
+        <resilience4jConfiguration>
+          <timeoutEnabled>true</timeoutEnabled>
+          <timeoutDuration>2000</timeoutDuration>
+        </resilience4jConfiguration>
+        <throwException exceptionType="java.lang.IllegalArgumentException" message="Forced"/>
+        <onFallback>
+          <transform>
+            <constant>Fallback message</constant>
+          </transform>
+        </onFallback>
+      </circuitBreaker>
+      <to uri="mock:result"/>
+    </route>
+
   </camelContext>
 
 </beans>

--- a/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.xml
+++ b/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.xml
@@ -38,6 +38,23 @@
     </route>
 
     <route>
+      <from uri="direct:start.with.timeout.enabled"/>
+      <circuitBreaker>
+        <resilience4jConfiguration>
+          <timeoutEnabled>true</timeoutEnabled>
+          <timeoutDuration>2000</timeoutDuration>
+        </resilience4jConfiguration>
+        <to uri="direct:foo"/>
+        <onFallback>
+          <transform>
+            <constant>Fallback message</constant>
+          </transform>
+        </onFallback>
+      </circuitBreaker>
+      <to uri="mock:result"/>
+    </route>
+    
+    <route>
       <from uri="direct:foo"/>
       <transform>
         <constant>Bye World</constant>


### PR DESCRIPTION
Fix not invoking fallback for resilience4j circuit breaker and not triggering circuit breaker for timeout exceptions
Detailed explanation of fix and test cases can be found in ticket itself - https://issues.apache.org/jira/browse/CAMEL-15928
You can start reading from - https://issues.apache.org/jira/browse/CAMEL-15928?focusedCommentId=17251773&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17251773