### PR TITLE
Skip integration tests for release building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -785,6 +785,13 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>true</skipITs>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
We want to skip running integration tests during release building.