### PR TITLE
Remove `enable-schemagen` in release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
                         <preparationGoals>clean install</preparationGoals>
                         <goals>deploy</goals>
                         <!-- The profile we want to use when doing the release -->
-                        <arguments>-Prelease,apache-release,enable-schemagen,sourcecheck,hibernate</arguments>
+                        <arguments>-Prelease,apache-release,sourcecheck,hibernate</arguments>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Disable the `enable-schemagen` profile for release building. Seems like this profile has been removed a while back and only produces noise/warnings during the release process.