### PR TITLE
CAMEL-16037 Minio: if autowiredEnabled is set to false on camelContext, minioClient is still autowired

### DIFF
--- a/components/camel-minio/src/main/java/org/apache/camel/component/minio/MinioComponent.java
+++ b/components/camel-minio/src/main/java/org/apache/camel/component/minio/MinioComponent.java
@@ -17,9 +17,7 @@
 package org.apache.camel.component.minio;
 
 import java.util.Map;
-import java.util.Set;
 
-import io.minio.MinioClient;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
@@ -58,7 +56,6 @@ public class MinioComponent extends DefaultComponent {
         configuration.setBucketName(remaining);
         MinioEndpoint endpoint = new MinioEndpoint(uri, this, configuration);
         setProperties(endpoint, parameters);
-        checkAndSetRegistryClient(configuration, endpoint);
 
         return endpoint;
     }
@@ -72,22 +69,5 @@ public class MinioComponent extends DefaultComponent {
      */
     public void setConfiguration(MinioConfiguration configuration) {
         this.configuration = configuration;
-    }
-
-    private void checkAndSetRegistryClient(MinioConfiguration configuration, MinioEndpoint endpoint) {
-        if (isEmpty(endpoint.getConfiguration().getMinioClient())) {
-            LOG.debug("Looking for an MinioClient instance in the registry");
-            Set<MinioClient> clients = getCamelContext().getRegistry().findByType(MinioClient.class);
-            if (clients.size() > 1) {
-                LOG.debug("Found more than one MinioClient instance in the registry");
-            } else if (clients.size() == 1) {
-                LOG.debug("Found exactly one MinioClient instance in the registry");
-                configuration.setMinioClient(clients.stream().findFirst().get());
-            } else {
-                LOG.debug("No MinioClient instance in the registry");
-            }
-        } else {
-            LOG.debug("MinioClient instance is already set at endpoint level: skipping the check in the registry");
-        }
     }
 }

--- a/components/camel-minio/src/test/java/org/apache/camel/component/minio/MinioComponentConfigurationTest.java
+++ b/components/camel-minio/src/test/java/org/apache/camel/component/minio/MinioComponentConfigurationTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class MinioComponentConfigurationTest extends CamelTestSupport {
@@ -54,5 +55,23 @@ class MinioComponentConfigurationTest extends CamelTestSupport {
 
         assertEquals("MyBucket", endpoint.getConfiguration().getBucketName());
         assertSame(client, endpoint.getConfiguration().getMinioClient());
+    }
+
+    @Test
+    void createEndpoinWthAutowiredDisabledAndClientExistInRegistry() throws Exception {
+        final Properties properties = MinioTestUtils.loadMinioPropertiesFile();
+
+        context.setAutowiredEnabled(false);
+        MinioClient client = MinioClient.builder()
+                .endpoint(properties.getProperty("endpoint"))
+                .build();
+        context.getRegistry().bind("minioClient", client);
+        MinioComponent component = context.getComponent("minio", MinioComponent.class);
+        MinioEndpoint endpoint = (MinioEndpoint) component
+                .createEndpoint(
+                        "minio://MyBucket?accessKey=RAW(XXX)&secretKey=RAW(XXX)&region=eu-west-1&endpoint=https://play.min.io");
+        context.setAutowiredEnabled(true);
+        assertEquals("MyBucket", endpoint.getConfiguration().getBucketName());
+        assertNull(endpoint.getConfiguration().getMinioClient());
     }
 }


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-16037

If autowired is disabled it doesn't make sense to load client from registry.
Junit test is added.

- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md