### PR TITLE
feat(core): hasErrorHandlerBuilder helper method

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/BuilderSupport.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/BuilderSupport.java
@@ -453,6 +453,10 @@ public abstract class BuilderSupport {
         this.context = context;
     }
 
+    public boolean hasErrorHandlerBuilder() {
+        return this.errorHandlerBuilder != null;
+    }
+
     public ErrorHandlerBuilder getErrorHandlerBuilder() {
         if (errorHandlerBuilder == null) {
             errorHandlerBuilder = createErrorHandlerBuilder();


### PR DESCRIPTION
Adding this method allows to check if any errorHandlerBuilder exists, before to be initialized by the getErrorHandlerBuilder method (which set a default one if it does not exists).

We are implementing a mechanism to [enable error handling in KameletBinding](https://github.com/apache/camel-k/issues/1941) and we need to check if any exists in the BuilderSupport prior to its default setting.
