### PR TITLE
[CAMEL-16449]: Introduces ContentBasedServiceFilter

### DIFF
--- a/components/camel-ribbon/pom.xml
+++ b/components/camel-ribbon/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>camel-cloud</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.netflix.ribbon</groupId>
             <artifactId>ribbon-core</artifactId>
             <version>${ribbon-version}</version>
@@ -53,6 +57,12 @@
             <groupId>com.netflix.ribbon</groupId>
             <artifactId>ribbon-loadbalancer</artifactId>
             <version>${ribbon-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-core</artifactId>
+            <scope>provided</scope>
+            <version>${servo-version}</version>
         </dependency>
 
         <!-- testing -->

--- a/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/RibbonServerListTest.java
+++ b/components/camel-ribbon/src/test/java/org/apache/camel/component/ribbon/cloud/RibbonServerListTest.java
@@ -20,6 +20,7 @@ import com.netflix.loadbalancer.LoadBalancerBuilder;
 import com.netflix.loadbalancer.RoundRobinRule;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.cloud.PassThroughServiceFilter;
 import org.apache.camel.impl.cloud.StaticServiceDiscovery;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ public class RibbonServerListTest {
     public void testFixedServerList() throws Exception {
         ZoneAwareLoadBalancer<RibbonServiceDefinition> lb = LoadBalancerBuilder.<RibbonServiceDefinition> newBuilder()
                 .withDynamicServerList(new RibbonServiceLoadBalancer.RibbonServerList(
+                        new DefaultCamelContext(),
                         "unknown",
                         StaticServiceDiscovery.forServices(
                                 new RibbonServiceDefinition("unknown", "localhost", 9090),

--- a/core/camel-api/src/main/java/org/apache/camel/cloud/ServiceFilter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/cloud/ServiceFilter.java
@@ -18,6 +18,8 @@ package org.apache.camel.cloud;
 
 import java.util.List;
 
+import org.apache.camel.Exchange;
+
 /**
  * Allows SPIs to implement custom Service Filter.
  *
@@ -27,10 +29,12 @@ import java.util.List;
 public interface ServiceFilter {
 
     /**
-     * Chooses one of the service to use
+     * Chooses service candidates to use
      *
+     * @param  exchange for content-based filtering
      * @param  services list of services
      * @return          the chosen service to use.
      */
-    List<ServiceDefinition> apply(List<ServiceDefinition> services);
+    List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services);
+
 }

--- a/core/camel-api/src/main/java/org/apache/camel/cloud/ServiceLoadBalancer.java
+++ b/core/camel-api/src/main/java/org/apache/camel/cloud/ServiceLoadBalancer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.cloud;
 
+import org.apache.camel.Exchange;
+
 /**
  * Represents a Load Balancer.
  *
@@ -25,5 +27,5 @@ package org.apache.camel.cloud;
  */
 @FunctionalInterface
 public interface ServiceLoadBalancer {
-    <T> T process(String serviceName, ServiceLoadBalancerFunction<T> function) throws Exception;
+    <T> T process(Exchange exchange, String serviceName, ServiceLoadBalancerFunction<T> function) throws Exception;
 }

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/BlacklistServiceFilter.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/BlacklistServiceFilter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.cloud.ServiceFilter;
 
@@ -83,7 +84,7 @@ public class BlacklistServiceFilter implements ServiceFilter {
     }
 
     @Override
-    public List<ServiceDefinition> apply(List<ServiceDefinition> services) {
+    public List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services) {
         return services.stream().filter(
                 s -> this.services.stream().noneMatch(b -> b.matches(s))).collect(
                         Collectors.toList());

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/CombinedServiceFilter.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/CombinedServiceFilter.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.cloud.ServiceFilter;
 
@@ -38,9 +39,9 @@ public class CombinedServiceFilter implements ServiceFilter {
     }
 
     @Override
-    public List<ServiceDefinition> apply(List<ServiceDefinition> services) {
+    public List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services) {
         for (int i = 0; i < delegatesSize; i++) {
-            services = delegates.get(i).apply(services);
+            services = delegates.get(i).apply(exchange, services);
         }
 
         return services;

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceCallProcessor.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceCallProcessor.java
@@ -184,7 +184,7 @@ public class DefaultServiceCallProcessor extends AsyncProcessorSupport {
         message.setHeader(ServiceCallConstants.SERVICE_NAME, serviceName);
 
         try {
-            return loadBalancer.process(serviceName, server -> execute(server, exchange, callback));
+            return loadBalancer.process(exchange, serviceName, server -> execute(server, exchange, callback));
         } catch (Exception e) {
             exchange.setException(e);
             callback.done(true);

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceFilter.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceFilter.java
@@ -18,13 +18,14 @@ package org.apache.camel.impl.cloud;
 
 import java.util.List;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.cloud.ServiceFilter;
 
 public class DefaultServiceFilter implements ServiceFilter {
 
     @Override
-    public List<ServiceDefinition> apply(List<ServiceDefinition> services) {
+    public List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services) {
         return services;
     }
 }

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceLoadBalancer.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceLoadBalancer.java
@@ -21,6 +21,7 @@ import java.util.concurrent.RejectedExecutionException;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceChooser;
 import org.apache.camel.cloud.ServiceChooserAware;
 import org.apache.camel.cloud.ServiceDefinition;
@@ -125,7 +126,7 @@ public class DefaultServiceLoadBalancer
     // *************************************
 
     @Override
-    public <T> T process(String serviceName, ServiceLoadBalancerFunction<T> function) throws Exception {
+    public <T> T process(Exchange exchange, String serviceName, ServiceLoadBalancerFunction<T> function) throws Exception {
         ServiceDefinition service;
 
         List<ServiceDefinition> services = serviceDiscovery.getServices(serviceName);
@@ -133,7 +134,7 @@ public class DefaultServiceLoadBalancer
             throw new RejectedExecutionException("No active services with name " + serviceName);
         } else {
             // filter services
-            services = serviceFilter.apply(services);
+            services = serviceFilter.apply(exchange, services);
             // let the client service chooser find which server to use
             service = services.isEmpty() ? null : services.size() > 1 ? serviceChooser.choose(services) : services.get(0);
             if (service == null) {

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/HealthyServiceFilter.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/HealthyServiceFilter.java
@@ -19,12 +19,13 @@ package org.apache.camel.impl.cloud;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.cloud.ServiceFilter;
 
 public class HealthyServiceFilter implements ServiceFilter {
     @Override
-    public List<ServiceDefinition> apply(List<ServiceDefinition> services) {
+    public List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services) {
         return services.stream().filter(s -> s.getHealth().isHealthy()).collect(Collectors.toList());
     }
 }

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/PassThroughServiceFilter.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/PassThroughServiceFilter.java
@@ -18,12 +18,13 @@ package org.apache.camel.impl.cloud;
 
 import java.util.List;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.cloud.ServiceFilter;
 
 public class PassThroughServiceFilter implements ServiceFilter {
     @Override
-    public List<ServiceDefinition> apply(List<ServiceDefinition> services) {
+    public List<ServiceDefinition> apply(Exchange exchange, List<ServiceDefinition> services) {
         return services;
     }
 }

--- a/core/camel-cloud/src/test/java/org/apache/camel/impl/cloud/ServiceCallConfigurationTest.java
+++ b/core/camel-cloud/src/test/java/org/apache/camel/impl/cloud/ServiceCallConfigurationTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
@@ -31,6 +32,7 @@ import org.apache.camel.model.cloud.ServiceCallConfigurationDefinition;
 import org.apache.camel.model.cloud.ServiceCallDefinitionConstants;
 import org.apache.camel.model.cloud.ServiceCallExpressionConfiguration;
 import org.apache.camel.model.language.SimpleExpression;
+import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -372,11 +374,12 @@ public class ServiceCallConfigurationTest {
 
             assertTrue(lb.getServiceDiscovery() instanceof StaticServiceDiscovery);
 
+            Exchange exchange = new DefaultExchange(context);
             List<ServiceDefinition> services1 = lb.getServiceDiscovery().getServices("hello-service");
-            assertEquals(2, filter.apply(services1).size());
+            assertEquals(2, filter.apply(exchange, services1).size());
 
             List<ServiceDefinition> services2 = lb.getServiceDiscovery().getServices("hello-svc");
-            assertEquals(1, filter.apply(services2).size());
+            assertEquals(1, filter.apply(exchange, services2).size());
 
         } finally {
             if (context != null) {

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/serviceCall-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/serviceCall-eip.adoc
@@ -380,7 +380,9 @@ And in XML
 </camelContext>
 ----
 
-== Blacklist Service Filter
+== Service Filter
+
+=== Blacklist Service Filter
 
 This service filter implementation removes the listed services from those found by the service discovery.
 Each service should be provided in the following form:
@@ -439,13 +441,55 @@ And in XML
 </camelContext>
 ----
 
+=== Custom Service Filter
+
+Service Filters choose suitable candidates from the service definitions found in the service discovery. 
+
+As of Camel 3.10.0 they have access to the current exchange, which allows you to create service filters 
+comparing service metadata with message content.
+
+Assuming you have labeled one of the services in your service discovery to support a certain type of requests:
+
+[source,java]
+----
+serviceDiscovery.addServer(new DefaultServiceDefinition("service", "127.0.0.1", 1003, 
+    Collections.singletonMap("supports", "foo")));
+----
+
+The current exchange has a property which says that it needs a foo service:
+
+[source,java]
+----
+exchange.setProperty("needs", "foo")
+----
+
+You can then use a `ServiceFilter` to select the service instances which match the exchange:
+
+[source,java]
+----
+from("direct:start")
+    .serviceCall()
+        .name("service")
+        .serviceFilter((exchange, services) -> services.stream()
+			.filter(serviceDefinition -> Optional.ofNullable(serviceDefinition.getMetadata()
+				.get("supports"))
+				.orElse("")
+				.equals(exchange.getProperty("needs", String.class)))
+			.collect(Collectors.toList()));
+        .end()
+    .to("mock:result");
+----
+
 == Load Balancer
 
-The Service Call EIP comes with its own Load Balancer which is instantiated by default if a custom is not configured and
-glues Service Discovery, Service Filer, Service Chooser and Service Expression together to load balance requests among the available services.
+The Service Call EIP comes with its own loadbalancer which is instantiated by default if a custom loadbalancer is not configured. It glues Service Discovery, Service Filter, Service Chooser and Service Expression together to load balance requests among the available services.
 
-If you need a more sophisticate load balancer you can use Ribbon by adding camel-ribbon to the mix,
+If you need a more sophisticated load balancer you can use Ribbon by adding camel-ribbon to the mix,
 maven users will need to add the following dependency to their pom.xml
+
+NOTE: The `RibbonServiceLoadBalancer` has no concept of a current `Exchange`. 
+Service filters therefore receive a dummy exchange when used with Ribbon.
+
 
 [source,xml]
 ----
@@ -492,7 +536,7 @@ And in XML
 </camelContext>
 ----
 
-You can configure Ribbon key programmatic using `RibbonConfiguration`:
+You can configure Ribbon key programmatically using `RibbonConfiguration`:
 
 [source,java]
 ----
@@ -541,7 +585,7 @@ globalConf.setServiceChooser(
 
 ServiceCallConfigurationDefinition httpsConf = new ServiceCallConfigurationDefinition();
 httpsConf.setServiceFilter(
-    list -> list.stream().filter(s -> s.getPort() == 443).collect(toList())
+    list -> list.stream().filter((exchange, s) -> s.getPort() == 443).collect(toList())
 );
 
 getContext().setServiceCallConfiguration(globalConf);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/cloud/CombinedServiceCallServiceFilterConfiguration.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/cloud/CombinedServiceCallServiceFilterConfiguration.java
@@ -59,7 +59,7 @@ public class CombinedServiceCallServiceFilterConfiguration extends ServiceCallSe
 
     /**
      * List of ServiceFilter configuration to use
-     * 
+     *
      * @param serviceFilterConfigurations
      */
     public void setServiceFilterConfigurations(List<ServiceCallServiceFilterConfiguration> serviceFilterConfigurations) {

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_10.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_10.adoc
@@ -10,6 +10,11 @@ from both 3.0 to 3.1 and 3.1 to 3.2.
 
 The method `concurrentTasks` on `org.apache.camel.support.DefaultScheduledPollConsumerScheduler ` has been renamed to `concurrentConsumers`.
 
+The `org.apache.camel.cloud.ServiceFilter` and `org.apache.camel.cloud.ServiceLoadBalancer` 
+functional interface methods take the current `Exchange` as additional parameter 
+to allow for content-based filtering of service candidates. `RibbonServiceLoadBalancer` 
+has no notion of a current exchange, service filters therefore receive a dummy exchange when used with Ribbon.
+
 === camel-scheduler
 
 The option `concurrentTasks` has been renamed to `poolSize` to better reflect its purpose.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -481,6 +481,7 @@
         <rhino-version>1.7.7.1</rhino-version>
         <rhino-js-version>1.7R2</rhino-js-version>
         <ribbon-version>2.3.0</ribbon-version>
+        <servo-version>0.10.1</servo-version>
         <roaster-version>2.22.0.Final</roaster-version>
         <robotframework-version>3.2.2</robotframework-version>
         <rome-version>1.15.0</rome-version>


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-16449

Main goal: pass the current exchange to `ServiceFilter.apply` without breaking existing `ServiceFilter` and `ServiceLoadBalancer` implementations. Make it as convenient as possible to implement service filters with access to the current exchange.

Trade-off: the old method cannot be executed upwards-compatibly on the new `ContentBasedServiceFilter`. Hence the implementation is a bit more convoluted than I would like it to be.

Implementation steps:

1. ​Introduce new `ServiceFilter.apply(exchange, services)` method with default impl that calls the old apply method without passing the exchange
2. Introduce new ServiceLoadBalancer.process(exchange, serviceName, serviceLoadBalancerFunction) method with default impl that calls the old process method without passing the exchange
3. Call the new `ServiceFilter.apply` method from the new `DefaultLoadBalancer.process` method
4. Let the old `DefaultLoadBalancer.process` method call the new one, passing a `null` exchange (it seems to me that the old method cannot throw an exception since that might break custom `ServiceLoadBalancer` impls, but that may be disputable). 
I pass `null`, but it should never be passed on to actual service filters because of the next step:
5. The default ServiceFilter.apply(exchange, services) method calls the old apply(services) without passing the `null` exchange, so that existing ServiceFilter and ServiceLoadBalancer impls remain compatible and the `null` exchange should usually not be encountered anywhere at runtime. 
5. Introduce new functional interface `ContentBasedServiceFilter` with a `ContentBasedServiceFilterAdapter` so that users can write a lambda based `ContentBasedServiceFilter` which is also a ServiceFilter (see `LoadBalancerTest#testLoadBalancerWithContentBasedServiceFilter)`
6. `ContentBasedServiceFilterAdapter` throws an exception if its old `apply(services)` method gets called, so that people who try to run a `ContentBasedServiceFilter` without passing an exchange are being told that this filter requires an exchange and that they might have to adjust their custom `ServiceLoadBalancer`.