### PR TITLE
CAMEL-14138: camel-salesforce: Deprecate synchronous processing

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceEndpoint.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceEndpoint.java
@@ -72,7 +72,14 @@ public class SalesforceEndpoint extends DefaultEndpoint {
             throw new IllegalArgumentException(String.format("Invalid Operation %s", topicName));
         }
 
-        return new SalesforceProducer(this);
+        SalesforceProducer producer = new SalesforceProducer(this);
+        if (isSynchronous()) {
+            LOG.warn("Synchronous processing for the Salesforce Component is deprecated and will " +
+                    "be removed in the next LTS release.");
+            return new SynchronousDelegateProducer(producer);
+        } else {
+            return producer;
+        }
     }
 
     @Override


### PR DESCRIPTION
This logs a deprecation warning at the WARN level. Not sure if there's a better way to deprecate the `synchronous` option for the salesforce component since it's defined in DefaultEndpoint.