### PR TITLE
CAMEL-16701: Set topic value after setProperties method

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
@@ -73,9 +73,10 @@ public class KafkaComponent extends DefaultComponent implements SSLContextParame
             endpoint.getConfiguration().getAdditionalProperties().putAll(endpointAdditionalProperties);
         }
 
-        // If a topic is not defined in the configuration but only in the uri, it can happen that it is not set
-        // correctly in the configuration of the endpoint.
-        // Therefore, the topic is still included in the configuration at the end.
+        // If a topic is not defined in the KafkaConfiguration (set as option parameter) but only in the uri,
+        // it can happen that it is not set correctly in the configuration of the endpoint.
+        // Therefore, the topic is added after setProperties method
+        // and an null check to avoid overwriting a value from the configuration.
         if (endpoint.getConfiguration().getTopic() == null) {
             endpoint.getConfiguration().setTopic(remaining);
         }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
@@ -61,7 +61,6 @@ public class KafkaComponent extends DefaultComponent implements SSLContextParame
 
         KafkaConfiguration copy = getConfiguration().copy();
         endpoint.setConfiguration(copy);
-        endpoint.getConfiguration().setTopic(remaining);
 
         setProperties(endpoint, parameters);
 
@@ -72,6 +71,13 @@ public class KafkaComponent extends DefaultComponent implements SSLContextParame
         // overwrite the additional properties from the endpoint
         if (!endpointAdditionalProperties.isEmpty()) {
             endpoint.getConfiguration().getAdditionalProperties().putAll(endpointAdditionalProperties);
+        }
+
+        // If a topic is not defined in the configuration but only in the uri, it can happen that it is not set
+        // correctly in the configuration of the endpoint.
+        // Therefore, the topic is still included in the configuration at the end.
+        if (endpoint.getConfiguration().getTopic() == null) {
+            endpoint.getConfiguration().setTopic(remaining);
         }
 
         return endpoint;


### PR DESCRIPTION
If a KafkaConfiguration is used (see code in jira ticket) and no topic is defined in the configuration, the parameter from the URI is not taken over, but a null value is set.
This leads to a consumer not having a valid topic name, but null being provided as a value.
Therefore, the topic is only set after this method if the topic is still null.

It looks like setProperties(endpoint, parameters); overrites the topic with null.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-16701) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md

