### PR TITLE
core: tidy up PropertyBindingSupport::resolveBean

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -1013,7 +1013,7 @@ public abstract class BaseMainSupport extends BaseService {
             if (key.indexOf('.') == -1) {
                 String name = key;
                 Object value = properties.remove(key);
-                Object bean = PropertyBindingSupport.resolveBean(camelContext, name, value);
+                Object bean = PropertyBindingSupport.resolveBean(camelContext, value);
                 if (bean == null) {
                     throw new IllegalArgumentException(
                             "Cannot create/resolve bean with name " + name + " from value: " + value);


### PR DESCRIPTION
- remove the name parameter as it was not used
- ensure the value is a string instead of rely to .toString() as it may
  produce false results if the .toString() method is crafted to generate
  a value starting with #bean:, #class:, #type: