### PR TITLE
[CAMEL-16047] Add a licenceHeader property (the pom properties already have properties set).

### DIFF
--- a/catalog/camel-catalog/pom.xml
+++ b/catalog/camel-catalog/pom.xml
@@ -171,6 +171,7 @@
                 <configuration>
                     <sourcePom>${basedir}/../../parent/pom.xml</sourcePom>
                     <targetPom>${basedir}/../../camel-dependencies/pom.xml</targetPom>
+                    <licenceHeader>${basedir}/../../etc/apache-header.xml</licenceHeader>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Add a licenceHeader property (the pom properties already have properties set).

https://issues.apache.org/jira/browse/CAMEL-16047

