### PR TITLE
[Lambda] Also check CamelAwsLambdaZipFile in createFunction

### DIFF
--- a/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
+++ b/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
@@ -270,6 +270,7 @@ public class Lambda2Producer extends DefaultProducer {
             }
 
             if (ObjectHelper.isNotEmpty(exchange.getIn().getBody())
+                    || ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.ZIP_FILE))
                     || (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_BUCKET))
                             && ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_KEY)))) {
                 builder.code(functionCode.build());


### PR DESCRIPTION
according to the lambda docs, the source code zip can be in message body or in `CamelAwsLambdaZipFile` header, but the header isn't checked in the code and it fails at runtime with

```
java.lang.IllegalArgumentException: At least S3 bucket/S3 key or zip file must be specified
	at org.apache.camel.component.aws2.lambda.Lambda2Producer.createFunction(Lambda2Producer.java:277)
```
