### PR TITLE
implement logging mdc support CAMEL-12879

### DIFF
--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -100,6 +100,16 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
         span.addEvent(getEventNameFromFields(fields), convertToAttributes(fields));
     }
 
+    @Override
+    public String traceId() {
+        return span.getSpanContext().getTraceIdAsHexString();
+    }
+
+    @Override
+    public String spanId() {
+        return span.getSpanContext().getSpanIdAsHexString();
+    }
+
     String getEventNameFromFields(Map<String, ?> fields) {
         Object eventValue = fields == null ? null : fields.get("event");
         if (eventValue != null) {

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
@@ -90,4 +90,14 @@ public class OpenTracingSpanAdapter implements SpanAdapter {
         this.span.log(fields);
     }
 
+    @Override
+    public String traceId() {
+        return this.span.context().toTraceId();
+    }
+
+    @Override
+    public String spanId() {
+        return this.span.context().toSpanId();
+    }
+
 }

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracingStrategy.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracingStrategy.java
@@ -76,7 +76,7 @@ public class OpenTracingTracingStrategy implements InterceptStrategy {
                 ActiveSpanManager.activate(exchange, new OpenTracingSpanAdapter(processorSpan));
             }
 
-            try (Scope scope = tracer.getTracer().scopeManager().activate(processorSpan, false)) {
+            try (Scope scope = tracer.getTracer().scopeManager().activate(processorSpan)) {
                 target.process(exchange);
             } catch (Exception ex) {
                 processorSpan.log(errorLogs(ex));

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MDCSupportTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MDCSupportTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentracing;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MDCSupportTest extends CamelOpenTracingTestSupport {
+
+    private static SpanTestData[] testdata = {
+            new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
+                    .setParentId(1),
+            new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
+    };
+
+    public MDCSupportTest() {
+        super(testdata);
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        camelContext.setUseMDCLogging(true);
+        return camelContext;
+    }
+
+    @Test
+    public void testRoute() throws Exception {
+        template.requestBody("direct:start", "Hello");
+
+        verify();
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").to("seda:a").routeId("start");
+
+                from("seda:a").routeId("a")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                assertNotNull(MDC.get("traceId"));
+                                assertNotNull(MDC.get("spanId"));
+                            }
+                        });
+            }
+        };
+    }
+}

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ThirdPartyInstrumentationIntegrationTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/ThirdPartyInstrumentationIntegrationTest.java
@@ -115,7 +115,7 @@ public class ThirdPartyInstrumentationIntegrationTest extends CamelTestSupport {
         Tracer.SpanBuilder spanBuilder = tracer.buildSpan("third-party-span")
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
         Span span = spanBuilder.start();
-        try (Scope ignored = tracer.scopeManager().activate(span, false)) {
+        try (Scope ignored = tracer.scopeManager().activate(span)) {
             closure.run();
         } catch (Exception e) {
             Tags.ERROR.set(span, Boolean.TRUE);

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
@@ -34,4 +34,8 @@ public interface SpanAdapter {
     void setTag(String key, Boolean value);
 
     void log(Map<String, String> log);
+
+    String traceId();
+
+    String spanId();
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
@@ -25,6 +25,8 @@ public class MockSpanAdapter implements SpanAdapter {
 
     private List<LogEntry> logEntries = new ArrayList<>();
     private HashMap<String, Object> tags = new HashMap<>();
+    private String traceId = null;
+    private String spanId = null;
 
     static long nowMicros() {
         return System.currentTimeMillis() * 1000;
@@ -73,9 +75,27 @@ public class MockSpanAdapter implements SpanAdapter {
         this.tags.put(key, value);
     }
 
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    public void setSpanId(String spanId) {
+        this.spanId = spanId;
+    }
+
     @Override
     public void log(Map<String, String> fields) {
         this.logEntries.add(new LogEntry(nowMicros(), fields));
+    }
+
+    @Override
+    public String traceId() {
+        return this.traceId;
+    }
+
+    @Override
+    public String spanId() {
+        return this.spanId;
     }
 
     public List<LogEntry> logEntries() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -439,8 +439,7 @@
         <openjpa-version>3.1.2</openjpa-version>
         <openstack4j-version>3.8</openstack4j-version>
         <opentelemetry-version>0.11.0</opentelemetry-version>
-        <!-- cannot upgrade opentracing until https://github.com/eclipse/microprofile-opentracing v2 is released -->
-        <opentracing-version>0.31.0</opentracing-version>
+        <opentracing-version>0.33.0</opentracing-version>
         <opentracing-tracerresolver-version>0.1.8</opentracing-tracerresolver-version>
         <optaplanner-version>7.46.0.Final</optaplanner-version>
         <os-maven-plugin-version>1.6.2</os-maven-plugin-version>


### PR DESCRIPTION
Adds traceId and spanId string methods to SpanAdapter
Adds and replaces MDC fields when activating, deactivating a span
Bumps opentracing to 0.33.0

Note, there was a warning in the parent pom
```
cannot upgrade opentracing until https://github.com/eclipse/microprofile-opentracing v2 is released
```

microprofile-opentracing v2 was released about a month ago, however I could not find the dependencies to that artifact, so I'm not sure if there's anything else that needs to be changed