### PR TITLE
CAMEL-16640 camel-kafka race conditions during shut down

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -234,6 +234,10 @@ public class KafkaConsumer extends DefaultConsumer {
 
                 first = false;
 
+                if (!isRunAllowed() || isStoppingOrStopped() || isSuspendingOrSuspended()) {
+                    return;
+                }
+
                 // doRun keeps running until we either shutdown or is told to re-connect
                 doRun(reTry, reConnect);
             }


### PR DESCRIPTION
Ticket: https://issues.apache.org/jira/browse/CAMEL-16640 . 

It is about the plain camel-kafka component as in 3.10. The changes which have been added for this ticket: https://issues.apache.org/jira/browse/CAMEL-14980 are causing this problem.

In KafkaConsumer class in the run() method if the thread is sleeping and an Interrupted Exception occurs, then the thread will leave the loop, which is fine. But, if before the thread enters the sleeping, something happens then the thread will remain running without caring about the stopping state(Zombie Thread). 

In the doPollRun() method, the retry flag is set to false only when the consumer wakeup method throws an exception which  causes the thread again to keep running in the loop without stopping which leaves the thread to be zombie. 