### PR TITLE
[MINOR] password parsing bugfix in jt400 component

### DIFF
--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Configuration.java
@@ -167,7 +167,7 @@ public class Jt400Configuration {
         ObjectHelper.notNull(connectionPool, "connectionPool", this);
 
         URI uri = new URI(endpointUri);
-        String[] credentials = uri.getUserInfo().split(":");
+        String[] credentials = uri.getUserInfo().split(":", 2);
         systemName = uri.getHost();
         userID = credentials[0];
         password = credentials[1];


### PR DESCRIPTION

Current username/password parsing in the jt400 has two very minor bugs. Both should be fixed with a simple one-line change. 

**Bug 1: using an empty password results in an exception**
An empty password is allowed when the username is `*CURRENT`. However, specifying `*CURRENT:` as the `uid:pwd` string results in an exception
```pascal
Caused by: java.lang.ArrayIndexOutOfBoundsException: Array index out of range: 1
    at org.apache.camel.component.jt400.Jt400Configuration.<init> (Jt400Configuration.java:130)
    at org.apache.camel.component.jt400.Jt400Endpoint.<init> (Jt400Endpoint.java:68)
    at org.apache.camel.component.jt400.Jt400Component.createEndpoint (Jt400Component.java:77)
    at org.apache.camel.support.DefaultComponent.createEndpoint (DefaultComponent.java:237)
    at org.apache.camel.impl.engine.AbstractCamelContext.doGetEndpoint (AbstractCamelContext.java:846)
    at org.apache.camel.impl.engine.AbstractCamelContext.getEndpoint (AbstractCamelContext.java:768)
    at org.apache.camel.support.CamelContextHelper.resolveEndpoint (CamelContextHelper.java:123)
```

**~~Bug 2: passwords are allowed to have colons~~**
~~If my password has a colon (for instance, `pass:word`), then it is not parsed properly. It will parse the password as just `pass` rather than the full `pass:word`~~
[not a bug, should use RAW() ]