### PR TITLE
CAMEL-16153: Added overall coverage threshold (across all routes) to camel-report-maven-plugin

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
+++ b/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
@@ -136,6 +136,7 @@ The maven plugin *validate* goal supports the following options which can be con
 | downloadVersion | true | Whether to allow downloading Camel catalog version from the internet. This is needed if the project uses a different Camel version than this plugin is using by default.
 | failOnError | false | Whether to fail if invalid Camel endpoints was found. By default the plugin logs the errors at WARN level.
 | coverageThreshold | 100 | The minimum route coverage in percent when using failOnError.
+| overallCoverageThreshold | 0 | The minimum coverage across all routes in percent when using failOnError.
 | logUnparseable | false | Whether to log endpoint URIs which was un-parsable and therefore not possible to validate.
 | includeJava | true | Whether to include Java files to be validated for invalid Camel endpoints.
 | includeXml | true | Whether to include XML files to be validated for invalid Camel endpoints.

--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -94,6 +95,14 @@ public class RouteCoverageMojo extends AbstractExecMojo {
      */
     @Parameter(property = "camel.coverageThreshold", defaultValue = "100")
     private byte coverageThreshold = 100;
+
+    /**
+     * The minimum coverage across all routes in percent when using failOnError.
+     *
+     * @parameter property="camel.overallCoverageThreshold" default-value="0"
+     */
+    @Parameter(property = "camel.overallCoverageThreshold", defaultValue = "0")
+    private byte overallCoverageThreshold;
 
     /**
      * Whether to include test source code
@@ -209,6 +218,8 @@ public class RouteCoverageMojo extends AbstractExecMojo {
         }
 
         final AtomicInteger notCovered = new AtomicInteger();
+        final AtomicInteger coveredNodes = new AtomicInteger();
+        int totalNumberOfNodes = 0;
 
         List<CamelNodeDetails> routeIdTrees = routeTrees.stream().filter(t -> t.getRouteId() != null).collect(Collectors.toList());
         List<CamelNodeDetails> anonymousRouteTrees = routeTrees.stream().filter(t -> t.getRouteId() == null).collect(Collectors.toList());
@@ -257,7 +268,8 @@ public class RouteCoverageMojo extends AbstractExecMojo {
                         + ". Make sure to enable route coverage in your unit tests and assign unique route ids to your routes. Also remember to run unit tests first.");
                 } else {
                     List<RouteCoverageNode> coverage = gatherRouteCoverageSummary(Collections.singletonList(t), coverageData);
-                    String out = templateCoverageData(fileName, routeId, coverage, notCovered);
+                    totalNumberOfNodes += coverage.size();
+                    String out = templateCoverageData(fileName, routeId, coverage, notCovered, coveredNodes);
                     getLog().info("Route coverage summary:\n\n" + out);
                     getLog().info("");
 
@@ -307,8 +319,9 @@ public class RouteCoverageMojo extends AbstractExecMojo {
                         }
 
                         if (!coverage.isEmpty()) {
+                            totalNumberOfNodes += coverage.size();
                             String fileName = stripRootPath(asRelativeFile(t.getValue().get(0).getFileName()));
-                            String out = templateCoverageData(fileName, null, coverage, notCovered);
+                            String out = templateCoverageData(fileName, null, coverage, notCovered, coveredNodes);
                             getLog().info("Route coverage summary:\n\n" + out);
                             getLog().info("");
                         }
@@ -319,8 +332,16 @@ public class RouteCoverageMojo extends AbstractExecMojo {
             }
         }
 
+        // compute and log overall coverage across routes
+        AtomicBoolean overallCoverageAboveThreshold = new AtomicBoolean();
+        String out = templateOverallCoverageData(coveredNodes.get(), totalNumberOfNodes, overallCoverageAboveThreshold);
+        getLog().info("Overall coverage summary:\n\n" + out);
+        getLog().info("");
+
         if (failOnError && notCovered.get() > 0) {
             throw new MojoExecutionException("There are " + notCovered.get() + " route(s) not fully covered!");
+        } else if (failOnError && !overallCoverageAboveThreshold.get()) {
+            throw new MojoExecutionException("The overall coverage is below " + overallCoverageThreshold + "%!");
         }
     }
 
@@ -379,7 +400,8 @@ public class RouteCoverageMojo extends AbstractExecMojo {
 
     @SuppressWarnings("unchecked")
     private String templateCoverageData(
-            String fileName, String routeId, List<RouteCoverageNode> model, AtomicInteger notCovered)
+            String fileName, String routeId, List<RouteCoverageNode> model, AtomicInteger notCovered,
+            AtomicInteger coveredNodes)
             throws MojoExecutionException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         PrintStream sw = new PrintStream(bos);
@@ -405,6 +427,8 @@ public class RouteCoverageMojo extends AbstractExecMojo {
             sw.println(String.format("%8s    %8s    %s", node.getLineNumber(), node.getCount(), pad + node.getName()));
         }
 
+        coveredNodes.addAndGet(covered);
+
         // calculate percentage of route coverage (must use double to have decimals)
         double percentage = ((double) covered / (double) model.size()) * 100;
 
@@ -419,6 +443,24 @@ public class RouteCoverageMojo extends AbstractExecMojo {
         sw.println("Coverage: " + covered + " out of " + model.size() + " (" + String.format("%.1f", percentage)
                    + "% / threshold " + coverageThreshold + ".0%)");
         sw.println("Status: " + (success ? "Success" : "Failed"));
+        sw.println();
+
+        return bos.toString();
+    }
+
+    private String templateOverallCoverageData(
+            int coveredNodes, int totalNumberOfNodes, AtomicBoolean overallCoverageAboveThreshold) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        PrintStream sw = new PrintStream(bos);
+
+        // calculate percentage of overall coverage (must use double to have decimals)
+        double percentage = totalNumberOfNodes > 0 ? ((double) coveredNodes / (double) totalNumberOfNodes) * 100 : 100;
+
+        overallCoverageAboveThreshold.set(coveredNodes == totalNumberOfNodes || percentage >= overallCoverageThreshold);
+
+        sw.println("Coverage: " + coveredNodes + " out of " + totalNumberOfNodes + " (" + String.format("%.1f", percentage)
+                   + "% / threshold " + overallCoverageThreshold + ".0%)");
+        sw.println("Status: " + (overallCoverageAboveThreshold.get() ? "Success" : "Failed"));
         sw.println();
 
         return bos.toString();


### PR DESCRIPTION
Added an overall coverage threshold to the camel-report-maven-plugin. It takes into account all nodes across all routes. Thus, we do not have to fail if every route is reasonably covered except a small minority of simple helper routes. 
E.g. set coverageThreshold per route to 60% but overallCoverageThreshold should still be 90% in total.