### PR TITLE
[CAMEL-16559] fixes catalog LIST_SERVICES

### DIFF
--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulCatalogProducer.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulCatalogProducer.java
@@ -56,7 +56,7 @@ public final class ConsulCatalogProducer extends AbstractConsulProducer<CatalogC
 
     @InvokeOnHeader(ConsulCatalogActions.LIST_SERVICES)
     protected void listServices(Message message) throws Exception {
-        processConsulResponse(message, getClient().getNodes(buildQueryOptions(message, getConfiguration())));
+        processConsulResponse(message, getClient().getServices(buildQueryOptions(message, getConfiguration())));
     }
 
     @InvokeOnHeader(ConsulCatalogActions.GET_SERVICE)

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulCatalogIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulCatalogIT.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.consul;
 
 import java.util.List;
+import java.util.Map;
 
 import com.orbitz.consul.model.health.Node;
 import org.apache.camel.builder.RouteBuilder;
@@ -42,6 +43,18 @@ public class ConsulCatalogIT extends ConsulTestSupport {
         List<Node> ref = getConsul().catalogClient().getNodes().getResponse();
         List<Node> res = fluentTemplate().withHeader(ConsulConstants.CONSUL_ACTION, ConsulCatalogActions.LIST_NODES)
                 .to("direct:consul").request(List.class);
+
+        Assertions.assertFalse(ref.isEmpty());
+        Assertions.assertFalse(res.isEmpty());
+        Assertions.assertEquals(ref, res);
+    }
+
+    @Test
+    public void testListServices() {
+        Map<String, List<String>> ref = getConsul().catalogClient().getServices().getResponse();
+        Map<String, List<String>> res
+                = fluentTemplate().withHeader(ConsulConstants.CONSUL_ACTION, ConsulCatalogActions.LIST_SERVICES)
+                        .to("direct:consul").request(Map.class);
 
         Assertions.assertFalse(ref.isEmpty());
         Assertions.assertFalse(res.isEmpty());


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-16559

- replaces erroneous call to `CatalogClient.getNodes` by `CatalogClient.getServices`