### PR TITLE
CAMEL-16357: Camel-splunk define tcpLocalReceiver port

### DIFF
--- a/components/camel-splunk/src/generated/java/org/apache/camel/component/splunk/SplunkEndpointConfigurer.java
+++ b/components/camel-splunk/src/generated/java/org/apache/camel/component/splunk/SplunkEndpointConfigurer.java
@@ -82,6 +82,8 @@ public class SplunkEndpointConfigurer extends PropertyConfigurerSupport implemen
         case "startscheduler":
         case "startScheduler": target.setStartScheduler(property(camelContext, boolean.class, value)); return true;
         case "streaming": target.getConfiguration().setStreaming(property(camelContext, boolean.class, value)); return true;
+        case "tcpreceiverlocalport":
+        case "tcpReceiverLocalPort": target.getConfiguration().setTcpReceiverLocalPort(property(camelContext, java.lang.Integer.class, value)); return true;
         case "tcpreceiverport":
         case "tcpReceiverPort": target.getConfiguration().setTcpReceiverPort(property(camelContext, int.class, value)); return true;
         case "timeunit":
@@ -159,6 +161,8 @@ public class SplunkEndpointConfigurer extends PropertyConfigurerSupport implemen
         case "startscheduler":
         case "startScheduler": return boolean.class;
         case "streaming": return boolean.class;
+        case "tcpreceiverlocalport":
+        case "tcpReceiverLocalPort": return java.lang.Integer.class;
         case "tcpreceiverport":
         case "tcpReceiverPort": return int.class;
         case "timeunit":
@@ -237,6 +241,8 @@ public class SplunkEndpointConfigurer extends PropertyConfigurerSupport implemen
         case "startscheduler":
         case "startScheduler": return target.isStartScheduler();
         case "streaming": return target.getConfiguration().isStreaming();
+        case "tcpreceiverlocalport":
+        case "tcpReceiverLocalPort": return target.getConfiguration().getTcpReceiverLocalPort();
         case "tcpreceiverport":
         case "tcpReceiverPort": return target.getConfiguration().getTcpReceiverPort();
         case "timeunit":

--- a/components/camel-splunk/src/generated/java/org/apache/camel/component/splunk/SplunkEndpointUriFactory.java
+++ b/components/camel-splunk/src/generated/java/org/apache/camel/component/splunk/SplunkEndpointUriFactory.java
@@ -20,7 +20,7 @@ public class SplunkEndpointUriFactory extends org.apache.camel.support.component
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
     static {
-        Set<String> props = new HashSet<>(44);
+        Set<String> props = new HashSet<>(45);
         props.add("backoffMultiplier");
         props.add("scheme");
         props.add("earliestTime");
@@ -60,6 +60,7 @@ public class SplunkEndpointUriFactory extends org.apache.camel.support.component
         props.add("startScheduler");
         props.add("initEarliestTime");
         props.add("name");
+        props.add("tcpReceiverLocalPort");
         props.add("sslProtocol");
         props.add("latestTime");
         props.add("eventHost");

--- a/components/camel-splunk/src/main/docs/splunk-component.adoc
+++ b/components/camel-splunk/src/main/docs/splunk-component.adoc
@@ -132,7 +132,7 @@ with the following path and query parameters:
 |===
 
 
-=== Query Parameters (43 parameters):
+=== Query Parameters (44 parameters):
 
 
 [width="100%",cols="2,5,^1,2",options="header"]
@@ -162,6 +162,7 @@ with the following path and query parameters:
 | *raw* (producer) | Should the payload be inserted raw | false | boolean
 | *source* (producer) | Splunk source argument |  | String
 | *sourceType* (producer) | Splunk sourcetype argument |  | String
+| *tcpReceiverLocalPort* (producer) | Splunk tcp receiver port defined locally on splunk server. (For example if splunk port 9997 is mapped to 12345, tcpReceiverLocalPort has to be 9997) |  | Integer
 | *tcpReceiverPort* (producer) | Splunk tcp receiver port |  | int
 | *backoffErrorThreshold* (scheduler) | The number of subsequent error polls (failed due some error) that should happen before the backoffMultipler should kick-in. |  | int
 | *backoffIdleThreshold* (scheduler) | The number of subsequent idle polls that should happen before the backoffMultipler should kick-in. |  | int

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConfiguration.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConfiguration.java
@@ -63,6 +63,8 @@ public class SplunkConfiguration {
     private String eventHost;
     @UriParam(label = "producer")
     private int tcpReceiverPort;
+    @UriParam(label = "producer")
+    private Integer tcpReceiverLocalPort;
     @UriParam(label = "producer", defaultValue = "false")
     private boolean raw;
 
@@ -153,6 +155,18 @@ public class SplunkConfiguration {
      */
     public void setTcpReceiverPort(int tcpReceiverPort) {
         this.tcpReceiverPort = tcpReceiverPort;
+    }
+
+    public Integer getTcpReceiverLocalPort() {
+        return tcpReceiverLocalPort;
+    }
+
+    /**
+     * Splunk tcp receiver port defined locally on splunk server. (For example if splunk port 9997 is mapped to 12345,
+     * tcpReceiverLocalPort has to be 9997)
+     */
+    public void setTcpReceiverLocalPort(Integer tcpReceiverLocalPort) {
+        this.tcpReceiverLocalPort = tcpReceiverLocalPort;
     }
 
     public boolean isRaw() {

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkProducer.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkProducer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.splunk;
 
+import java.util.Optional;
+
 import com.splunk.Args;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.splunk.event.SplunkEvent;
@@ -72,6 +74,9 @@ public class SplunkProducer extends DefaultProducer {
                 LOG.debug("Creating TcpDataWriter");
                 dataWriter = new TcpDataWriter(endpoint, buildSplunkArgs());
                 ((TcpDataWriter) dataWriter).setPort(endpoint.getConfiguration().getTcpReceiverPort());
+                ((TcpDataWriter) dataWriter).setHost(endpoint.getConfiguration().getHost());
+                ((TcpDataWriter) dataWriter)
+                        .setLocalPort(Optional.ofNullable(endpoint.getConfiguration().getTcpReceiverLocalPort()));
                 LOG.debug("TcpDataWriter created for endpoint {}", endpoint);
                 break;
             }

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/support/TcpDataWriter.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/support/TcpDataWriter.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.splunk.support;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Optional;
 
 import com.splunk.Args;
 import com.splunk.Service;
@@ -26,6 +27,8 @@ import org.apache.camel.component.splunk.SplunkEndpoint;
 
 public class TcpDataWriter extends SplunkDataWriter {
     private int port;
+    private Optional<Integer> localPort;
+    private String host;
 
     public TcpDataWriter(SplunkEndpoint endpoint, Args args) {
         super(endpoint, args);
@@ -35,15 +38,34 @@ public class TcpDataWriter extends SplunkDataWriter {
         this.port = port;
     }
 
+    public void setLocalPort(Optional<Integer> localPort) {
+        this.localPort = localPort;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
     @Override
     protected Socket createSocket(Service service) throws IOException {
-        TcpInput input = (TcpInput) service.getInputs().get(String.valueOf(port));
+        int p = localPort.isPresent() ? localPort.get() : port;
+        TcpInput input = (TcpInput) service.getInputs().get(String.valueOf(p));
         if (input == null) {
             throw new RuntimeException("no input defined for port " + port);
         }
         if (input.isDisabled()) {
             throw new RuntimeException(String.format("input on port %d is disabled", port));
         }
-        return input.attach();
+        return getSocket(input, service);
     }
+
+    Socket getSocket(TcpInput tcpInput, Service service) throws IOException {
+        if (localPort.isPresent() || (host != null && !host.equals(tcpInput.getHost()))) {
+            String h = host == null ? service.getHost() : host;
+            return new Socket(h, port);
+        }
+
+        return tcpInput.attach();
+    }
+
 }

--- a/components/camel-splunk/src/test/java/org/apache/camel/component/splunk/RawProducerTest.java
+++ b/components/camel-splunk/src/test/java/org/apache/camel/component/splunk/RawProducerTest.java
@@ -66,6 +66,7 @@ public class RawProducerTest extends SplunkMockTestSupport {
         when(service.getIndexes()).thenReturn(indexColl);
         when(service.getInputs()).thenReturn(inputCollection);
         when(input.attach()).thenReturn(socket);
+        when(input.getHost()).thenReturn("localhost");
         when(inputCollection.get(anyString())).thenReturn(input);
         when(indexColl.get(anyString())).thenReturn(index);
         when(index.attach(isA(Args.class))).thenReturn(socket);


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-16357

Added parameter `tcpLocalReceiverPort`, which could be used in case that port for tcp receiver differs in splunk server and real value used for connection (e.g. when port is mapped via docker)
Junit test is present.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md
-->
