### PR TITLE
Allow customizing SpringBoot @RequestMapping paths

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
@@ -48,6 +48,9 @@ public class GenerateMojo extends AbstractGenerateMojo {
     @Parameter
     private String packageName;
 
+    @Parameter(defaultValue = "/**", required = true)
+    private String[] requestMappingValues;
+
     @Override
     public void execute() throws MojoExecutionException {
         if (skip) {
@@ -69,10 +72,6 @@ public class GenerateMojo extends AbstractGenerateMojo {
         }
 
         final RestDslSourceCodeGenerator<Path> generator = RestDslGenerator.toPath(openapi);
-
-        if (ObjectHelper.isNotEmpty(basePath)) {
-            generator.withBasePath(basePath);
-        }
 
         if (ObjectHelper.isNotEmpty(filterOperation)) {
             generator.withOperationFilter(filterOperation);
@@ -121,7 +120,8 @@ public class GenerateMojo extends AbstractGenerateMojo {
                     }
                     getLog().info("Generating Camel Rest Controller source with package name " + packageName
                                   + " in source directory: " + outputPath);
-                    SpringBootProjectSourceCodeGenerator.generator().withPackageName(packageName).generate(outputPath);
+                    SpringBootProjectSourceCodeGenerator.generator().withPackageName(packageName)
+                            .withMappingValues(requestMappingValues).generate(outputPath);
                     // the Camel Rest Controller allows to use root as context-path
                     generator.withRestContextPath("/");
                 } catch (final IOException e) {


### PR DESCRIPTION
Instead of configuring RequestMapping with "/**" this change allows inserting custom paths. Usually the "/**" conflicts with /actuator/hawtio. On the other hand, there may be paths that we don't want to be handled by the Controller. ** This change depends on the acceptance of the change in class https://github.com/apache/camel/blob/main/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi /SpringBootProjectSourceCodeGenerator.java from the openapi-rest-dsl-generator project.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
