### PR TITLE
Change "Created ClientConnectionManager" log level to debug

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
@@ -518,7 +518,7 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
         if (localConnectionsPerRoute > 0) {
             answer.setDefaultMaxPerRoute(localConnectionsPerRoute);
         }
-        LOG.info("Created ClientConnectionManager {}", answer);
+        LOG.debug("Created ClientConnectionManager {}", answer);
 
         return answer;
     }


### PR DESCRIPTION
Camel-http component creates unimportant log entries on INFO level. Change it to debug so it can be activated to those who really need it by enabling debug logging.
