### PR TITLE
Feature/fix zipkin span backport

### DIFF
--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinState.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinState.java
@@ -18,6 +18,7 @@ package org.apache.camel.zipkin;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import brave.Span;
 import org.apache.camel.Exchange;
@@ -33,8 +34,8 @@ public final class ZipkinState implements CamelCopySafeProperty<ZipkinState> {
 
     public static final String KEY = "CamelZipkinState";
 
-    private final Deque<Span> clientSpans = new ArrayDeque<>();
-    private final Deque<Span> serverSpans = new ArrayDeque<>();
+    private final Deque<Span> clientSpans = new ConcurrentLinkedDeque<>();
+    private final Deque<Span> serverSpans = new ConcurrentLinkedDeque<>();
 
     public ZipkinState() {
 
@@ -45,11 +46,11 @@ public final class ZipkinState implements CamelCopySafeProperty<ZipkinState> {
         this.serverSpans.addAll(state.serverSpans);
     }
 
-    public synchronized void pushClientSpan(Span span) {
+    public void pushClientSpan(Span span) {
         clientSpans.push(span);
     }
 
-    public synchronized Span popClientSpan() {
+    public Span popClientSpan() {
         if (!clientSpans.isEmpty()) {
             return clientSpans.pop();
         } else {
@@ -57,11 +58,11 @@ public final class ZipkinState implements CamelCopySafeProperty<ZipkinState> {
         }
     }
 
-    public synchronized void pushServerSpan(Span span) {
+    public void pushServerSpan(Span span) {
         serverSpans.push(span);
     }
 
-    public synchronized Span popServerSpan() {
+    public Span popServerSpan() {
         if (!serverSpans.isEmpty()) {
             return serverSpans.pop();
         } else {
@@ -69,7 +70,7 @@ public final class ZipkinState implements CamelCopySafeProperty<ZipkinState> {
         }
     }
 
-    public synchronized Span peekServerSpan() {
+    public Span peekServerSpan() {
         if (!serverSpans.isEmpty()) {
             return serverSpans.peek();
         } else {

--- a/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinTracer.java
+++ b/components/camel-zipkin/src/main/java/org/apache/camel/zipkin/ZipkinTracer.java
@@ -593,7 +593,7 @@ public class ZipkinTracer extends ServiceSupport implements RoutePolicyFactory, 
         }
         // if we started from a server span then lets reuse that when we call a
         // downstream service
-        Span last = state.findMatchingServerSpan(event.getExchange());
+        Span last = state.peekServerSpan();
         Span span;
         if (last != null) {
             span = brave.tracer().newChild(last.context());

--- a/core/camel-core/src/test/java/org/apache/camel/support/DefaultExchangeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/DefaultExchangeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.support;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultExchangeTest {
+
+    private static final String SAFE_PROPERTY = "SAFE_PROPERTY";
+    private static final String UNSAFE_PROPERTY = "UNSAFE_PROPERTY";
+
+    @Test
+    public void testExchangeCopy() {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        SafeProperty property = new SafeProperty();
+        UnsafeProperty unsafeProperty = new UnsafeProperty();
+        exchange.setProperty(SAFE_PROPERTY, property);
+        exchange.setProperty(UNSAFE_PROPERTY, unsafeProperty);
+
+        Exchange copy = ExchangeHelper.createCorrelatedCopy(exchange, false);
+
+        assertThat(copy.getProperty(SAFE_PROPERTY)).isNotSameAs(property);
+        assertThat(copy.getProperty(UNSAFE_PROPERTY)).isSameAs(unsafeProperty);
+
+    }
+
+    private static final class SafeProperty implements CamelCopySafeProperty<SafeProperty> {
+
+        private SafeProperty() {
+
+        }
+
+        @Override
+        public SafeProperty safeCopy() {
+            return new SafeProperty();
+        }
+
+    }
+
+    private static class UnsafeProperty {
+
+    }
+
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/CamelCopySafeProperty.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/CamelCopySafeProperty.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+/**
+ *
+ * @author     Samrat.Dhillon
+ *
+ * @param  <T>
+ *
+ *             Interface that allows safe copy of property value object when creating copy of Exchange objects. Classes
+ *             implementing this interface are responsible for creating deep copy of the property value object.
+ */
+public interface CamelCopySafeProperty<T> {
+
+    T safeCopy();
+
+}


### PR DESCRIPTION
Fixing CAMEL-16509

When copying Exchange properties, provide a mechanism to set the copy object as property value instead of the original value object. This will allow the properties to be safely shared between Exchange objects operating in parallelProcessing and in this case ZipkinState will be easily shared without it getting corrupted.