### PR TITLE
Add unit test for CAMEL-16699: HttpProducer skip request headers for …

### DIFF
--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerBridgeEndpointTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.http.handler.HeaderValidationHandler;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpProducerBridgeEndpointTest extends BaseHttpTest {
+
+    private static final Instant INSTANT = Instant.parse("2021-06-10T14:42:00Z");
+    private static final String STRING = "text";
+    private static final Integer INTEGER = Integer.valueOf(1);
+    private static final Long LONG = Long.valueOf(999999999999999L);
+    private static final Boolean BOOLEAN = true;
+    private static final String QUERY
+            = "qp1=" + INSTANT + "&qp2=" + STRING + "&qp3=" + INTEGER + "&qp4=" + LONG + "&qp5=" + BOOLEAN;
+
+    private HttpServer localServer;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        String[] absentHeaders = new String[] { "qp1", "qp2", "qp3", "qp4", "qp5" };
+        Map<String, String> noBridgeExpectedHeaders = new HashMap<>();
+        noBridgeExpectedHeaders.put("qp1", INSTANT.toString());
+        noBridgeExpectedHeaders.put("qp2", STRING);
+        noBridgeExpectedHeaders.put("qp3", INTEGER.toString());
+        noBridgeExpectedHeaders.put("qp4", LONG.toString());
+        noBridgeExpectedHeaders.put("qp5", BOOLEAN.toString());
+
+        localServer = ServerBootstrap.bootstrap().setHttpProcessor(getBasicHttpProcessor())
+                .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())
+                .setExpectationVerifier(getHttpExpectationVerifier()).setSslContext(getSSLContext())
+                .registerHandler("/bridged",
+                        new HeaderValidationHandler(
+                                "GET",
+                                QUERY,
+                                null,
+                                getExpectedContent(),
+                                null,
+                                Arrays.asList(absentHeaders)))
+                .registerHandler("/notbridged",
+                        new HeaderValidationHandler(
+                                "GET",
+                                QUERY,
+                                null,
+                                getExpectedContent(),
+                                noBridgeExpectedHeaders))
+                .create();
+
+        localServer.start();
+
+        super.setUp();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        if (localServer != null) {
+            localServer.stop();
+        }
+    }
+
+    @Test
+    public void testHttpProducerBridgeEndpointSkipRequestHeaders() throws Exception {
+
+        HttpComponent component = context.getComponent("http", HttpComponent.class);
+        component.setConnectionTimeToLive(1000L);
+
+        HttpEndpoint endpoint = (HttpEndpoint) component
+                .createEndpoint("http://" + localServer.getInetAddress().getHostName() + ":"
+                                + localServer.getLocalPort() + "/bridged?bridgeEndpoint=true");
+        HttpProducer producer = new HttpProducer(endpoint);
+
+        Exchange exchange = producer.createExchange();
+        exchange.getIn().setBody(null);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, QUERY);
+        exchange.getIn().setHeader("qp1", INSTANT);
+        exchange.getIn().setHeader("qp2", STRING);
+        exchange.getIn().setHeader("qp3", INTEGER);
+        exchange.getIn().setHeader("qp4", LONG);
+        exchange.getIn().setHeader("qp5", BOOLEAN);
+
+        producer.start();
+        producer.process(exchange);
+        producer.stop();
+
+        assertExchange(exchange);
+    }
+
+    @Test
+    public void testHttpProducerNoBridgeEndpointRequestHeaders() throws Exception {
+
+        HttpComponent component = context.getComponent("http", HttpComponent.class);
+        component.setConnectionTimeToLive(1000L);
+
+        HttpEndpoint endpoint = (HttpEndpoint) component
+                .createEndpoint("http://" + localServer.getInetAddress().getHostName() + ":"
+                                + localServer.getLocalPort() + "/notbridged");
+        HttpProducer producer = new HttpProducer(endpoint);
+
+        Exchange exchange = producer.createExchange();
+        exchange.getIn().setBody(null);
+        exchange.getIn().setHeader(Exchange.HTTP_QUERY, QUERY);
+        exchange.getIn().setHeader("qp1", INSTANT);
+        exchange.getIn().setHeader("qp2", STRING);
+        exchange.getIn().setHeader("qp3", INTEGER);
+        exchange.getIn().setHeader("qp4", LONG);
+        exchange.getIn().setHeader("qp5", BOOLEAN);
+
+        producer.start();
+        producer.process(exchange);
+        producer.stop();
+
+        assertExchange(exchange);
+    }
+}


### PR DESCRIPTION
…query params on bridge endpoint broken for common types.

Added unit tests created to verify fix for [CAMEL-16699](https://issues.apache.org/jira/browse/CAMEL-16699) on 'camel-3.7.x' branch to 'main'. Cherry-pick of commits [80bef70b](https://github.com/apache/camel/pull/5655/commits/80bef70b8dd67aaa5397ac6228241db5d990812e) and [c1ab9345](https://github.com/apache/camel/pull/5655/commits/c1ab934581245d82f3a786b80b351339e66e89df), squashed to single commit.