### PR TITLE
[CAMEL-16595] Swift getall filter path

### DIFF
--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
@@ -98,6 +98,7 @@ public class ObjectProducer extends AbstractOpenstackProducer {
 
         List<? extends SwiftObject> out;
         if (path != null) {
+            StringHelper.notEmpty(name, "Path");
             ObjectListOptions objectListOptions = ObjectListOptions.create();
             objectListOptions.startsWith(path).delimiter('/');
             out = os.objectStorage().objects().list(name, objectListOptions);

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
@@ -98,7 +98,7 @@ public class ObjectProducer extends AbstractOpenstackProducer {
 
         List<? extends SwiftObject> out;
         if (path != null) {
-            StringHelper.notEmpty(name, "Path");
+            StringHelper.notEmpty(path, "Path");
             ObjectListOptions objectListOptions = ObjectListOptions.create();
             objectListOptions.startsWith(path).delimiter('/');
             out = os.objectStorage().objects().list(name, objectListOptions);

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
@@ -95,11 +95,15 @@ public class ObjectProducer extends AbstractOpenstackProducer {
                 String.class);
         StringHelper.notEmpty(name, "Container name");
         final String path = msg.getHeader(SwiftConstants.PATH, String.class);
-        ObjectListOptions objectListOptions = ObjectListOptions.create();
+
+        List<? extends SwiftObject> out;
         if (path != null) {
+            ObjectListOptions objectListOptions = ObjectListOptions.create();
             objectListOptions.startsWith(path).delimiter('/');
+            out = os.objectStorage().objects().list(name, objectListOptions);
+        } else {
+            out = os.objectStorage().objects().list(name);
         }
-        List<? extends SwiftObject> out = os.objectStorage().objects().list(name, objectListOptions);
 
         exchange.getIn().setBody(out);
     }

--- a/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
+++ b/components/camel-openstack/src/main/java/org/apache/camel/component/openstack/swift/producer/ObjectProducer.java
@@ -31,6 +31,7 @@ import org.openstack4j.api.OSClient;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.storage.object.SwiftObject;
+import org.openstack4j.model.storage.object.options.ObjectListOptions;
 import org.openstack4j.model.storage.object.options.ObjectLocation;
 
 public class ObjectProducer extends AbstractOpenstackProducer {
@@ -93,7 +94,13 @@ public class ObjectProducer extends AbstractOpenstackProducer {
         final String name = msg.getHeader(SwiftConstants.CONTAINER_NAME, msg.getHeader(OpenstackConstants.NAME, String.class),
                 String.class);
         StringHelper.notEmpty(name, "Container name");
-        final List<? extends SwiftObject> out = os.objectStorage().objects().list(name);
+        final String path = msg.getHeader(SwiftConstants.PATH, String.class);
+        ObjectListOptions objectListOptions = ObjectListOptions.create();
+        if (path != null) {
+            objectListOptions.startsWith(path).delimiter('/');
+        }
+        List<? extends SwiftObject> out = os.objectStorage().objects().list(name, objectListOptions);
+
         exchange.getIn().setBody(out);
     }
 


### PR DESCRIPTION
The code adds the ability to modify the behavior of getAll in the swift client by putting "path"=value in the header.
The result is that a list of objects whose path starts with value are returned.
If the "path" is not set it has the usual behavior.