### PR TITLE
CAMEL-16110: don't leak internal QUERY_STRING header

### DIFF
--- a/components/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
+++ b/components/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
@@ -91,7 +91,8 @@ public final class CxfHeaderHelper {
 
             // drop this header as we do not want to propagate the http method/path into the CXF request message
             if (Exchange.HTTP_METHOD.equalsIgnoreCase(entry.getKey())
-                    || Exchange.HTTP_PATH.equalsIgnoreCase(entry.getKey())) {
+                    || Exchange.HTTP_PATH.equalsIgnoreCase(entry.getKey())
+                    || Exchange.HTTP_QUERY.equalsIgnoreCase(entry.getKey())) {
                 return;
             }
 

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerHttpMethodHeaderTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducerHttpMethodHeaderTest.java
@@ -48,6 +48,7 @@ public class CxfRsProducerHttpMethodHeaderTest extends CamelTestSupport {
                         Message inMessage = exchange.getIn();
                         inMessage.setHeader(Exchange.HTTP_METHOD, "GET");
                         inMessage.setHeader(Exchange.HTTP_PATH, "/CxfRsProducerHttpMethodHeaderTest/");
+                        inMessage.setHeader(Exchange.HTTP_QUERY, "q=1");
                         inMessage.setHeader(Exchange.CONTENT_TYPE, "application/text");
                         inMessage.setBody("Hello World");
                     }


### PR DESCRIPTION
Don't leak the internal CXF QUERY_STRING header in external REST requests