### PR TITLE
Improved conditional test execution

### DIFF
--- a/components/camel-google/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveChangesIntegrationTest.java
+++ b/components/camel-google/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveChangesIntegrationTest.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Test class for com.google.api.services.drive.Drive$Changes APIs.
@@ -41,16 +42,16 @@ public class DriveChangesIntegrationTest extends AbstractGoogleDriveTestSupport 
     public void testGet() throws Exception {
         final com.google.api.services.drive.model.ChangeList list = requestBody("direct://LIST", null);
         List<Change> items = list.getItems();
-        if (!items.isEmpty()) {
-            Change change = items.get(0);
-            Long id = change.getId();
+        assumeFalse(items.isEmpty());
 
-            // using String message body for single parameter "changeId"
-            final com.google.api.services.drive.model.Change result = requestBody("direct://GET", id);
+        Change change = items.get(0);
+        Long id = change.getId();
 
-            assertNotNull(result, "get result");
-            LOG.debug("get: " + result);
-        }
+        // using String message body for single parameter "changeId"
+        final com.google.api.services.drive.model.Change result = requestBody("direct://GET", id);
+
+        assertNotNull(result, "get result");
+        LOG.debug("get: " + result);
     }
 
     @Test


### PR DESCRIPTION
**Problem:**
Conditions within the test method may produce a false test outcome. Once a condition is not met, and the code block inside the condition is not executed, a false 'passed' outcome can be produced without the test ever being executed.

**Solution:**
Instead of using a conditional to control the test execution, we propose using JUnit Assumptions — a failed assumption results in a test being aborted. Assumptions are typically used whenever it does not make sense to continue executing a given test method. 

**Result:**
_Before:_
```
...
if (!items.isEmpty()) {
    ...
    assertNotNull(result, "get result");
}
```

_After:_
```
...
assumeFalse(items.isEmpty());
...
assertNotNull(result, "get result");
```