### PR TITLE
CAMEL-16049: Reuse ObjectMapper in camel-json-validator

### DIFF
--- a/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
+++ b/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
@@ -45,6 +45,8 @@ public class JsonValidatorEndpoint extends ResourceEndpoint {
 
     private volatile JsonSchema schema;
 
+    private final ObjectMapper mapper = new ObjectMapper();
+
     @UriParam(defaultValue = "true")
     private boolean failOnNullBody = true;
     @UriParam(defaultValue = "true")
@@ -108,7 +110,6 @@ public class JsonValidatorEndpoint extends ResourceEndpoint {
                 if (cache == null) {
                     cache = exchange.getContext().getTypeConverter().convertTo(StreamCache.class, exchange, content);
                 }
-                ObjectMapper mapper = new ObjectMapper();
                 InputStream is = exchange.getContext().getTypeConverter().mandatoryConvertTo(InputStream.class, exchange,
                         cache != null ? cache : content);
                 JsonNode node = mapper.readTree(is);


### PR DESCRIPTION
Reuse ObjectMapper because it's thread safe.