### PR TITLE
CAMEL-16263 camel-google-pubsub - Consumer does not recover from 500 series error from Google

### DIFF
--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import com.google.api.core.AbstractApiService;
+import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
@@ -177,6 +178,12 @@ public class GooglePubsubConsumer extends DefaultConsumer {
                     }
                 } catch (IOException e) {
                     localLog.error("Failure getting messages from PubSub", e);
+                } catch (ApiException e) {
+                    if (e.isRetryable()) {
+                        localLog.error("Retryable API exception in getting messages from PubSub", e);
+                    } else {
+                        throw e;
+                    }
                 }
             }
         }


### PR DESCRIPTION
In the synchronous consumer, catch and log retryable ApiException-s in addition to IOExcepion-s.
The synchronous consumer will still die on all other exceptions.