### PR TITLE
Mark NatsEndpoint as supporting MultipleConsumers.

### DIFF
--- a/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsEndpoint.java
+++ b/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsEndpoint.java
@@ -28,6 +28,7 @@ import io.nats.client.Options;
 import io.nats.client.Options.Builder;
 import org.apache.camel.Category;
 import org.apache.camel.Consumer;
+import org.apache.camel.MultipleConsumersSupport;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.spi.UriEndpoint;
@@ -38,7 +39,7 @@ import org.apache.camel.support.DefaultEndpoint;
  * Send and receive messages from <a href="http://nats.io/">NATS</a> messaging system.
  */
 @UriEndpoint(firstVersion = "2.17.0", scheme = "nats", title = "Nats", syntax = "nats:topic", category = { Category.MESSAGING })
-public class NatsEndpoint extends DefaultEndpoint {
+public class NatsEndpoint extends DefaultEndpoint implements MultipleConsumersSupport {
 
     @UriParam
     private NatsConfiguration configuration;
@@ -58,6 +59,11 @@ public class NatsEndpoint extends DefaultEndpoint {
         NatsConsumer consumer = new NatsConsumer(this, processor);
         configureConsumer(consumer);
         return consumer;
+    }
+
+    @Override
+    public boolean isMultipleConsumersSupported() {
+        return true;
     }
 
     public ExecutorService createExecutor() {


### PR DESCRIPTION
Mark `NatsEndpoint` as supporting `MultipleConsumers`.
    
Per nats documentation:
NATS implements a publish-subscribe message distribution model for one-to-many communication.