### PR TITLE
CAMEL-16674 : More functional test cases

### DIFF
--- a/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionCombinedFunctionalTest.java
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionCombinedFunctionalTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.constants.FunctionGraphProperties;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvokeFunctionCombinedFunctionalTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(InvokeFunctionCombinedFunctionalTest.class.getName());
+
+    private static final String AUTHENTICATION_KEY = "replace_this_with_authentication_key";
+    private static final String SECRET_KEY = "replace_this_with_secret_key";
+    private static final String FUNCTION_NAME = "replace_this_with_function_name";
+    private static final String FUNCTION_PACKAGE = "replace_this_with_function_package";
+    private static final String PROJECT_ID = "replace_this_with_project_id";
+    private static final String ENDPOINT = "replace_this_with_endpoint";
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("direct:invoke_function")
+                        .setProperty(FunctionGraphProperties.XCFFLOGTYPE, constant("tail"))
+                        .setProperty(FunctionGraphProperties.OPERATION, constant("invokeFunction"))
+                        .setProperty(FunctionGraphProperties.FUNCTION_NAME, constant(FUNCTION_NAME))
+                        .setProperty(FunctionGraphProperties.FUNCTION_PACKAGE, constant(FUNCTION_PACKAGE))
+                        .to("hwcloud-functiongraph:dummy-operation?" +
+                            "authenticationKey=" + AUTHENTICATION_KEY +
+                            "&secretKey=" + SECRET_KEY +
+                            "&functionName=dummy-function-name" +
+                            "&functionPackage=dummy-function-package" +
+                            "&projectId=" + PROJECT_ID +
+                            "&region=dummy-region" +
+                            "&endpoint=" + ENDPOINT +
+                            "&ignoreSslVerification=true")
+                        .log("Invoke function successful")
+                        .to("log:LOG?showAll=true")
+                        .to("mock:invoke_function_result");
+            }
+        };
+    }
+
+    /**
+     * The following test cases should be manually enabled to perform test against the actual HuaweiCloud FunctionGraph
+     * server with real user credentials. To perform this test, manually comment out the @Ignore annotation and enter
+     * relevant service parameters in the placeholders above (static variables of this test class)
+     *
+     * @throws Exception
+     */
+    @Ignore("Manually enable this once you configure the parameters in the placeholders above")
+    @Test
+    public void testInvokeFunction() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:invoke_function_result");
+        mock.expectedMinimumMessageCount(1);
+        String sampleBody = "replace_with_your_body";
+        template.sendBody("direct:invoke_function", sampleBody);
+        Exchange responseExchange = mock.getExchanges().get(0);
+
+        mock.assertIsSatisfied();
+
+        assertNotNull(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS));
+        assertTrue(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS).toString().length() > 0);
+    }
+}

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionExchangeFunctionalTest.java
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionExchangeFunctionalTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.constants.FunctionGraphProperties;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvokeFunctionExchangeFunctionalTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(InvokeFunctionExchangeFunctionalTest.class.getName());
+
+    private static final String AUTHENTICATION_KEY = "replace_this_with_authentication_key";
+    private static final String SECRET_KEY = "replace_this_with_secret_key";
+    private static final String FUNCTION_NAME = "replace_this_with_function_name";
+    private static final String FUNCTION_PACKAGE = "replace_this_with_function_package";
+    private static final String PROJECT_ID = "replace_this_with_project_id";
+    private static final String REGION = "replace_this_with_region";
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("direct:invoke_function")
+                        .setProperty(FunctionGraphProperties.XCFFLOGTYPE, constant("tail"))
+                        .setProperty(FunctionGraphProperties.OPERATION, constant("invokeFunction"))
+                        .setProperty(FunctionGraphProperties.FUNCTION_NAME, constant(FUNCTION_NAME))
+                        .setProperty(FunctionGraphProperties.FUNCTION_PACKAGE, constant(FUNCTION_PACKAGE))
+                        .to("hwcloud-functiongraph:?" +
+                            "authenticationKey=" + AUTHENTICATION_KEY +
+                            "&secretKey=" + SECRET_KEY +
+                            "&projectId=" + PROJECT_ID +
+                            "&region=" + REGION +
+                            "&ignoreSslVerification=true")
+                        .log("Invoke function successful")
+                        .to("log:LOG?showAll=true")
+                        .to("mock:invoke_function_result");
+            }
+        };
+    }
+
+    /**
+     * The following test cases should be manually enabled to perform test against the actual HuaweiCloud FunctionGraph
+     * server with real user credentials. To perform this test, manually comment out the @Ignore annotation and enter
+     * relevant service parameters in the placeholders above (static variables of this test class)
+     *
+     * @throws Exception
+     */
+    @Ignore("Manually enable this once you configure the parameters in the placeholders above")
+    @Test
+    public void testInvokeFunction() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:invoke_function_result");
+        mock.expectedMinimumMessageCount(1);
+        String sampleBody = "replace_with_your_body";
+        template.sendBody("direct:invoke_function", sampleBody);
+        Exchange responseExchange = mock.getExchanges().get(0);
+
+        mock.assertIsSatisfied();
+
+        assertNotNull(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS));
+        assertTrue(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS).toString().length() > 0);
+    }
+}

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionFunctionalTest.java
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionFunctionalTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.constants.FunctionGraphProperties;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvokeFunctionFunctionalTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(InvokeFunctionFunctionalTest.class.getName());
+
+    private static final String AUTHENTICATION_KEY = "replace_this_with_authentication_key";
+    private static final String SECRET_KEY = "replace_this_with_secret_key";
+    private static final String FUNCTION_NAME = "replace_this_with_function_name";
+    private static final String FUNCTION_PACKAGE = "replace_this_with_function_package";
+    private static final String PROJECT_ID = "replace_this_with_project_id";
+    private static final String REGION = "replace_this_with_region";
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("direct:invoke_function")
+                        .setProperty(FunctionGraphProperties.XCFFLOGTYPE, constant("tail"))
+                        .to("hwcloud-functiongraph:invokeFunction?" +
+                            "authenticationKey=" + AUTHENTICATION_KEY +
+                            "&secretKey=" + SECRET_KEY +
+                            "&functionName=" + FUNCTION_NAME +
+                            "&functionPackage=" + FUNCTION_PACKAGE +
+                            "&projectId=" + PROJECT_ID +
+                            "&region=" + REGION +
+                            "&ignoreSslVerification=true")
+                        .log("Invoke function successful")
+                        .to("log:LOG?showAll=true")
+                        .to("mock:invoke_function_result");
+            }
+        };
+    }
+
+    /**
+     * The following test cases should be manually enabled to perform test against the actual HuaweiCloud FunctionGraph
+     * server with real user credentials. To perform this test, manually comment out the @Ignore annotation and enter
+     * relevant service parameters in the placeholders above (static variables of this test class)
+     *
+     * @throws Exception
+     */
+    @Ignore("Manually enable this once you configure the parameters in the placeholders above")
+    @Test
+    public void testInvokeFunction() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:invoke_function_result");
+        mock.expectedMinimumMessageCount(1);
+        String sampleBody = "replace_with_your_body";
+        template.sendBody("direct:invoke_function", sampleBody);
+        Exchange responseExchange = mock.getExchanges().get(0);
+
+        mock.assertIsSatisfied();
+
+        assertNotNull(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS));
+        assertTrue(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS).toString().length() > 0);
+    }
+}

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionServiceKeyFunctionalTest.java
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/src/test/java/org/apache/camel/InvokeFunctionServiceKeyFunctionalTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.constants.FunctionGraphProperties;
+import org.apache.camel.models.ServiceKeys;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvokeFunctionServiceKeyFunctionalTest extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(InvokeFunctionServiceKeyFunctionalTest.class.getName());
+
+    private static final String AUTHENTICATION_KEY = "replace_this_with_authentication_key";
+    private static final String SECRET_KEY = "replace_this_with_secret_key";
+    private static final String FUNCTION_NAME = "replace_this_with_function_name";
+    private static final String FUNCTION_PACKAGE = "replace_this_with_function_package";
+    private static final String PROJECT_ID = "replace_this_with_project_id";
+    private static final String REGION = "replace_this_with_region";
+
+    @BindToRegistry("serviceKeys")
+    ServiceKeys serviceKeys = new ServiceKeys(AUTHENTICATION_KEY, SECRET_KEY);
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("direct:invoke_function")
+                        .setProperty(FunctionGraphProperties.XCFFLOGTYPE, constant("tail"))
+                        .to("hwcloud-functiongraph:invokeFunction?" +
+                            "serviceKeys=#serviceKeys" +
+                            "&functionName=" + FUNCTION_NAME +
+                            "&functionPackage=" + FUNCTION_PACKAGE +
+                            "&projectId=" + PROJECT_ID +
+                            "&region=" + REGION +
+                            "&ignoreSslVerification=true")
+                        .log("Invoke function successful")
+                        .to("log:LOG?showAll=true")
+                        .to("mock:invoke_function_result");
+            }
+        };
+    }
+
+    /**
+     * The following test cases should be manually enabled to perform test against the actual HuaweiCloud FunctionGraph
+     * server with real user credentials. To perform this test, manually comment out the @Ignore annotation and enter
+     * relevant service parameters in the placeholders above (static variables of this test class)
+     *
+     * @throws Exception
+     */
+    @Ignore("Manually enable this once you configure the parameters in the placeholders above")
+    @Test
+    public void testInvokeFunction() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:invoke_function_result");
+        mock.expectedMinimumMessageCount(1);
+        String sampleBody = "replace_with_your_body";
+        template.sendBody("direct:invoke_function", sampleBody);
+        Exchange responseExchange = mock.getExchanges().get(0);
+
+        mock.assertIsSatisfied();
+
+        assertNotNull(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS));
+        assertTrue(responseExchange.getProperty(FunctionGraphProperties.XCFFLOGS).toString().length() > 0);
+    }
+}


### PR DESCRIPTION
Added more functional test cases to HuaweiCloud FunctionGraph component.
1. Testing functionality options through exchange properties
2. Testing functionality options through both exchange properties and endpoint (exchange parameters should carry precedence over endpoint options)
3. Testing standard functionality with region instead of endpoint url
4. Testing authentication with service keys

JIRA: https://issues.apache.org/jira/browse/CAMEL-16674

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
