### PR TITLE
[CAMEL-16699] Fix HttpProducer bridged endpoint skipRequestHeaders for common type headers

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -134,10 +134,14 @@ public class HttpProducer extends DefaultProducer {
             final TypeConverter tc = exchange.getContext().getTypeConverter();
             for (Map.Entry<String, Object> entry : in.getHeaders().entrySet()) {
                 String key = entry.getKey();
+                // we should not add headers for the parameters in the uri if we bridge the endpoint
+                // as then we would duplicate headers on both the endpoint uri, and in HTTP headers as well
+                if (skipRequestHeaders != null && skipRequestHeaders.containsKey(key)) {
+                    continue;
+                }
                 Object headerValue = entry.getValue();
 
                 if (headerValue != null) {
-
                     if (headerValue instanceof String) {
                         // optimise for string values
                         String value = (String) headerValue;
@@ -166,12 +170,6 @@ public class HttpProducer extends DefaultProducer {
                     // should be combined into a single value
                     while (it.hasNext()) {
                         String value = tc.convertTo(String.class, it.next());
-
-                        // we should not add headers for the parameters in the uri if we bridge the endpoint
-                        // as then we would duplicate headers on both the endpoint uri, and in HTTP headers as well
-                        if (skipRequestHeaders != null && skipRequestHeaders.containsKey(key)) {
-                            continue;
-                        }
                         if (value != null && !strategy.applyFilterToCamelHeaders(key, value, exchange)) {
                             if (prev == null) {
                                 prev = value;

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
@@ -36,7 +36,7 @@ public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
     private static final Integer INTEGER = Integer.valueOf(1);
     private static final Long LONG = Long.valueOf(999999999999999L);
     private static final Boolean BOOLEAN = true;
-    private static final String query
+    private static final String QUERY
             = "qp1=" + INSTANT + "&qp2=" + STRING + "&qp3=" + INTEGER + "&qp4=" + LONG + "&qp5=" + BOOLEAN;
 
     private HttpServer localServer;
@@ -58,7 +58,7 @@ public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
                 .registerHandler("/bridged",
                         new HeaderValidationHandler(
                                 "GET",
-                                query,
+                                QUERY,
                                 null,
                                 getExpectedContent(),
                                 null,
@@ -66,7 +66,7 @@ public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
                 .registerHandler("/notbridged",
                         new HeaderValidationHandler(
                                 "GET",
-                                query,
+                                QUERY,
                                 null,
                                 getExpectedContent(),
                                 noBridgeExpectedHeaders))
@@ -100,7 +100,7 @@ public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
 
         Exchange exchange = producer.createExchange();
         exchange.getIn().setBody(null);
-        exchange.getIn().setHeader(Exchange.HTTP_QUERY, query);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, QUERY);
         exchange.getIn().setHeader("qp1", INSTANT);
         exchange.getIn().setHeader("qp2", STRING);
         exchange.getIn().setHeader("qp3", INTEGER);
@@ -127,7 +127,7 @@ public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
 
         Exchange exchange = producer.createExchange();
         exchange.getIn().setBody(null);
-        exchange.getIn().setHeader(Exchange.HTTP_QUERY, query);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, QUERY);
         exchange.getIn().setHeader("qp1", INSTANT);
         exchange.getIn().setHeader("qp2", STRING);
         exchange.getIn().setHeader("qp3", INTEGER);

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.http.handler.HeaderValidationHandler;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
+
+    private static final Instant INSTANT = Instant.parse("2021-06-10T14:42:00Z");
+    private static final String STRING = "text";
+    private static final Integer INTEGER = Integer.valueOf(1);
+    private static final Long LONG = Long.valueOf(999999999999999L);
+    private static final Boolean BOOLEAN = true;
+    private static final String query
+            = "qp1=" + INSTANT + "&qp2=" + STRING + "&qp3=" + INTEGER + "&qp4=" + LONG + "&qp5=" + BOOLEAN;
+
+    private HttpServer localServer;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        String[] absentHeaders = new String[] { "qp1", "qp2", "qp3", "qp4", "qp5" };
+        Map<String, String> noBridgeExpectedHeaders = new HashMap<>();
+        noBridgeExpectedHeaders.put("qp1", INSTANT.toString());
+        noBridgeExpectedHeaders.put("qp2", STRING);
+        noBridgeExpectedHeaders.put("qp3", INTEGER.toString());
+        noBridgeExpectedHeaders.put("qp4", LONG.toString());
+        noBridgeExpectedHeaders.put("qp5", BOOLEAN.toString());
+
+        localServer = ServerBootstrap.bootstrap().setHttpProcessor(getBasicHttpProcessor())
+                .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())
+                .setExpectationVerifier(getHttpExpectationVerifier()).setSslContext(getSSLContext())
+                .registerHandler("/bridged",
+                        new HeaderValidationHandler(
+                                "GET",
+                                query,
+                                null,
+                                getExpectedContent(),
+                                null,
+                                Arrays.asList(absentHeaders)))
+                .registerHandler("/notbridged",
+                        new HeaderValidationHandler(
+                                "GET",
+                                query,
+                                null,
+                                getExpectedContent(),
+                                noBridgeExpectedHeaders))
+                .create();
+
+        localServer.start();
+
+        super.setUp();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        if (localServer != null) {
+            localServer.stop();
+        }
+    }
+
+    @Test
+    public void testHttpProducerBridgeEndpointSkipRequestHeaders() throws Exception {
+
+        HttpComponent component = context.getComponent("http", HttpComponent.class);
+        component.setConnectionTimeToLive(1000L);
+
+        HttpEndpoint endpoint = (HttpEndpoint) component
+                .createEndpoint("http://" + localServer.getInetAddress().getHostName() + ":"
+                                + localServer.getLocalPort() + "/bridged?bridgeEndpoint=true");
+        HttpProducer producer = new HttpProducer(endpoint);
+
+        Exchange exchange = producer.createExchange();
+        exchange.getIn().setBody(null);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, query);
+        exchange.getIn().setHeader("qp1", INSTANT);
+        exchange.getIn().setHeader("qp2", STRING);
+        exchange.getIn().setHeader("qp3", INTEGER);
+        exchange.getIn().setHeader("qp4", LONG);
+        exchange.getIn().setHeader("qp5", BOOLEAN);
+
+        producer.start();
+        producer.process(exchange);
+        producer.stop();
+
+        assertExchange(exchange);
+    }
+
+    @Test
+    public void testHttpProducerNoBridgeEndpointRequestHeaders() throws Exception {
+
+        HttpComponent component = context.getComponent("http", HttpComponent.class);
+        component.setConnectionTimeToLive(1000L);
+
+        HttpEndpoint endpoint = (HttpEndpoint) component
+                .createEndpoint("http://" + localServer.getInetAddress().getHostName() + ":"
+                                + localServer.getLocalPort() + "/notbridged");
+        HttpProducer producer = new HttpProducer(endpoint);
+
+        Exchange exchange = producer.createExchange();
+        exchange.getIn().setBody(null);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, query);
+        exchange.getIn().setHeader("qp1", INSTANT);
+        exchange.getIn().setHeader("qp2", STRING);
+        exchange.getIn().setHeader("qp3", INTEGER);
+        exchange.getIn().setHeader("qp4", LONG);
+        exchange.getIn().setHeader("qp5", BOOLEAN);
+
+        producer.start();
+        producer.process(exchange);
+        producer.stop();
+
+        assertExchange(exchange);
+    }
+}


### PR DESCRIPTION
Added unit test that reproduces error and applied fix included in version 3.9.0 (cherry-pick [031ea4b4](https://github.com/apache/camel/commit/031ea4b4098834d72390d9c699fcb45e6838f57c)).
