### PR TITLE
fix CAMEL-16182: test-infra modules don't support testcontainers hub.image.name.prefix configuration.

### DIFF
--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.artemis.services;
 
+import org.apache.camel.test.infra.common.TestUtils;
 import org.apache.camel.test.infra.messaging.services.MessagingContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -27,11 +28,14 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> impleme
     private static final int DEFAULT_AMQP_PORT = 5672;
     private static final int DEFAULT_ADMIN_PORT = 8161;
     private static final int DEFAULT_ACCEPTOR_PORT = 61616;
+    private static final String FROM_IMAGE_NAME = "fedora:33";
+    private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public ArtemisContainer() {
-        super(new ImageFromDockerfile("apache-artemis:ckc", false)
+        super(new ImageFromDockerfile("localhost/apache-artemis:ckc", false)
                 .withFileFromClasspath("Dockerfile",
-                        "org/apache/camel/test/infra/artemis/services/Dockerfile"));
+                        "org/apache/camel/test/infra/artemis/services/Dockerfile")
+                .withBuildArg(FROM_IMAGE_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME)));
 
         withExposedPorts(DEFAULT_MQTT_PORT, DEFAULT_AMQP_PORT,
                 DEFAULT_ADMIN_PORT, DEFAULT_ACCEPTOR_PORT);

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
@@ -32,7 +32,7 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> impleme
     private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public ArtemisContainer() {
-        super(new ImageFromDockerfile("localhost/apache-artemis:ckc", false)
+        super(new ImageFromDockerfile("localhost/apache-artemis:camel", false)
                 .withFileFromClasspath("Dockerfile",
                         "org/apache/camel/test/infra/artemis/services/Dockerfile")
                 .withBuildArg(FROM_IMAGE_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME)));

--- a/test-infra/camel-test-infra-artemis/src/test/resources/org/apache/camel/test/infra/artemis/services/Dockerfile
+++ b/test-infra/camel-test-infra-artemis/src/test/resources/org/apache/camel/test/infra/artemis/services/Dockerfile
@@ -12,7 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM fedora:33 as artemis-base
+ARG FROMIMAGE
+FROM $FROMIMAGE as artemis-base
 LABEL maintainer="orpiske@apache.org"
 ARG ARTEMIS_VERSION
 ENV ARTEMIS_VERSION ${ARTEMIS_VERSION:-2.7.0}

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/TestUtils.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/TestUtils.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 /**
  * Test utilities
@@ -100,5 +101,15 @@ public final class TestUtils {
         int range = (max - min) + 1;
 
         return (int) (Math.random() * range) + min;
+    }
+
+    /**
+     * Prepend imageName with configured hub.image.name.prefix if any is configured in testcontainers
+     *
+     * @param  imageName
+     * @return           a String composed of hub.image.name.prefix as configured in testcontainers + imageName
+     */
+    public static String prependHubImageNamePrefixIfNeeded(String imageName) {
+        return TestcontainersConfiguration.getInstance().getEnvVarOrProperty("hub.image.name.prefix", "") + imageName;
     }
 }

--- a/test-infra/camel-test-infra-dispatch-router/src/test/java/org/apache/camel/test/infra/dispatch/router/services/DispatchRouterContainer.java
+++ b/test-infra/camel-test-infra-dispatch-router/src/test/java/org/apache/camel/test/infra/dispatch/router/services/DispatchRouterContainer.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.dispatch.router.services;
 
+import org.apache.camel.test.infra.common.TestUtils;
 import org.apache.camel.test.infra.messaging.services.MessagingContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -24,11 +25,14 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public class DispatchRouterContainer extends GenericContainer<DispatchRouterContainer> implements MessagingContainer {
     private static final int DEFAULT_AMQP_PORT = 5672;
+    private static final String FROM_IMAGE_NAME = "fedora:33";
+    private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public DispatchRouterContainer() {
-        super(new ImageFromDockerfile("qpid-dispatch:camel", false)
+        super(new ImageFromDockerfile("localhost/qpid-dispatch:camel", false)
                 .withFileFromClasspath("Dockerfile",
-                        "org/apache/camel/test/infra/dispatch/router/services/Dockerfile"));
+                        "org/apache/camel/test/infra/dispatch/router/services/Dockerfile")
+                .withBuildArg(FROM_IMAGE_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME)));
 
         withExposedPorts(DEFAULT_AMQP_PORT);
 

--- a/test-infra/camel-test-infra-dispatch-router/src/test/resources/org/apache/camel/test/infra/dispatch/router/services/Dockerfile
+++ b/test-infra/camel-test-infra-dispatch-router/src/test/resources/org/apache/camel/test/infra/dispatch/router/services/Dockerfile
@@ -12,7 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM fedora:33
+ARG FROMIMAGE
+FROM $FROMIMAGE
 LABEL maintainer="orpiske@apache.org"
 EXPOSE 5672
 RUN dnf install -y qpid-dispatch-router && dnf clean all

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HadoopBaseContainer.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HadoopBaseContainer.java
@@ -28,7 +28,7 @@ abstract class HadoopBaseContainer<T extends GenericContainer<T>> extends Generi
     private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public HadoopBaseContainer(Network network, String name) {
-        super(new ImageFromDockerfile("localhost/hadoop-2x:ckc", false)
+        super(new ImageFromDockerfile("localhost/hadoop-2x:camel", false)
                 .withFileFromClasspath(".",
                         "org/apache/camel/test/infra/hdfs/v2/services/")
                 .withBuildArg(FROM_IMAGE_BUILDER_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME))

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HadoopBaseContainer.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HadoopBaseContainer.java
@@ -17,16 +17,22 @@
 
 package org.apache.camel.test.infra.hdfs.v2.services;
 
+import org.apache.camel.test.infra.common.TestUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 abstract class HadoopBaseContainer<T extends GenericContainer<T>> extends GenericContainer<T> {
+    private static final String FROM_IMAGE_NAME = "fedora:33";
+    private static final String FROM_IMAGE_BUILDER_ARG = "FROMIMAGE_BUILDER";
+    private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public HadoopBaseContainer(Network network, String name) {
-        super(new ImageFromDockerfile("hadoop-2x:ckc", false)
+        super(new ImageFromDockerfile("localhost/hadoop-2x:ckc", false)
                 .withFileFromClasspath(".",
-                        "org/apache/camel/test/infra/hdfs/v2/services/"));
+                        "org/apache/camel/test/infra/hdfs/v2/services/")
+                .withBuildArg(FROM_IMAGE_BUILDER_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME))
+                .withBuildArg(FROM_IMAGE_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(FROM_IMAGE_NAME)));
 
         withNetwork(network);
 

--- a/test-infra/camel-test-infra-hdfs/src/test/resources/org/apache/camel/test/infra/hdfs/v2/services/Dockerfile
+++ b/test-infra/camel-test-infra-hdfs/src/test/resources/org/apache/camel/test/infra/hdfs/v2/services/Dockerfile
@@ -12,8 +12,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-FROM fedora:33 as builder
+ARG FROMIMAGE_BUILDER
+ARG FROMIMAGE
+FROM ${FROMIMAGE_BUILDER} as builder
 ARG HADOOP_VERSION
 ENV HADOOP_VERSION ${HADOOP_VERSION:-2.10.0}
 RUN curl https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -o hadoop.tar.gz
@@ -23,7 +24,8 @@ ADD hdfs-site.xml /hadoop/etc/hadoop/hdfs-site.xml
 ADD run-datanode.sh /hadoop
 ADD run-namenode.sh /hadoop
 
-FROM fedora:33
+ARG FROMIMAGE
+FROM $FROMIMAGE
 LABEL maintainer="orpiske@apache.org"
 ARG HADOOP_VERSION
 ENV HADOOP_VERSION ${HADOOP_VERSION:-2.10.0}


### PR DESCRIPTION
- [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
- [X] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
