### PR TITLE
Avoid false positives within assertThrows in tests

### DIFF
--- a/components/camel-atlasmap/src/test/java/org/apache/camel/component/atlasmap/AtlasMapEndpointTest.java
+++ b/components/camel-atlasmap/src/test/java/org/apache/camel/component/atlasmap/AtlasMapEndpointTest.java
@@ -65,11 +65,13 @@ public class AtlasMapEndpointTest {
         perform(ds, "my-source-doc", "my-target-doc", false);
     }
 
+    private void execute() throws Exception {
+        perform(new ArrayList<>(), null, null, true);
+    }
+
     @Test
     public void noConversionIfNoDataSource() throws Exception {
-        assertThrows(AssertionFailedError.class, () -> {
-            perform(new ArrayList<>(), null, null, true);
-        });
+        assertThrows(AssertionFailedError.class, this::execute);
     }
 
     @Test
@@ -196,5 +198,4 @@ public class AtlasMapEndpointTest {
         when(exchange.getMessage()).thenReturn(outMessage);
         endpoint.onExchange(exchange);
     }
-
 }

--- a/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomProducerTest.java
+++ b/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomProducerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.atom;
 
+import org.apache.camel.Endpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +29,9 @@ public class AtomProducerTest extends CamelTestSupport {
 
     @Test
     void testNotYetImplemented() {
-        assertThrows(UnsupportedOperationException.class,
-                () -> context.getEndpoint("atom:file://target/out.atom").createProducer());
+        Endpoint ep = context.getEndpoint("atom:file://target/out.atom");
+
+        assertThrows(UnsupportedOperationException.class, () -> ep.createProducer());
     }
 
 }

--- a/components/camel-avro-rpc/src/test/java/org/apache/camel/component/avro/AvroSettingsTest.java
+++ b/components/camel-avro-rpc/src/test/java/org/apache/camel/component/avro/AvroSettingsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.avro;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.FailedToCreateRouteException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
@@ -24,43 +25,50 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AvroSettingsTest extends AvroTestSupport {
 
+    private void runTest(RouteBuilder rb) {
+        CamelContext context = context();
+
+        assertThrows(FailedToCreateRouteException.class, () -> context.addRoutes(rb));
+    }
+
     @Test
     public void testConsumerForUnknownMessage() {
-        assertThrows(FailedToCreateRouteException.class, () -> {
-            context().addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("avro:http:localhost:" + avroPort
-                         + "/notValid?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol").to("log:test");
-                }
-            });
-        });
+        RouteBuilder rb = new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("avro:http:localhost:" + avroPort
+                     + "/notValid?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol").to("log:test");
+            }
+        };
+
+        runTest(rb);
     }
 
     @Test
     public void testProducerForUnknownMessage() {
-        assertThrows(FailedToCreateRouteException.class, () -> {
-            context().addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("direct:test").to("avro:http:localhost:" + avroPort
-                                           + "/notValid?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol");
-                }
-            });
-        });
+        RouteBuilder rb = new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:test").to("avro:http:localhost:" + avroPort
+                                       + "/notValid?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol");
+            }
+        };
+
+        runTest(rb);
+
     }
 
     @Test
     public void testProducerForNonSingleParamMessage() {
-        assertThrows(FailedToCreateRouteException.class, () -> {
-            context().addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("direct:test")
-                            .to("avro:http:localhost:" + avroPort
-                                + "/put?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol&singleParameter=true");
-                }
-            });
-        });
+        RouteBuilder rb = new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:test")
+                        .to("avro:http:localhost:" + avroPort
+                            + "/put?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol&singleParameter=true");
+            }
+        };
+
+        runTest(rb);
     }
 }

--- a/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/component/DataLakeComponentTest.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/component/DataLakeComponentTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.azure.storage.datalake.component;
 
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
+import org.apache.camel.Producer;
 import org.apache.camel.component.azure.storage.datalake.DataLakeConfiguration;
 import org.apache.camel.component.azure.storage.datalake.DataLakeEndpoint;
 import org.apache.camel.component.azure.storage.datalake.DataLakeOperationsDefinition;
@@ -70,13 +71,16 @@ class DataLakeComponentTest extends CamelTestSupport {
     }
 
     @Test
-    public void testProducerWithoutFileName() {
+    public void testProducerWithoutFileName() throws Exception {
         context.getRegistry().bind("credentials", storageSharedKeyCredentials());
         final DataLakeEndpoint endpoint = (DataLakeEndpoint) context
                 .getEndpoint("azure-storage-datalake:cameltesting/abc?sharedKeyCredential=#credentials&operation=deleteFile");
 
         DefaultExchange exchange = new DefaultExchange(context);
-        assertThrows(IllegalArgumentException.class, () -> endpoint.createProducer().process(exchange));
+
+        Producer producer = endpoint.createProducer();
+
+        assertThrows(IllegalArgumentException.class, () -> producer.process(exchange));
     }
 
     private StorageSharedKeyCredential storageSharedKeyCredentials() {

--- a/components/camel-azure/camel-azure-storage-queue/src/test/java/org/apache/camel/component/azure/storage/queue/QueueComponentTest.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/test/java/org/apache/camel/component/azure/storage/queue/QueueComponentTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.queue.QueueServiceClient;
+import org.apache.camel.Producer;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.component.azure.storage.queue.client.QueueClientFactory;
 import org.apache.camel.support.DefaultExchange;
@@ -96,13 +97,15 @@ class QueueComponentTest extends CamelTestSupport {
     }
 
     @Test
-    public void testNoQueueNameProducerWithOpNeedsQueueName() {
+    public void testNoQueueNameProducerWithOpNeedsQueueName() throws Exception {
         context.getRegistry().bind("creds", new StorageSharedKeyCredential("fake", "fake"));
 
         final QueueEndpoint endpoint = (QueueEndpoint) context
                 .getEndpoint("azure-storage-queue://camelazure?credentials=#creds&operation=deleteQueue");
 
-        assertThrows(IllegalArgumentException.class, () -> endpoint.createProducer().process(new DefaultExchange(context)));
+        Producer producer = endpoint.createProducer();
+        DefaultExchange exchange = new DefaultExchange(context);
+        assertThrows(IllegalArgumentException.class, () -> producer.process(exchange));
     }
 
     @Test

--- a/components/camel-beanstalk/src/test/java/org/apache/camel/component/beanstalk/ConnectionSettingsTest.java
+++ b/components/camel-beanstalk/src/test/java/org/apache/camel/component/beanstalk/ConnectionSettingsTest.java
@@ -48,8 +48,9 @@ public class ConnectionSettingsTest {
 
     @Test
     void notValidHost() {
+        final ConnectionSettingsFactory factory = BeanstalkComponent.getConnectionSettingsFactory();
+
         assertThrows(IllegalArgumentException.class, () -> {
-            final ConnectionSettingsFactory factory = BeanstalkComponent.getConnectionSettingsFactory();
             factory.parseUri("not_valid?host/tube?");
         }, "Calling on not valid URI must raise exception");
     }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/format/factories/DefaultFactoryRegistryTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/format/factories/DefaultFactoryRegistryTest.java
@@ -26,13 +26,14 @@ public class DefaultFactoryRegistryTest {
 
     @Test
     public void unregisterFormatFactory() {
+        FactoryRegistry reg = new DefaultFactoryRegistry();
+        FormattingOptions formattingOptions = new FormattingOptions().forClazz(String.class);
+
+        assertNotNull(reg.findForFormattingOptions(formattingOptions));
+
+        reg.unregister(StringFormatFactory.class);
+
         assertThrows(IllegalArgumentException.class, () -> {
-            FactoryRegistry reg = new DefaultFactoryRegistry();
-            FormattingOptions formattingOptions = new FormattingOptions().forClazz(String.class);
-
-            assertNotNull(reg.findForFormattingOptions(formattingOptions));
-
-            reg.unregister(StringFormatFactory.class);
             reg.findForFormattingOptions(formattingOptions);
         });
     }

--- a/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAPITest.java
+++ b/components/camel-bonita/src/test/java/org/apache/camel/component/bonita/api/BonitaAPITest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.bonita.api;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.camel.component.bonita.api.model.ProcessDefinitionResponse;
 import org.apache.camel.component.bonita.api.util.BonitaAPIConfig;
@@ -38,8 +39,11 @@ public class BonitaAPITest {
     public void testStartCaseEmptyProcessDefinitionId() throws Exception {
         BonitaAPI bonitaApi = BonitaAPIBuilder
                 .build(new BonitaAPIConfig("hostname", "port", "username", "password"));
+
+        Map<String, Serializable> map = new HashMap<>();
+
         assertThrows(IllegalArgumentException.class,
-                () -> bonitaApi.startCase(null, new HashMap<String, Serializable>()));
+                () -> bonitaApi.startCase(null, map));
     }
 
     @Test

--- a/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxCollaborationsManagerTest.java
+++ b/components/camel-box/camel-box-component/src/test/java/org/apache/camel/component/box/BoxCollaborationsManagerTest.java
@@ -30,13 +30,15 @@ class BoxCollaborationsManagerTest {
     public void testAddFolderCollaborationNullFolderId() {
         BoxCollaborationsManager bcm = new BoxCollaborationsManager(null);
 
+        BoxUser user = new BoxUser(null, "id");
+
         assertThrows(IllegalArgumentException.class,
-                () -> bcm.addFolderCollaboration(null, new BoxUser(null, "id"), BoxCollaboration.Role.EDITOR));
+                () -> bcm.addFolderCollaboration(null, user, BoxCollaboration.Role.EDITOR));
 
         assertThrows(IllegalArgumentException.class,
                 () -> bcm.addFolderCollaboration("123", null, BoxCollaboration.Role.EDITOR));
 
         assertThrows(IllegalArgumentException.class,
-                () -> bcm.addFolderCollaboration("123", new BoxUser(null, "id"), null));
+                () -> bcm.addFolderCollaboration("123", user, null));
     }
 }

--- a/components/camel-cm-sms/src/test/java/org/apache/camel/component/cm/test/CMTest.java
+++ b/components/camel-cm-sms/src/test/java/org/apache/camel/component/cm/test/CMTest.java
@@ -125,16 +125,18 @@ public class CMTest {
     public void testNotRequiredProductToken() throws Throwable {
         String schemedUri
                 = "cm-sms://sgw01.cm.nl/gateway.ashx?defaultFrom=MyBusiness&defaultMaxNumberOfParts=8&testConnectionOnStartup=true";
+
         assertThrows(ResolveEndpointFailedException.class,
-                () -> camelContext.getEndpoint(schemedUri).start());
+                () -> camelContext.getEndpoint(schemedUri));
     }
 
     @Test
     public void testNotRequiredDefaultFrom() throws Throwable {
         String schemedUri
                 = "cm-sms://sgw01.cm.nl/gateway.ashx?defaultFrom=MyBusiness&defaultMaxNumberOfParts=8&testConnectionOnStartup=true";
+
         assertThrows(ResolveEndpointFailedException.class,
-                () -> camelContext.getEndpoint(schemedUri).start());
+                () -> camelContext.getEndpoint(schemedUri));
     }
 
     @Test

--- a/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISProducerTest.java
+++ b/components/camel-cmis/src/test/java/org/apache/camel/component/cmis/CMISProducerTest.java
@@ -33,6 +33,7 @@ import org.apache.chemistry.opencmis.client.api.CmisObject;
 import org.apache.chemistry.opencmis.client.api.Document;
 import org.apache.chemistry.opencmis.client.api.FileableCmisObject;
 import org.apache.chemistry.opencmis.client.api.Folder;
+import org.apache.chemistry.opencmis.client.api.Session;
 import org.apache.chemistry.opencmis.commons.PropertyIds;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
@@ -263,9 +264,12 @@ public class CMISProducerTest extends CMISTestSupport {
         List<String> unsuccessfullyDeletedObjects = exchange.getMessage().getBody(List.class);
         assertTrue(unsuccessfullyDeletedObjects.isEmpty());
 
+        final Session session = createSession();
+        final String id = folder.getId();
+
         assertThrows(CmisObjectNotFoundException.class, () -> {
             // Try to get already deleted object by id should throw
-            createSession().getObject(folder.getId());
+            session.getObject(id);
         });
     }
 

--- a/components/camel-couchbase/src/test/java/org/apache/camel/component/couchbase/CouchbaseEndpointTest.java
+++ b/components/camel-couchbase/src/test/java/org/apache/camel/component/couchbase/CouchbaseEndpointTest.java
@@ -45,14 +45,22 @@ public class CouchbaseEndpointTest {
 
     @Test
     public void testHostnameRequired() throws Exception {
+        final CouchbaseComponent component = new CouchbaseComponent();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new CouchbaseEndpoint("couchbase:http://:80/bucket", "couchbase://:80/bucket", new CouchbaseComponent()));
+                () -> {
+                    new CouchbaseEndpoint("couchbase:http://:80/bucket", "couchbase://:80/bucket", component);
+                });
     }
 
     @Test
     public void testSchemeRequired() throws Exception {
+        final CouchbaseComponent component = new CouchbaseComponent();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new CouchbaseEndpoint("couchbase:localhost:80/bucket", "localhost:80/bucket", new CouchbaseComponent()));
+                () -> {
+                    new CouchbaseEndpoint("couchbase:localhost:80/bucket", "localhost:80/bucket", component);
+                });
     }
 
     @Test
@@ -62,8 +70,12 @@ public class CouchbaseEndpointTest {
 
     @Test
     public void testCouchbaseEndpointWithoutProtocol() throws Exception {
+        final CouchbaseComponent component = new CouchbaseComponent();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new CouchbaseEndpoint("localhost:80/bucket", "localhost:80/bucket", new CouchbaseComponent()));
+                () -> {
+                    new CouchbaseEndpoint("localhost:80/bucket", "localhost:80/bucket", component);
+                });
     }
 
     @Test
@@ -96,7 +108,7 @@ public class CouchbaseEndpointTest {
     }
 
     @Test
-    public void testCouchbaseEndpontSettersAndGetters() {
+    public void testCouchbaseEndpointSettersAndGetters() {
         CouchbaseEndpoint endpoint = new CouchbaseEndpoint();
 
         endpoint.setProtocol("couchbase");

--- a/components/camel-couchdb/src/test/java/org/apache/camel/component/couchdb/CouchDbEndpointTest.java
+++ b/components/camel-couchdb/src/test/java/org/apache/camel/component/couchdb/CouchDbEndpointTest.java
@@ -34,8 +34,10 @@ public class CouchDbEndpointTest {
 
     @Test
     void testDbRequired() {
+        final CouchDbComponent component = new CouchDbComponent();
+
         assertThrows(IllegalArgumentException.class, () -> {
-            new CouchDbEndpoint("couchdb:http://localhost:80", "http://localhost:80", new CouchDbComponent());
+            new CouchDbEndpoint("couchdb:http://localhost:80", "http://localhost:80", component);
         });
     }
 
@@ -49,15 +51,19 @@ public class CouchDbEndpointTest {
 
     @Test
     void testHostnameRequired() {
+        final CouchDbComponent component = new CouchDbComponent();
+
         assertThrows(IllegalArgumentException.class, () -> {
-            new CouchDbEndpoint("couchdb:http://:80/db", "http://:80/db", new CouchDbComponent());
+            new CouchDbEndpoint("couchdb:http://:80/db", "http://:80/db", component);
         });
     }
 
     @Test
     void testSchemeRequired() {
+        final CouchDbComponent component = new CouchDbComponent();
+
         assertThrows(IllegalArgumentException.class, () -> {
-            new CouchDbEndpoint("couchdb:localhost:80/db", "localhost:80/db", new CouchDbComponent());
+            new CouchDbEndpoint("couchdb:localhost:80/db", "localhost:80/db", component);
         });
     }
 }

--- a/components/camel-debezium/camel-debezium-common/camel-debezium-maven-plugin/src/test/java/org/apache/camel/maven/config/ConnectorConfigGeneratorTest.java
+++ b/components/camel-debezium/camel-debezium-common/camel-debezium-maven-plugin/src/test/java/org/apache/camel/maven/config/ConnectorConfigGeneratorTest.java
@@ -63,8 +63,12 @@ public class ConnectorConfigGeneratorTest {
 
     @Test
     void testIfItHandlesWrongClassInput() {
+        final MySqlConnector connector = new MySqlConnector();
+        final Map<String, Object> overridenDefaultValues = Collections.emptyMap();
+        final Set<String> requiredFields = Collections.emptySet();
+
         assertThrows(IllegalArgumentException.class, () -> {
-            ConnectorConfigGenerator.create(new MySqlConnector(), getClass(), Collections.emptySet(), Collections.emptyMap());
+            ConnectorConfigGenerator.create(connector, getClass(), requiredFields, overridenDefaultValues);
         });
     }
 

--- a/components/camel-debezium/camel-debezium-mongodb/src/test/java/org/apache/camel/component/debezium/DebeziumMongodbComponentTest.java
+++ b/components/camel-debezium/camel-debezium-mongodb/src/test/java/org/apache/camel/component/debezium/DebeziumMongodbComponentTest.java
@@ -104,8 +104,10 @@ public class DebeziumMongodbComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
+
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }
@@ -120,8 +122,10 @@ public class DebeziumMongodbComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
+
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }

--- a/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/DebeziumMySqlComponentTest.java
+++ b/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/DebeziumMySqlComponentTest.java
@@ -106,8 +106,10 @@ public class DebeziumMySqlComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
+
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }
@@ -122,8 +124,9 @@ public class DebeziumMySqlComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }

--- a/components/camel-debezium/camel-debezium-postgres/src/test/java/org/apache/camel/component/debezium/DebeziumPostgresComponentTest.java
+++ b/components/camel-debezium/camel-debezium-postgres/src/test/java/org/apache/camel/component/debezium/DebeziumPostgresComponentTest.java
@@ -106,8 +106,9 @@ public class DebeziumPostgresComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }
@@ -122,8 +123,9 @@ public class DebeziumPostgresComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }

--- a/components/camel-debezium/camel-debezium-sqlserver/src/test/java/org/apache/camel/component/debezium/DebeziumSqlserverComponentTest.java
+++ b/components/camel-debezium/camel-debezium-sqlserver/src/test/java/org/apache/camel/component/debezium/DebeziumSqlserverComponentTest.java
@@ -106,8 +106,9 @@ public class DebeziumSqlserverComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }
@@ -122,8 +123,9 @@ public class DebeziumSqlserverComponentTest {
             // set configurations
             debeziumComponent.setConfiguration(null);
 
+            final Map<String, Object> parameters = Collections.emptyMap();
             assertThrows(IllegalArgumentException.class, () -> {
-                debeziumComponent.createEndpoint(uri, remaining, Collections.emptyMap());
+                debeziumComponent.createEndpoint(uri, remaining, parameters);
             });
         }
     }

--- a/components/camel-disruptor/src/test/java/org/apache/camel/component/disruptor/DisruptorBlockWhenFullTest.java
+++ b/components/camel-disruptor/src/test/java/org/apache/camel/component/disruptor/DisruptorBlockWhenFullTest.java
@@ -61,15 +61,13 @@ public class DisruptorBlockWhenFullTest extends CamelTestSupport {
 
     @Test
     void testDisruptorExceptionWhenFull() throws Exception {
-        assertThrows(CamelExecutionException.class, () -> {
-            getMockEndpoint(MOCK_URI).setExpectedMessageCount(QUEUE_SIZE + 20);
+        getMockEndpoint(MOCK_URI).setExpectedMessageCount(QUEUE_SIZE + 20);
 
-            final DisruptorEndpoint disruptor = context.getEndpoint(DEFAULT_URI, DisruptorEndpoint.class);
-            assertEquals(QUEUE_SIZE, disruptor.getRemainingCapacity());
+        final DisruptorEndpoint disruptor = context.getEndpoint(DEFAULT_URI, DisruptorEndpoint.class);
+        assertEquals(QUEUE_SIZE, disruptor.getRemainingCapacity());
 
-            sendSoManyOverCapacity(EXCEPTION_WHEN_FULL_URI, QUEUE_SIZE, 20);
-            assertMockEndpointsSatisfied();
-        });
+        assertThrows(CamelExecutionException.class,
+                () -> sendSoManyOverCapacity(EXCEPTION_WHEN_FULL_URI, QUEUE_SIZE, 20));
     }
 
     /**

--- a/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerClientProfileTest.java
+++ b/components/camel-docker/src/test/java/org/apache/camel/component/docker/DockerClientProfileTest.java
@@ -74,11 +74,10 @@ public class DockerClientProfileTest {
 
     @Test
     void clientProfileNoPortSpecifiedUrlTest() throws DockerException {
-        IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, () -> {
-            DockerClientProfile profile = new DockerClientProfile();
-            profile.setHost("localhost");
-            profile.toUrl();
-        });
+        DockerClientProfile profile = new DockerClientProfile();
+        profile.setHost("localhost");
+
+        IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, () -> profile.toUrl());
         assertEquals("port must be specified", iaex.getMessage());
     }
 

--- a/components/camel-ganglia/src/test/java/org/apache/camel/component/ganglia/GangliaProtocolV31CamelTest.java
+++ b/components/camel-ganglia/src/test/java/org/apache/camel/component/ganglia/GangliaProtocolV31CamelTest.java
@@ -154,36 +154,48 @@ public class GangliaProtocolV31CamelTest extends CamelGangliaTestSupport {
 
     @Test
     public void sendWrongMetricTypeShouldThrow() throws Exception {
+        final String testUri = getTestUri();
+
         assertThrows(CamelExecutionException.class, () -> {
-            template.sendBodyAndHeader(getTestUri(), "28.0", METRIC_TYPE, "NotAGMetricType");
+            template.sendBodyAndHeader(testUri, "28.0", METRIC_TYPE, "NotAGMetricType");
         });
     }
 
     @Test
     public void sendWrongMetricSlopeShouldThrow() throws Exception {
+        final String testUri = getTestUri();
+
         assertThrows(CamelExecutionException.class, () -> {
-            template.sendBodyAndHeader(getTestUri(), "28.0", METRIC_SLOPE, "NotAGMetricSlope");
+            template.sendBodyAndHeader(testUri, "28.0", METRIC_SLOPE, "NotAGMetricSlope");
         });
     }
 
     @Test
     public void sendWrongMetricTMaxShouldThrow() throws Exception {
+        final String testUri = getTestUri();
+        final Object headerValue = new Object();
+
         assertThrows(CamelExecutionException.class, () -> {
-            template.sendBodyAndHeader(getTestUri(), "28.0", METRIC_TMAX, new Object());
+            template.sendBodyAndHeader(testUri, "28.0", METRIC_TMAX, headerValue);
         });
     }
 
     @Test
     public void sendWrongMetricDMaxShouldThrow() throws Exception {
+        final String testUri = getTestUri();
+        final Object headerValue = new Object();
+
         assertThrows(CamelExecutionException.class, () -> {
-            template.sendBodyAndHeader(getTestUri(), "28.0", METRIC_DMAX, new Object());
+            template.sendBodyAndHeader(testUri, "28.0", METRIC_DMAX, headerValue);
         });
     }
 
     @Test
     public void sendWithWrongTypeShouldThrow() throws Exception {
+        final String endpointUri = getTestUri() + "&type=wrong";
+
         assertThrows(ResolveEndpointFailedException.class, () -> {
-            template.sendBody(getTestUri() + "&type=wrong", "");
+            template.sendBody(endpointUri, "");
         });
     }
 

--- a/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/sql/GoogleBigQuerySQLProducerWithParamersTest.java
+++ b/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/sql/GoogleBigQuerySQLProducerWithParamersTest.java
@@ -131,7 +131,8 @@ public class GoogleBigQuerySQLProducerWithParamersTest extends GoogleBigQuerySQL
 
     @Test
     public void sendMessageWithoutParameters() throws Exception {
-        assertThrows(RuntimeExchangeException.class,
-                () -> producer.process(createExchangeWithBody(new HashMap<>())));
+        final Exchange exchangeWithBody = createExchangeWithBody(new HashMap<>());
+
+        assertThrows(RuntimeExchangeException.class, () -> producer.process(exchangeWithBody));
     }
 }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositoryConstructorsTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositoryConstructorsTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor.aggregate.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -33,11 +34,13 @@ public class HazelcastAggregationRepositoryConstructorsTest extends CamelTestSup
         repo.doStart();
 
         try {
-            Exchange oldOne = new DefaultExchange(context());
-            Exchange newOne = new DefaultExchange(context());
+            final CamelContext context = context();
+            Exchange oldOne = new DefaultExchange(context);
+            Exchange newOne = new DefaultExchange(context);
             final String key = "abrakadabra";
+
             assertThrows(UnsupportedOperationException.class,
-                    () -> repo.add(context(), key, oldOne, newOne));
+                    () -> repo.add(context, key, oldOne, newOne));
         } finally {
             repo.doStop();
         }
@@ -50,10 +53,11 @@ public class HazelcastAggregationRepositoryConstructorsTest extends CamelTestSup
         repo.doStart();
 
         try {
-            Exchange ex = new DefaultExchange(context());
+            final CamelContext context = context();
+            Exchange ex = new DefaultExchange(context);
             final String key = "abrakadabra";
             assertThrows(UnsupportedOperationException.class,
-                    () -> repo.add(context(), key, ex));
+                    () -> repo.add(context, key, ex));
         } finally {
             repo.doStop();
         }

--- a/components/camel-hl7/src/test/java/org/apache/camel/component/hl7/TerserExpressionTest.java
+++ b/components/camel-hl7/src/test/java/org/apache/camel/component/hl7/TerserExpressionTest.java
@@ -59,8 +59,12 @@ public class TerserExpressionTest extends CamelTestSupport {
 
     @Test
     public void testTerserInvalidExpression() throws Exception {
+        final Message adt01Message = createADT01Message();
+
         assertThrows(CamelExecutionException.class,
-                () -> template.sendBody("direct:test4", createADT01Message()));
+                () -> {
+                    template.sendBody("direct:test4", adt01Message);
+                });
     }
 
     @Test

--- a/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQBatchProducerTest.java
+++ b/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQBatchProducerTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.ironmq;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.iron.ironmq.Ids;
@@ -52,8 +53,10 @@ public class IronMQBatchProducerTest extends CamelTestSupport {
 
     @Test
     public void testProduceBatchWithIllegalPayload() throws Exception {
+        final List<String> body = Arrays.asList("foo", "bar");
+
         assertThrows(CamelExecutionException.class,
-                () -> template.sendBody("direct:start", Arrays.asList("foo", "bar")));
+                () -> template.sendBody("direct:start", body));
     }
 
     @Override

--- a/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/JCacheManagerTest.java
+++ b/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/JCacheManagerTest.java
@@ -40,7 +40,11 @@ public class JCacheManagerTest extends JCacheComponentTestSupport {
         conf.setCacheName(randomString());
         conf.setCreateCacheIfNotExists(false);
 
+        final JCacheManager<Object, Object> objectObjectJCacheManager = new JCacheManager<>(conf);
+
         assertThrows(IllegalStateException.class,
-                () -> new JCacheManager<>(conf).getCache());
+                () -> {
+                    objectObjectJCacheManager.getCache();
+                });
     }
 }

--- a/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/processor/aggregate/JCacheAggregationRepositoryTest.java
+++ b/components/camel-jcache/src/test/java/org/apache/camel/component/jcache/processor/aggregate/JCacheAggregationRepositoryTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jcache.processor.aggregate;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
@@ -32,10 +33,11 @@ public class JCacheAggregationRepositoryTest extends JCacheAggregationRepository
         repo.start();
 
         try {
-            Exchange oldOne = new DefaultExchange(context());
-            Exchange newOne = new DefaultExchange(context());
+            final CamelContext context = context();
+            Exchange oldOne = new DefaultExchange(context);
+            Exchange newOne = new DefaultExchange(context);
             assertThrows(UnsupportedOperationException.class,
-                    () -> repo.add(context(), "myKey", oldOne, newOne));
+                    () -> repo.add(context, "myKey", oldOne, newOne));
         } finally {
             repo.stop();
         }
@@ -47,9 +49,10 @@ public class JCacheAggregationRepositoryTest extends JCacheAggregationRepository
         repo.start();
 
         try {
-            Exchange ex = new DefaultExchange(context());
+            final CamelContext context = context();
+            Exchange ex = new DefaultExchange(context);
             assertThrows(UnsupportedOperationException.class,
-                    () -> repo.add(context(), "myKey", ex));
+                    () -> repo.add(context, "myKey", ex));
         } finally {
             repo.stop();
         }

--- a/components/camel-jsonapi/src/test/java/org/apache/camel/component/jsonapi/JsonApiDataFormatTest.java
+++ b/components/camel-jsonapi/src/test/java/org/apache/camel/component/jsonapi/JsonApiDataFormatTest.java
@@ -98,8 +98,10 @@ public class JsonApiDataFormatTest extends CamelTestSupport {
         String jsonApiInput = "{\"data\":{\"type\":\"animal\",\"id\":\"camel\",\"attributes\":{\"humps\":\"2\"}}}";
 
         Exchange exchange = new DefaultExchange(context);
+        final ByteArrayInputStream stream = new ByteArrayInputStream(jsonApiInput.getBytes());
+
         assertThrows(UnregisteredTypeException.class,
-                () -> jsonApiDataFormat.unmarshal(exchange, new ByteArrayInputStream(jsonApiInput.getBytes())));
+                () -> jsonApiDataFormat.unmarshal(exchange, stream));
     }
 
     @Test

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerTest.java
@@ -47,8 +47,9 @@ public class KafkaConsumerTest {
         when(endpoint.getConfiguration().getGroupId()).thenReturn("groupOne");
         when(component.getKafkaClientFactory()).thenReturn(clientFactory);
         when(clientFactory.getBrokers(any())).thenThrow(new IllegalArgumentException());
-        assertThrows(IllegalArgumentException.class,
-                () -> new KafkaConsumer(endpoint, processor).getProps());
+        final KafkaConsumer kafkaConsumer = new KafkaConsumer(endpoint, processor);
+
+        assertThrows(IllegalArgumentException.class, () -> kafkaConsumer.getProps());
     }
 
     @Test

--- a/components/camel-microprofile/camel-microprofile-metrics/src/test/java/org/apache/camel/component/microprofile/metrics/MicroProfileMetricsHelperTest.java
+++ b/components/camel-microprofile/camel-microprofile-metrics/src/test/java/org/apache/camel/component/microprofile/metrics/MicroProfileMetricsHelperTest.java
@@ -73,7 +73,9 @@ public class MicroProfileMetricsHelperTest {
 
     @Test
     public void testGetMetricRegistryWhenNoRegistryConfigured() {
+        final DefaultCamelContext camelContext = new DefaultCamelContext();
+
         assertThrows(IllegalStateException.class,
-                () -> MicroProfileMetricsHelper.getMetricRegistry(new DefaultCamelContext()));
+                () -> MicroProfileMetricsHelper.getMetricRegistry(camelContext));
     }
 }

--- a/components/camel-protobuf/src/test/java/org/apache/camel/dataformat/protobuf/ProtobufConverterTest.java
+++ b/components/camel-protobuf/src/test/java/org/apache/camel/dataformat/protobuf/ProtobufConverterTest.java
@@ -84,8 +84,9 @@ public class ProtobufConverterTest {
         input.put("id", 1234);
         input.put("address", "wrong address");
 
+        final AddressBookProtos.Person defaultInstance = AddressBookProtos.Person.getDefaultInstance();
         assertThrows(IllegalArgumentException.class,
-                () -> ProtobufConverter.toProto(input, AddressBookProtos.Person.getDefaultInstance()));
+                () -> ProtobufConverter.toProto(input, defaultInstance));
     }
 
     @Test
@@ -96,8 +97,9 @@ public class ProtobufConverterTest {
         input.put("id", 1234);
         input.put("nicknames", "wrong nickname");
 
+        final AddressBookProtos.Person defaultInstance = AddressBookProtos.Person.getDefaultInstance();
         assertThrows(IllegalArgumentException.class,
-                () -> ProtobufConverter.toProto(input, AddressBookProtos.Person.getDefaultInstance()));
+                () -> ProtobufConverter.toProto(input, defaultInstance));
     }
 
     @Test

--- a/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/DelayedMonoPublisherTest.java
+++ b/components/camel-reactive-streams/src/test/java/org/apache/camel/component/reactive/streams/DelayedMonoPublisherTest.java
@@ -286,9 +286,10 @@ public class DelayedMonoPublisherTest {
     @Test
     public void testOnlyOneExceptionAllowed() throws Exception {
         DelayedMonoPublisher<Integer> pub = new DelayedMonoPublisher<>(service);
-        pub.setException(new RuntimeException("An exception"));
+        final RuntimeException runtimeException = new RuntimeException("An exception");
+        pub.setException(runtimeException);
         assertThrows(IllegalStateException.class,
-                () -> pub.setException(new RuntimeException("An exception")));
+                () -> pub.setException(runtimeException));
     }
 
 }

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointTest.java
@@ -377,8 +377,9 @@ public class RestOpenApiEndpointTest {
         final CamelContext camelContext = mock(CamelContext.class);
         when(camelContext.getClassResolver()).thenReturn(new DefaultClassResolver());
 
+        final URI uri = URI.create("non-existant.json");
         assertThrows(IllegalArgumentException.class,
-                () -> RestOpenApiEndpoint.loadSpecificationFrom(camelContext, URI.create("non-existant.json")));
+                () -> RestOpenApiEndpoint.loadSpecificationFrom(camelContext, uri));
     }
 
     @Test

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointV3Test.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointV3Test.java
@@ -387,8 +387,9 @@ public class RestOpenApiEndpointV3Test {
         final CamelContext camelContext = mock(CamelContext.class);
         when(camelContext.getClassResolver()).thenReturn(new DefaultClassResolver());
 
+        final URI uri = URI.create("non-existant.json");
         assertThrows(IllegalArgumentException.class,
-                () -> RestOpenApiEndpoint.loadSpecificationFrom(camelContext, URI.create("non-existant.json")));
+                () -> RestOpenApiEndpoint.loadSpecificationFrom(camelContext, uri));
     }
 
     @Test

--- a/components/camel-rest-swagger/src/test/java/org/apache/camel/component/rest/swagger/RestSwaggerEndpointTest.java
+++ b/components/camel-rest-swagger/src/test/java/org/apache/camel/component/rest/swagger/RestSwaggerEndpointTest.java
@@ -366,8 +366,9 @@ public class RestSwaggerEndpointTest {
         final CamelContext camelContext = mock(CamelContext.class);
         when(camelContext.getClassResolver()).thenReturn(new DefaultClassResolver());
 
+        final URI uri = URI.create("non-existant.json");
         assertThrows(IllegalArgumentException.class,
-                () -> RestSwaggerEndpoint.loadSpecificationFrom(camelContext, URI.create("non-existant.json"), null));
+                () -> RestSwaggerEndpoint.loadSpecificationFrom(camelContext, uri, null));
     }
 
     @Test

--- a/components/camel-servicenow/camel-servicenow-component/src/test/java/org/apache/camel/component/servicenow/ServiceNowMetaDataExtensionTest.java
+++ b/components/camel-servicenow/camel-servicenow-component/src/test/java/org/apache/camel/component/servicenow/ServiceNowMetaDataExtensionTest.java
@@ -107,7 +107,8 @@ public class ServiceNowMetaDataExtensionTest extends ServiceNowTestSupport {
         parameters.put("objectType", "test");
         parameters.put("objectName", "incident");
 
+        final MetaDataExtension extension = getExtension();
         assertThrows(UnsupportedOperationException.class,
-                () -> getExtension().meta(parameters));
+                () -> extension.meta(parameters));
     }
 }

--- a/components/camel-servicenow/camel-servicenow-component/src/test/java/org/apache/camel/component/servicenow/ServiceNowServiceCatalogTest.java
+++ b/components/camel-servicenow/camel-servicenow-component/src/test/java/org/apache/camel/component/servicenow/ServiceNowServiceCatalogTest.java
@@ -61,15 +61,17 @@ public class ServiceNowServiceCatalogTest extends ServiceNowTestSupport {
 
     @Test
     public void testWrongSubject() throws Exception {
+        final Map<String, Object> invalid = kvBuilder()
+                .put(ServiceNowConstants.RESOURCE, ServiceNowConstants.RESOURCE_SERVICE_CATALOG)
+                .put(ServiceNowConstants.ACTION, ServiceNowConstants.ACTION_RETRIEVE)
+                .put(ServiceNowConstants.ACTION_SUBJECT, "Invalid")
+                .build();
+
         assertThrows(CamelExecutionException.class,
                 () -> template.requestBodyAndHeaders(
                         "direct:servicenow",
                         null,
-                        kvBuilder()
-                                .put(ServiceNowConstants.RESOURCE, ServiceNowConstants.RESOURCE_SERVICE_CATALOG)
-                                .put(ServiceNowConstants.ACTION, ServiceNowConstants.ACTION_RETRIEVE)
-                                .put(ServiceNowConstants.ACTION_SUBJECT, "Invalid")
-                                .build(),
+                        invalid,
                         List.class));
     }
 

--- a/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/XmlRootElementPreferringElementNameStrategyTest.java
+++ b/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/XmlRootElementPreferringElementNameStrategyTest.java
@@ -56,8 +56,10 @@ public class XmlRootElementPreferringElementNameStrategyTest {
 
     @Test
     public void testFindExceptionForFaultName() throws Exception {
+        final QName faultName = new QName(LOCAL_NAME, CUSTOM_NS);
+
         assertThrows(UnsupportedOperationException.class,
-                () -> ens.findExceptionForFaultName(new QName(LOCAL_NAME, CUSTOM_NS)));
+                () -> ens.findExceptionForFaultName(faultName));
     }
 
     @XmlType(name = "", propOrder = { LOCAL_NAME })

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerEndpointMappingRouteTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/ConsumerEndpointMappingRouteTest.java
@@ -92,10 +92,12 @@ public class ConsumerEndpointMappingRouteTest extends CamelSpringTestSupport {
 
     @Test
     public void testWrongSoapAction() throws Exception {
+        final Source defaultXmlRequestSource = getDefaultXmlRequestSource();
+        final SoapActionCallback requestCallback = new SoapActionCallback("http://this-is-a-wrong-soap-action");
+
         assertThrows(WebServiceIOException.class, () -> {
-            webServiceTemplate.sendSourceAndReceive(getDefaultXmlRequestSource(),
-                    new SoapActionCallback("http://this-is-a-wrong-soap-action"), NOOP_SOURCE_EXTRACTOR);
-            resultEndpointSoapAction.assertIsNotSatisfied();
+            webServiceTemplate.sendSourceAndReceive(defaultXmlRequestSource,
+                    requestCallback, NOOP_SOURCE_EXTRACTOR);
         });
     }
 
@@ -145,10 +147,11 @@ public class ConsumerEndpointMappingRouteTest extends CamelSpringTestSupport {
 
     @Test
     public void testWrongUri() throws Exception {
+        final Source defaultXmlRequestSource = getDefaultXmlRequestSource();
+
         assertThrows(WebServiceIOException.class, () -> {
-            webServiceTemplate.sendSourceAndReceive("http://localhost/wrong", getDefaultXmlRequestSource(),
+            webServiceTemplate.sendSourceAndReceive("http://localhost/wrong", defaultXmlRequestSource,
                     NOOP_SOURCE_EXTRACTOR);
-            resultEndpointUri.assertIsNotSatisfied();
         });
     }
 

--- a/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/addressing/ConsumerWSAEndpointMappingRouteTest.java
+++ b/components/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/addressing/ConsumerWSAEndpointMappingRouteTest.java
@@ -171,11 +171,11 @@ public class ConsumerWSAEndpointMappingRouteTest extends CamelSpringTestSupport 
 
     @Test
     public void testWrongWSAddressingAction() throws Exception {
+        StreamSource source = new StreamSource(new StringReader(xmlBody));
+        final ActionCallback requestCallback = new ActionCallback("http://this-is-a-wrong-ws-addressing-action");
+
         assertThrows(WebServiceIOException.class, () -> {
-            StreamSource source = new StreamSource(new StringReader(xmlBody));
-            webServiceTemplate.sendSourceAndReceive(source, new ActionCallback("http://this-is-a-wrong-ws-addressing-action"),
-                    TestUtil.NOOP_SOURCE_EXTRACTOR);
-            resultEndpointAction.assertIsSatisfied();
+            webServiceTemplate.sendSourceAndReceive(source, requestCallback, TestUtil.NOOP_SOURCE_EXTRACTOR);
         });
     }
 

--- a/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/StitchClientBuilderTest.java
+++ b/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/StitchClientBuilderTest.java
@@ -25,16 +25,15 @@ class StitchClientBuilderTest {
 
     @Test
     void shouldNotCreateClientIfTokenOrRegionIsMissing() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            StitchClientBuilder.builder().build();
-        });
+        final StitchClientBuilder builder = StitchClientBuilder.builder();
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            StitchClientBuilder.builder().withToken("test").build();
-        });
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
 
+        assertThrows(IllegalArgumentException.class, () -> builder.withToken("test").build());
+
+        final StitchClientBuilder europeBuilder = StitchClientBuilder.builder().withRegion(StitchRegion.EUROPE);
         assertThrows(IllegalArgumentException.class, () -> {
-            StitchClientBuilder.builder().withRegion(StitchRegion.EUROPE).build();
+            europeBuilder.build();
         });
     }
 

--- a/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/StitchClientImplIT.java
+++ b/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/StitchClientImplIT.java
@@ -27,6 +27,7 @@ import org.apache.camel.component.stitch.client.models.StitchRequestBody;
 import org.apache.camel.component.stitch.client.models.StitchResponse;
 import org.apache.camel.component.stitch.client.models.StitchSchema;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -104,6 +105,7 @@ class StitchClientImplIT {
                 .withKeyNames("id")
                 .build();
 
-        assertThrows(StitchException.class, () -> client.batch(body).block());
+        final Mono<StitchResponse> batch = client.batch(body);
+        assertThrows(StitchException.class, () -> batch.block());
     }
 }

--- a/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/models/StitchMessageTest.java
+++ b/components/camel-stitch/src/test/java/org/apache/camel/component/stitch/client/models/StitchMessageTest.java
@@ -48,14 +48,13 @@ class StitchMessageTest {
 
     @Test
     void testIfNotCreateFromMapFromInvalidData() {
-        final Map<String, Object> data = new LinkedHashMap<>();
+        final LinkedHashMap<String, Object> data = new LinkedHashMap<>();
         data.put(StitchMessage.ACTION, "upsert");
         data.put(StitchMessage.DATA, 1);
         data.put(StitchMessage.SEQUENCE, 1122544L);
 
         assertThrows(IllegalArgumentException.class, () -> StitchMessage
-                .fromMap(data)
-                .build());
+                .fromMap(data));
     }
 
     @Test

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
@@ -133,8 +133,10 @@ public class TarFileDataFormatTest extends CamelTestSupport {
 
     @Test
     public void testUntarWithCorruptedTarFile() throws Exception {
+        final File body = new File("src/test/resources/data/corrupt.tar");
+
         assertThrows(CamelExecutionException.class,
-                () -> template.sendBody("direct:corruptUntar", new File("src/test/resources/data/corrupt.tar")));
+                () -> template.sendBody("direct:corruptUntar", body));
     }
 
     @Test
@@ -238,9 +240,11 @@ public class TarFileDataFormatTest extends CamelTestSupport {
 
     @Test
     public void testUnzipMaxDecompressedSize() throws Exception {
+        final byte[] files = getTaredText("file");
+
         // We are only allowing 10 bytes to be decompressed, so we expect an error
         assertThrows(CamelExecutionException.class,
-                () -> template.sendBody("direct:untarMaxDecompressedSize", getTaredText("file")));
+                () -> template.sendBody("direct:untarMaxDecompressedSize", files));
     }
 
     @Override

--- a/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramComponentParametersTest.java
+++ b/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramComponentParametersTest.java
@@ -39,43 +39,47 @@ public class TelegramComponentParametersTest extends TelegramTestSupport {
         TelegramEndpoint ep2 = (TelegramEndpoint) component.createEndpoint("telegram:bots?authorizationToken=CUSTOM");
         assertEquals("CUSTOM", ep2.getConfiguration().getAuthorizationToken());
 
-        TelegramEndpoint ep3
-                = (TelegramEndpoint) component.createEndpoint("telegram:bots?authorizationToken=ANOTHER&chatId=123");
+        TelegramEndpoint ep3 = (TelegramEndpoint) component
+                .createEndpoint("telegram:bots?authorizationToken=ANOTHER&chatId=123");
         assertEquals("ANOTHER", ep3.getConfiguration().getAuthorizationToken());
     }
 
     @Test
     public void testNonDefaultConfig() {
+        TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
+        component.setAuthorizationToken(null);
+
         assertThrows(IllegalArgumentException.class, () -> {
-            TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
-            component.setAuthorizationToken(null);
             component.createEndpoint("telegram:bots");
         });
     }
 
     @Test
     public void testWrongURI1() {
+        TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
+        component.setAuthorizationToken("ANY");
+
         assertThrows(IllegalArgumentException.class, () -> {
-            TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
-            component.setAuthorizationToken("ANY");
             component.createEndpoint("telegram:bots/ ");
         });
     }
 
     @Test
     public void testWrongURI2() {
+        TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
+        component.setAuthorizationToken("ANY");
+
         assertThrows(IllegalArgumentException.class, () -> {
-            TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
-            component.setAuthorizationToken("ANY");
             component.createEndpoint("telegram:bots/token/s");
         });
     }
 
     @Test
     public void testWrongURI3() {
+        TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
+        component.setAuthorizationToken("ANY");
+
         assertThrows(PropertyBindingException.class, () -> {
-            TelegramComponent component = (TelegramComponent) context().getComponent("telegram");
-            component.setAuthorizationToken("ANY");
             component.createEndpoint("telegram:bots?proxyType=ANY");
         });
     }

--- a/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramConsumerEmptyResponseTest.java
+++ b/components/camel-telegram/src/test/java/org/apache/camel/component/telegram/TelegramConsumerEmptyResponseTest.java
@@ -44,10 +44,11 @@ public class TelegramConsumerEmptyResponseTest extends TelegramTestSupport {
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
                 .until(() -> getMockRoutes().getMock("getUpdates").getRecordedMessages().size() >= 1);
 
+        endpoint.setResultWaitTime(500L);
+        endpoint.expectedMinimumMessageCount(1);
+
         /* Then make sure that the consumer has sent zero exchanges to the route */
         assertThrows(AssertionError.class, () -> {
-            endpoint.setResultWaitTime(500L);
-            endpoint.expectedMinimumMessageCount(1);
             endpoint.assertIsSatisfied();
         });
     }

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/XAdESSignaturePropertiesTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/XAdESSignaturePropertiesTest.java
@@ -231,7 +231,7 @@ public class XAdESSignaturePropertiesTest extends CamelTestSupport {
         checkXpath(doc, pathToSignatureProperties + "etsi:SignatureProductionPlace/etsi:CountryName/text()", prefix2Namespace,
                 "Germany");
 
-        // signer role 
+        // signer role
         checkXpath(doc, pathToSignatureProperties + "etsi:SignerRole/etsi:ClaimedRoles/etsi:ClaimedRole[1]/text()",
                 prefix2Namespace,
                 "test");
@@ -268,7 +268,7 @@ public class XAdESSignaturePropertiesTest extends CamelTestSupport {
                         + "etsi:DataObjectFormat/etsi:ObjectIdentifier/etsi:DocumentationReferences/etsi:DocumentationReference[2]/text()",
                 prefix2Namespace, "http://test.com/dataobject.format.doc.ref2.txt");
 
-        //commitment 
+        //commitment
         checkXpath(doc,
                 pathToDataObjectProperties + "etsi:CommitmentTypeIndication/etsi:CommitmentTypeId/etsi:Identifier/text()",
                 prefix2Namespace, "1.2.840.113549.1.9.16.6.4");
@@ -668,129 +668,169 @@ public class XAdESSignaturePropertiesTest extends CamelTestSupport {
 
     @Test
     public void namespaceNull() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setNamespace(null));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setNamespace(null));
     }
 
     @Test
     public void signingCertificateURIsNull() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSigningCertificateURIs(null));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setSigningCertificateURIs(null));
     }
 
     @Test
     public void sigPolicyInvalid() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSignaturePolicy("invalid"));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setSignaturePolicy("invalid"));
     }
 
     @Test
     public void sigPolicyIdDocumentationReferencesNull() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSigPolicyIdDocumentationReferences(null));
+                () -> xAdESSignatureProperties.setSigPolicyIdDocumentationReferences(null));
     }
 
     @Test
     public void sigPolicyIdDocumentationReferencesNullEntry() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setSigPolicyIdDocumentationReferences(Collections.<String> singletonList(null)));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> sigPolicyIdDocumentationReferences = Collections.<String> singletonList(null);
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties
+                .setSigPolicyIdDocumentationReferences(sigPolicyIdDocumentationReferences));
     }
 
     @Test
     public void sigPolicyIdDocumentationReferencesEmptyEntry() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setSigPolicyIdDocumentationReferences(Collections.<String> singletonList("")));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> sigPolicyIdDocumentationReferences = Collections.singletonList("");
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties
+                .setSigPolicyIdDocumentationReferences(sigPolicyIdDocumentationReferences));
     }
 
     @Test
     public void dataObjectFormatIdentifierDocumentationReferencesNull() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setDataObjectFormatIdentifierDocumentationReferences(null));
+                () -> xAdESSignatureProperties.setDataObjectFormatIdentifierDocumentationReferences(null));
     }
 
     @Test
     public void dataObjectFormatIdentifierDocumentationReferencesNullEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> dataObjectFormatIdentifierDocumentationReferences = Collections.singletonList(null);
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setDataObjectFormatIdentifierDocumentationReferences(Collections.<String> singletonList(null)));
+                () -> xAdESSignatureProperties.setDataObjectFormatIdentifierDocumentationReferences(
+                        dataObjectFormatIdentifierDocumentationReferences));
     }
 
     @Test
     public void dataObjectFormatIdentifierDocumentationReferencesEmptyEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> dataObjectFormatIdentifierDocumentationReferences = Collections.singletonList("");
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setDataObjectFormatIdentifierDocumentationReferences(Collections.<String> singletonList("")));
+                () -> xAdESSignatureProperties.setDataObjectFormatIdentifierDocumentationReferences(
+                        dataObjectFormatIdentifierDocumentationReferences));
     }
 
     @Test
     public void signerClaimedRolesNull() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSignerClaimedRoles(null));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setSignerClaimedRoles(null));
     }
 
     @Test
     public void signerClaimedRolesNullEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> signerClaimedRoles = Collections.singletonList(null);
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSignerClaimedRoles(Collections.<String> singletonList(null)));
+                () -> xAdESSignatureProperties.setSignerClaimedRoles(signerClaimedRoles));
     }
 
     @Test
     public void signerClaimedRolesEmptyEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> signerClaimedRoles = Collections.singletonList("");
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSignerClaimedRoles(Collections.<String> singletonList("")));
+                () -> xAdESSignatureProperties.setSignerClaimedRoles(signerClaimedRoles));
     }
 
     @Test
     public void signerCertifiedRolesNull() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setSignerCertifiedRoles(null));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setSignerCertifiedRoles(null));
     }
 
     @Test
     public void signerCertifiedRolesNullEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<XAdESEncapsulatedPKIData> signerCertifiedRoles = Collections.singletonList(null);
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setSignerCertifiedRoles(Collections.<XAdESEncapsulatedPKIData> singletonList(null)));
+                () -> xAdESSignatureProperties.setSignerCertifiedRoles(signerCertifiedRoles));
     }
 
     @Test
     public void commitmentTypeIdDocumentationReferencesNull() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setCommitmentTypeIdDocumentationReferences(null));
+                () -> xAdESSignatureProperties.setCommitmentTypeIdDocumentationReferences(null));
     }
 
     @Test
     public void commitmentTypeIdDocumentationReferencesNullEntry() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setCommitmentTypeIdDocumentationReferences(Collections.<String> singletonList(null)));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> commitmentTypeIdDocumentationReferences = Collections.singletonList(null);
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties
+                .setCommitmentTypeIdDocumentationReferences(commitmentTypeIdDocumentationReferences));
     }
 
     @Test
     public void commitmentTypeIdDocumentationReferencesEmptyEntry() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties()
-                        .setCommitmentTypeIdDocumentationReferences(Collections.<String> singletonList("")));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> commitmentTypeIdDocumentationReferences = Collections.singletonList("");
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties
+                .setCommitmentTypeIdDocumentationReferences(commitmentTypeIdDocumentationReferences));
     }
 
     @Test
     public void commitmentTypeQualifiersNull() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setCommitmentTypeQualifiers(null));
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+
+        assertThrows(IllegalArgumentException.class, () -> xAdESSignatureProperties.setCommitmentTypeQualifiers(null));
     }
 
     @Test
     public void commitmentTypeQualifiersNullEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> commitmentTypeQualifiers = Collections.singletonList(null);
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setCommitmentTypeQualifiers(Collections.<String> singletonList(null)));
+                () -> xAdESSignatureProperties.setCommitmentTypeQualifiers(commitmentTypeQualifiers));
     }
 
     @Test
     public void commitmentTypeQualifiersEmptyEntry() throws Exception {
+        final XAdESSignatureProperties xAdESSignatureProperties = new XAdESSignatureProperties();
+        final List<String> commitmentTypeQualifiers = Collections.singletonList("");
+
         assertThrows(IllegalArgumentException.class,
-                () -> new XAdESSignatureProperties().setCommitmentTypeQualifiers(Collections.<String> singletonList("")));
+                () -> xAdESSignatureProperties.setCommitmentTypeQualifiers(commitmentTypeQualifiers));
     }
 
     //


### PR DESCRIPTION
There should be only one method in the executable code within assertThrows in order to
prevent the test having false positives due to the same exception potentially being
thrown by other methods.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md
-->