### PR TITLE
CAMEL-16083: Route Scoped OnCompletion After Consumer routeId check.

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -190,6 +190,7 @@ public interface Exchange {
     String NOTIFY_EVENT = "CamelNotifyEvent";
 
     String ON_COMPLETION = "CamelOnCompletion";
+    String ON_COMPLETION_ROUTE_IDS = "CamelOnCompletionRouteIds";
     String OVERRULE_FILE_NAME = "CamelOverruleFileName";
 
     String PARENT_UNIT_OF_WORK = "CamelParentUnitOfWork";

--- a/core/camel-core/src/test/java/org/apache/camel/issues/OnCompletionAfterConsumerModeIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/OnCompletionAfterConsumerModeIssueTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.issues;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+public class OnCompletionAfterConsumerModeIssueTest extends ContextTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testOnCompletionInSub() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                        .transform(constant("a"))
+                        .to("mock:a")
+                        .to("direct:sub")
+                        .transform(constant("c"))
+                        .to("mock:c");
+
+                from("direct:sub")
+                        .transform(constant("b"))
+                        .to("mock:b")
+                        .onCompletion()
+                            .to("mock:end")
+                        .end();
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:a").expectedBodiesReceived("a");
+        getMockEndpoint("mock:b").expectedBodiesReceived("b");
+        getMockEndpoint("mock:c").expectedBodiesReceived("c");
+        getMockEndpoint("mock:end").expectedBodiesReceived("c");
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testOnCompletionInMainAndSub() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                from("direct:start")
+                        .transform(constant("a"))
+                        .to("mock:a")
+                        .to("direct:sub")
+                        .transform(constant("c"))
+                        .to("mock:c")
+                        .onCompletion()
+                            .to("mock:end")
+                        .end();
+
+                from("direct:sub")
+                        .transform(constant("b"))
+                        .to("mock:b")
+                        .onCompletion()
+                            .to("mock:end")
+                        .end();
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:a").expectedBodiesReceived("a");
+        getMockEndpoint("mock:b").expectedBodiesReceived("b");
+        getMockEndpoint("mock:c").expectedBodiesReceived("c");
+        getMockEndpoint("mock:end").expectedBodiesReceived("c", "c");
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testOnCompletionInGlobalAndSub() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                onCompletion().to("mock:end");
+
+                from("direct:start")
+                        .transform(constant("a"))
+                        .to("mock:a")
+                        .to("direct:sub")
+                        .transform(constant("c"))
+                        .to("mock:c");
+
+                from("direct:sub")
+                        .transform(constant("b"))
+                        .to("mock:b")
+                        .onCompletion()
+                            .to("mock:end")
+                        .end();
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:a").expectedBodiesReceived("a");
+        getMockEndpoint("mock:b").expectedBodiesReceived("b");
+        getMockEndpoint("mock:c").expectedBodiesReceived("c");
+        getMockEndpoint("mock:end").expectedBodiesReceived("c", "c");
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+
+}


### PR DESCRIPTION
Hi this is a suggested fix to CAMEL-16083 to support After Consumer mode onCompletion definitions in routeScope.  Open to other suggestions. 

The testOnCompletionInSub is the usecase I'm trying to solve for.  The other unit tests were just other regressions I was concerned about.  


- [ x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x ] Each commit in the pull request should have a meaningful subject line and body.
- [ x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md