### PR TITLE
fix(mongodb): converter failure

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/converters/MongoDbBasicConverters.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/converters/MongoDbBasicConverters.java
@@ -117,8 +117,11 @@ public final class MongoDbBasicConverters {
         return true;
     }
 
-    @Converter
+    @Converter(allowNull = true)
     public static List<Bson> fromStringToList(String value) {
+        if (!isArrayNotation(value)) {
+            return null;
+        }
 
         final CodecRegistry codecRegistry = CodecRegistries.fromProviders(
                 Arrays.asList(new ValueCodecProvider(), new BsonValueCodecProvider(), new DocumentCodecProvider()));
@@ -134,6 +137,11 @@ public final class MongoDbBasicConverters {
             answer.add(doc.asDocument());
         }
         return answer;
+    }
+
+    private static boolean isArrayNotation(String value) {
+        return value != null && !value.isEmpty() && value.length() > 1 && value.charAt(0) == '['
+                && value.charAt(value.length() - 1) == ']';
     }
 
 }

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbConversionsTest.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/MongoDbConversionsTest.java
@@ -18,15 +18,19 @@ package org.apache.camel.component.mongodb;
 
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mongodb.converters.MongoDbBasicConverters;
 import org.apache.camel.converter.IOConverter;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.apache.camel.component.mongodb.MongoDbConstants.MONGO_ID;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -133,6 +137,26 @@ public class MongoDbConversionsTest extends AbstractMongoDbTest {
         // CHECKSTYLE:OFF
         public String _id = "testInsertPojo";
         // CHECKSTYLE:ON
+    }
+
+    @Test
+    public void shouldConvertJsonStringListToBSONList() throws InterruptedException {
+        String jsonListArray = "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]";
+        List<Bson> bsonList = MongoDbBasicConverters.fromStringToList(jsonListArray);
+        assertNotNull(bsonList);
+        assertEquals(2, bsonList.size());
+
+        String jsonEmptyArray = "[]";
+        bsonList = MongoDbBasicConverters.fromStringToList(jsonEmptyArray);
+        assertNotNull(bsonList);
+        assertEquals(0, bsonList.size());
+    }
+
+    @Test
+    public void shouldNotConvertJsonStringListToBSONList() throws InterruptedException {
+        String jsonSingleValue = "{\"key\":\"value1\"}";
+        List<Bson> bsonList = MongoDbBasicConverters.fromStringToList(jsonSingleValue);
+        assertNull(bsonList);
     }
 
 }


### PR DESCRIPTION
Checking that the value to be converted from a String to List is an array in order to avoid a BsonInvalidOperationException when the method is called.

With this PR we fix a minor issue caused when we try to convert to a List, ie:
```
if (exchange.getIn().getBody(List.class) != null) {
                    List<?> body = exchange.getIn().getBody(List.class);
...
```
The above call would fail with a single document as the method assumes it's going to be an array of them. We should therefore return `null` if the passed in value is not an array and not proceed to the conversion.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md
-->
