### PR TITLE
CAMEL-15928: TimeoutException does not trigger Resilience4j circuit

### DIFF
--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceExistingCircuitBreakerTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceExistingCircuitBreakerTest.java
@@ -35,11 +35,20 @@ public class ResilienceExistingCircuitBreakerTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws InterruptedException {
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
 
@@ -57,6 +66,11 @@ public class ResilienceExistingCircuitBreakerTest extends CamelTestSupport {
             public void configure() throws Exception {
                 from("direct:start").to("log:start").circuitBreaker().resilience4jConfiguration()
                         .circuitBreakerRef("myCircuitBreaker").end()
+                        .throwException(new IllegalArgumentException("Forced")).onFallback().transform()
+                        .constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration()
+                        .circuitBreakerRef("myCircuitBreaker").timeoutEnabled(true).timeoutDuration(2000).end()
                         .throwException(new IllegalArgumentException("Forced")).onFallback().transform()
                         .constant("Fallback message").end().to("log:result").to("mock:result");
             }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceInheritErrorHandlerTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceInheritErrorHandlerTest.java
@@ -24,11 +24,20 @@ public class ResilienceInheritErrorHandlerTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws InterruptedException {
         getMockEndpoint("mock:a").expectedMessageCount(3 + 1);
         getMockEndpoint("mock:dead").expectedMessageCount(1);
         getMockEndpoint("mock:result").expectedMessageCount(0);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -44,6 +53,13 @@ public class ResilienceInheritErrorHandlerTest extends CamelTestSupport {
                         // turn on Camel's error handler on hystrix so it can do
                         // redeliveries
                         .circuitBreaker().inheritErrorHandler(true).to("mock:a")
+                        .throwException(new IllegalArgumentException("Forced")).end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:direct:start.with.timeout.enabled")
+                        // turn on Camel's error handler on hystrix so it can do
+                        // redeliveries
+                        .circuitBreaker().inheritErrorHandler(true).resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("mock:a")
                         .throwException(new IllegalArgumentException("Forced")).end().to("log:result").to("mock:result");
             }
         };

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceManagementTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceManagementTest.java
@@ -38,9 +38,18 @@ public class ResilienceManagementTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("start", "myResilience");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("start.with.timeout.enabled", "myResilienceWithTimeout");
+    }
+
+    public void test(String routId, String circuitBreakerName) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody("direct:" + routId, "Hello World");
 
         assertMockEndpointsSatisfied();
 
@@ -52,11 +61,12 @@ public class ResilienceManagementTest extends CamelTestSupport {
         String name = context.getManagementName();
 
         // get the object name for the delayer
-        ObjectName on = ObjectName.getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"myResilience\"");
+        ObjectName on = ObjectName
+                .getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"" + circuitBreakerName + "\"");
 
         // should be on start
         String routeId = (String) mbeanServer.getAttribute(on, "RouteId");
-        assertEquals("start", routeId);
+        assertEquals(routId, routeId);
 
         Integer num = (Integer) mbeanServer.getAttribute(on, "CircuitBreakerMinimumNumberOfCalls");
         assertEquals("100", num.toString());
@@ -81,6 +91,12 @@ public class ResilienceManagementTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").routeId("start").circuitBreaker().id("myResilience").to("direct:foo").onFallback()
+                        .transform().constant("Fallback message").end()
+                        .to("mock:result");
+
+                from("direct:start.with.timeout.enabled").routeId("start.with.timeout.enabled").circuitBreaker().id("myResilienceWithTimeout")
+                        .resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("direct:foo").onFallback()
                         .transform().constant("Fallback message").end()
                         .to("mock:result");
 

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteBulkheadFallbackTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteBulkheadFallbackTest.java
@@ -25,11 +25,20 @@ public class ResilienceRouteBulkheadFallbackTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -40,6 +49,11 @@ public class ResilienceRouteBulkheadFallbackTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").to("log:start").circuitBreaker().resilience4jConfiguration().bulkheadEnabled(true).end()
+                        .throwException(new IllegalArgumentException("Forced"))
+                        .onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration().bulkheadEnabled(true)
+                        .timeoutEnabled(true).timeoutDuration(2000).end()
                         .throwException(new IllegalArgumentException("Forced"))
                         .onFallback().transform().constant("Fallback message").end().to("log:result").to("mock:result");
             }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteBulkheadOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteBulkheadOkTest.java
@@ -25,11 +25,20 @@ public class ResilienceRouteBulkheadOkTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -40,6 +49,11 @@ public class ResilienceRouteBulkheadOkTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").circuitBreaker().resilience4jConfiguration().bulkheadEnabled(true).end().to("direct:foo")
+                        .to("log:foo").onFallback().transform()
+                        .constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration().bulkheadEnabled(true).timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("direct:foo")
                         .to("log:foo").onFallback().transform()
                         .constant("Fallback message").end().to("log:result").to("mock:result");
 

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteFallbackTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteFallbackTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.resilience4j;
 
+import java.util.concurrent.TimeoutException;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.CircuitBreakerConstants;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -25,11 +27,20 @@ public class ResilienceRouteFallbackTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -40,6 +51,12 @@ public class ResilienceRouteFallbackTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").to("log:start").circuitBreaker().throwException(new IllegalArgumentException("Forced"))
+                        .onFallback().transform().constant("Fallback message")
+                        .end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").to("log:start.with.timeout.enabled").circuitBreaker()
+                        .resilience4jConfiguration().timeoutEnabled(true).timeoutDuration(2000).end()
+                        .throwException(new TimeoutException("Forced"))
                         .onFallback().transform().constant("Fallback message")
                         .end().to("log:result").to("mock:result");
             }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteOkTest.java
@@ -49,13 +49,22 @@ public class ResilienceRouteOkTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         assertEquals(0, bi.getInvokedCounter());
 
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
 
@@ -68,6 +77,11 @@ public class ResilienceRouteOkTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").circuitBreaker().to("direct:foo").to("log:foo").onFallback().transform()
+                        .constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration()
+                        .timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("direct:foo").to("log:foo").onFallback().transform()
                         .constant("Fallback message").end().to("log:result").to("mock:result");
 
                 from("direct:foo").transform().constant("Bye World");

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteRejectedTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceRouteRejectedTest.java
@@ -38,6 +38,15 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start", "myResilience");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled", "myResilienceWithTimeout");
+    }
+
+    private void test(String endPointUri, String circuitBreakerName) throws Exception {
         // look inside jmx
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
@@ -45,7 +54,8 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
         // context name
         String name = context.getManagementName();
 
-        ObjectName on = ObjectName.getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"myResilience\"");
+        ObjectName on = ObjectName
+                .getInstance("org.apache.camel:context=" + name + ",type=processors,name=\"" + circuitBreakerName + "\"");
 
         // force it into open state
         mbeanServer.invoke(on, "transitionToForcedOpenState", null, null);
@@ -55,7 +65,7 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
         // send message which should get rejected, so the message is not changed
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }
@@ -66,6 +76,11 @@ public class ResilienceRouteRejectedTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start").circuitBreaker().id("myResilience").to("direct:foo").to("log:foo").end().to("log:result")
+                        .to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration()
+                        .timeoutEnabled(true).timeoutDuration(2000).end()
+                        .id("myResilienceWithTimeout").to("direct:foo").to("log:foo").end().to("log:result")
                         .to("mock:result");
 
                 from("direct:foo").transform().constant("Bye World");

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.java
@@ -34,11 +34,20 @@ public class SpringResilienceRouteFallbackTest extends CamelSpringTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Fallback message");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, false);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, true);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.java
@@ -33,11 +33,20 @@ public class SpringResilienceRouteOkTest extends CamelSpringTestSupport {
 
     @Test
     public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
         getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
 
-        template.sendBody("direct:start", "Hello World");
+        template.sendBody(endPointUri, "Hello World");
 
         assertMockEndpointsSatisfied();
     }

--- a/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.xml
+++ b/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteFallbackTest.xml
@@ -37,6 +37,23 @@
       <to uri="mock:result"/>
     </route>
 
+    <route>
+      <from uri="direct:start.with.timeout.enabled"/>
+      <circuitBreaker>
+        <resilience4jConfiguration>
+          <timeoutEnabled>true</timeoutEnabled>
+          <timeoutDuration>2000</timeoutDuration>
+        </resilience4jConfiguration>
+        <throwException exceptionType="java.lang.IllegalArgumentException" message="Forced"/>
+        <onFallback>
+          <transform>
+            <constant>Fallback message</constant>
+          </transform>
+        </onFallback>
+      </circuitBreaker>
+      <to uri="mock:result"/>
+    </route>
+
   </camelContext>
 
 </beans>

--- a/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.xml
+++ b/components/camel-resilience4j/src/test/resources/org/apache/camel/component/resilience4j/SpringResilienceRouteOkTest.xml
@@ -38,6 +38,23 @@
     </route>
 
     <route>
+      <from uri="direct:start.with.timeout.enabled"/>
+      <circuitBreaker>
+        <resilience4jConfiguration>
+          <timeoutEnabled>true</timeoutEnabled>
+          <timeoutDuration>2000</timeoutDuration>
+        </resilience4jConfiguration>
+        <to uri="direct:foo"/>
+        <onFallback>
+          <transform>
+            <constant>Fallback message</constant>
+          </transform>
+        </onFallback>
+      </circuitBreaker>
+      <to uri="mock:result"/>
+    </route>
+
+    <route>
       <from uri="direct:foo"/>
       <transform>
         <constant>Bye World</constant>


### PR DESCRIPTION
Fix not invoking fallback for resilience4j circuit breaker and not triggering circuit breaker for timeout exceptions
Detailed explanation of fix and test cases can be found in ticket itself - https://issues.apache.org/jira/browse/CAMEL-15928
You can start reading from - https://issues.apache.org/jira/browse/CAMEL-15928?focusedCommentId=17251773&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17251773