### PR TITLE
Fix Consul key path used when determining leader.

### DIFF
--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/cluster/ConsulClusterView.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/cluster/ConsulClusterView.java
@@ -69,7 +69,7 @@ final class ConsulClusterView extends AbstractCamelClusterView {
             return Optional.empty();
         }
 
-        return keyValueClient.getSession(configuration.getRootPath()).map(ConsulClusterMember::new);
+        return keyValueClient.getSession(path).map(ConsulClusterMember::new);
     }
 
     @Override

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewTest.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.consul.cluster;
+
+import java.util.Optional;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.cluster.CamelClusterMember;
+import org.apache.camel.cluster.CamelClusterView;
+import org.apache.camel.component.master.MasterComponent;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.infra.consul.services.ConsulService;
+import org.apache.camel.test.infra.consul.services.ConsulServiceFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ConsulClusterViewTest {
+    @RegisterExtension
+    public static ConsulService service = ConsulServiceFactory.createService();
+
+    @Test
+    public void getLeader_singleNode_localLeader() throws Exception {
+        //Set up a single node cluster.
+        ConsulClusterService consulClusterService = new ConsulClusterService();
+        consulClusterService.setId("node");
+        consulClusterService.setUrl(service.getConsulUrl());
+        consulClusterService.setRootPath("root");
+
+        //Set up context with single locked route.
+        DefaultCamelContext context = new DefaultCamelContext();
+        context.setName("context");
+        context.addService(consulClusterService);
+
+        context.addRoutes(new RouteBuilder() {
+              @Override
+              public void configure() {
+                  from("master:key:timer:consul?repeatCount=1")
+                      .routeId("route1")
+                      .stop();
+              }
+        });
+
+        context.start();
+
+        //Get view and leader.
+        CamelClusterView view = consulClusterService.getView("key");
+        Optional<CamelClusterMember> leaderOptional = view.getLeader();
+
+        Assertions.assertTrue(leaderOptional.isPresent());
+        Assertions.assertTrue(leaderOptional.get().isLeader());
+        Assertions.assertTrue(leaderOptional.get().isLocal());
+
+        context.stop();
+    }
+
+}

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewTest.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewTest.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.cluster.CamelClusterMember;
 import org.apache.camel.cluster.CamelClusterView;
-import org.apache.camel.component.master.MasterComponent;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.infra.consul.services.ConsulService;
 import org.apache.camel.test.infra.consul.services.ConsulServiceFactory;
@@ -34,7 +33,7 @@ public class ConsulClusterViewTest {
     public static ConsulService service = ConsulServiceFactory.createService();
 
     @Test
-    public void getLeader_singleNode_localLeader() throws Exception {
+    public void getLeaderTest() throws Exception {
         //Set up a single node cluster.
         ConsulClusterService consulClusterService = new ConsulClusterService();
         consulClusterService.setId("node");
@@ -47,12 +46,12 @@ public class ConsulClusterViewTest {
         context.addService(consulClusterService);
 
         context.addRoutes(new RouteBuilder() {
-              @Override
-              public void configure() {
-                  from("master:key:timer:consul?repeatCount=1")
-                      .routeId("route1")
-                      .stop();
-              }
+            @Override
+            public void configure() {
+                from("master:key:timer:consul?repeatCount=1")
+                        .routeId("route1")
+                        .stop();
+            }
         });
 
         context.start();


### PR DESCRIPTION
The session lock is on the full key path, not on the root path. As far as I can tell, the result of this method isn't actually used anywhere, but this fix at least makes it correct.

I discovered this issue due to my Consul ACL policy. My application has access to the full key path, but does not have access to the configured root path, so I was getting an error at startup. 