### PR TITLE
CAMEL-16280: NettyEndpointUriFactory#buildUri() not compatible with Netty endpoint URL

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-component.adoc
@@ -146,7 +146,7 @@ The Netty component supports 72 options, which are listed below.
 The Netty endpoint is configured using URI syntax:
 
 ----
-netty:protocol:host:port
+netty:protocol://host:port
 ----
 
 with the following path and query parameters:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-http-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-http-component.adoc
@@ -195,7 +195,7 @@ The Netty HTTP component supports 75 options, which are listed below.
 The Netty HTTP endpoint is configured using URI syntax:
 
 ----
-netty-http:protocol:host:port/path
+netty-http:protocol://host:port/path
 ----
 
 with the following path and query parameters:

--- a/components/camel-netty-http/src/generated/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactory.java
+++ b/components/camel-netty-http/src/generated/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactory.java
@@ -15,7 +15,7 @@ import org.apache.camel.spi.EndpointUriFactory;
  */
 public class NettyHttpEndpointUriFactory extends org.apache.camel.support.component.EndpointUriFactorySupport implements EndpointUriFactory {
 
-    private static final String BASE = ":protocol:host:port/path";
+    private static final String BASE = ":protocol://host:port/path";
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;

--- a/components/camel-netty-http/src/generated/resources/org/apache/camel/component/netty/http/netty-http.json
+++ b/components/camel-netty-http/src/generated/resources/org/apache/camel/component/netty/http/netty-http.json
@@ -15,7 +15,7 @@
     "version": "3.9.0-SNAPSHOT",
     "scheme": "netty-http",
     "extendsScheme": "netty",
-    "syntax": "netty-http:protocol:host:port\/path",
+    "syntax": "netty-http:protocol:\/\/host:port\/path",
     "async": true,
     "api": false,
     "consumerOnly": false,

--- a/components/camel-netty-http/src/main/docs/netty-http-component.adoc
+++ b/components/camel-netty-http/src/main/docs/netty-http-component.adoc
@@ -195,7 +195,7 @@ The Netty HTTP component supports 75 options, which are listed below.
 The Netty HTTP endpoint is configured using URI syntax:
 
 ----
-netty-http:protocol:host:port/path
+netty-http:protocol://host:port/path
 ----
 
 with the following path and query parameters:

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpEndpoint.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpEndpoint.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Netty HTTP server and client using the Netty 4.x.
  */
 @UriEndpoint(firstVersion = "2.14.0", scheme = "netty-http", extendsScheme = "netty", title = "Netty HTTP",
-             syntax = "netty-http:protocol:host:port/path", category = { Category.NETWORKING, Category.HTTP },
+             syntax = "netty-http:protocol://host:port/path", category = { Category.NETWORKING, Category.HTTP },
              lenientProperties = true)
 @Metadata(excludeProperties = "textline,delimiter,autoAppendDelimiter,decoderMaxLineLength,encoding,allowDefaultCodec,udpConnectionlessSending,networkInterface"
                               + ",clientMode,reconnect,reconnectInterval,useByteBuf,udpByteArrayCodec,broadcast,correlationManager")

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriAssemblerTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriAssemblerTest.java
@@ -39,7 +39,7 @@ public class NettyHttpEndpointUriAssemblerTest extends CamelTestSupport {
         map.put("port", "8080");
         map.put("path", "anything");
         String uri = assembler.buildUri("netty-http", map);
-        assertEquals("netty-http:http:a-b-c.hostname.tld:8080/anything", uri);
+        assertEquals("netty-http:http://a-b-c.hostname.tld:8080/anything", uri);
 
         map = new LinkedHashMap<>();
         map.put("protocol", "http");
@@ -47,7 +47,7 @@ public class NettyHttpEndpointUriAssemblerTest extends CamelTestSupport {
         map.put("port", "8888");
         map.put("path", "service/v3");
         uri = assembler.buildUri("netty-http", map);
-        assertEquals("netty-http:http:a-b-c.server.net:8888/service/v3", uri);
+        assertEquals("netty-http:http://a-b-c.server.net:8888/service/v3", uri);
 
         map = new HashMap<>();
         // use http protocol
@@ -58,20 +58,20 @@ public class NettyHttpEndpointUriAssemblerTest extends CamelTestSupport {
         map.put("disconnect", "true");
 
         uri = assembler.buildUri("netty-http", map);
-        assertEquals("netty-http:http:localhost:8080/foo/bar?disconnect=true", uri);
+        assertEquals("netty-http:http://localhost:8080/foo/bar?disconnect=true", uri);
 
         // lets switch protocol
         map.put("protocol", "https");
 
         uri = assembler.buildUri("netty-http", map);
-        assertEquals("netty-http:https:localhost:8080/foo/bar?disconnect=true", uri);
+        assertEquals("netty-http:https://localhost:8080/foo/bar?disconnect=true", uri);
 
         // lets set a query parameter in the path
         map.put("path", "foo/bar?verbose=true");
         map.put("disconnect", "true");
 
         uri = assembler.buildUri("netty-http", map);
-        assertEquals("netty-http:https:localhost:8080/foo/bar?verbose=true&disconnect=true", uri);
+        assertEquals("netty-http:https://localhost:8080/foo/bar?verbose=true&disconnect=true", uri);
     }
 
 }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactoryTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.EndpointUriFactory;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class NettyHttpEndpointUriFactoryTest extends CamelTestSupport {
+
+    @Test
+    void buildUri() {
+        // let's just see if the route starts successfully
+    }
+
+    private String scheme() {
+        return "netty-http";
+    }
+
+    private Map<String, Object> pathParameters() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("protocol", "http");
+        params.put("host", "localhost");
+        params.put("port", AvailablePortFinder.getNextAvailable());
+        params.put("path", "test");
+        return params;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                EndpointUriFactory factory = getContext().adapt(ExtendedCamelContext.class).getEndpointUriFactory(scheme());
+                String uri = factory.buildUri(scheme(), pathParameters(), false);
+                from(uri).to("mock:out");
+            }
+        };
+    }
+}

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactoryTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpEndpointUriFactoryTest.java
@@ -19,41 +19,23 @@ package org.apache.camel.component.netty.http;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.spi.EndpointUriFactory;
 import org.apache.camel.test.AvailablePortFinder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
+import org.apache.camel.test.junit5.EndpointUriFactoryTestSupport;
 
-public class NettyHttpEndpointUriFactoryTest extends CamelTestSupport {
+public class NettyHttpEndpointUriFactoryTest extends EndpointUriFactoryTestSupport {
 
-    @Test
-    void buildUri() {
-        // let's just see if the route starts successfully
-    }
-
-    private String scheme() {
+    @Override
+    protected String scheme() {
         return "netty-http";
     }
 
-    private Map<String, Object> pathParameters() {
+    @Override
+    protected Map<String, Object> pathParameters() {
         Map<String, Object> params = new HashMap<>();
         params.put("protocol", "http");
         params.put("host", "localhost");
         params.put("port", AvailablePortFinder.getNextAvailable());
         params.put("path", "test");
         return params;
-    }
-
-    @Override
-    protected RouteBuilder createRouteBuilder() {
-        return new RouteBuilder() {
-            public void configure() throws Exception {
-                EndpointUriFactory factory = getContext().adapt(ExtendedCamelContext.class).getEndpointUriFactory(scheme());
-                String uri = factory.buildUri(scheme(), pathParameters(), false);
-                from(uri).to("mock:out");
-            }
-        };
     }
 }

--- a/components/camel-netty/src/generated/java/org/apache/camel/component/netty/NettyEndpointUriFactory.java
+++ b/components/camel-netty/src/generated/java/org/apache/camel/component/netty/NettyEndpointUriFactory.java
@@ -15,7 +15,7 @@ import org.apache.camel.spi.EndpointUriFactory;
  */
 public class NettyEndpointUriFactory extends org.apache.camel.support.component.EndpointUriFactorySupport implements EndpointUriFactory {
 
-    private static final String BASE = ":protocol:host:port";
+    private static final String BASE = ":protocol://host:port";
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;

--- a/components/camel-netty/src/generated/resources/org/apache/camel/component/netty/netty.json
+++ b/components/camel-netty/src/generated/resources/org/apache/camel/component/netty/netty.json
@@ -14,7 +14,7 @@
     "version": "3.9.0-SNAPSHOT",
     "scheme": "netty",
     "extendsScheme": "",
-    "syntax": "netty:protocol:host:port",
+    "syntax": "netty:protocol:\/\/host:port",
     "async": true,
     "api": false,
     "consumerOnly": false,

--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -146,7 +146,7 @@ The Netty component supports 72 options, which are listed below.
 The Netty endpoint is configured using URI syntax:
 
 ----
-netty:protocol:host:port
+netty:protocol://host:port
 ----
 
 with the following path and query parameters:

--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyEndpoint.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyEndpoint.java
@@ -40,7 +40,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * Socket level networking using TCP or UDP with the Netty 4.x.
  */
-@UriEndpoint(firstVersion = "2.14.0", scheme = "netty", title = "Netty", syntax = "netty:protocol:host:port",
+@UriEndpoint(firstVersion = "2.14.0", scheme = "netty", title = "Netty", syntax = "netty:protocol://host:port",
              category = { Category.NETWORKING, Category.TCP, Category.UDP })
 public class NettyEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     @UriParam

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyEndpointUriFactoryTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyEndpointUriFactoryTest.java
@@ -19,40 +19,22 @@ package org.apache.camel.component.netty;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.spi.EndpointUriFactory;
 import org.apache.camel.test.AvailablePortFinder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
+import org.apache.camel.test.junit5.EndpointUriFactoryTestSupport;
 
-public class NettyEndpointUriFactoryTest extends CamelTestSupport {
+public class NettyEndpointUriFactoryTest extends EndpointUriFactoryTestSupport {
 
-    @Test
-    void buildUri() {
-        // let's just see if the route starts successfully
-    }
-
-    private String scheme() {
+    @Override
+    protected String scheme() {
         return "netty";
     }
 
-    private Map<String, Object> pathParameters() {
+    @Override
+    protected Map<String, Object> pathParameters() {
         Map<String, Object> params = new HashMap<>();
         params.put("protocol", "tcp");
         params.put("host", "localhost");
         params.put("port", AvailablePortFinder.getNextAvailable());
         return params;
-    }
-
-    @Override
-    protected RouteBuilder createRouteBuilder() {
-        return new RouteBuilder() {
-            public void configure() throws Exception {
-                EndpointUriFactory factory = getContext().adapt(ExtendedCamelContext.class).getEndpointUriFactory(scheme());
-                String uri = factory.buildUri(scheme(), pathParameters(), false);
-                from(uri).to("mock:out");
-            }
-        };
     }
 }

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyEndpointUriFactoryTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyEndpointUriFactoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.EndpointUriFactory;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class NettyEndpointUriFactoryTest extends CamelTestSupport {
+
+    @Test
+    void buildUri() {
+        // let's just see if the route starts successfully
+    }
+
+    private String scheme() {
+        return "netty";
+    }
+
+    private Map<String, Object> pathParameters() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("protocol", "tcp");
+        params.put("host", "localhost");
+        params.put("port", AvailablePortFinder.getNextAvailable());
+        return params;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                EndpointUriFactory factory = getContext().adapt(ExtendedCamelContext.class).getEndpointUriFactory(scheme());
+                String uri = factory.buildUri(scheme(), pathParameters(), false);
+                from(uri).to("mock:out");
+            }
+        };
+    }
+}

--- a/components/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/EndpointUriFactoryTestSupport.java
+++ b/components/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/EndpointUriFactoryTestSupport.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5;
+
+import java.util.Map;
+
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.EndpointUriFactory;
+import org.junit.jupiter.api.Test;
+
+public abstract class EndpointUriFactoryTestSupport extends CamelTestSupport {
+
+    @Test
+    public void buildUri() {
+        // let's just see if the route starts successfully
+    }
+
+    protected abstract String scheme();
+
+    protected abstract Map<String, Object> pathParameters();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                EndpointUriFactory factory = getContext().adapt(ExtendedCamelContext.class).getEndpointUriFactory(scheme());
+                String uri = factory.buildUri(scheme(), pathParameters(), false);
+                from(uri).to("mock:out");
+            }
+        };
+    }
+}

--- a/core/camel-componentdsl/src/generated/resources/metadata.json
+++ b/core/camel-componentdsl/src/generated/resources/metadata.json
@@ -5089,7 +5089,7 @@
     "version": "3.9.0-SNAPSHOT",
     "scheme": "netty-http",
     "extendsScheme": "netty",
-    "syntax": "netty-http:protocol:host:port\/path",
+    "syntax": "netty-http:protocol:\/\/host:port\/path",
     "async": true,
     "api": false,
     "consumerOnly": false,

--- a/core/camel-componentdsl/src/generated/resources/metadata.json
+++ b/core/camel-componentdsl/src/generated/resources/metadata.json
@@ -5066,7 +5066,7 @@
     "version": "3.9.0-SNAPSHOT",
     "scheme": "netty",
     "extendsScheme": "",
-    "syntax": "netty:protocol:host:port",
+    "syntax": "netty:protocol:\/\/host:port",
     "async": true,
     "api": false,
     "consumerOnly": false,

--- a/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
+++ b/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
@@ -10623,7 +10623,7 @@ public class StaticEndpointBuilders {
      * Since: 2.14
      * Maven coordinates: org.apache.camel:camel-netty-http
      * 
-     * Syntax: <code>netty-http:protocol:host:port/path</code>
+     * Syntax: <code>netty-http:protocol://host:port/path</code>
      * 
      * Path parameter: protocol (required)
      * The protocol to use which is either http, https or proxy - a consumer
@@ -10640,7 +10640,7 @@ public class StaticEndpointBuilders {
      * Path parameter: path
      * Resource path
      * 
-     * @param path protocol:host:port/path
+     * @param path protocol://host:port/path
      * @return the dsl builder
      */
     public static org.apache.camel.builder.endpoint.dsl.NettyHttpEndpointBuilderFactory.NettyHttpEndpointBuilder nettyHttp(
@@ -10655,7 +10655,7 @@ public class StaticEndpointBuilders {
      * Since: 2.14
      * Maven coordinates: org.apache.camel:camel-netty-http
      * 
-     * Syntax: <code>netty-http:protocol:host:port/path</code>
+     * Syntax: <code>netty-http:protocol://host:port/path</code>
      * 
      * Path parameter: protocol (required)
      * The protocol to use which is either http, https or proxy - a consumer
@@ -10674,7 +10674,7 @@ public class StaticEndpointBuilders {
      * 
      * @param componentName to use a custom component name for the endpoint
      * instead of the default name
-     * @param path protocol:host:port/path
+     * @param path protocol://host:port/path
      * @return the dsl builder
      */
     public static org.apache.camel.builder.endpoint.dsl.NettyHttpEndpointBuilderFactory.NettyHttpEndpointBuilder nettyHttp(

--- a/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
+++ b/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
@@ -10564,7 +10564,7 @@ public class StaticEndpointBuilders {
      * Since: 2.14
      * Maven coordinates: org.apache.camel:camel-netty
      * 
-     * Syntax: <code>netty:protocol:host:port</code>
+     * Syntax: <code>netty:protocol://host:port</code>
      * 
      * Path parameter: protocol (required)
      * The protocol to use which can be tcp or udp.
@@ -10577,7 +10577,7 @@ public class StaticEndpointBuilders {
      * Path parameter: port (required)
      * The host port number
      * 
-     * @param path protocol:host:port
+     * @param path protocol://host:port
      * @return the dsl builder
      */
     public static org.apache.camel.builder.endpoint.dsl.NettyEndpointBuilderFactory.NettyEndpointBuilder netty(
@@ -10592,7 +10592,7 @@ public class StaticEndpointBuilders {
      * Since: 2.14
      * Maven coordinates: org.apache.camel:camel-netty
      * 
-     * Syntax: <code>netty:protocol:host:port</code>
+     * Syntax: <code>netty:protocol://host:port</code>
      * 
      * Path parameter: protocol (required)
      * The protocol to use which can be tcp or udp.
@@ -10607,7 +10607,7 @@ public class StaticEndpointBuilders {
      * 
      * @param componentName to use a custom component name for the endpoint
      * instead of the default name
-     * @param path protocol:host:port
+     * @param path protocol://host:port
      * @return the dsl builder
      */
     public static org.apache.camel.builder.endpoint.dsl.NettyEndpointBuilderFactory.NettyEndpointBuilder netty(

--- a/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/NettyEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/NettyEndpointBuilderFactory.java
@@ -4846,7 +4846,7 @@ public interface NettyEndpointBuilderFactory {
          * Since: 2.14
          * Maven coordinates: org.apache.camel:camel-netty
          * 
-         * Syntax: <code>netty:protocol:host:port</code>
+         * Syntax: <code>netty:protocol://host:port</code>
          * 
          * Path parameter: protocol (required)
          * The protocol to use which can be tcp or udp.
@@ -4859,7 +4859,7 @@ public interface NettyEndpointBuilderFactory {
          * Path parameter: port (required)
          * The host port number
          * 
-         * @param path protocol:host:port
+         * @param path protocol://host:port
          * @return the dsl builder
          */
         default NettyEndpointBuilder netty(String path) {
@@ -4873,7 +4873,7 @@ public interface NettyEndpointBuilderFactory {
          * Since: 2.14
          * Maven coordinates: org.apache.camel:camel-netty
          * 
-         * Syntax: <code>netty:protocol:host:port</code>
+         * Syntax: <code>netty:protocol://host:port</code>
          * 
          * Path parameter: protocol (required)
          * The protocol to use which can be tcp or udp.
@@ -4888,7 +4888,7 @@ public interface NettyEndpointBuilderFactory {
          * 
          * @param componentName to use a custom component name for the endpoint
          * instead of the default name
-         * @param path protocol:host:port
+         * @param path protocol://host:port
          * @return the dsl builder
          */
         default NettyEndpointBuilder netty(String componentName, String path) {

--- a/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/NettyHttpEndpointBuilderFactory.java
+++ b/core/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/NettyHttpEndpointBuilderFactory.java
@@ -5316,7 +5316,7 @@ public interface NettyHttpEndpointBuilderFactory {
          * Since: 2.14
          * Maven coordinates: org.apache.camel:camel-netty-http
          * 
-         * Syntax: <code>netty-http:protocol:host:port/path</code>
+         * Syntax: <code>netty-http:protocol://host:port/path</code>
          * 
          * Path parameter: protocol (required)
          * The protocol to use which is either http, https or proxy - a consumer
@@ -5333,7 +5333,7 @@ public interface NettyHttpEndpointBuilderFactory {
          * Path parameter: path
          * Resource path
          * 
-         * @param path protocol:host:port/path
+         * @param path protocol://host:port/path
          * @return the dsl builder
          */
         default NettyHttpEndpointBuilder nettyHttp(String path) {
@@ -5347,7 +5347,7 @@ public interface NettyHttpEndpointBuilderFactory {
          * Since: 2.14
          * Maven coordinates: org.apache.camel:camel-netty-http
          * 
-         * Syntax: <code>netty-http:protocol:host:port/path</code>
+         * Syntax: <code>netty-http:protocol://host:port/path</code>
          * 
          * Path parameter: protocol (required)
          * The protocol to use which is either http, https or proxy - a consumer
@@ -5366,7 +5366,7 @@ public interface NettyHttpEndpointBuilderFactory {
          * 
          * @param componentName to use a custom component name for the endpoint
          * instead of the default name
-         * @param path protocol:host:port/path
+         * @param path protocol://host:port/path
          * @return the dsl builder
          */
         default NettyHttpEndpointBuilder nettyHttp(

--- a/docs/components/modules/ROOT/pages/netty-component.adoc
+++ b/docs/components/modules/ROOT/pages/netty-component.adoc
@@ -148,7 +148,7 @@ The Netty component supports 72 options, which are listed below.
 The Netty endpoint is configured using URI syntax:
 
 ----
-netty:protocol:host:port
+netty:protocol://host:port
 ----
 
 with the following path and query parameters:

--- a/docs/components/modules/ROOT/pages/netty-http-component.adoc
+++ b/docs/components/modules/ROOT/pages/netty-http-component.adoc
@@ -197,7 +197,7 @@ The Netty HTTP component supports 75 options, which are listed below.
 The Netty HTTP endpoint is configured using URI syntax:
 
 ----
-netty-http:protocol:host:port/path
+netty-http:protocol://host:port/path
 ----
 
 with the following path and query parameters:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-16280