### PR TITLE
CAMEL-16145: Made coverageThreshold configurable in camel-report-maven-plugin

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
+++ b/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
@@ -135,6 +135,7 @@ The maven plugin *validate* goal supports the following options which can be con
 | Parameter | Default Value | Description
 | downloadVersion | true | Whether to allow downloading Camel catalog version from the internet. This is needed if the project uses a different Camel version than this plugin is using by default.
 | failOnError | false | Whether to fail if invalid Camel endpoints was found. By default the plugin logs the errors at WARN level.
+| coverageThreshold | 100 | The minimum route coverage in percent when using failOnError.
 | logUnparseable | false | Whether to log endpoint URIs which was un-parsable and therefore not possible to validate.
 | includeJava | true | Whether to include Java files to be validated for invalid Camel endpoints.
 | includeXml | true | Whether to include XML files to be validated for invalid Camel endpoints.

--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -92,6 +92,7 @@ public class RouteCoverageMojo extends AbstractExecMojo {
      *
      * @parameter property="camel.coverageThreshold" default-value="100"
      */
+    @Parameter(property = "camel.coverageThreshold", defaultValue = "100")
     private byte coverageThreshold = 100;
 
     /**


### PR DESCRIPTION
Added the missing @Parameter annotation in RouteCoverageMojo.java of the camel-report-maven-plugin