### PR TITLE
CAMEL-16018: HazelcastReplicatedConsumer not receiving events

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastComponentHelper.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastComponentHelper.java
@@ -41,8 +41,8 @@ public final class HazelcastComponentHelper {
         }
 
         // propagate headers if OUT message created
-        if (ex.hasOut()) {
-            ex.getOut().setHeaders(headers);
+        if (ex.getMessage() != null) {
+            ex.getMessage().setHeaders(headers);
         }
     }
 

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/atomicnumber/HazelcastAtomicnumberProducer.java
@@ -92,15 +92,15 @@ public class HazelcastAtomicnumberProducer extends HazelcastDefaultProducer {
     }
 
     private void get(Exchange exchange) {
-        exchange.getOut().setBody(this.atomicnumber.get());
+        exchange.getMessage().setBody(this.atomicnumber.get());
     }
 
     private void increment(Exchange exchange) {
-        exchange.getOut().setBody(this.atomicnumber.incrementAndGet());
+        exchange.getMessage().setBody(this.atomicnumber.incrementAndGet());
     }
 
     private void decrement(Exchange exchange) {
-        exchange.getOut().setBody(this.atomicnumber.decrementAndGet());
+        exchange.getMessage().setBody(this.atomicnumber.decrementAndGet());
     }
 
     private void compare(long expected, Exchange exchange) {
@@ -108,12 +108,12 @@ public class HazelcastAtomicnumberProducer extends HazelcastDefaultProducer {
         if (ObjectHelper.isEmpty(expected)) {
             throw new IllegalArgumentException("Expected value must be specified");
         }
-        exchange.getOut().setBody(this.atomicnumber.compareAndSet(expected, update));
+        exchange.getMessage().setBody(this.atomicnumber.compareAndSet(expected, update));
     }
 
     private void getAndAdd(Exchange exchange) {
         long delta = exchange.getIn().getBody(Long.class);
-        exchange.getOut().setBody(this.atomicnumber.getAndAdd(delta));
+        exchange.getMessage().setBody(this.atomicnumber.getAndAdd(delta));
     }
 
     private void set(Exchange exchange) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/list/HazelcastListProducer.java
@@ -114,7 +114,7 @@ public class HazelcastListProducer extends HazelcastDefaultProducer {
     }
 
     private void get(Integer pos, Exchange exchange) {
-        exchange.getOut().setBody(this.list.get(pos));
+        exchange.getMessage().setBody(this.list.get(pos));
     }
 
     private void set(Integer pos, Exchange exchange) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/map/HazelcastMapProducer.java
@@ -128,7 +128,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
                 break;
 
             case CLEAR:
-                this.clear(exchange);
+                this.clear();
                 break;
 
             case EVICT:
@@ -159,7 +159,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
         } else {
             result = this.cache.values();
         }
-        exchange.getOut().setBody(result);
+        exchange.getMessage().setBody(result);
     }
 
     /**
@@ -193,14 +193,14 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
      * find an object by the given id and give it back
      */
     private void get(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.get(oid));
+        exchange.getMessage().setBody(this.cache.get(oid));
     }
 
     /**
      * GET All objects and give it back
      */
     private void getAll(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.getAll((Set<Object>) oid));
+        exchange.getMessage().setBody(this.cache.getAll((Set<Object>) oid));
     }
 
     /**
@@ -239,7 +239,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
     /**
      * Clear all the entries
      */
-    private void clear(Exchange exchange) {
+    private void clear() {
         this.cache.clear();
     }
 
@@ -261,7 +261,7 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
      * Check for a specific key in the cache and return true if it exists or false otherwise
      */
     private void containsKey(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.containsKey(oid));
+        exchange.getMessage().setBody(this.cache.containsKey(oid));
     }
 
     /**
@@ -269,13 +269,13 @@ public class HazelcastMapProducer extends HazelcastDefaultProducer {
      */
     private void containsValue(Exchange exchange) {
         Object body = exchange.getIn().getBody();
-        exchange.getOut().setBody(this.cache.containsValue(body));
+        exchange.getMessage().setBody(this.cache.containsValue(body));
     }
 
     /**
      * GET keys set of objects and give it back
      */
     private void getKeys(Exchange exchange) {
-        exchange.getOut().setBody(this.cache.keySet());
+        exchange.getMessage().setBody(this.cache.keySet());
     }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/multimap/HazelcastMultimapProducer.java
@@ -99,7 +99,7 @@ public class HazelcastMultimapProducer extends HazelcastDefaultProducer {
     }
 
     private void get(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.get(oid));
+        exchange.getMessage().setBody(this.cache.get(oid));
     }
 
     private void delete(Object oid) {
@@ -111,7 +111,7 @@ public class HazelcastMultimapProducer extends HazelcastDefaultProducer {
     }
 
     private void valuecount(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.valueCount(oid));
+        exchange.getMessage().setBody(this.cache.valueCount(oid));
     }
 
     private void clear(Exchange exchange) {
@@ -119,11 +119,11 @@ public class HazelcastMultimapProducer extends HazelcastDefaultProducer {
     }
 
     private void containsKey(Object oid, Exchange exchange) {
-        exchange.getOut().setBody(this.cache.containsKey(oid));
+        exchange.getMessage().setBody(this.cache.containsKey(oid));
     }
 
     private void containsValue(Exchange exchange) {
         Object body = exchange.getIn().getBody();
-        exchange.getOut().setBody(this.cache.containsValue(body));
+        exchange.getMessage().setBody(this.cache.containsValue(body));
     }
 }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/queue/HazelcastQueueProducer.java
@@ -127,11 +127,11 @@ public class HazelcastQueueProducer extends HazelcastDefaultProducer {
     }
 
     private void poll(Exchange exchange) {
-        exchange.getOut().setBody(this.queue.poll());
+        exchange.getMessage().setBody(this.queue.poll());
     }
 
     private void peek(Exchange exchange) {
-        exchange.getOut().setBody(this.queue.peek());
+        exchange.getMessage().setBody(this.queue.peek());
     }
 
     private void offer(Exchange exchange) {
@@ -149,12 +149,12 @@ public class HazelcastQueueProducer extends HazelcastDefaultProducer {
     }
 
     private void remainingCapacity(Exchange exchange) {
-        exchange.getOut().setBody(this.queue.remainingCapacity());
+        exchange.getMessage().setBody(this.queue.remainingCapacity());
     }
 
     private void drainTo(Collection c, Exchange exchange) {
-        exchange.getOut().setBody(this.queue.drainTo(c));
-        exchange.getOut().setHeader(HazelcastConstants.DRAIN_TO_COLLECTION, c);
+        exchange.getMessage().setBody(this.queue.drainTo(c));
+        exchange.getMessage().setHeader(HazelcastConstants.DRAIN_TO_COLLECTION, c);
     }
 
     private void removeAll(Exchange exchange) {
@@ -164,11 +164,11 @@ public class HazelcastQueueProducer extends HazelcastDefaultProducer {
 
     private void removeIf(Exchange exchange) {
         Predicate filter = exchange.getIn().getBody(Predicate.class);
-        exchange.getOut().setBody(this.queue.removeIf(filter));
+        exchange.getMessage().setBody(this.queue.removeIf(filter));
     }
 
     private void take(Exchange exchange) throws InterruptedException {
-        exchange.getOut().setBody(this.queue.take());
+        exchange.getMessage().setBody(this.queue.take());
     }
 
     private void retainAll(Exchange exchange) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/replicatedmap/HazelcastReplicatedmapConsumer.java
@@ -45,7 +45,7 @@ public class HazelcastReplicatedmapConsumer extends HazelcastDefaultConsumer {
     protected void doStart() throws Exception {
         super.doStart();
 
-        listener = cache.addEntryListener(new CamelEntryListener(this, cacheName), true);
+        listener = cache.addEntryListener(new CamelEntryListener(this, cacheName));
     }
 
     /**

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/HazelcastRingbufferProducer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/ringbuffer/HazelcastRingbufferProducer.java
@@ -73,23 +73,23 @@ public class HazelcastRingbufferProducer extends HazelcastDefaultProducer {
     }
 
     private void readOnceHead(Exchange exchange) throws InterruptedException {
-        exchange.getOut().setBody(this.ringbuffer.readOne(ringbuffer.headSequence()));
+        exchange.getMessage().setBody(this.ringbuffer.readOne(ringbuffer.headSequence()));
     }
 
     private void readOnceTail(Exchange exchange) throws InterruptedException {
-        exchange.getOut().setBody(this.ringbuffer.readOne(ringbuffer.tailSequence()));
+        exchange.getMessage().setBody(this.ringbuffer.readOne(ringbuffer.tailSequence()));
     }
 
-    private void getCapacity(Exchange exchange) throws InterruptedException {
-        exchange.getOut().setBody(this.ringbuffer.capacity());
+    private void getCapacity(Exchange exchange) {
+        exchange.getMessage().setBody(this.ringbuffer.capacity());
     }
 
-    private void getRemainingCapacity(Exchange exchange) throws InterruptedException {
-        exchange.getOut().setBody(this.ringbuffer.remainingCapacity());
+    private void getRemainingCapacity(Exchange exchange) {
+        exchange.getMessage().setBody(this.ringbuffer.remainingCapacity());
     }
 
     private void add(Exchange exchange) {
         final Object body = exchange.getIn().getBody();
-        exchange.getOut().setBody(ringbuffer.add(body));
+        exchange.getMessage().setBody(ringbuffer.add(body));
     }
 }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastCamelTestSupport.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastCamelTestSupport.java
@@ -32,7 +32,7 @@ public class HazelcastCamelTestSupport extends CamelTestSupport {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         CamelContext context = super.createCamelContext();
         HazelcastCamelTestHelper.registerHazelcastComponents(context, hazelcastInstance);
         trainHazelcastInstance(hazelcastInstance);


### PR DESCRIPTION
This PR : 
- Fixes the bug of HazelcastReplicatedConsumer not receiving events on ReplicatedMap
- Adds an integration test for HazelcastReplicatedConsumer
- Fixes the warnings for deprecated Exchange.getOut(), Exchange.hasOut() and MockitoAnnotations.initMocks.