### PR TITLE
CAMEL-16619: change channel pool configuration in RabbitMQProducer

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQProducer.java
@@ -109,10 +109,20 @@ public class RabbitMQProducer extends DefaultAsyncProducer {
         LOG.debug("Created connection: {}", conn);
 
         LOG.trace("Creating channel pool...");
+        int channelPoolMaxSize = getEndpoint().getChannelPoolMaxSize();
         channelPool = new GenericObjectPool<>(
-                new PoolableChannelFactory(this.conn), getEndpoint().getChannelPoolMaxSize(),
+                new PoolableChannelFactory(this.conn),
+                channelPoolMaxSize,
                 GenericObjectPool.WHEN_EXHAUSTED_BLOCK,
-                getEndpoint().getChannelPoolMaxWait());
+                getEndpoint().getChannelPoolMaxWait(),
+                channelPoolMaxSize,
+                GenericObjectPool.DEFAULT_MIN_IDLE,
+                GenericObjectPool.DEFAULT_TEST_ON_BORROW,
+                GenericObjectPool.DEFAULT_TEST_ON_RETURN,
+                GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS,
+                GenericObjectPool.DEFAULT_NUM_TESTS_PER_EVICTION_RUN,
+                GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS,
+                GenericObjectPool.DEFAULT_TEST_WHILE_IDLE);
         attemptDeclaration();
     }
 


### PR DESCRIPTION
camel-rabbitmq - Producer destroys rabbit channels when returns it back to the pool

- for RabbitMQProducer specify `GenericObjectPool._maxIdle` property of channel pool with `RabbitMQEndpoint.channelPoolMaxSize` value
