### PR TITLE
CAMEL-16336 Make CustomSlackHttpClient compatible with okhttp 3.x

### DIFF
--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -50,12 +50,6 @@
             <groupId>com.slack.api</groupId>
             <artifactId>slack-api-client</artifactId>
             <version>${slack-api-model-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -72,6 +66,13 @@
                    <artifactId>junit</artifactId>
                </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- forcing okhttp v3.x related to https://issues.apache.org/jira/browse/CAMEL-16336 -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${squareup-okhttp-version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/CustomSlackHttpClient.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/CustomSlackHttpClient.java
@@ -39,7 +39,7 @@ public class CustomSlackHttpClient extends SlackHttpClient {
 
     @Override
     public Response postJsonBody(String url, Object obj) throws IOException {
-        RequestBody body = RequestBody.create((String) obj, MEDIA_TYPE_APPLICATION_JSON);
+        RequestBody body = RequestBody.create(MEDIA_TYPE_APPLICATION_JSON, (String) obj);
         Request request = new Request.Builder().url(url).post(body).build();
         return okHttpClient.newCall(request).execute();
     }

--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackConsumer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackConsumer.java
@@ -152,7 +152,7 @@ public class SlackConsumer extends ScheduledBatchPollingConsumer {
                     .filter(it -> it.getName().equals(channel))
                     .map(Conversation::getId)
                     .findFirst().orElseGet(() -> {
-                        if (ObjectHelper.isNotEmpty(response.getResponseMetadata().getNextCursor())) {
+                        if (ObjectHelper.isEmpty(response.getResponseMetadata().getNextCursor())) {
                             throw new RuntimeCamelException(String.format("Channel %s not found", channel));
                         }
                         return getChannelId(channel, response.getResponseMetadata().getNextCursor());

--- a/components/camel-slack/src/test/java/org/apache/camel/component/slack/SlackConsumerTest.java
+++ b/components/camel-slack/src/test/java/org/apache/camel/component/slack/SlackConsumerTest.java
@@ -68,7 +68,7 @@ public class SlackConsumerTest extends CamelTestSupport {
 
     private void sendMessage(String message) throws IOException {
         RequestBody requestBody
-                = RequestBody.create(String.format("{ 'text': '%s'}", message), MediaType.parse("application/json"));
+                = RequestBody.create(MediaType.parse("application/json"), String.format("{ 'text': '%s'}", message));
 
         Request request = new Request.Builder()
                 .url(hook)


### PR DESCRIPTION
- Forcing the v3.x in the pom.xml. You can see the discussion in Zulip here: https://camel.zulipchat.com/#narrow/stream/257298-camel/topic/CustomSlackHttpClient
- Mistake on SlackConsumer while checking if the cursor is empty or not (**isNotEmpty** => **isEmpty**)
- The dependency:tree is correctly displaying the v3.14.7

```
$ mvn dependency:tree 

[INFO] BuildTimeEventSpy is registered.
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------< org.apache.camel:camel-slack >--------------------
[INFO] Building Camel :: Slack 3.9.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ camel-slack ---
[INFO] org.apache.camel:camel-slack:jar:3.9.0-SNAPSHOT
[INFO] +- org.apache.camel:camel-support:jar:3.9.0-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-api:jar:3.9.0-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-management-api:jar:3.9.0-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-util:jar:3.9.0-SNAPSHOT:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] +- org.apache.camel:camel-util-json:jar:3.9.0-SNAPSHOT:compile
[INFO] +- com.slack.api:slack-api-client:jar:1.6.1:compile
[INFO] |  \- com.slack.api:slack-api-model:jar:1.6.1:compile
[INFO] +- com.google.code.gson:gson:jar:2.8.5:compile
[INFO] +- com.googlecode.json-simple:json-simple:jar:1.1.1:compile
[INFO] +- com.squareup.okhttp3:okhttp:jar:3.14.7:compile
[INFO] |  \- com.squareup.okio:okio:jar:1.17.2:compile
[INFO] +- org.apache.camel:camel-test-junit5:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-core-engine:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  +- org.apache.camel:camel-base-engine:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  \- org.apache.camel:camel-core-reifier:jar:3.9.0-SNAPSHOT:test
[INFO] |  |     \- org.apache.camel:camel-core-processor:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-core-languages:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-bean:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-browse:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-controlbus:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-dataformat:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-dataset:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-direct:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-directvm:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-file:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  \- org.apache.camel:camel-cluster:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-language:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-log:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-mock:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-ref:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-rest:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-saga:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-scheduler:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-seda:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-stub:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-timer:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-validator:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  \- org.apache.camel:camel-xml-jaxp:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-vm:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-xpath:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-xslt:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.7.1:test
[INFO] |  |  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.7.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-engine:jar:5.7.1:test
[INFO] |  |  \- org.junit.platform:junit-platform-engine:jar:1.7.1:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-params:jar:5.7.1:test
[INFO] +- org.apache.camel:camel-core-catalog:jar:3.9.0-SNAPSHOT:test
[INFO] |  \- org.apache.camel:camel-tooling-model:jar:3.9.0-SNAPSHOT:test
[INFO] +- org.apache.camel:camel-undertow:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-base:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-cloud:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  \- org.apache.camel:camel-core-model:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- org.apache.camel:camel-attachments:jar:3.9.0-SNAPSHOT:test
[INFO] |  |  \- com.sun.activation:javax.activation:jar:1.2.0:test
[INFO] |  +- org.apache.camel:camel-http-base:jar:3.9.0-SNAPSHOT:test
[INFO] |  +- io.undertow:undertow-core:jar:2.2.3.Final:test
[INFO] |  |  +- org.jboss.logging:jboss-logging:jar:3.4.1.Final:test
[INFO] |  |  +- org.jboss.xnio:xnio-api:jar:3.8.0.Final:test
[INFO] |  |  |  +- org.wildfly.common:wildfly-common:jar:1.5.2.Final:test
[INFO] |  |  |  \- org.wildfly.client:wildfly-client-config:jar:1.0.1.Final:test
[INFO] |  |  +- org.jboss.xnio:xnio-nio:jar:3.8.0.Final:test
[INFO] |  |  \- org.jboss.threads:jboss-threads:jar:3.1.0.Final:test
[INFO] |  \- io.undertow:undertow-servlet:jar:2.2.3.Final:test
[INFO] |     +- org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec:jar:2.0.0.Final:test
[INFO] |     \- org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec:jar:2.0.1.Final:test
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.13.3:test
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.13.3:test
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.13.3:test
[INFO] +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- javax.xml.ws:jaxws-api:jar:2.3.0:compile
[INFO] +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
[INFO] |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:compile
[INFO] +- org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec:jar:1.1.3:compile
[INFO] +- com.sun.xml.messaging.saaj:saaj-impl:jar:1.3.28:compile
[INFO] |  \- org.jvnet.mimepull:mimepull:jar:1.9.7:compile
[INFO] +- org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1.1:compile
[INFO] +- org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:jar:1.0.6.Final:compile
[INFO] +- org.glassfish.jaxb:jaxb-runtime:jar:2.3.3:compile
[INFO] |  +- org.glassfish.jaxb:txw2:jar:2.3.3:compile
[INFO] |  +- com.sun.istack:istack-commons-runtime:jar:3.0.11:compile
[INFO] |  \- com.sun.activation:jakarta.activation:jar:1.2.2:runtime
[INFO] \- javax.xml.soap:javax.xml.soap-api:jar:1.4.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.479 s
[INFO] Finished at: 2021-03-11T09:38:03+01:00
[INFO] ------------------------------------------------------------------------```
