### PR TITLE
CAMEL-16139: Support for global autoDiscoverObjectMapper override

### DIFF
--- a/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonObjectMapperRegistryGlobalOptionTest.java
+++ b/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonObjectMapperRegistryGlobalOptionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.dataformat.JsonLibrary;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JacksonObjectMapperRegistryGlobalOptionTest extends CamelTestSupport {
+
+    @BindToRegistry("myMapper")
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testMarshalAndUnmarshalMapGlobalOverride() throws Exception {
+        //Add Jaxb Module to global object mapper
+        objectMapper.registerModule(new JaxbAnnotationModule());
+        TestJAXBPojo in = new TestJAXBPojo();
+        in.setName("Camel");
+
+        MockEndpoint mock = getMockEndpoint("mock:reverse");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isInstanceOf(TestJAXBPojo.class);
+        mock.message(0).body().isEqualTo(in);
+
+        Object marshalled = template.requestBody("direct:inGlobal", in);
+        String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
+        assertEquals("{\"PojoName\":\"Camel\"}", marshalledAsString);
+
+        template.sendBody("direct:backGlobal", marshalled);
+
+        mock.assertIsSatisfied();
+
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                getContext().getGlobalOptions().put("jackson.json.autoDiscoverObjectMapper", "true");
+
+                from("direct:inGlobal").marshal().json(JsonLibrary.Jackson);
+                from("direct:backGlobal").unmarshal().json(JsonLibrary.Jackson, TestJAXBPojo.class).to("mock:reverse");
+            }
+        };
+    }
+
+}

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifier.java
@@ -39,7 +39,14 @@ public class JsonDataFormatReifier extends DataFormatReifier<JsonDataFormat> {
             } else {
                 properties.put("useDefaultObjectMapper", definition.getUseDefaultObjectMapper());
             }
-            properties.put("autoDiscoverObjectMapper", definition.getAutoDiscoverObjectMapper());
+
+            if (definition.getAutoDiscoverObjectMapper() != null) {
+                properties.put("autoDiscoverObjectMapper", definition.getAutoDiscoverObjectMapper());
+            } else if (camelContext.getGlobalOption("jackson.json.autoDiscoverObjectMapper") != null) {
+                properties.put("autoDiscoverObjectMapper",
+                        camelContext.getGlobalOption("jackson.json.autoDiscoverObjectMapper"));
+            }
+
             if (definition.getJsonView() != null) {
                 properties.put("jsonViewTypeName", asTypeName(definition.getJsonView()));
             } else {


### PR DESCRIPTION
I would like to be able to override the global default of autoDiscoverObjectMapper  in the Java DSL.  Picked an option similar to how spring boot does this.  Global override is only applied if defined and not overridden in the definition.

- [ X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [X ] Each commit in the pull request should have a meaningful subject line and body.
- [X ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md