### PR TITLE
Parallel

### DIFF
--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -31,6 +31,10 @@
     <name>Camel :: Kafka</name>
     <description>Camel Kafka support</description>
 
+    <properties>
+        <camel.surefire.parallel>true</camel.surefire.parallel>
+    </properties>
+
     <dependencies>
 
         <!-- camel -->

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/MockConsumerInterceptor.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/MockConsumerInterceptor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.kafka;
 
-import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
@@ -26,11 +25,8 @@ import org.apache.kafka.common.TopicPartition;
 
 public class MockConsumerInterceptor implements ConsumerInterceptor<String, String> {
 
-    public static ArrayList<ConsumerRecords<String, String>> recordsCaptured = new ArrayList<>();
-
     @Override
     public ConsumerRecords<String, String> onConsume(ConsumerRecords<String, String> consumerRecords) {
-        recordsCaptured.add(consumerRecords);
         return consumerRecords;
     }
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/BaseEmbeddedKafkaTestSupport.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/BaseEmbeddedKafkaTestSupport.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.kafka.KafkaComponent;
 import org.apache.camel.component.kafka.KafkaConstants;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.test.infra.kafka.services.KafkaService;
 import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -29,13 +30,15 @@ import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class BaseEmbeddedKafkaTestSupport extends CamelTestSupport {
     @RegisterExtension
-    public static KafkaService service = KafkaServiceFactory.createService();
+    public static KafkaServiceExtension service = new KafkaServiceExtension();
 
     protected static AdminClient kafkaAdminClient;
 
@@ -88,5 +91,56 @@ public abstract class BaseEmbeddedKafkaTestSupport extends CamelTestSupport {
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, service.getBootstrapServers());
 
         return KafkaAdminClient.create(properties);
+    }
+
+    static class KafkaServiceExtension implements BeforeAllCallback {
+
+        ExtensionContext.Store store;
+
+        public String getBootstrapServers() {
+            return store.get(KafkaServiceHolder.class, KafkaServiceHolder.class).getService().getBootstrapServers();
+        }
+
+        @Override
+        public void beforeAll(ExtensionContext context) throws Exception {
+            ExtensionContext root = context.getRoot();
+            store = root.getStore(ExtensionContext.Namespace.GLOBAL);
+            store.getOrComputeIfAbsent(KafkaServiceHolder.class, o -> new KafkaServiceHolder(root), KafkaServiceHolder.class);
+        }
+    }
+
+    static class KafkaServiceHolder implements ExtensionContext.Store.CloseableResource {
+        final ExtensionContext context;
+        volatile KafkaService kafka;
+
+        public KafkaServiceHolder(ExtensionContext context) {
+            this.context = context;
+        }
+
+        public KafkaService getService() {
+            if (kafka == null) {
+                synchronized (this) {
+                    if (kafka == null) {
+                        kafka = create();
+                    }
+                }
+            }
+            return kafka;
+        }
+
+        private KafkaService create() {
+            KafkaService kafka = KafkaServiceFactory.createService();
+            try {
+                kafka.beforeAll(context);
+            } catch (Exception e) {
+                throw new RuntimeCamelException("Unable to initialize kafka service", e);
+            }
+            return kafka;
+        }
+
+        @Override
+        public void close() throws Throwable {
+            getService().close();
+        }
     }
 }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerLastRecordHeaderIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerLastRecordHeaderIT.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KafkaConsumerLastRecordHeaderIT extends BaseEmbeddedKafkaTestSupport {
-    private static final String TOPIC = "last-record";
+    private static final String TOPIC = "KafkaConsumerLastRecordHeaderTest";
 
     @EndpointInject("mock:result")
     private MockEndpoint result;
@@ -88,7 +88,8 @@ public class KafkaConsumerLastRecordHeaderIT extends BaseEmbeddedKafkaTestSuppor
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("kafka:" + TOPIC + "?groupId=A&autoOffsetReset=earliest&autoCommitEnable=false").to("mock:result");
+                from("kafka:" + TOPIC + "?groupId=" + TOPIC + "_GROUP&autoOffsetReset=earliest&autoCommitEnable=false")
+                        .to("mock:result");
             }
         };
     }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerManualCommitIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerManualCommitIT.java
@@ -34,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KafkaConsumerManualCommitIT extends BaseEmbeddedKafkaTestSupport {
 
-    public static final String TOPIC = "testManualCommitTest";
+    public static final String TOPIC = "KafkaConsumerManualCommitTest";
 
     @EndpointInject("kafka:" + TOPIC
-                    + "?groupId=group1&sessionTimeoutMs=30000&autoCommitEnable=false"
+                    + "?groupId=" + TOPIC + "_GROUP&sessionTimeoutMs=30000&autoCommitEnable=false"
                     + "&allowManualCommit=true&autoOffsetReset=earliest")
     private Endpoint from;
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerRebalanceIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerRebalanceIT.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaConsumerRebalanceIT extends BaseEmbeddedKafkaTestSupport {
-    private static final String TOPIC = "offset-rebalance";
+    private static final String TOPIC = "KafkaConsumerRebalanceTest";
 
     @EndpointInject("mock:result")
     private MockEndpoint result;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
@@ -62,14 +62,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
 
-    private static final String TOPIC_STRINGS = "test";
-    private static final String TOPIC_INTERCEPTED = "test";
-    private static final String TOPIC_STRINGS_IN_HEADER = "testHeader";
-    private static final String TOPIC_BYTES = "testBytes";
-    private static final String TOPIC_BYTES_IN_HEADER = "testBytesHeader";
-    private static final String GROUP_BYTES = "groupStrings";
-    private static final String TOPIC_PROPAGATED_HEADERS = "testPropagatedHeaders";
-    private static final String TOPIC_NO_RECORD_SPECIFIC_HEADERS = "noRecordSpecificHeaders";
+    private static final String TOPIC_STRINGS = "KafkaProducerFullTest.test";
+    private static final String TOPIC_INTERCEPTED = "KafkaProducerFullTest.test";
+    private static final String TOPIC_STRINGS_IN_HEADER = "KafkaProducerFullTest.testHeader";
+    private static final String TOPIC_BYTES = "KafkaProducerFullTest.testBytes";
+    private static final String TOPIC_BYTES_IN_HEADER = "KafkaProducerFullTest.testBytesHeader";
+    private static final String GROUP_BYTES = "KafkaProducerFullTest.groupStrings";
+    private static final String TOPIC_PROPAGATED_HEADERS = "KafkaProducerFullTest.testPropagatedHeaders";
+    private static final String TOPIC_NO_RECORD_SPECIFIC_HEADERS = "KafkaProducerFullTest.noRecordSpecificHeaders";
 
     private static KafkaConsumer<String, String> stringsConsumerConn;
     private static KafkaConsumer<byte[], byte[]> bytesConsumerConn;
@@ -187,7 +187,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
                     = (List<RecordMetadata>) (exchange.getIn().getHeader(KafkaConstants.KAFKA_RECORDMETA));
             assertEquals(1, recordMetaData1.size(), "One RecordMetadata is expected.");
             assertTrue(recordMetaData1.get(0).offset() >= 0, "Offset is positive");
-            assertTrue(recordMetaData1.get(0).topic().startsWith("test"), "Topic Name start with 'test'");
+            assertTrue(recordMetaData1.get(0).topic().startsWith("KafkaProducerFullTest.test"), "Topic Name start with 'test'");
         }
     }
 
@@ -218,7 +218,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
                     = (List<RecordMetadata>) (exchange.getIn().getHeader(KafkaConstants.KAFKA_RECORDMETA));
             assertEquals(1, recordMetaData1.size(), "One RecordMetadata is expected.");
             assertTrue(recordMetaData1.get(0).offset() >= 0, "Offset is positive");
-            assertTrue(recordMetaData1.get(0).topic().startsWith("test"), "Topic Name start with 'test'");
+            assertTrue(recordMetaData1.get(0).topic().startsWith("KafkaProducerFullTest.test"), "Topic Name start with 'test'");
         }
     }
 
@@ -277,7 +277,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
         assertEquals(10, recordMetaData1.size(), "Ten RecordMetadata is expected.");
         for (RecordMetadata recordMeta : recordMetaData1) {
             assertTrue(recordMeta.offset() >= 0, "Offset is positive");
-            assertTrue(recordMeta.topic().startsWith("test"), "Topic Name start with 'test'");
+            assertTrue(recordMeta.topic().startsWith("KafkaProducerFullTest.test"), "Topic Name start with 'test'");
         }
         Exchange e2 = exchangeList.get(1);
         @SuppressWarnings("unchecked")
@@ -285,7 +285,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
         assertEquals(5, recordMetaData2.size(), "Five RecordMetadata is expected.");
         for (RecordMetadata recordMeta : recordMetaData2) {
             assertTrue(recordMeta.offset() >= 0, "Offset is positive");
-            assertTrue(recordMeta.topic().startsWith("test"), "Topic Name start with 'test'");
+            assertTrue(recordMeta.topic().startsWith("KafkaProducerFullTest.test"), "Topic Name start with 'test'");
         }
     }
 
@@ -320,7 +320,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
                     = (List<RecordMetadata>) (exchange.getIn().getHeader(KafkaConstants.KAFKA_RECORDMETA));
             assertEquals(1, recordMetaData1.size(), "One RecordMetadata is expected.");
             assertTrue(recordMetaData1.get(0).offset() >= 0, "Offset is positive");
-            assertTrue(recordMetaData1.get(0).topic().startsWith("test"), "Topic Name start with 'test'");
+            assertTrue(recordMetaData1.get(0).topic().startsWith("KafkaProducerFullTest.test"), "Topic Name start with 'test'");
         }
     }
 

--- a/components/camel-ldif/src/test/java/org/apache/camel/component/ldif/LdifTestSupport.java
+++ b/components/camel-ldif/src/test/java/org/apache/camel/component/ldif/LdifTestSupport.java
@@ -19,10 +19,13 @@ package org.apache.camel.component.ldif;
 import org.apache.camel.test.infra.openldap.services.OpenldapService;
 import org.apache.camel.test.infra.openldap.services.OpenldapServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.apache.camel.test.junit5.resources.SuiteScope;
+import org.apache.camel.test.junit5.resources.TestService;
 
 public class LdifTestSupport extends CamelTestSupport {
-    @RegisterExtension
+
+    @TestService
+    @SuiteScope
     public static OpenldapService service = OpenldapServiceFactory.createService();
 
     protected int port;

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LeakDetection.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LeakDetection.java
@@ -1,0 +1,41 @@
+package org.apache.camel.component.netty.http;
+
+import java.util.Collection;
+
+import io.netty.buffer.ByteBufAllocator;
+import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LeakDetection implements BeforeAllCallback, AfterAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        System.setProperty("io.netty.leakDetection.maxRecords", "100");
+        System.setProperty("io.netty.leakDetection.acquireAndReleaseOnly", "true");
+        System.setProperty("io.netty.leakDetection.targetRecords", "100");
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        // Force GC to bring up leaks
+        System.gc();
+        // Kick leak detection logging
+        ByteBufAllocator.DEFAULT.buffer(1).release();
+        final Collection<LogEvent> events = LogCaptureAppender.getEvents();
+        if (!events.isEmpty()) {
+            final String message = "Leaks detected while running tests: " + events;
+            // Just write the message into log to help debug
+            Logger log = LoggerFactory.getLogger(context.getRequiredTestClass());
+            for (final LogEvent event : events) {
+                log.info(event.getMessage().getFormattedMessage());
+            }
+            LogCaptureAppender.reset();
+            throw new AssertionError(message);
+        }
+    }
+
+}

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LeakDetection.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LeakDetection.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.netty.http;
 
 import java.util.Collection;

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LogCaptureTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LogCaptureTest.java
@@ -19,12 +19,14 @@ package org.apache.camel.component.netty.http;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This test ensures LogCaptureAppender is configured properly
  */
+@Isolated
 public class LogCaptureTest {
     @Test
     public void testCapture() {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyEnricherLeakTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyEnricherLeakTest.java
@@ -35,11 +35,11 @@ public class NettyEnricherLeakTest extends BaseNettyTest {
             public void configure() throws Exception {
                 ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
-                from("netty-http:http://localhost:" + getPort() + "/test")
+                from("netty-http:http://localhost:{{port}}/test")
                         .transform().simple("${body}");
 
                 from("direct:outer")
-                        .to("netty-http:http://localhost:" + getPort() + "/test?disconnect=true");
+                        .to("netty-http:http://localhost:{{port}}/test?disconnect=true");
             }
         });
         context.start();
@@ -57,11 +57,11 @@ public class NettyEnricherLeakTest extends BaseNettyTest {
             public void configure() throws Exception {
                 ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
-                from("netty-http:http://localhost:" + getPort() + "/test")
+                from("netty-http:http://localhost:{{port}}/test")
                         .transform().simple("${body}");
 
                 from("direct:outer")
-                        .enrich("netty-http:http://localhost:" + getPort() + "/test?disconnect=true",
+                        .enrich("netty-http:http://localhost:{{port}}/test?disconnect=true",
                                 AggregationStrategies.string(), false, false);
             }
         });

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
@@ -22,30 +22,28 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NettyHttpBridgeEncodedPathTest extends BaseNettyTest {
 
-    AvailablePortFinder.Port port1 = port;
-    @RegisterExtension
-    AvailablePortFinder.Port port2 = AvailablePortFinder.find();
-    @RegisterExtension
-    AvailablePortFinder.Port port3 = AvailablePortFinder.find();
-    @RegisterExtension
-    AvailablePortFinder.Port port4 = AvailablePortFinder.find();
+    @AvailablePort
+    int port2;
+    @AvailablePort
+    int port3;
+    @AvailablePort
+    int port4;
 
     @Test
     public void testEncodedQuery() throws Exception {
-        String response = template.requestBody("http://localhost:" + port2 + "/nettyTestRouteA?param1=%2B447777111222", null,
+        String response = template.requestBody("http://localhost:{{port2}}/nettyTestRouteA?param1=%2B447777111222", null,
                 String.class);
         assertEquals("param1=+447777111222", response, "Get a wrong response");
     }
@@ -87,21 +85,19 @@ public class NettyHttpBridgeEncodedPathTest extends BaseNettyTest {
                     exchange.getMessage().setBody(exchange.getIn().getHeader(Exchange.HTTP_QUERY));
                 };
 
-                from("netty-http:http://localhost:" + port2 + "/nettyTestRouteA?matchOnUriPrefix=true")
+                from("netty-http:http://localhost:{{port2}}/nettyTestRouteA?matchOnUriPrefix=true")
                         .log("Using NettyTestRouteA route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
-                        .to("netty-http:http://localhost:" + port1
-                            + "/nettyTestRouteB?throwExceptionOnFailure=false&bridgeEndpoint=true");
+                        .to("netty-http:http://localhost:{{port}}/nettyTestRouteB?throwExceptionOnFailure=false&bridgeEndpoint=true");
 
-                from("netty-http:http://localhost:" + port1 + "/nettyTestRouteB?matchOnUriPrefix=true")
+                from("netty-http:http://localhost:{{port}}/nettyTestRouteB?matchOnUriPrefix=true")
                         .log("Using NettyTestRouteB route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .process(serviceProc);
 
-                from("netty-http:http://localhost:" + port4 + "/nettyTestRouteC?matchOnUriPrefix=true")
+                from("netty-http:http://localhost:{{port4}}/nettyTestRouteC?matchOnUriPrefix=true")
                         .log("Using NettyTestRouteC route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
-                        .to("netty-http:http://localhost:" + port3
-                            + "/nettyTestRouteD?throwExceptionOnFailure=false&bridgeEndpoint=true");
+                        .to("netty-http:http://localhost:{{port3}}/nettyTestRouteD?throwExceptionOnFailure=false&bridgeEndpoint=true");
 
-                from("netty-http:http://localhost:" + port3 + "/nettyTestRouteD?matchOnUriPrefix=true")
+                from("netty-http:http://localhost:{{port3}}/nettyTestRouteD?matchOnUriPrefix=true")
                         .log("Using NettyTestRouteD route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .setBody(constant("test"))
                         .to("mock:encodedPath");

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpCompressTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpCompressTest.java
@@ -24,12 +24,12 @@ import java.util.zip.GZIPInputStream;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Isolated
+@Disabled("flaky test")
 public class NettyHttpCompressTest extends BaseNettyTest {
 
     @Test

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpContentTypeTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpContentTypeTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.netty.http;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -34,7 +34,7 @@ public class NettyHttpContentTypeTest extends BaseNettyTest {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URL, "http://localhost:" + getPort() + "/foo");
         getMockEndpoint("mock:input").expectedPropertyReceived(Exchange.CHARSET_NAME, "iso-8859-1");
 
-        byte[] data = "Hello World".getBytes(Charset.forName("iso-8859-1"));
+        byte[] data = "Hello World".getBytes(StandardCharsets.ISO_8859_1);
         String out = template.requestBodyAndHeader("netty-http:http://localhost:{{port}}/foo", data,
                 "content-type", "text/plain; charset=\"iso-8859-1\"", String.class);
         assertEquals("Bye World", out);
@@ -51,7 +51,7 @@ public class NettyHttpContentTypeTest extends BaseNettyTest {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URL, "http://localhost:" + getPort() + "/foo");
         getMockEndpoint("mock:input").expectedPropertyReceived(Exchange.CHARSET_NAME, "iso-8859-1");
 
-        byte[] data = "Hello World".getBytes(Charset.forName("iso-8859-1"));
+        byte[] data = "Hello World".getBytes(StandardCharsets.ISO_8859_1);
         String out = template.requestBodyAndHeader("netty-http:http://localhost:{{port}}/foo", data,
                 "content-type", "text/plain;charset=\"iso-8859-1\";action=\"http://somewhere.com/foo\"", String.class);
         assertEquals("Bye World", out);
@@ -68,7 +68,7 @@ public class NettyHttpContentTypeTest extends BaseNettyTest {
         getMockEndpoint("mock:input").expectedHeaderReceived(Exchange.HTTP_URL, "http://localhost:" + getPort() + "/foo");
         getMockEndpoint("mock:input").expectedPropertyReceived(Exchange.CHARSET_NAME, "utf-8");
 
-        byte[] data = "Hello World".getBytes(Charset.forName("utf-8"));
+        byte[] data = "Hello World".getBytes(StandardCharsets.UTF_8);
         String out = template.requestBodyAndHeader("netty-http:http://localhost:{{port}}/foo", data,
                 "content-type", "application/soap+xml;charset=\"utf-8\";action=\"http://somewhere.com/foo\"", String.class);
         assertEquals("Bye World", out);

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamAsExchangeHeaderTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamAsExchangeHeaderTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class NettyHttpGetWithParamAsExchangeHeaderTest extends BaseNettyTest {
 
-    private String serverUri = "netty-http:http://localhost:" + getPort() + "/myservice?urlDecodeHeaders=true";
+    private String serverUri = "netty-http:http://localhost:{{port}}/myservice?urlDecodeHeaders=true";
 
     @Test
     public void testHttpGetWithParamsViaURI() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NettyHttpGetWithParamTest extends BaseNettyTest {
 
-    private String serverUri = "netty-http:http://localhost:" + getPort() + "/myservice";
+    private String serverUri = "netty-http:http://localhost:{{port}}/myservice";
     private MyParamsProcessor processor = new MyParamsProcessor();
 
     @Test

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerBridgeTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerBridgeTest.java
@@ -20,23 +20,21 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NettyHttpProducerBridgeTest extends BaseNettyTest {
 
-    AvailablePortFinder.Port port1 = port;
-    @RegisterExtension
-    AvailablePortFinder.Port port2 = AvailablePortFinder.find();
-    @RegisterExtension
-    AvailablePortFinder.Port port3 = AvailablePortFinder.find();
+    @AvailablePort
+    int port2;
+    @AvailablePort
+    int port3;
 
     @Test
     public void testProxy() throws Exception {
-        String reply = template.requestBody("netty-http:http://localhost:" + port1 + "/foo", "World", String.class);
+        String reply = template.requestBody("netty-http:http://localhost:{{port}}/foo", "World", String.class);
         assertEquals("Bye World", reply);
     }
 
@@ -46,7 +44,7 @@ public class NettyHttpProducerBridgeTest extends BaseNettyTest {
         mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
         mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
 
-        template.request("netty-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+        template.request("netty-http:http://localhost:{{port3}}/query?bridgeEndpoint=true", new Processor() {
             @Override
             public void process(Exchange exchange) throws Exception {
                 exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
@@ -62,7 +60,7 @@ public class NettyHttpProducerBridgeTest extends BaseNettyTest {
         mock.message(0).header(Exchange.HTTP_RAW_QUERY).isEqualTo("x=%3B");
         mock.message(0).header(Exchange.HTTP_QUERY).isEqualTo("x=;");
 
-        template.request("netty-http:http://localhost:" + port3 + "/query?bridgeEndpoint=true", new Processor() {
+        template.request("netty-http:http://localhost:{{port3}}/query?bridgeEndpoint=true", new Processor() {
             @Override
             public void process(Exchange exchange) throws Exception {
                 exchange.getIn().setHeader(Exchange.HTTP_URI, "http://host:8080/");
@@ -78,13 +76,13 @@ public class NettyHttpProducerBridgeTest extends BaseNettyTest {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("netty-http:http://0.0.0.0:" + port1 + "/foo")
-                        .to("netty-http:http://localhost:" + port2 + "/bar?bridgeEndpoint=true&throwExceptionOnFailure=false");
+                from("netty-http:http://0.0.0.0:{{port}}/foo")
+                        .to("netty-http:http://localhost:{{port2}}/bar?bridgeEndpoint=true&throwExceptionOnFailure=false");
 
-                from("netty-http:http://0.0.0.0:" + port2 + "/bar")
+                from("netty-http:http://0.0.0.0:{{port2}}/bar")
                         .transform().simple("Bye ${body}");
 
-                from("netty-http:http://0.0.0.0:" + port3 + "/query")
+                from("netty-http:http://0.0.0.0:{{port3}}/query")
                         .to("mock:query");
             }
         };

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerQueryParamTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpProducerQueryParamTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class NettyHttpProducerQueryParamTest extends BaseNettyTest {
 
-    private String url = "netty-http:http://localhost:" + getPort() + "/cheese?urlDecodeHeaders=true";
+    private String url = "netty-http:http://localhost:{{port}}/cheese?urlDecodeHeaders=true";
 
     @Test
     public void testQueryParameters() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpRedirectNoLocationTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpRedirectNoLocationTest.java
@@ -19,9 +19,8 @@ package org.apache.camel.component.netty.http;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,8 +31,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class NettyHttpRedirectNoLocationTest extends BaseNettyTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port nextPort = AvailablePortFinder.find();
+    @AvailablePort
+    int nextPort;
 
     @Test
     public void testHttpRedirectNoLocation() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResume503Test.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResume503Test.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class NettyHttpSuspendResume503Test extends BaseNettyTest {
 
-    private String serverUri = "netty-http:http://localhost:" + getPort() + "/cool?disconnect=true";
+    private String serverUri = "netty-http:http://localhost:{{port}}/cool?disconnect=true";
 
     @Test
     public void testNettySuspendResume() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResumeTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResumeTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class NettyHttpSuspendResumeTest extends BaseNettyTest {
 
-    private String serverUri = "netty-http:http://localhost:" + getPort() + "/cool?disconnect=true&send503whenSuspended=false";
+    private String serverUri = "netty-http:http://localhost:{{port}}/cool?disconnect=true&send503whenSuspended=false";
 
     @Test
     public void testNettySuspendResume() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpTraceDisabledTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpTraceDisabledTest.java
@@ -17,22 +17,21 @@
 package org.apache.camel.component.netty.http;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NettyHttpTraceDisabledTest extends BaseNettyTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port portTraceOn = AvailablePortFinder.find();
-    @RegisterExtension
-    AvailablePortFinder.Port portTraceOff = AvailablePortFinder.find();
+    @AvailablePort
+    int portTraceOn;
+    @AvailablePort
+    int portTraceOff;
 
     @Test
     public void testTraceDisabled() throws Exception {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyRouteSimpleDynamicURITest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyRouteSimpleDynamicURITest.java
@@ -17,16 +17,15 @@
 package org.apache.camel.component.netty.http;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NettyRouteSimpleDynamicURITest extends BaseNettyTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port2 = AvailablePortFinder.find();
+    @AvailablePort
+    int port2;
 
     @Test
     public void testHttpSimple() throws Exception {
@@ -48,8 +47,8 @@ public class NettyRouteSimpleDynamicURITest extends BaseNettyTest {
                         .to("mock:input1")
                         .setHeader("id", constant("bar"))
                         .setHeader("host", constant("localhost"))
-                        .toD("netty-http:http://${header.host}:" + port2 + "/${header.id}");
-                from("netty-http:http://0.0.0.0:" + port2 + "/bar")
+                        .toD("netty-http:http://${header.host}:{{port2}}/${header.id}");
+                from("netty-http:http://0.0.0.0:{{port2}}/bar")
                         .to("mock:input2")
                         .transform().constant("Bye World");
             }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyRouteSimpleTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyRouteSimpleTest.java
@@ -17,16 +17,15 @@
 package org.apache.camel.component.netty.http;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NettyRouteSimpleTest extends BaseNettyTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port2 = AvailablePortFinder.find();
+    @AvailablePort
+    int port2;
 
     @Test
     public void testHttpSimple() throws Exception {
@@ -46,9 +45,9 @@ public class NettyRouteSimpleTest extends BaseNettyTest {
             public void configure() throws Exception {
                 from("netty-http:http://0.0.0.0:{{port}}/foo")
                         .to("mock:input1")
-                        .to("netty-http:http://localhost:" + port2 + "/bar");
+                        .to("netty-http:http://localhost:{{port2}}/bar");
 
-                from("netty-http:http://0.0.0.0:" + port2 + "/bar")
+                from("netty-http:http://0.0.0.0:{{port2}}/bar")
                         .to("mock:input2")
                         .transform().constant("Bye World");
             }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
@@ -57,15 +57,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 // now this real caused exception is detected by Camel
 public class ProxyProtocolTest {
 
-    private DefaultCamelContext context;
-
-    private String url;
-
     @AvailablePort
     static int originPort;
 
     @AvailablePort
     static int proxyPort;
+
+    private DefaultCamelContext context;
+
+    private String url;
 
     public void createContext(final Function<RouteBuilder, RouteDefinition> variant, final String url) throws Exception {
         this.url = url;

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
@@ -43,7 +43,6 @@ import org.apache.camel.test.junit5.resources.Resources;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/test/infra/services/QpidEmbeddedService.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/test/infra/services/QpidEmbeddedService.java
@@ -79,7 +79,6 @@ public class QpidEmbeddedService implements RabbitMQService {
         throw new UnsupportedOperationException("Qpid embedded broker does not have a HTTP admin service");
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/components/camel-test/camel-test-junit5/pom.xml
+++ b/components/camel-test/camel-test-junit5/pom.xml
@@ -49,6 +49,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-management</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
@@ -41,11 +41,9 @@ public final class AvailablePortFinder {
     public class Port implements BeforeEachCallback, AfterAllCallback, AutoCloseable {
         final int port;
         String testClass;
-        Throwable creation;
 
         public Port(int port) {
             this.port = port;
-            this.creation = new Throwable();
         }
 
         public int getPort() {

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -60,11 +60,13 @@ import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.spi.CamelBeanPostProcessor;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.PropertiesComponent;
-import org.apache.camel.spi.PropertiesSource;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.support.BreakpointSupport;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.test.CamelRouteCoverageDumper;
+import org.apache.camel.test.junit5.properties.PropertiesSource;
+import org.apache.camel.test.junit5.properties.TestPropertiesSource;
+import org.apache.camel.test.junit5.resources.Resources;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
@@ -80,6 +82,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.commons.util.AnnotationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,6 +94,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * {@link org.apache.camel.ProducerTemplate} for use in the test case Do <tt>not</tt> use this class for Spring Boot
  * testing.
  */
+@Resources
 public abstract class CamelTestSupport
         implements BeforeEachCallback, AfterEachCallback, AfterAllCallback, BeforeAllCallback, BeforeTestExecutionCallback,
         AfterTestExecutionCallback {
@@ -479,17 +483,9 @@ public abstract class CamelTestSupport
         if (extra != null && !extra.isEmpty()) {
             pc.setOverrideProperties(extra);
         }
-        pc.addPropertiesSource(new PropertiesSource() {
-            @Override
-            public String getName() {
-                return "junit-store";
-            }
-
-            @Override
-            public String getProperty(String name) {
-                return globalStore.get(name, String.class);
-            }
-        });
+        if (AnnotationUtils.isAnnotated(getClass(), PropertiesSource.class)) {
+            pc.addPropertiesSource(new TestPropertiesSource(context, this));
+        }
         Boolean ignore = ignoreMissingLocationWithPropertiesComponent();
         if (ignore != null) {
             pc.setIgnoreMissingLocation(ignore);

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/properties/PropertiesSource.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/properties/PropertiesSource.java
@@ -14,25 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.properties;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
-
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
-
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface PropertiesSource {
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/properties/TestPropertiesSource.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/properties/TestPropertiesSource.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.properties;
+
+import java.lang.reflect.Field;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.RuntimeCamelException;
+
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
+
+public class TestPropertiesSource implements org.apache.camel.spi.PropertiesSource {
+
+    private final CamelContext context;
+    private final Object instance;
+
+    public TestPropertiesSource(CamelContext context, Object instance) {
+        this.context = context;
+        this.instance = instance;
+    }
+
+    @Override
+    public String getName() {
+        return "TestPropertiesSource[" + instance + "]";
+    }
+
+    @Override
+    public String getProperty(String name) {
+        Class<?> clazz = instance.getClass();
+        while (clazz != null) {
+            for (Field f : clazz.getDeclaredFields()) {
+                if (f.getName().equals(name)) {
+                    try {
+                        Object value = makeAccessible(f).get(instance);
+                        if (value != null) {
+                            return context.getTypeConverter().mandatoryConvertTo(String.class, value);
+                        }
+                    } catch (Throwable t) {
+                        throw new RuntimeCamelException("Unable to retrieve property " + name + " from field " + f, t);
+                    }
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return null;
+    }
+
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/AvailablePort.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/AvailablePort.java
@@ -14,25 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.junit5.resources.impl.AvailablePortManager;
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Resource(AvailablePortManager.class)
+public @interface AvailablePort {
 
-    }
+    int size() default 1;
 
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/BaseResourceManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/BaseResourceManager.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.resources;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.ExceptionUtils;
+
+import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
+
+public abstract class BaseResourceManager<T extends Annotation> implements ResourceManager {
+
+    protected final Class<T> annotation;
+    protected final ExtensionContext.Namespace namespace = ExtensionContext.Namespace.create(getClass());
+
+    public BaseResourceManager(Class<T> annotation) {
+        this.annotation = annotation;
+    }
+
+    public void inject(ExtensionContext context, Object testInstance, Field field) {
+        T ap = field.getAnnotation(annotation);
+        verifyType(field, ap);
+        try {
+            ExtensionContext.Store store = getStore(context, testInstance, field, ap);
+            Holder holder = store.getOrComputeIfAbsent(field, f -> createHolder(context, field), Holder.class);
+            makeAccessible(field).set(testInstance, holder.get());
+        } catch (Throwable t) {
+            ExceptionUtils.throwAsUncheckedException(t);
+        }
+    }
+
+    protected void verifyType(Field field, T ann) {
+        if (isPrivate(field)) {
+            throw new ExtensionConfigurationException(
+                    "@" + ann.annotationType().getSimpleName() + " field [" + field + "] must not be private.");
+        }
+    }
+
+    protected abstract Holder createHolder(ExtensionContext context, Field field);
+
+    protected Scope.ScopeValue getScope(Field field) {
+        return AnnotationUtils.findAnnotation(field, Scope.class)
+                .map(Scope::value)
+                .orElse(Scope.ScopeValue.Default);
+    }
+
+    protected <T extends Annotation> ExtensionContext.Store getStore(
+            ExtensionContext context, Object testInstance,
+            Field field, T ann) {
+        ExtensionContext.Store store;
+        Scope.ScopeValue scope = getScope(field);
+        switch (scope) {
+            case Default:
+                store = context.getStore(namespace);
+                break;
+            case Test:
+                if (testInstance == null) {
+                    throw new ExtensionConfigurationException(
+                            "Scope of @" + ann.annotationType().getSimpleName()
+                                                              + " field [" + field
+                                                              + "] is set to Test but no test instance is available");
+                } else {
+                    store = context.getStore(namespace);
+                }
+                break;
+            case Class:
+                if (testInstance == null) {
+                    store = context.getStore(namespace);
+                } else {
+                    store = context.getParent().get().getStore(namespace);
+                }
+                break;
+            case Suite:
+                if (testInstance == null) {
+                    store = context.getParent().get().getStore(namespace);
+                } else {
+                    store = context.getParent().get().getParent().get().getStore(namespace);
+                }
+                break;
+            default:
+                throw new ExtensionConfigurationException(
+                        "Scope of @" + ann.annotationType().getSimpleName()
+                                                          + " field [" + field + "] is unknown: " + scope);
+        }
+        return store;
+    }
+
+    protected interface Holder extends ExtensionContext.Store.CloseableResource {
+        Object get() throws Exception;
+    }
+
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/ClassScope.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/ClassScope.java
@@ -14,25 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
-
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
-
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Scope(Scope.ScopeValue.Class)
+public @interface ClassScope {
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Resource.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Resource.java
@@ -14,25 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Resource {
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+    Class<? extends ResourceManager> value();
 
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/ResourceManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/ResourceManager.java
@@ -14,25 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.reflect.Field;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+public interface ResourceManager {
 
-    }
+    void inject(ExtensionContext context, Object testInstance, Field field);
 
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Resources.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Resources.java
@@ -14,25 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.junit5.resources.impl.ResourcesExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(ResourcesExtension.class)
+public @interface Resources {
 
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Scope.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/Scope.java
@@ -14,25 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Scope {
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+    ScopeValue value();
 
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
+    enum ScopeValue {
+        Default,
+        Test,
+        Class,
+        Suite
     }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/SuiteScope.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/SuiteScope.java
@@ -14,25 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
-
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
-
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Scope(Scope.ScopeValue.Suite)
+public @interface SuiteScope {
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/TestScope.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/TestScope.java
@@ -14,25 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
-
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
-
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Scope(Scope.ScopeValue.Test)
+public @interface TestScope {
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/TestService.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/TestService.java
@@ -14,25 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.test.junit5.resources;
 
-package org.apache.camel.test.infra.kafka.services;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.junit5.resources.impl.TestServiceManager;
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Resource(TestServiceManager.class)
+public @interface TestService {
 
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/AvailablePortManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/AvailablePortManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.resources.impl;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit5.resources.AvailablePort;
+import org.apache.camel.test.junit5.resources.BaseResourceManager;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class AvailablePortManager extends BaseResourceManager<AvailablePort> {
+
+    public AvailablePortManager() {
+        super(AvailablePort.class);
+    }
+
+    @Override
+    protected Holder createHolder(ExtensionContext context, Field field) {
+        return new Holder() {
+            AvailablePortFinder.Port[] ports;
+
+            @Override
+            public synchronized Object get() {
+                if (ports == null) {
+                    AvailablePort ap = field.getAnnotation(AvailablePort.class);
+                    ports = new AvailablePortFinder.Port[ap.size()];
+                    for (int i = 0; i < ports.length; i++) {
+                        ports[i] = AvailablePortFinder.find();
+                    }
+                }
+                if (field.getType() == int.class) {
+                    return ports[0].getPort();
+                } else {
+                    int[] ints = new int[ports.length];
+                    for (int i = 0; i < ports.length; i++) {
+                        ints[i] = ports[i].getPort();
+                    }
+                    return ints;
+                }
+            }
+
+            @Override
+            public void close() {
+                if (ports != null) {
+                    Arrays.stream(ports).forEach(AvailablePortFinder.Port::release);
+                }
+            }
+        };
+    }
+
+    @Override
+    protected void verifyType(Field field, AvailablePort ap) {
+        Class<?> type = field.getType();
+        if (type == int.class) {
+            if (ap.size() != 1) {
+                throw new ExtensionConfigurationException(
+                        "The size on @AvailablePort field [" + field + "] must be 1 but was: " + ap.size());
+            }
+        } else if (type == int[].class) {
+            if (ap.size() < 1) {
+                throw new ExtensionConfigurationException(
+                        "The size on @AvailablePort field [" + field + "] must be greater or equals to 1 but was: "
+                                                          + ap.size());
+            }
+        } else {
+            throw new ExtensionConfigurationException(
+                    "Can only resolve @AvailablePort field [" + field + "] of type int or int[] but was: " + type.getName());
+        }
+        super.verifyType(field, ap);
+    }
+
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/ResourcesExtension.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/ResourcesExtension.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.resources.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.function.Predicate;
+
+import org.apache.camel.test.junit5.resources.Resource;
+import org.apache.camel.test.junit5.resources.ResourceManager;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+public class ResourcesExtension implements BeforeAllCallback, BeforeEachCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(ResourcesExtension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        injectFields(context, null, context.getRequiredTestClass(), ReflectionUtils::isStatic);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        context.getRequiredTestInstances().getAllInstances() //
+                .forEach(instance -> injectFields(context, instance, instance.getClass(), ReflectionUtils::isNotStatic));
+    }
+
+    private void injectFields(ExtensionContext context, Object testInstance, Class<?> testClass, Predicate<Field> predicate) {
+        ReflectionUtils.findFields(testClass, predicate, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN).forEach(field -> {
+            Resource res = null;
+            for (Annotation a : field.getDeclaredAnnotations()) {
+                Resource r = a.annotationType().getAnnotation(Resource.class);
+                if (r != null) {
+                    if (res == null) {
+                        res = r;
+                    } else {
+                        throw new ExtensionConfigurationException(
+                                "Field [" + field + "] has more than one @Resource annotation");
+                    }
+                }
+            }
+            if (res != null) {
+                ResourceManager manager = context.getStore(NAMESPACE).getOrComputeIfAbsent(res.value());
+                manager.inject(context, testInstance, field);
+            }
+        });
+    }
+
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/TestServiceManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/resources/impl/TestServiceManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.resources.impl;
+
+import java.lang.reflect.Field;
+
+import org.apache.camel.test.junit5.resources.BaseResourceManager;
+import org.apache.camel.test.junit5.resources.TestService;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class TestServiceManager extends BaseResourceManager<TestService> {
+
+    public TestServiceManager() {
+        super(TestService.class);
+    }
+
+    @Override
+    protected Holder createHolder(ExtensionContext context, Field field) {
+        return new Holder() {
+            org.apache.camel.test.infra.common.services.TestService service;
+
+            @Override
+            public synchronized Object get() throws Exception {
+                if (service == null) {
+                    Class<?> serviceClass = field.getType();
+                    Class<?> factoryClass = serviceClass.getClassLoader().loadClass(serviceClass.getName() + "Factory");
+                    service = (org.apache.camel.test.infra.common.services.TestService) factoryClass.getMethod("createService")
+                            .invoke(null);
+                    if (service instanceof BeforeAllCallback) {
+                        ((BeforeAllCallback) service).beforeAll(context);
+                    } else {
+                        service.initialize();
+                    }
+                }
+                return service;
+            }
+
+            @Override
+            public synchronized void close() throws Exception {
+                if (service instanceof AfterAllCallback) {
+                    ((AfterAllCallback) service).afterAll(context);
+                } else if (service != null) {
+                    service.close();
+                }
+            }
+        };
+    }
+
+}

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/resources/PortTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/resources/PortTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+@SuppressWarnings({ "checkstyle:HideUtilityClassConstructor", "checkstyle:DeclarationOrder" })
 public class PortTest {
 
     @Resources

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/resources/PortTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/resources/PortTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5.resources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class PortTest {
+
+    @Resources
+    public static class ScopeTestTest {
+
+        @AvailablePort
+        @TestScope
+        int port;
+
+        static int testPort;
+
+        @Test
+        void testPort1() {
+            assertNotEquals(0, port);
+            if (testPort == 0) {
+                testPort = port;
+            } else {
+                assertNotEquals(testPort, port);
+            }
+        }
+
+        @Test
+        void testPort2() {
+            assertNotEquals(0, port);
+            if (testPort == 0) {
+                testPort = port;
+            } else {
+                assertNotEquals(testPort, port);
+            }
+        }
+
+    }
+
+    @Resources
+    public static class ScopeClassTest {
+
+        @AvailablePort
+        @ClassScope
+        int port;
+
+        static int classPort;
+
+        @Test
+        void testPort1() {
+            assertNotEquals(0, port);
+            if (classPort == 0) {
+                classPort = port;
+            } else {
+                assertEquals(classPort, port);
+            }
+        }
+
+        @Test
+        void testPort2() {
+            assertNotEquals(0, port);
+            if (classPort == 0) {
+                classPort = port;
+            } else {
+                assertEquals(classPort, port);
+            }
+        }
+
+    }
+
+    static int suitePort;
+
+    @Resources
+    public static class ScopeSuite1Test {
+
+        @AvailablePort
+        @SuiteScope
+        int port;
+
+        @Test
+        void testPort() {
+            assertNotEquals(0, port);
+            if (suitePort == 0) {
+                suitePort = port;
+            } else {
+                assertNotEquals(suitePort, port);
+            }
+        }
+
+    }
+
+    @Resources
+    public static class ScopeSuite2Test {
+
+        @AvailablePort
+        @SuiteScope
+        int port;
+
+        @Test
+        void testPort() {
+            assertNotEquals(0, port);
+            if (suitePort == 0) {
+                suitePort = port;
+            } else {
+                assertNotEquals(suitePort, port);
+            }
+        }
+
+    }
+
+    @Resources
+    public static class ScopeClassStaticTest {
+
+        @AvailablePort
+        static int port;
+
+        static int classPort;
+
+        @Test
+        void testPort1() {
+            assertNotEquals(0, port);
+            if (classPort == 0) {
+                classPort = port;
+            } else {
+                assertEquals(classPort, port);
+            }
+        }
+
+        @Test
+        void testPort2() {
+            assertNotEquals(0, port);
+            if (classPort == 0) {
+                classPort = port;
+            } else {
+                assertEquals(classPort, port);
+            }
+        }
+
+    }
+
+    static int staticSuitePort;
+
+    @Resources
+    public static class ScopeSuite1StaticTest {
+
+        @AvailablePort
+        @SuiteScope
+        static int port;
+
+        @Test
+        void testPort() {
+            assertNotEquals(0, port);
+            if (staticSuitePort == 0) {
+                staticSuitePort = port;
+            } else {
+                assertNotEquals(staticSuitePort, port);
+            }
+        }
+
+    }
+
+    @Resources
+    public static class ScopeSuite2StaticTest {
+
+        @AvailablePort
+        @SuiteScope
+        static int port;
+
+        @Test
+        void testPort() {
+            assertNotEquals(0, port);
+            if (staticSuitePort == 0) {
+                staticSuitePort = port;
+            } else {
+                assertNotEquals(staticSuitePort, port);
+            }
+        }
+
+    }
+}

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerService.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerService.java
@@ -52,7 +52,6 @@ public class ArangoDBLocalContainerService implements ArangoDBService, Container
         return container.getHost();
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(ArangoDBProperties.ARANGODB_HOST, container.getHost());
         System.setProperty(ArangoDBProperties.ARANGODB_PORT, String.valueOf(container.getServicePort()));

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBRemoteService.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBRemoteService.java
@@ -30,7 +30,6 @@ public class ArangoDBRemoteService implements ArangoDBService {
         return System.getProperty(ArangoDBProperties.ARANGODB_HOST);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
@@ -79,7 +79,6 @@ public abstract class AWSLocalContainerService implements AWSService, ContainerS
         return container.getServiceEndpoint();
     }
 
-    @Override
     public void registerProperties() {
         AwsCredentials credentials = container.getCredentialsProvider().resolveCredentials();
 

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSRemoteService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSRemoteService.java
@@ -40,7 +40,6 @@ public class AWSRemoteService implements AWSService {
         return properties;
     }
 
-    @Override
     public void registerProperties() {
 
     }

--- a/test-infra/camel-test-infra-azure-storage-blob/src/test/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobLocalContainerService.java
+++ b/test-infra/camel-test-infra-azure-storage-blob/src/test/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobLocalContainerService.java
@@ -24,7 +24,6 @@ import org.apache.camel.test.infra.azure.common.services.AzureStorageService;
 
 public class AzureStorageBlobLocalContainerService extends AzureStorageService {
 
-    @Override
     public void registerProperties() {
         super.registerProperties();
 

--- a/test-infra/camel-test-infra-azure-storage-blob/src/test/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobRemoteService.java
+++ b/test-infra/camel-test-infra-azure-storage-blob/src/test/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobRemoteService.java
@@ -23,7 +23,6 @@ import org.apache.camel.test.infra.azure.common.services.AzureService;
 
 public class AzureStorageBlobRemoteService implements AzureService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-azure-storage-datalake/src/test/java/org/apache/camel/test/infra/azure/storage/datalake/services/AzureStorageDataLakeRemoteService.java
+++ b/test-infra/camel-test-infra-azure-storage-datalake/src/test/java/org/apache/camel/test/infra/azure/storage/datalake/services/AzureStorageDataLakeRemoteService.java
@@ -37,7 +37,6 @@ public class AzureStorageDataLakeRemoteService implements AzureService {
         };
     }
 
-    @Override
     public void registerProperties() {
 
     }

--- a/test-infra/camel-test-infra-azure-storage-queue/src/test/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueLocalContainerService.java
+++ b/test-infra/camel-test-infra-azure-storage-queue/src/test/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueLocalContainerService.java
@@ -24,7 +24,6 @@ import org.apache.camel.test.infra.azure.common.services.AzureStorageService;
 
 public class AzureStorageQueueLocalContainerService extends AzureStorageService {
 
-    @Override
     public void registerProperties() {
         super.registerProperties();
 

--- a/test-infra/camel-test-infra-azure-storage-queue/src/test/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueRemoteService.java
+++ b/test-infra/camel-test-infra-azure-storage-queue/src/test/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueRemoteService.java
@@ -23,7 +23,6 @@ import org.apache.camel.test.infra.azure.common.services.AzureService;
 
 public class AzureStorageQueueRemoteService implements AzureService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerService.java
+++ b/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerService.java
@@ -57,7 +57,6 @@ public class CassandraLocalContainerService implements CassandraService, Contain
         return container.getHost();
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(CassandraProperties.CASSANDRA_HOST, getCassandraHost());
         System.setProperty(CassandraProperties.CASSANDRA_CQL3_PORT, String.valueOf(getCQL3Port()));

--- a/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/RemoteCassandraService.java
+++ b/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/RemoteCassandraService.java
@@ -44,7 +44,6 @@ public class RemoteCassandraService implements CassandraService {
         return System.getProperty(CassandraProperties.CASSANDRA_HOST);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerService.java
+++ b/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerService.java
@@ -36,7 +36,6 @@ public class ChatScriptLocalContainerService implements ChatScriptService, Conta
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withTty(true));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(ChatScriptProperties.CHATSCRIPT_ADDRESS, serviceAddress());
     }
@@ -46,6 +45,7 @@ public class ChatScriptLocalContainerService implements ChatScriptService, Conta
         LOG.info("Trying to start the ChatScript container");
         container.start();
 
+        registerProperties();
         LOG.info("ChatScript instance running at {}", serviceAddress());
     }
 

--- a/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptRemoteService.java
+++ b/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptRemoteService.java
@@ -21,13 +21,8 @@ import org.apache.camel.test.infra.chatscript.common.ChatScriptProperties;
 public class ChatScriptRemoteService implements ChatScriptService {
 
     @Override
-    public void registerProperties() {
-        // NO-OP
-    }
-
-    @Override
     public void initialize() {
-        registerProperties();
+        // NO-OP
     }
 
     @Override

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/AbstractTestService.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/AbstractTestService.java
@@ -27,7 +27,6 @@ public abstract class AbstractTestService implements TestService, BeforeAllCallb
 
     protected ExtensionContext context;
 
-    @Override
     public void registerProperties() {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
         registerProperties(store::put);

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestService.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestService.java
@@ -20,13 +20,6 @@ package org.apache.camel.test.infra.common.services;
 public interface TestService extends AutoCloseable {
 
     /**
-     * Register service properties (such as using System.setProperties) so that they can be resolved at distance (ie.:
-     * when using Spring's PropertySourcesPlaceholderConfigurer or simply when trying to collect test infra information
-     * outside of the test class itself).
-     */
-    void registerProperties();
-
-    /**
      * Perform any initialization necessary
      */
     void initialize();

--- a/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulLocalContainerService.java
+++ b/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulLocalContainerService.java
@@ -52,7 +52,6 @@ public class ConsulLocalContainerService implements ConsulService, ContainerServ
                 .withCommand("agent", "-dev", "-server", "-bootstrap", "-client", "0.0.0.0", "-log-level", "trace");
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(ConsulProperties.CONSUL_URL, getConsulUrl());
         System.setProperty(ConsulProperties.CONSUL_HOST, host());

--- a/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulRemoteService.java
+++ b/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulRemoteService.java
@@ -21,7 +21,6 @@ import org.apache.camel.test.infra.consul.common.ConsulProperties;
 
 public class ConsulRemoteService implements ConsulService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerService.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerService.java
@@ -97,7 +97,6 @@ public class CouchbaseLocalContainerService implements CouchbaseService, Contain
         return container.getBootstrapHttpDirectPort();
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(CouchbaseProperties.COUCHBASE_HOSTNAME, getHostname());
         System.setProperty(CouchbaseProperties.COUCHBASE_PORT, String.valueOf(getPort()));

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseRemoteService.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseRemoteService.java
@@ -48,7 +48,6 @@ public class CouchbaseRemoteService implements CouchbaseService {
         return Integer.parseInt(portValue);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerService.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerService.java
@@ -51,7 +51,6 @@ public class CouchDbLocalContainerService implements CouchDbService, ContainerSe
                 .waitingFor(Wait.forListeningPort());
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(CouchDbProperties.SERVICE_ADDRESS, getServiceAddress());
         System.setProperty(CouchDbProperties.PORT, String.valueOf(port()));

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbRemoteService.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.couchdb.common.CouchDbProperties;
 
 public class CouchDbRemoteService implements CouchDbService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
@@ -62,7 +62,6 @@ public class ElasticSearchLocalContainerService implements ElasticSearchService,
         return container.getHttpHostAddress();
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(ElasticSearchProperties.ELASTIC_SEARCH_HOST, getElasticSearchHost());
         System.setProperty(ElasticSearchProperties.ELASTIC_SEARCH_PORT, String.valueOf(getPort()));

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/RemoteElasticSearchService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/RemoteElasticSearchService.java
@@ -38,7 +38,6 @@ public class RemoteElasticSearchService implements ElasticSearchService {
         return System.getProperty(ElasticSearchProperties.ELASTIC_SEARCH_HOST);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-etcd/src/test/java/org/apache/camel/test/infra/etcd/services/EtcDLocalContainerService.java
+++ b/test-infra/camel-test-infra-etcd/src/test/java/org/apache/camel/test/infra/etcd/services/EtcDLocalContainerService.java
@@ -58,7 +58,6 @@ public class EtcDLocalContainerService implements EtcDService, ContainerService<
                         "-listen-client-urls", "http://0.0.0.0:" + ETCD_CLIENT_PORT);
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(EtcDProperties.SERVICE_ADDRESS, getServiceAddress());
     }

--- a/test-infra/camel-test-infra-etcd/src/test/java/org/apache/camel/test/infra/etcd/services/EtcDRemoteService.java
+++ b/test-infra/camel-test-infra-etcd/src/test/java/org/apache/camel/test/infra/etcd/services/EtcDRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.etcd.common.EtcDProperties;
 
 public class EtcDRemoteService implements EtcDService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
+++ b/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
@@ -54,7 +54,6 @@ public class FhirLocalContainerService implements FhirService, ContainerService<
                 .waitingFor(Wait.forHttp("/hapi-fhir-jpaserver/fhir/metadata"));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(FhirProperties.SERVICE_BASE_URL, getServiceBaseURL());
         System.setProperty(FhirProperties.SERVICE_HOST, getHost());

--- a/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirRemoteService.java
+++ b/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.fhir.common.FhirProperties;
 
 public class FhirRemoteService implements FhirService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-ftp/src/test/java/org/apache/camel/test/infra/ftp/services/FtpRemoteService.java
+++ b/test-infra/camel-test-infra-ftp/src/test/java/org/apache/camel/test/infra/ftp/services/FtpRemoteService.java
@@ -18,7 +18,6 @@ package org.apache.camel.test.infra.ftp.services;
 
 public class FtpRemoteService implements FtpService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerService.java
@@ -52,7 +52,6 @@ public class GooglePubSubLocalContainerService implements GooglePubSubService, C
         return new PubSubEmulatorContainer(DockerImageName.parse(imageName));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(GooglePubSubProperties.SERVICE_ADDRESS, getServiceAddress());
     }

--- a/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubRemoteService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.google.pubsub.common.GooglePubSubProperties;
 
 public class GooglePubSubRemoteService implements GooglePubSubService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-hbase/src/test/java/org/apache/camel/test/infra/hbase/services/HBaseLocalContainerService.java
+++ b/test-infra/camel-test-infra-hbase/src/test/java/org/apache/camel/test/infra/hbase/services/HBaseLocalContainerService.java
@@ -38,7 +38,6 @@ public class HBaseLocalContainerService implements HBaseService, ContainerServic
         return new HBaseContainer();
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/ContainerLocalHDFSService.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/ContainerLocalHDFSService.java
@@ -63,7 +63,6 @@ public class ContainerLocalHDFSService implements HDFSService, ContainerService<
         return nameNodeContainer;
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(HDFSProperties.HDFS_HOST, getHDFSHost());
         System.getProperty(HDFSProperties.HDFS_PORT, String.valueOf(getPort()));

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/RemoteHDFSService.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/RemoteHDFSService.java
@@ -21,7 +21,6 @@ import org.apache.camel.test.infra.hdfs.v2.common.HDFSProperties;
 
 public class RemoteHDFSService implements HDFSService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteEmbeddedService.java
+++ b/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteEmbeddedService.java
@@ -42,7 +42,6 @@ public class IgniteEmbeddedService implements IgniteService {
 
     private Ignite ignite;
 
-    @Override
     public void registerProperties() {
 
     }

--- a/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteRemoteService.java
+++ b/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 
 public class IgniteRemoteService implements IgniteService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerService.java
+++ b/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerService.java
@@ -63,7 +63,6 @@ public class InfinispanLocalContainerService implements InfinispanService, Conta
                 .waitingFor(Wait.forLogMessage(".*Infinispan.*Server.*started.*", 1));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(InfinispanProperties.SERVICE_HOST, host());
         System.setProperty(InfinispanProperties.SERVICE_PORT, String.valueOf(port()));

--- a/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanRemoteService.java
+++ b/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.infinispan.common.InfinispanProperties;
 
 public class InfinispanRemoteService implements InfinispanService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCLocalContainerService.java
+++ b/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCLocalContainerService.java
@@ -32,7 +32,6 @@ public class JDBCLocalContainerService<T extends JdbcDatabaseContainer<T>> imple
         this.container = container;
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(JDBCProperties.JDBC_CONNECTION_URL, jdbcUrl());
     }

--- a/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCRemoteService.java
+++ b/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCRemoteService.java
@@ -26,7 +26,6 @@ public class JDBCRemoteService implements JDBCService {
         CONNECTION_URL = System.getProperty(JDBCProperties.JDBC_CONNECTION_URL);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/AbstractKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/AbstractKafkaService.java
@@ -14,25 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.camel.test.infra.kafka.services;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.AbstractTestService;
 
-public final class KafkaServiceFactory {
-    private KafkaServiceFactory() {
-
-    }
-
-    public static SimpleTestServiceBuilder<AbstractKafkaService> builder() {
-        return new SimpleTestServiceBuilder<>("kafka");
-    }
-
-    public static KafkaService createService() {
-        return builder()
-                .addLocalMapping(ContainerLocalKafkaService::new)
-                .addMapping("local-strimzi-container", StrimziService::new)
-                .addRemoteMapping(RemoteKafkaService::new)
-                .build();
-    }
+public abstract class AbstractKafkaService extends AbstractTestService implements KafkaService {
 }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -19,14 +19,13 @@ package org.apache.camel.test.infra.kafka.services;
 
 import java.util.function.BiConsumer;
 
-import org.apache.camel.test.infra.common.services.AbstractTestService;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 
-public class ContainerLocalKafkaService extends AbstractTestService implements KafkaService, ContainerService<KafkaContainer> {
+public class ContainerLocalKafkaService extends AbstractKafkaService implements ContainerService<KafkaContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -17,13 +17,16 @@
 
 package org.apache.camel.test.infra.kafka.services;
 
+import java.util.function.BiConsumer;
+
+import org.apache.camel.test.infra.common.services.AbstractTestService;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 
-public class ContainerLocalKafkaService implements KafkaService, ContainerService<KafkaContainer> {
+public class ContainerLocalKafkaService extends AbstractTestService implements KafkaService, ContainerService<KafkaContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;
 
@@ -44,20 +47,18 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     }
 
     @Override
-    public void registerProperties() {
-        System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
+    protected void registerProperties(BiConsumer<String, String> store) {
+        store.accept(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }
 
     @Override
-    public void initialize() {
+    protected void setUp() throws Exception {
         kafka.start();
-        registerProperties();
-
         LOG.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
     }
 
     @Override
-    public void shutdown() {
+    protected void tearDown() throws Exception {
         kafka.stop();
     }
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaService.java
@@ -17,18 +17,10 @@
 
 package org.apache.camel.test.infra.kafka.services;
 
-import org.apache.camel.test.infra.common.services.TestService;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 /**
  * Provides an interface for any type of Kafka service: remote instances, local container, etc
  */
-public interface KafkaService
-        extends TestService, BeforeAllCallback, BeforeTestExecutionCallback, AfterAllCallback, AfterTestExecutionCallback {
+public interface KafkaService {
 
     /**
      * Gets the addresses of the bootstrap servers in the format host1:port,host2:port,etc
@@ -37,23 +29,4 @@ public interface KafkaService
      */
     String getBootstrapServers();
 
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        initialize();
-    }
-
-    @Override
-    default void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
-        //no op
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        shutdown();
-    }
-
-    @Override
-    default void afterTestExecution(ExtensionContext context) throws Exception {
-        //no op
-    }
 }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaService.java
@@ -17,11 +17,12 @@
 
 package org.apache.camel.test.infra.kafka.services;
 
+import org.apache.camel.test.infra.common.services.AbstractTestService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RemoteKafkaService implements KafkaService {
+public class RemoteKafkaService extends AbstractTestService implements KafkaService {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteKafkaService.class);
 
     @Override
@@ -30,18 +31,8 @@ public class RemoteKafkaService implements KafkaService {
     }
 
     @Override
-    public void registerProperties() {
-        // NO-OP
-    }
-
-    @Override
-    public void initialize() {
-        registerProperties();
+    protected void setUp() throws Exception {
         LOG.info("Kafka bootstrap server running at address {}", getBootstrapServers());
     }
 
-    @Override
-    public void shutdown() {
-        // NO-OP
-    }
 }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaService.java
@@ -17,12 +17,11 @@
 
 package org.apache.camel.test.infra.kafka.services;
 
-import org.apache.camel.test.infra.common.services.AbstractTestService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RemoteKafkaService extends AbstractTestService implements KafkaService {
+public class RemoteKafkaService extends AbstractKafkaService {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteKafkaService.class);
 
     @Override

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziService.java
@@ -20,14 +20,13 @@ package org.apache.camel.test.infra.kafka.services;
 import java.util.function.BiConsumer;
 
 import org.apache.camel.test.infra.common.TestUtils;
-import org.apache.camel.test.infra.common.services.AbstractTestService;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 
-public class StrimziService extends AbstractTestService implements KafkaService, ContainerService<StrimziContainer> {
+public class StrimziService extends AbstractKafkaService implements ContainerService<StrimziContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(StrimziService.class);
 
     private final ZookeeperContainer zookeeperContainer;

--- a/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingLocalContainerService.java
+++ b/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingLocalContainerService.java
@@ -49,7 +49,6 @@ public class MessagingLocalContainerService<T extends GenericContainer<T>> imple
         return endpointFunction.apply(container);
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(MessagingProperties.MESSAGING_BROKER_ADDRESS, defaultEndpoint());
     }

--- a/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingRemoteService.java
+++ b/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingRemoteService.java
@@ -21,7 +21,6 @@ import org.apache.camel.test.infra.messaging.common.MessagingProperties;
 
 public class MessagingRemoteService implements MessagingService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerService.java
+++ b/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerService.java
@@ -66,7 +66,6 @@ public class MinioLocalContainerService implements MinioService, ContainerServic
                         .withStartupTimeout(Duration.ofSeconds(10)));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(MinioProperties.ACCESS_KEY, accessKey());
         System.setProperty(MinioProperties.SECRET_KEY, secretKey());

--- a/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioRemoteService.java
+++ b/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.minio.common.MinioProperties;
 
 public class MinioRemoteService implements MinioService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerService.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerService.java
@@ -59,7 +59,6 @@ public class MongoDBLocalContainerService implements MongoDBService, ContainerSe
         return container.getContainerIpAddress() + ":" + container.getMappedPort(DEFAULT_MONGODB_PORT);
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(MongoDBProperties.MONGODB_URL, getReplicaSetUrl());
         System.setProperty(MongoDBProperties.MONGODB_CONNECTION_ADDRESS, getConnectionAddress());

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBRemoteService.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBRemoteService.java
@@ -30,7 +30,6 @@ public class MongoDBRemoteService implements MongoDBService {
         return System.getProperty(MongoDBProperties.MONGODB_URL);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerService.java
@@ -73,7 +73,6 @@ public class MosquittoLocalContainerService implements MosquittoService, Contain
         return ret;
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(MosquittoProperties.PORT, String.valueOf(getPort()));
     }

--- a/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoRemoteService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoRemoteService.java
@@ -27,7 +27,6 @@ public class MosquittoRemoteService implements MosquittoService {
         System.setProperty(MosquittoProperties.PORT, String.valueOf(port));
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthService.java
@@ -34,7 +34,6 @@ public class NatsLocalContainerAuthService extends NatsLocalContainerService {
         return container;
     }
 
-    @Override
     public void registerProperties() {
         super.registerProperties();
 

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthTokenService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthTokenService.java
@@ -33,7 +33,6 @@ public class NatsLocalContainerAuthTokenService extends NatsLocalContainerServic
         return container;
     }
 
-    @Override
     public void registerProperties() {
         super.registerProperties();
 

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerService.java
@@ -46,7 +46,6 @@ public class NatsLocalContainerService implements NatsService, ContainerService<
                 .waitingFor(Wait.forLogMessage(".*Listening.*for.*route.*connections.*", 1));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(NatsProperties.SERVICE_ADDRESS, getServiceAddress());
     }

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsRemoteService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.nats.common.NatsProperties;
 
 public class NatsRemoteService implements NatsService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-nsq/src/test/java/org/apache/camel/test/infra/nsq/services/NsqLocalContainerService.java
+++ b/test-infra/camel-test-infra-nsq/src/test/java/org/apache/camel/test/infra/nsq/services/NsqLocalContainerService.java
@@ -70,7 +70,6 @@ public class NsqLocalContainerService implements NsqService, ContainerService<Ge
                 .waitingFor(Wait.forLogMessage(".*TCP: listening on.*", 1));
     }
 
-    @Override
     public void registerProperties() {
         System.getProperty(NsqProperties.PRODUCER_URL, getNsqProducerUrl());
         System.getProperty(NsqProperties.CONSUMER_URL, getNsqConsumerUrl());

--- a/test-infra/camel-test-infra-nsq/src/test/java/org/apache/camel/test/infra/nsq/services/NsqRemoteService.java
+++ b/test-infra/camel-test-infra-nsq/src/test/java/org/apache/camel/test/infra/nsq/services/NsqRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.nsq.common.NsqProperties;
 
 public class NsqRemoteService implements NsqService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/AbstractOpenldapService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/AbstractOpenldapService.java
@@ -16,21 +16,17 @@
  */
 package org.apache.camel.test.infra.openldap.services;
 
-import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import java.util.function.BiConsumer;
 
-public final class OpenldapServiceFactory {
-    private OpenldapServiceFactory() {
+import org.apache.camel.test.infra.common.services.AbstractTestService;
+import org.apache.camel.test.infra.openldap.common.OpenldapProperties;
 
+public abstract class AbstractOpenldapService extends AbstractTestService implements OpenldapService {
+
+    @Override
+    protected void registerProperties(BiConsumer<String, String> store) {
+        store.accept(OpenldapProperties.PORT_LDAP, String.valueOf(getPort()));
+        store.accept(OpenldapProperties.PORT_LDAP_OVER_SSL, String.valueOf(getSslPort()));
     }
 
-    public static SimpleTestServiceBuilder<AbstractOpenldapService> builder() {
-        return new SimpleTestServiceBuilder<>("openldap");
-    }
-
-    public static OpenldapService createService() {
-        return builder()
-                .addLocalMapping(OpenldapLocalContainerService::new)
-                .addRemoteMapping(OpenldapRemoteService::new)
-                .build();
-    }
 }

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerService.java
@@ -74,7 +74,6 @@ public class OpenldapLocalContainerService implements OpenldapService, Container
         return ret;
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(OpenldapProperties.PORT_LDAP, String.valueOf(getPort()));
         System.setProperty(OpenldapProperties.PORT_LDAP_OVER_SSL, String.valueOf(getSslPort()));

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapRemoteService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapRemoteService.java
@@ -18,7 +18,7 @@ package org.apache.camel.test.infra.openldap.services;
 
 import org.apache.camel.test.infra.openldap.common.OpenldapProperties;
 
-public class OpenldapRemoteService implements OpenldapService {
+public class OpenldapRemoteService extends AbstractOpenldapService {
 
     public OpenldapRemoteService() {
     }
@@ -27,20 +27,6 @@ public class OpenldapRemoteService implements OpenldapService {
         System.setProperty(OpenldapProperties.HOST, host);
         System.setProperty(OpenldapProperties.PORT_LDAP, String.valueOf(port));
         System.setProperty(OpenldapProperties.PORT_LDAP_OVER_SSL, String.valueOf(sslPort));
-    }
-
-    public void registerProperties() {
-        // NO-OP
-    }
-
-    @Override
-    public void initialize() {
-        registerProperties();
-    }
-
-    @Override
-    public void shutdown() {
-        // NO-OP
     }
 
     @Override

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapRemoteService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapRemoteService.java
@@ -29,7 +29,6 @@ public class OpenldapRemoteService implements OpenldapService {
         System.setProperty(OpenldapProperties.PORT_LDAP_OVER_SSL, String.valueOf(sslPort));
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapService.java
@@ -16,15 +16,10 @@
  */
 package org.apache.camel.test.infra.openldap.services;
 
-import org.apache.camel.test.infra.common.services.TestService;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 /**
  * Test infra service for Openldap
  */
-public interface OpenldapService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface OpenldapService {
 
     Integer getPort();
 
@@ -32,13 +27,4 @@ public interface OpenldapService extends BeforeAllCallback, AfterAllCallback, Te
 
     String getHost();
 
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        initialize();
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        shutdown();
-    }
 }

--- a/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
+++ b/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
@@ -43,7 +43,6 @@ public class PostgresLocalContainerService implements PostgresService, Container
         return new PostgreSQLContainer(imageName);
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(PostgresProperties.SERVICE_ADDRESS, getServiceAddress());
         System.setProperty(PostgresProperties.HOST, host());

--- a/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresRemoteService.java
+++ b/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.postgres.common.PostgresProperties;
 
 public class PostgresRemoteService implements PostgresService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
+++ b/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
@@ -46,7 +46,6 @@ public class PulsarLocalContainerService implements PulsarService, ContainerServ
         return new PulsarContainer(DockerImageName.parse(imageName));
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(PulsarProperties.PULSAR_ADMIN_URL, getPulsarAdminUrl());
         System.setProperty(PulsarProperties.PULSAR_BROKER_URL, getPulsarBrokerUrl());

--- a/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarRemoteService.java
+++ b/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.pulsar.common.PulsarProperties;
 
 public class PulsarRemoteService implements PulsarService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
@@ -84,7 +84,6 @@ public class RabbitMQLocalContainerService implements RabbitMQService, Container
         return container.getHttpPort();
     }
 
-    @Override
     public void registerProperties() {
         ConnectionProperties properties = connectionProperties();
 

--- a/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQRemoteService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQRemoteService.java
@@ -55,7 +55,6 @@ public class RabbitMQRemoteService implements RabbitMQService {
         return Integer.parseInt(httpPort);
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerService.java
+++ b/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerService.java
@@ -51,7 +51,6 @@ public class RedisLocalContainerService implements RedisService, ContainerServic
                 .waitingFor(Wait.forListeningPort());
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(RedisProperties.SERVICE_ADDRESS, getServiceAddress());
         System.setProperty(RedisProperties.PORT, String.valueOf(port()));

--- a/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisRemoteService.java
+++ b/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.redis.common.RedisProperties;
 
 public class RedisRemoteService implements RedisService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerService.java
+++ b/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerService.java
@@ -49,7 +49,6 @@ public class SolrLocalContainerService implements SolrService, ContainerService<
                 .withCommand(isCloudMode() ? "-c" : "");
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(SolrProperties.SERVICE_ADDRESS, getSolrBaseUrl());
     }

--- a/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrRemoteService.java
+++ b/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrRemoteService.java
@@ -30,7 +30,6 @@ public class SolrRemoteService implements SolrService {
         return System.getProperty(SolrProperties.SOLR_MODE).equals("solrcloud");
     }
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerService.java
+++ b/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerService.java
@@ -42,7 +42,6 @@ public class XmppLocalContainerService implements XmppService, ContainerService<
         return new XmppServerContainer();
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(XmppProperties.XMPP_URL, getUrl());
         System.setProperty(XmppProperties.XMPP_HOST, container.getHost());

--- a/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppRemoteService.java
+++ b/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.xmpp.common.XmppProperties;
 
 public class XmppRemoteService implements XmppService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerService.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerService.java
@@ -46,7 +46,6 @@ public class ZooKeeperLocalContainerService implements ZooKeeperService, Contain
         }
     }
 
-    @Override
     public void registerProperties() {
         System.setProperty(ZooKeeperProperties.CONNECTION_STRING, getConnectionString());
     }

--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperRemoteService.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperRemoteService.java
@@ -20,7 +20,6 @@ import org.apache.camel.test.infra.zookeeper.common.ZooKeeperProperties;
 
 public class ZooKeeperRemoteService implements ZooKeeperService {
 
-    @Override
     public void registerProperties() {
         // NO-OP
     }


### PR DESCRIPTION
@orpiske I'd be interested in your input on the changes in the service containers.
The main idea is to simplify the interface of the test containers to only contain things related to the container itself and not to the testing environment (before/after callbacks...) and to introduce an `AbstractTestService` class which does most of the job and can be easily reused.  I've also removed the `registerProperties` from the API.
Instead of using the `@RegisterExtension`, tests can now use `TestService`.  In addition, the container lifecycle can be changed from test scope to suite `@SuiteScope` or class `@ClassScope`. 