### PR TITLE
fixing Camel-16681 where LazyStartProducer can result in Exceptions w…

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/LazyStartProducer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/LazyStartProducer.java
@@ -44,10 +44,10 @@ public final class LazyStartProducer extends DefaultAsyncProducer implements Del
                     if (delegate == null) {
                         delegate = AsyncProcessorConverterHelper.convert(getEndpoint().createProducer());
                     }
+                    if (!ServiceHelper.isStarted(delegate)) {
+                        ServiceHelper.startService(delegate);
+                    }
                 }
-            }
-            if (!ServiceHelper.isStarted(delegate)) {
-                ServiceHelper.startService(delegate);
             }
         } catch (Throwable e) {
             exchange.setException(e);


### PR DESCRIPTION
- Fixing https://issues.apache.org/jira/browse/CAMEL-16681 
- Using LazyStartProducer in multithreaded context can result in exceptions. The fix is basically starting the producer in the same lock when it is initialized. If the producer was not created to begin with then it has definitely not been started as well. Starting the producer outside the lock can result in race condition where some threads see the service in STARTING state and org.apache.camel.support.service.ServiceHelper.isStarted(Object) returns true. This results in  LazyStartProducer assuming that the producer is fully initialized. The producer is not fully initialized until ServiceHelper.startService(delegate) returns after starting the delegate producer. Hence the delegate producer should be started in the same lock where delegate is initialized so that other threads do not start using the producer in half baked state.