### PR TITLE
Missing one rename of 'useIAMCredentials' as 'useDefaultCredentialsProvider' with the rename in 3.7

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Component.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Component.java
@@ -61,7 +61,7 @@ public class AWS2S3Component extends DefaultComponent {
         if (!configuration.isUseDefaultCredentialsProvider() && configuration.getAmazonS3Client() == null
                 && (configuration.getAccessKey() == null || configuration.getSecretKey() == null)) {
             throw new IllegalArgumentException(
-                    "useIAMCredentials is set to false, AmazonS3Client or accessKey and secretKey must be specified");
+                    "useDefaultCredentialsProvider is set to false, AmazonS3Client or accessKey and secretKey must be specified");
         }
 
         return endpoint;


### PR DESCRIPTION
Noticed a missing rename of 'useIAMCredentials' as 'useDefaultCredentialsProvider' with the 3.7 migration.
