### PR TITLE
Kamelet: remove null check for unused tid variable.

### DIFF
--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
@@ -110,10 +110,8 @@ public final class Kamelet {
 
     public static RouteDefinition templateToRoute(RouteTemplateDefinition in, Map<String, Object> parameters) {
         final String rid = (String) parameters.get(PARAM_ROUTE_ID);
-        final String tid = (String) parameters.get(PARAM_TEMPLATE_ID);
 
         ObjectHelper.notNull(rid, PARAM_ROUTE_ID);
-        ObjectHelper.notNull(tid, PARAM_TEMPLATE_ID);
 
         RouteDefinition def = in.asRouteDefinition();
         def.setId(rid);


### PR DESCRIPTION
This doesn't seem to be used.