### PR TITLE
Move version of camel-yaml-dsl-maven-plugin into parent pom

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/pom.xml
@@ -114,7 +114,6 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-yaml-dsl-maven-plugin</artifactId>
-                <version>3.10.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4009,6 +4009,11 @@
                     <version>${project.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-yaml-dsl-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
                     <version>${jaxb2-maven-plugin-version}</version>


### PR DESCRIPTION
No JIRA issue, but the version of camel-yaml-dsl-maven-plugin should be moved into the parent/pom.xml into the pluginManagement and removed from camel-yaml-dsl-deserializers.
