### PR TITLE
CAMEL-16227: Netty with reuseChannel invokes wrong callback

### DIFF
--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyReuseChannelCallbackTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyReuseChannelCallbackTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.channel.Channel;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.event.ExchangeSentEvent;
+import org.apache.camel.spi.CamelEvent;
+import org.apache.camel.spi.CamelEvent.ExchangeSendingEvent;
+import org.apache.camel.support.EventNotifierSupport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for CAMEL-16227
+ */
+class NettyReuseChannelCallbackTest extends BaseNettyTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NettyReuseChannelCallbackTest.class);
+
+    private final List<Channel> channels = new ArrayList<>();
+
+    @Test
+    void testReuse() throws Exception {
+        final List<Endpoint> eventEndpoints = new ArrayList<>(4);
+        final List<Long> times = new ArrayList<>(2);
+
+        final EventNotifierSupport nettyEventRecorder = new EventNotifierSupport() {
+            @Override
+            public void notify(CamelEvent event) throws Exception {
+                if (event instanceof ExchangeSendingEvent) {
+                    LOG.info("Got event {}", event);
+                    add(((ExchangeSendingEvent) event).getEndpoint());
+                }
+                if (event instanceof ExchangeSentEvent) {
+                    LOG.info("Got event {}", event);
+                    add(((ExchangeSentEvent) event).getEndpoint());
+                    if (((ExchangeSentEvent) event).getEndpoint() instanceof NettyEndpoint) {
+                        times.add(((ExchangeSentEvent) event).getTimeTaken());
+                    }
+                }
+            }
+
+            private void add(Endpoint endpoint) {
+                if (endpoint instanceof NettyEndpoint) {
+                    eventEndpoints.add(endpoint);
+                }
+            }
+        };
+        nettyEventRecorder.start();
+        context.getManagementStrategy().addEventNotifier(nettyEventRecorder);
+
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+
+        getMockEndpoint("mock:a").expectedBodiesReceived("Hello World");
+        getMockEndpoint("mock:b").expectedBodiesReceived("Hello Hello World");
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello World", "Hello Hello World");
+
+        template.sendBody("direct:start", "World\n");
+
+        assertMockEndpointsSatisfied(10, TimeUnit.SECONDS);
+
+        assertTrue(notify.matchesWaitTime());
+
+        assertEquals(2, channels.size());
+        assertSame(channels.get(0), channels.get(1), "Should reuse channel");
+        assertFalse(channels.get(0).isOpen(), "And closed when routing done");
+        assertFalse(channels.get(1).isOpen(), "And closed when routing done");
+
+        assertEquals(4, eventEndpoints.size(), "Should get 4 events for netty endpoints");
+        assertSame(eventEndpoints.get(0), eventEndpoints.get(1), "Sending and sent event should contain the same endpoint");
+        assertSame(eventEndpoints.get(2), eventEndpoints.get(3), "Sending and sent event should contain the same endpoint");
+        assertEquals(2, times.size(), "Should get 2 ExchangeSent events");
+        // one side effect of mixing callbacks in wrong time taken reported in event
+        times.forEach(time -> assertTrue(time < 900));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // Netty URIs are slightly different (different requestTimeout)
+                // so there is different NettyEndpoint instance for each of them.
+                // This makes distinguishing events easier in test.
+                // If they URIs would be the same there would be one NettyEndpoint instance
+                // but still 2 separate NettyProducer instances.
+                from("direct:start")
+                        .to("netty:tcp://localhost:{{port}}?textline=true&sync=true&reuseChannel=true&disconnect=true&requestTimeout=1000")
+                        .process(new Processor() {
+                            @Override
+                            public void process(Exchange exchange) throws Exception {
+                                Channel channel = exchange.getProperty(NettyConstants.NETTY_CHANNEL, Channel.class);
+                                channels.add(channel);
+                                assertTrue(channel.isActive(), "Should be active");
+                            }
+                        })
+                        .to("mock:a")
+                        .to("netty:tcp://localhost:{{port}}?textline=true&sync=true&reuseChannel=true&disconnect=true&requestTimeout=2000")
+                        .process(new Processor() {
+                            @Override
+                            public void process(Exchange exchange) throws Exception {
+                                Channel channel = exchange.getProperty(NettyConstants.NETTY_CHANNEL, Channel.class);
+                                channels.add(channel);
+                                assertTrue(channel.isActive(), "Should be active");
+                            }
+                        })
+                        .to("mock:b");
+
+                from("netty:tcp://localhost:{{port}}?textline=true&sync=true")
+                        .transform(body().prepend("Hello "))
+                        .delay(500)
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
With this fix NettyReuseChannelTest in PR #5093 should pass.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md