### PR TITLE
Fixed some camel-netty and camel-netty-http tests failing on Windows

### DIFF
--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpRedeliveryTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpRedeliveryTest.java
@@ -63,8 +63,8 @@ public class NettyHttpRedeliveryTest extends BaseNettyTest {
                                     }
                                 });
 
-                from("timer:foo").routeId("foo")
-                        .to("netty-http:http://0.0.0.0:{{port}}/bar?keepAlive=false&disconnect=true")
+                from("timer:foo?repeatCount=1").routeId("foo")
+                        .to("netty-http:http://0.0.0.0:{{port}}/bar?keepAlive=false&disconnect=true&connectTimeout=100ms")
                         .to("mock:result");
 
                 from("netty-http:http://0.0.0.0:{{port}}/bar").routeId("bar").autoStartup(false)

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettySSLTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettySSLTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.netty;
 
 import java.io.File;
 import java.security.Principal;
+import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLSession;
 
@@ -63,7 +64,7 @@ public class NettySSLTest extends BaseNettyTest {
                                 SSLSession session
                                         = exchange.getIn().getHeader(NettyConstants.NETTY_SSL_SESSION, SSLSession.class);
                                 if (session != null) {
-                                    javax.security.cert.X509Certificate cert = session.getPeerCertificateChain()[0];
+                                    X509Certificate cert = (X509Certificate) session.getPeerCertificates()[0];
                                     Principal principal = cert.getSubjectDN();
                                     log.info("Client Cert SubjectDN: {}", principal.getName());
                                     exchange.getOut().setBody(


### PR DESCRIPTION
On Windows when the port is not opened one gets connection timeout instead of connection refused (may depend on firewall configuration). Made `NettyHttpRedeliveryTest` to work as intended in this case.

`NettySSLTest` used deprecated API which threw: `java.lang.UnsupportedOperationException: This method is deprecated and marked for removal. Use the getPeerCertificates() method instead.`

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [X] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md