### PR TITLE
[CAMEL-16663]: camel-file - excludeExt/includeExt non-single extensions

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
@@ -36,7 +36,6 @@ import org.apache.camel.support.EmptyAsyncCallback;
 import org.apache.camel.support.ScheduledBatchPollingConsumer;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.CastUtils;
-import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
@@ -72,8 +71,8 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
 
         this.includePattern = endpoint.getIncludePattern();
         this.excludePattern = endpoint.getExcludePattern();
-        this.includeExt = endpoint.getIncludeExt() != null ? endpoint.getIncludeExt().split(",") : null;
-        this.excludeExt = endpoint.getExcludeExt() != null ? endpoint.getExcludeExt().split(",") : null;
+        this.includeExt = endpoint.getIncludeExt() != null ? endpoint.getIncludeExt().toLowerCase().split(",") : null;
+        this.excludeExt = endpoint.getExcludeExt() != null ? endpoint.getExcludeExt().toLowerCase().split(",") : null;
     }
 
     public Processor getCustomProcessor() {
@@ -679,9 +678,9 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
             }
         }
         if (excludeExt != null) {
-            String ext = FileUtil.onlyExt(file.getFileName());
+            String fname = file.getFileName().toLowerCase();
             for (String exclude : excludeExt) {
-                if (exclude.equalsIgnoreCase(ext)) {
+                if (fname.endsWith("." + exclude)) {
                     return false;
                 }
             }
@@ -692,10 +691,10 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
             }
         }
         if (includeExt != null) {
-            String ext = FileUtil.onlyExt(file.getFileName());
+            String fname = file.getFileName().toLowerCase();
             boolean any = false;
             for (String include : includeExt) {
-                any |= include.equalsIgnoreCase(ext);
+                any |= fname.endsWith("." + include);
             }
             if (!any) {
                 return false;


### PR DESCRIPTION


For example:
"excludeExt=filepart" would match file "foo.bar.filepart" (previously it would not)
"excludeExt=gz" would match files "foo.tar.gz" and "foo.gz" (previously only "foo.gz" would match)
"excludeExt=tar.gz" would match file "foo.tar.gz" but not "foo.gz" (same as before)

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
