### PR TITLE
[CAMEL-16181] Fix KafkaIdempotentRepository flagging cache as ready incorrectly

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryEagerTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryEagerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.processor.idempotent.kafka;
 
+import java.util.UUID;
+
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.EndpointInject;
@@ -31,9 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Test for eager idempotentRepository usage.
  */
 public class KafkaIdempotentRepositoryEagerTest extends BaseEmbeddedKafkaTest {
+
+    // Every instance of the repository must use a different topic to guarantee isolation between tests
     @BindToRegistry("kafkaIdempotentRepository")
     private KafkaIdempotentRepository kafkaIdempotentRepository
-            = new KafkaIdempotentRepository("TEST_IDEM", getBootstrapServers());
+            = new KafkaIdempotentRepository("TEST_EAGER_" + UUID.randomUUID().toString(), getBootstrapServers());
 
     @EndpointInject("mock:out")
     private MockEndpoint mockOut;

--- a/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceTest.java
@@ -16,30 +16,33 @@
  */
 package org.apache.camel.processor.idempotent.kafka;
 
-import java.util.UUID;
-
 import org.apache.camel.BindToRegistry;
-import org.apache.camel.CamelExecutionException;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.kafka.BaseEmbeddedKafkaTest;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Test for non-eager idempotentRepository usage.
+ * Test whether the KafkaIdempotentRepository successfully recreates its cache from pre-existing topics. This guarantees
+ * that the de-duplication state survives application instance restarts.
+ *
+ * This test requires running in a certain order (which isn't great for unit testing), hence the ordering-related
+ * annotations.
  */
-public class KafkaIdempotentRepositoryNonEagerTest extends BaseEmbeddedKafkaTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class KafkaIdempotentRepositoryPersistenceTest extends BaseEmbeddedKafkaTest {
 
     // Every instance of the repository must use a different topic to guarantee isolation between tests
     @BindToRegistry("kafkaIdempotentRepository")
     private KafkaIdempotentRepository kafkaIdempotentRepository
-            = new KafkaIdempotentRepository(
-                    "TEST_NON_EAGER_" + UUID.randomUUID().toString(),
-                    getBootstrapServers());
+            = new KafkaIdempotentRepository("TEST_PERSISTENCE", getBootstrapServers());
 
     @EndpointInject("mock:out")
     private MockEndpoint mockOut;
@@ -53,49 +56,42 @@ public class KafkaIdempotentRepositoryNonEagerTest extends BaseEmbeddedKafkaTest
             @Override
             public void configure() throws Exception {
                 from("direct:in").to("mock:before").idempotentConsumer(header("id"))
-                        .messageIdRepositoryRef("kafkaIdempotentRepository").eager(false).to("mock:out").end();
+                        .messageIdRepositoryRef("kafkaIdempotentRepository").to("mock:out").end();
             }
         };
     }
 
+    @Order(1)
     @Test
-    public void testRemovesDuplicates() throws InterruptedException {
+    public void testFirstPassFiltersAsExpected() throws InterruptedException {
         for (int i = 0; i < 10; i++) {
             template.sendBodyAndHeader("direct:in", "Test message", "id", i % 5);
         }
 
+        // all records sent initially
+        assertEquals(10, mockBefore.getReceivedCounter());
+
+        // filters second attempt with same value
         assertEquals(5, kafkaIdempotentRepository.getDuplicateCount());
 
+        // only first 1-4 records are received, the rest are filtered
         assertEquals(5, mockOut.getReceivedCounter());
-        assertEquals(10, mockBefore.getReceivedCounter());
     }
 
+    @Order(2)
     @Test
-    public void testRollsBackOnException() throws InterruptedException {
-        mockOut.whenAnyExchangeReceived(exchange -> {
-            int id = exchange.getIn().getHeader("id", Integer.class);
-            if (id == 0) {
-                throw new IllegalArgumentException("Boom!");
-            }
-        });
-
+    public void testSecondPassFiltersEverything() throws InterruptedException {
         for (int i = 0; i < 10; i++) {
-            try {
-                template.sendBodyAndHeader("direct:in", "Test message", "id", i % 5);
-            } catch (CamelExecutionException cex) {
-                // no-op; expected
-            }
+            template.sendBodyAndHeader("direct:in", "Test message", "id", i % 5);
         }
 
-        assertEquals(4, kafkaIdempotentRepository.getDuplicateCount()); // id{0}
-                                                                       // is
-                                                                       // not a
-                                                                       // duplicate
-
-        assertEquals(6, mockOut.getReceivedCounter()); // id{0} goes through the
-                                                      // idempotency check
-                                                      // twice
+        // all records sent initially
         assertEquals(10, mockBefore.getReceivedCounter());
-    }
 
+        // the state from the previous test guarantees that all attempts now are blocked
+        assertEquals(10, kafkaIdempotentRepository.getDuplicateCount());
+
+        // nothing gets passed the idempotent consumer this time
+        assertEquals(0, mockOut.getReceivedCounter());
+    }
 }


### PR DESCRIPTION
- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md

Jira ticket: https://issues.apache.org/jira/browse/CAMEL-16181

This PR fixes an issue where the `KafkaIdempotentRepository` flags its cache as ready before it has finished consuming all records in the backing Kafka repository