### PR TITLE
[CAMEL-15983] Fixes bug in camel-util URISupport

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -671,6 +671,7 @@ public final class URISupport {
                             sort = true;
                             break;
                         }
+                        prev = key;
                     }
                 }
                 if (sort) {


### PR DESCRIPTION
[JIRA issue]https://issues.apache.org/jira/browse/CAMEL-15983

Did not set prev with key after compareTo, and prev value is always the first item of parameter.keySet(), if keyset like this: a, c, b, and the value of sort after for loop is false, but its shoud be true.