### PR TITLE
camel-16400: rename properties used for triggering AWS manual tests

### DIFF
--- a/components/camel-aws/camel-aws2-ec2/src/test/java/org/apache/camel/component/aws2/ec2/integration/EC2ComponentManualIT.java
+++ b/components/camel-aws/camel-aws2-ec2/src/test/java/org/apache/camel/component/aws2/ec2/integration/EC2ComponentManualIT.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperties;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class EC2ComponentManualIT extends CamelTestSupport {
 
@@ -219,23 +219,23 @@ public class EC2ComponentManualIT extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:createAndRun")
-                        .to("aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=createAndRunInstances");
+                        .to("aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=createAndRunInstances");
                 from("direct:stop").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=stopInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=stopInstances");
                 from("direct:start").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=startInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=startInstances");
                 from("direct:terminate").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=terminateInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=terminateInstances");
                 from("direct:describe").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=describeInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=describeInstances");
                 from("direct:describeStatus")
-                        .to("aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=describeInstancesStatus");
+                        .to("aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=describeInstancesStatus");
                 from("direct:reboot").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=rebootInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=rebootInstances");
                 from("direct:monitor").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=monitorInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=monitorInstances");
                 from("direct:unmonitor").to(
-                        "aws2-ec2://TestDomain?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&operation=unmonitorInstances");
+                        "aws2-ec2://TestDomain?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&operation=unmonitorInstances");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-ecs/src/test/java/org/apache/camel/component/aws2/ecs/integration/ECS2ProducerManualIT.java
+++ b/components/camel-aws/camel-aws2-ecs/src/test/java/org/apache/camel/component/aws2/ecs/integration/ECS2ProducerManualIT.java
@@ -29,10 +29,10 @@ import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class ECS2ProducerManualIT extends CamelTestSupport {
 
@@ -60,7 +60,7 @@ public class ECS2ProducerManualIT extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:listClusters")
-                        .to("aws2-ecs://test?accessKey=RAW({{aws.access.key}})&secretKey=RAW({{aws.secret.key}})&region=eu-west-1&operation=listClusters")
+                        .to("aws2-ecs://test?accessKey=RAW({{aws.manual.access.key}})&secretKey=RAW({{aws.manual.secret.key}})&region=eu-west-1&operation=listClusters")
                         .to("mock:result");
             }
         };

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/integration/EventbridgePutRuleManualIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/integration/EventbridgePutRuleManualIT.java
@@ -37,14 +37,14 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class EventbridgePutRuleManualIT extends CamelTestSupport {
-    private static String accessKey = System.getProperty("aws.access.key");
-    private static String secretKey = System.getProperty("aws.secret.key");
+    private static String accessKey = System.getProperty("aws.manual.access.key");
+    private static String secretKey = System.getProperty("aws.manual.secret.key");
 
     @BindToRegistry("eventbridge-client")
     EventBridgeClient client

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/integration/EventbridgePutRuleSqsManualIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/integration/EventbridgePutRuleSqsManualIT.java
@@ -41,14 +41,14 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class EventbridgePutRuleSqsManualIT extends CamelTestSupport {
-    private static String accessKey = System.getProperty("aws.access.key");
-    private static String secretKey = System.getProperty("aws.secret.key");
+    private static String accessKey = System.getProperty("aws.manual.access.key");
+    private static String secretKey = System.getProperty("aws.manual.secret.key");
 
     @BindToRegistry("eventbridge-client")
     EventBridgeClient eventbridgeClient

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaComponentManualIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaComponentManualIT.java
@@ -31,10 +31,10 @@ import software.amazon.awssdk.services.lambda.model.Runtime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class LambdaComponentManualIT extends CamelTestSupport {
 
@@ -74,10 +74,10 @@ public class LambdaComponentManualIT extends CamelTestSupport {
             public void configure() throws Exception {
 
                 from("direct:listFunctions")
-                        .to("aws2-lambda://myFunction?operation=listFunctions&accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&region=eu-west-1");
+                        .to("aws2-lambda://myFunction?operation=listFunctions&accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&region=eu-west-1");
 
                 from("direct:getFunction")
-                        .to("aws2-lambda://twitterTrends?operation=getFunction&accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&region=eu-west-1");
+                        .to("aws2-lambda://twitterTrends?operation=getFunction&accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&region=eu-west-1");
 
             }
         };

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ComponentManualIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ComponentManualIT.java
@@ -37,8 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class S3ComponentManualIT extends CamelTestSupport {
 

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ConsumerManualIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ConsumerManualIT.java
@@ -48,14 +48,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class S3ConsumerManualIT extends CamelTestSupport {
-    private static final String ACCESS_KEY = System.getProperty("aws.access.key");
-    private static final String SECRET_KEY = System.getProperty("aws.secret.key");
+    private static final String ACCESS_KEY = System.getProperty("aws.manual.access.key");
+    private static final String SECRET_KEY = System.getProperty("aws.manual.secret.key");
 
     @BindToRegistry("amazonS3Client")
     S3Client client

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectOperationManualIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectOperationManualIT.java
@@ -34,14 +34,14 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class S3CopyObjectOperationManualIT extends CamelTestSupport {
-    private static final String ACCESS_KEY = System.getProperty("aws.access.key");
-    private static final String SECRET_KEY = System.getProperty("aws.secret.key");
+    private static final String ACCESS_KEY = System.getProperty("aws.manual.access.key");
+    private static final String SECRET_KEY = System.getProperty("aws.manual.secret.key");
 
     @BindToRegistry("amazonS3Client")
     S3Client client

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ObjectRangeOperationManualIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3ObjectRangeOperationManualIT.java
@@ -44,14 +44,14 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class S3ObjectRangeOperationManualIT extends CamelTestSupport {
-    private static final String ACCESS_KEY = System.getProperty("aws.access.key");
-    private static final String SECRET_KEY = System.getProperty("aws.secret.key");
+    private static final String ACCESS_KEY = System.getProperty("aws.manual.access.key");
+    private static final String SECRET_KEY = System.getProperty("aws.manual.secret.key");
 
     private static final Logger LOG = LoggerFactory.getLogger(S3ObjectRangeOperationManualIT.class);
 

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsComponentFifoManualIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsComponentFifoManualIT.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class SnsComponentFifoManualIT extends CamelTestSupport {
 
@@ -65,7 +65,7 @@ public class SnsComponentFifoManualIT extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("aws2-sns://Order.fifo?accessKey=RAW({{aws.access.key}})&secretKey=RAW({{aws.secret.key}})&region=eu-west-1&subject=The+subject+message&messageGroupIdStrategy=useExchangeId&autoCreateTopic=true");
+                        .to("aws2-sns://Order.fifo?accessKey=RAW({{aws.manual.access.key}})&secretKey=RAW({{aws.manual.secret.key}})&region=eu-west-1&subject=The+subject+message&messageGroupIdStrategy=useExchangeId&autoCreateTopic=true");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsComponentManualIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsComponentManualIT.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class SnsComponentManualIT extends CamelTestSupport {
 
@@ -65,7 +65,7 @@ public class SnsComponentManualIT extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("aws2-sns://MyNewTopic?accessKey={{aws.access.key}}&secretKey={{aws.secret.key}}&policy=%7B%22Version%22%3A%222008-10-17%22,%22Statement%22%3A%5B%7B%22Sid%22%3A%221%22,%22Effect%22%3A%22Allow%22,"
+                        .to("aws2-sns://MyNewTopic?accessKey={{aws.manual.access.key}}&secretKey={{aws.manual.secret.key}}&policy=%7B%22Version%22%3A%222008-10-17%22,%22Statement%22%3A%5B%7B%22Sid%22%3A%221%22,%22Effect%22%3A%22Allow%22,"
                             + "%22Principal%22%3A%7B%22AWS%22%3A%5B%22*%22%5D%7D,%22Action%22%3A%5B%22sns%3ASubscribe%22%5D%7D%5D%7D&subject=The+subject+message&autoCreateTopic=true");
             }
         };

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicWithKmsEncryptionManualIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicWithKmsEncryptionManualIT.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// Must be manually tested. Provide your own accessKey and secretKey using -Daws.access.key and -Daws.secret.key
+// Must be manually tested. Provide your own accessKey and secretKey using -Daws.manual.access.key and -Daws.manual.secret.key
 @EnabledIfSystemProperties({
-        @EnabledIfSystemProperty(named = "aws.access.key", matches = ".*", disabledReason = "Access key not provided"),
-        @EnabledIfSystemProperty(named = "aws.secret.key", matches = ".*", disabledReason = "Secret key not provided")
+        @EnabledIfSystemProperty(named = "aws.manual.access.key", matches = ".*", disabledReason = "Access key not provided"),
+        @EnabledIfSystemProperty(named = "aws.manual.secret.key", matches = ".*", disabledReason = "Secret key not provided")
 })
 public class SnsTopicWithKmsEncryptionManualIT extends CamelTestSupport {
 
@@ -65,7 +65,9 @@ public class SnsTopicWithKmsEncryptionManualIT extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("aws2-sns://MyNewTopic1?accessKey=RAW({{aws.access.key}})&secretKey=RAW({{aws.secret.key}})&region=EU_WEST_1&subject=The+subject+message&serverSideEncryptionEnabled=true&kmsMasterKeyId=RAW(xxx)&autoCreateTopic=true");
+                        .to("aws2-sns://MyNewTopic1?accessKey=RAW({{aws.manual.access.key}})&secretKey=RAW({{aws.manual.secret.key}})"
+                            + "&region=EU_WEST_1&subject=The+subject+message&serverSideEncryptionEnabled=true&"
+                            + "kmsMasterKeyId=RAW(xxx)&autoCreateTopic=true");
             }
         };
     }


### PR DESCRIPTION
This avoids the manual tests from being inadvertdly triggered in CI due
to automated tests injecting the the same properties during integration test
initialization.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/master/CONTRIBUTING.md
-->