### PR TITLE
Test undertow http2 protocol

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -141,5 +141,29 @@
             <artifactId>httpmime</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-client</artifactId>
+            <version>${jetty9-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${jetty9-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <version>${jetty9-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty9-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttp2Test.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttp2Test.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class UndertowHttp2Test extends BaseUndertowTest {
+    private static final Logger LOG = LoggerFactory.getLogger(UndertowHttp2Test.class);
+
+    private static final String RESPONSE = "Http2 Greetings";
+
+    @Test
+    public void testHttp2Protocol() throws Exception {
+        final HTTP2Client http2Client = new HTTP2Client();
+        final HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        httpClient.start();
+
+        try {
+            final ContentResponse resp = httpClient.GET("http://localhost:" + getPort() + "/myapp");
+
+            assertEquals(200, resp.getStatus());
+            assertEquals(HttpVersion.HTTP_2, resp.getVersion());
+            assertEquals(RESPONSE, new String(resp.getContent()));
+        } catch (Throwable ex) {
+            LOG.error(ex.getMessage(), ex);
+            fail("HTTP2 endpoint not exposed!, maybe it's not supported?");
+        }
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        UndertowComponent component = context.getComponent("undertow", UndertowComponent.class);
+
+        UndertowHostOptions undertowHostOptions = new UndertowHostOptions();
+        undertowHostOptions.setHttp2Enabled(true);
+
+        component.setHostOptions(undertowHostOptions);
+
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("undertow:http://localhost:{{port}}/myapp")
+                        .setBody().constant(RESPONSE);
+            }
+        };
+    }
+}


### PR DESCRIPTION
I actually wanted to use 
```
@BindToRegistry("undertowHostOptions")
private UndertowHostOptions undertowHostOptions = new UndertowHostOptions();
```
and a route like
```
from("undertow:http://localhost:{{port}}/myapp?hostOptions=#undertowHostOptions")
```
but it's not working, maybe I'm missing something

Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
