### PR TITLE
[CAMEL-16561]: Add support for agent REGISTER/DEREGISTER

### DIFF
--- a/components/camel-consul/src/generated/java/org/apache/camel/component/consul/endpoint/ConsulAgentProducerInvokeOnHeaderFactory.java
+++ b/components/camel-consul/src/generated/java/org/apache/camel/component/consul/endpoint/ConsulAgentProducerInvokeOnHeaderFactory.java
@@ -20,8 +20,12 @@ public class ConsulAgentProducerInvokeOnHeaderFactory implements InvokeOnHeaderS
         case "AGENT": return target.invokeAgent(exchange.getMessage());
         case "checks":
         case "CHECKS": return target.invokeChecks(exchange.getMessage());
+        case "deregister":
+        case "DEREGISTER": target.invokeDeregister(exchange.getMessage()); return null;
         case "members":
         case "MEMBERS": return target.invokeMembers(exchange.getMessage());
+        case "register":
+        case "REGISTER": target.invokeRegister(exchange.getMessage()); return null;
         case "services":
         case "SERVICES": return target.invokeServices(exchange.getMessage());
         default: return null;

--- a/components/camel-consul/src/main/docs/consul-component.adoc
+++ b/components/camel-consul/src/main/docs/consul-component.adoc
@@ -171,6 +171,70 @@ with the following path and query parameters:
 |CamelConsulResult|boolean|true if the response has a result
 |CamelConsulSession|String|The session id
 |CamelConsulValueAsString|boolean|To transform values retrieved from Consul i.e. on KV endpoint to string.
+|CamelConsulServiceId|String|The service id for agent deregistration
 |=======================================================================
+
+== Api Endpoint
+
+The `apiEndpoint` denotes the type of https://www.consul.io/api-docs[consul api] which should be addressed.
+
+[width="100%",options="header"]
+|===
+| Domain | Producer | Consumer
+| kv | ConsulKeyValueProducer | ConsulKeyValueConsumer
+| event | ConsulEventProducer | ConsulEventConsumer
+| agent | ConsulAgentProducer | -
+| coordinates | ConsulCoordinatesProducer | -
+| health | ConsulHealthProducer | -
+| status | ConsulStatusProducer | -
+| preparedQuery | ConsulPreparedQueryProducer | -
+| catalog | ConsulCatalogProducer | -
+| session | ConsulSessionProducer | -
+|===
+
+== Producer Examples
+
+As an example, we will show how to use the `ConsulAgentProducer` to register a service by means of the Consul agent api.
+
+Registering and deregistering are examples for possible actions against the Consul agent api.
+
+The desired action can be defined by setting the header `ConsulConstants.CONSUL_ACTION` to a value from the `ConsulXXXActions` interface of the respective Consul api. E.g.  `ConsulAgentActions` contains the actions for the agent api.
+
+If you set `CONSUL_ACTION` to `ConsulAgentActions.REGISTER`, the agent action `REGISTER` will be executed.
+
+TIP: Which producer action invokes which consul api is defined by the respective producer.
+E.g. the `ConsulAgentProducer` maps `ConsulAgentActions.REGISTER` to an invocation of `AgentClient.register`.
+
+[source,java]
+----
+from("direct:registerFooService")
+    .setBody().constant(ImmutableRegistration.builder()
+        .id("foo-1")
+        .name("foo")
+        .address("localhost")
+        .port(80)
+        .build())
+    .setHeader(ConsulConstants.CONSUL_ACTION, constant(ConsulAgentActions.REGISTER))
+    .to("consul:agent");
+----
+
+It is also possible to set a default action on the consul endpoint and do without the header:
+
+----
+consul:agent?action=REGISTER
+----
+
+== Registering Camel Routes with Consul
+
+You can employ a `ServiceRegistrationRoutePolicy` to register Camel routes as services with Consul automatically.
+
+[source,java]
+----
+from("jetty:http://0.0.0.0:8080/service/endpoint").routeId("foo-1")
+    .routeProperty(ServiceDefinition.SERVICE_META_ID, "foo-1")
+    .routeProperty(ServiceDefinition.SERVICE_META_NAME, "foo")
+    .routePolicy(new ServiceRegistrationRoutePolicy())
+...
+----
 
 include::{page-component-version}@camel-spring-boot::page$consul-starter.adoc[]

--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/ConsulConstants.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/ConsulConstants.java
@@ -55,4 +55,5 @@ public interface ConsulConstants {
     String CONSUL_HEALTHY_ONLY = "CamelConsulHealthyOnly";
     String CONSUL_HEALTHY_STATE = "CamelConsulHealthyState";
     String CONSUL_PREPARED_QUERY_ID = "CamelConsulPreparedQueryID";
+    String CONSUL_SERVICE_ID = "CamelConsulServiceId";
 }

--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulAgentActions.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulAgentActions.java
@@ -21,4 +21,6 @@ public interface ConsulAgentActions {
     String SERVICES = "SERVICES";
     String MEMBERS = "MEMBERS";
     String AGENT = "AGENT";
+    String REGISTER = "REGISTER";
+    String DEREGISTER = "DEREGISTER";
 }

--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulAgentProducer.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/endpoint/ConsulAgentProducer.java
@@ -18,8 +18,10 @@ package org.apache.camel.component.consul.endpoint;
 
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.Consul;
+import com.orbitz.consul.model.agent.Registration;
 import org.apache.camel.Message;
 import org.apache.camel.component.consul.ConsulConfiguration;
+import org.apache.camel.component.consul.ConsulConstants;
 import org.apache.camel.component.consul.ConsulEndpoint;
 import org.apache.camel.spi.InvokeOnHeader;
 
@@ -47,6 +49,17 @@ public final class ConsulAgentProducer extends AbstractConsulProducer<AgentClien
     @InvokeOnHeader("AGENT")
     public Object invokeAgent(Message message) throws Exception {
         return getClient().getAgent();
+    }
+
+    @InvokeOnHeader("REGISTER")
+    public void invokeRegister(Message message) throws Exception {
+        getClient().register(message.getMandatoryBody(Registration.class));
+    }
+
+    @InvokeOnHeader("DEREGISTER")
+    public void invokeDeregister(Message message) throws Exception {
+        getClient().deregister(getMandatoryHeader(message, ConsulConstants.CONSUL_SERVICE_ID, String.class),
+                buildQueryOptions(message, getConfiguration()));
     }
 
 }

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulAgentIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulAgentIT.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.consul;
+
+import java.util.Map;
+
+import com.orbitz.consul.model.agent.ImmutableRegistration;
+import com.orbitz.consul.model.health.Service;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.consul.endpoint.ConsulAgentActions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConsulAgentIT extends ConsulTestSupport {
+
+    public final String serviceId = generateRandomString();
+
+    @Test
+    public void testRegisterDeregister() {
+        Map<String, Service> beforeRegistration = getConsul().agentClient()
+                .getServices();
+        Assertions.assertTrue(beforeRegistration.isEmpty());
+
+        fluentTemplate().withHeader(ConsulConstants.CONSUL_ACTION, ConsulAgentActions.REGISTER)
+                .withBody(ImmutableRegistration.builder()
+                        .id(serviceId)
+                        .name("foo")
+                        .address("localhost")
+                        .port(80)
+                        .build())
+                .to("direct:consul")
+                .request();
+
+        Map<String, Service> afterRegistration = getConsul().agentClient()
+                .getServices();
+        Assertions.assertEquals(1, afterRegistration.size());
+        Assertions.assertNotNull(afterRegistration.get(serviceId));
+
+        fluentTemplate().withHeader(ConsulConstants.CONSUL_ACTION, ConsulAgentActions.DEREGISTER)
+                .withHeader(ConsulConstants.CONSUL_SERVICE_ID, serviceId)
+                .to("direct:consul")
+                .request();
+
+        Map<String, Service> afterDeregistration = getConsul().agentClient()
+                .getServices();
+        Assertions.assertTrue(afterDeregistration.isEmpty());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:consul").to("consul:agent");
+
+                from("direct:register")
+                        .setBody().constant(ImmutableRegistration.builder()
+                                .id(serviceId)
+                                .name("foo")
+                                .address("localhost")
+                                .port(80)
+                                .build())
+                        .setHeader(ConsulConstants.CONSUL_ACTION, constant(ConsulAgentActions.REGISTER))
+                        .to("consul:agent?action=REGISTER");
+            }
+        };
+    }
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-16561

- added REGISTER and DEREGISTER agent actions
- introduced and documented new header `CamelConsulServiceId` to specify a service to deregister
- enhanced documentation, explaining the relationship between apiEndpoint, action and the component
- also mentioned `ServiceRegistrationRoutePolicy`
