### PR TITLE
Nats: document that the producer now supports request/reply.

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/nats-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/nats-component.adoc
@@ -170,8 +170,7 @@ camel.component.nats.servers=scott:tiger@someserver:4222,superman:123@someothers
 |=======================================================================
 
 == Request/Reply support
-The producer only supports publishing (sending) messages.
-The producer does not support request/reply where it can wait for an expected reply message.
+The producer supports request/reply where it can wait for an expected reply message.
 
 The consumer will when routing the message is complete, send back the message as reply-message if required.
 

--- a/components/camel-nats/src/main/docs/nats-component.adoc
+++ b/components/camel-nats/src/main/docs/nats-component.adoc
@@ -170,8 +170,7 @@ camel.component.nats.servers=scott:tiger@someserver:4222,superman:123@someothers
 |=======================================================================
 
 == Request/Reply support
-The producer only supports publishing (sending) messages.
-The producer does not support request/reply where it can wait for an expected reply message.
+The producer supports request/reply where it can wait for an expected reply message.
 
 The consumer will when routing the message is complete, send back the message as reply-message if required.
 

--- a/docs/components/modules/ROOT/pages/nats-component.adoc
+++ b/docs/components/modules/ROOT/pages/nats-component.adoc
@@ -172,8 +172,7 @@ camel.component.nats.servers=scott:tiger@someserver:4222,superman:123@someothers
 |=======================================================================
 
 == Request/Reply support
-The producer only supports publishing (sending) messages.
-The producer does not support request/reply where it can wait for an expected reply message.
+The producer supports request/reply where it can wait for an expected reply message.
 
 The consumer will when routing the message is complete, send back the message as reply-message if required.
 


### PR DESCRIPTION
Looks like I missed this in #5034.