### PR TITLE
CAMEL-16461Fix NPE in camel-aws2-s3 when determining aws s3 key name

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
@@ -96,7 +96,7 @@ public final class AWS2S3Utils {
             key = configuration.getKeyName();
         }
         if (key == null) {
-            throw new IllegalArgumentException("AWS S3 Key header missing.");
+            throw new IllegalArgumentException("AWS S3 Key missing.");
         }
         return key;
     }


### PR DESCRIPTION
If user sets only CamelAwsS3Key header, the producer throws an NPE
Slight change on the missing s3 key error message, to remove the word
header as the s3 key may be defined in the header or query parameter.

https://issues.apache.org/jira/browse/CAMEL-16461