### PR TITLE
Move the camel-dsl-support dependency entry above the autogeneration point

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -727,6 +727,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-dsl-support</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-health</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1282,11 +1287,6 @@
 			<dependency>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-dropbox</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.camel</groupId>
-				<artifactId>camel-dsl-support</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Move the camel-dsl-support dependency above the autogeneration point so it isn't removed by the camel catalog autogeneration.