### PR TITLE
CAMEL-16502: add optional basepath parameter to restdsl-generator

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/docs/camel-restdsl-openapi-plugin.adoc
@@ -68,7 +68,8 @@ in the `<configuration>` tag.
 | `outputDirectory` | `generated-sources/restdsl-openapi` | Where to place the generated source file, by default `generated-sources/restdsl-openapi` within the project directory
 | `destinationGenerator` | | Fully qualified class name of the class that implements `org.apache.camel.generator.openapi.DestinationGenerator` interface for customizing destination endpoint
 | `restConfiguration` | `true` | Whether to include generation of the rest configuration with detected rest component to be used. 
-| `apiContextPath` | | Define openapi endpoint path if `restConfiguration` is set to `true`. |
+| `apiContextPath` | | Define openapi endpoint path if `restConfiguration` is set to `true`.
+| `basePath` | | Overrides the api base path as defined in the OpenAPI specification. |
 |========================================
 
 === Spring Boot Project with Servlet component
@@ -143,7 +144,8 @@ in the `<configuration>` tag.
 | `blueprint` | `false` | If enabled generates OSGi Blueprint XML instead of Spring XML.
 | `destinationGenerator` | | Fully qualified class name of the class that implements `org.apache.camel.generator.openapi.DestinationGenerator` interface for customizing destination endpoint
 | `restConfiguration` | `true` | Whether to include generation of the rest configuration with detected rest component to be used.
-| `apiContextPath` | | Define openapi endpoint path if `restConfiguration` is set to `true`. |
+| `apiContextPath` | | Define openapi endpoint path if `restConfiguration` is set to `true`.
+| `basePath` | | Overrides the api base path as defined in the OpenAPI specification. |
 |========================================
 
 == camel-restdsl-openapi:generate-xml-with-dto

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
@@ -114,6 +114,9 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
     @Parameter(name = "auth")
     String auth;
 
+    @Parameter
+    String basePath;
+
     @Parameter(defaultValue = "3.0.19")
     String swaggerCodegenMavenPluginVersion;
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
@@ -70,6 +70,10 @@ public class GenerateMojo extends AbstractGenerateMojo {
 
         final RestDslSourceCodeGenerator<Path> generator = RestDslGenerator.toPath(openapi);
 
+        if (ObjectHelper.isNotEmpty(basePath)) {
+            generator.withBasePath(basePath);
+        }
+
         if (ObjectHelper.isNotEmpty(filterOperation)) {
             generator.withOperationFilter(filterOperation);
         }

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateXmlMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateXmlMojo.java
@@ -71,6 +71,10 @@ public class GenerateXmlMojo extends AbstractGenerateMojo {
             generator.withBlueprint();
         }
 
+        if (ObjectHelper.isNotEmpty(basePath)) {
+            generator.withBasePath(basePath);
+        }
+
         if (ObjectHelper.isNotEmpty(filterOperation)) {
             generator.withOperationFilter(filterOperation);
         }

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslDefinitionGenerator.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslDefinitionGenerator.java
@@ -28,7 +28,7 @@ public final class RestDslDefinitionGenerator extends RestDslGenerator<RestDslDe
 
     public RestsDefinition generate(final CamelContext context) {
         final RestDefinitionEmitter emitter = new RestDefinitionEmitter(context);
-        final String basePath = RestDslGenerator.determineBasePathFrom(document);
+        final String basePath = RestDslGenerator.determineBasePathFrom(this.basePath, document);
         final PathVisitor<RestsDefinition> restDslStatement
                 = new PathVisitor<>(basePath, emitter, filter, destinationGenerator());
 
@@ -36,5 +36,4 @@ public final class RestDslDefinitionGenerator extends RestDslGenerator<RestDslDe
 
         return emitter.result();
     }
-
 }

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslSourceCodeGenerator.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslSourceCodeGenerator.java
@@ -112,7 +112,7 @@ public abstract class RestDslSourceCodeGenerator<T> extends RestDslGenerator<Res
             configure.addCode(";\n\n");
         }
 
-        final String basePath = RestDslGenerator.determineBasePathFrom(document);
+        final String basePath = RestDslGenerator.determineBasePathFrom(this.basePath, document);
 
         final PathVisitor<MethodSpec> restDslStatement = new PathVisitor<>(basePath, emitter, filter, destinationGenerator());
         document.paths.getItems().forEach(restDslStatement::visit);

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslXmlGenerator.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslXmlGenerator.java
@@ -49,7 +49,7 @@ public class RestDslXmlGenerator extends RestDslGenerator<RestDslXmlGenerator> {
 
     public String generate(final CamelContext context) throws Exception {
         final RestDefinitionEmitter emitter = new RestDefinitionEmitter(context);
-        final String basePath = RestDslGenerator.determineBasePathFrom(document);
+        final String basePath = RestDslGenerator.determineBasePathFrom(this.basePath, document);
         final PathVisitor<RestsDefinition> restDslStatement = new PathVisitor<>(
                 basePath, emitter, filter,
                 destinationGenerator());

--- a/tooling/openapi-rest-dsl-generator/src/test/java/org/apache/camel/generator/openapi/RestDslGeneratorTest.java
+++ b/tooling/openapi-rest-dsl-generator/src/test/java/org/apache/camel/generator/openapi/RestDslGeneratorTest.java
@@ -106,6 +106,39 @@ public class RestDslGeneratorTest {
     }
 
     @Test
+    public void shouldDetermineBasePathFromParameterOverDocument() {
+        final Oas30Document oas30Document = new Oas30Document();
+        final Oas30Server server = new Oas30Server();
+        server.url = "/api/v3";
+
+        oas30Document.servers = Collections.singletonList(server);
+        assertThat(RestDslGenerator.determineBasePathFrom("/api/v4", oas30Document)).isEqualTo("/api/v4");
+    }
+
+    @Test
+    public void shouldDetermineBasePathFromParameterOverDocumentWithoutStartingSlash() {
+        final Oas30Document oas30Document = new Oas30Document();
+        final Oas30Server server = new Oas30Server();
+        server.url = "api/v3";
+
+        oas30Document.servers = Collections.singletonList(server);
+        assertThat(RestDslGenerator.determineBasePathFrom("api/v4", oas30Document)).isEqualTo("/api/v4");
+    }
+
+    @Test
+    public void shouldDetermineBasePathFromParameterOverDocumentWithEmptyParameter() {
+        final Oas30Document oas30Document = new Oas30Document();
+        final Oas30Server server = new Oas30Server();
+        server.url = "/api/v3";
+
+        oas30Document.servers = Collections.singletonList(server);
+        assertThat(RestDslGenerator.determineBasePathFrom(null, oas30Document)).isEqualTo("/api/v3");
+        assertThat(RestDslGenerator.determineBasePathFrom("/", oas30Document)).isEqualTo("");
+        assertThat(RestDslGenerator.determineBasePathFrom("", oas30Document)).isEqualTo("");
+        assertThat(RestDslGenerator.determineBasePathFrom("   ", oas30Document)).isEqualTo("");
+    }
+
+    @Test
     public void shouldGenerateSourceCodeWithDefaults() throws Exception {
         final StringBuilder code = new StringBuilder();
 


### PR DESCRIPTION
CAMEL-16502: This pull request add an optional basepath parameter to allow developers override the basepath evaluated from the first server entry in the openapi document.

Behaviour:
- If the basepath parameter is not set, the restdsl-generator behaves like before.
- In case the basepath parameter is set (e.g. in the according maven plugin mojos) it takes precedence over the basepath from the server entry.

Changes:
- The logic is implemented in a new method in the RestDslGenerator.
- Generators extended from the base RestDslGenerator are changed to call the new method.
- Maven plugins using the RestDslGenerator are extended to set the parameter if set in the plugin config.
- The documentation for the maven plugins is updated with the new parameter.
- Unit tests are extended with checks for the new method.