### PR TITLE
Bugfix/lazy start producer

### DIFF
--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
@@ -103,7 +103,7 @@ public class SmppConsumer extends DefaultConsumer {
     }
 
     /**
-     * Factory method to easily instantiate a mock SMPPSession
+     * Factory method to easily instantiate a SMPPSession
      * 
      * @return the SMPPSession
      */

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/CustomDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/CustomDataFormatReifier.java
@@ -31,7 +31,8 @@ public class CustomDataFormatReifier extends DataFormatReifier<CustomDataFormat>
 
     @Override
     protected DataFormat doCreateDataFormat() {
-        return DataFormatReifier.getDataFormat(camelContext, definition.getRef());
+        String ref = parseString(definition.getRef());
+        return DataFormatReifier.getDataFormat(camelContext, ref);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DataFormatPropertyPlaceholderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DataFormatPropertyPlaceholderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import java.util.Properties;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Registry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test of the string data format.
+ */
+public class DataFormatPropertyPlaceholderTest extends ContextTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        Properties prop = new Properties();
+        prop.put("myDataformat", "reverse");
+        context.getPropertiesComponent().setInitialProperties(prop);
+        return context;
+    }
+
+    @Override
+    protected Registry createRegistry() throws Exception {
+        Registry registry = super.createRegistry();
+        registry.bind("reverse", new RefDataFormatTest.MyReverseDataFormat());
+        return registry;
+    }
+
+    @Test
+    public void testMarshalRef() throws Exception {
+        getMockEndpoint("mock:a").expectedBodiesReceived("CBA");
+
+        template.sendBody("direct:a", "ABC");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testUnmarshalRef() throws Exception {
+        getMockEndpoint("mock:b").expectedBodiesReceived("ABC");
+
+        template.sendBody("direct:b", "CBA");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:a").marshal("{{myDataformat}}").to("mock:a");
+
+                from("direct:b").unmarshal("{{myDataformat}}").to("mock:b");
+            }
+        };
+    }
+
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/LazyStartProducer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/LazyStartProducer.java
@@ -44,10 +44,10 @@ public final class LazyStartProducer extends DefaultAsyncProducer implements Del
                     if (delegate == null) {
                         delegate = AsyncProcessorConverterHelper.convert(getEndpoint().createProducer());
                     }
+                    if (!ServiceHelper.isStarted(delegate)) {
+                        ServiceHelper.startService(delegate);
+                    }
                 }
-            }
-            if (!ServiceHelper.isStarted(delegate)) {
-                ServiceHelper.startService(delegate);
             }
         } catch (Throwable e) {
             exchange.setException(e);


### PR DESCRIPTION
- Fixing https://issues.apache.org/jira/browse/CAMEL-16681 
- Using LazyStartProducer in multithreaded context can result in exceptions. The fix is basically starting the producer in the same lock when it is initialized. If the producer was not created to begin with then it has definitely not been started as well. Starting the producer outside the lock can result in race condition where some threads see the service in STARTING state and org.apache.camel.support.service.ServiceHelper.isStarted(Object) returns true. This results in  LazyStartProducer assuming that the producer is fully initialized. The producer is not fully initialized until ServiceHelper.startService(delegate) returns after starting the delegate producer. Hence the delegate producer should be started in the same lock where delegate is initialized so that other threads do not start using the producer in half baked state.