### PR TITLE
Do not ignore mdn template from AS2 server configuration

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
@@ -67,14 +67,15 @@ public class AS2ServerConnection {
                                      AS2SignatureAlgorithm signatureAlgorithm,
                                      Certificate[] signingCertificateChain,
                                      PrivateKey signingPrivateKey,
-                                     PrivateKey decryptingPrivateKey)
-                                                                      throws IOException {
+                                     PrivateKey decryptingPrivateKey,
+                                     String mdnMessageTemplate)
+                                                                throws IOException {
             setName(REQUEST_LISTENER_THREAD_NAME_PREFIX + port);
             serversocket = new ServerSocket(port);
 
             // Set up HTTP protocol processor for incoming connections
             final HttpProcessor inhttpproc = initProtocolProcessor(as2Version, originServer, serverFqdn, port,
-                    signatureAlgorithm, signingCertificateChain, signingPrivateKey, decryptingPrivateKey);
+                    signatureAlgorithm, signingCertificateChain, signingPrivateKey, decryptingPrivateKey, mdnMessageTemplate);
 
             reqistry = new UriHttpRequestHandlerMapper();
 
@@ -185,6 +186,7 @@ public class AS2ServerConnection {
     private Certificate[] signingCertificateChain;
     private PrivateKey signingPrivateKey;
     private PrivateKey decryptingPrivateKey;
+    private String mdnMessageTemplate;
 
     public AS2ServerConnection(String as2Version,
                                String originServer,
@@ -193,8 +195,9 @@ public class AS2ServerConnection {
                                AS2SignatureAlgorithm signingAlgorithm,
                                Certificate[] signingCertificateChain,
                                PrivateKey signingPrivateKey,
-                               PrivateKey decryptingPrivateKey)
-                                                                throws IOException {
+                               PrivateKey decryptingPrivateKey,
+                               String mdnMessageTemplate)
+                                                          throws IOException {
         this.as2Version = Args.notNull(as2Version, "as2Version");
         this.originServer = Args.notNull(originServer, "userAgent");
         this.serverFqdn = Args.notNull(serverFqdn, "serverFqdn");
@@ -203,11 +206,12 @@ public class AS2ServerConnection {
         this.signingCertificateChain = signingCertificateChain;
         this.signingPrivateKey = signingPrivateKey;
         this.decryptingPrivateKey = decryptingPrivateKey;
+        this.mdnMessageTemplate = mdnMessageTemplate;
 
         listenerThread = new RequestListenerThread(
                 this.as2Version, this.originServer, this.serverFqdn,
                 this.serverPortNumber, this.signingAlgorithm, this.signingCertificateChain, this.signingPrivateKey,
-                this.decryptingPrivateKey);
+                this.decryptingPrivateKey, this.mdnMessageTemplate);
         listenerThread.setDaemon(true);
         listenerThread.start();
     }
@@ -257,11 +261,13 @@ public class AS2ServerConnection {
             AS2SignatureAlgorithm signatureAlgorithm,
             Certificate[] signingCertificateChain,
             PrivateKey signingPrivateKey,
-            PrivateKey decryptingPrivateKey) {
+            PrivateKey decryptingPrivateKey,
+            String mdnMessageTemplate) {
         return HttpProcessorBuilder.create().add(new ResponseContent(true)).add(new ResponseServer(originServer))
                 .add(new ResponseDate()).add(new ResponseConnControl()).add(new ResponseMDN(
                         as2Version, serverFqdn,
-                        signatureAlgorithm, signingCertificateChain, signingPrivateKey, decryptingPrivateKey))
+                        signatureAlgorithm, signingCertificateChain, signingPrivateKey, decryptingPrivateKey,
+                        mdnMessageTemplate))
                 .build();
     }
 

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/protocol/ResponseMDN.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/protocol/ResponseMDN.java
@@ -44,6 +44,7 @@ import org.apache.camel.component.as2.api.util.AS2Utils;
 import org.apache.camel.component.as2.api.util.EntityUtils;
 import org.apache.camel.component.as2.api.util.HttpMessageUtils;
 import org.apache.camel.component.as2.api.util.SigningUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -81,17 +82,26 @@ public class ResponseMDN implements HttpResponseInterceptor {
     private Certificate[] signingCertificateChain;
     private PrivateKey signingPrivateKey;
     private PrivateKey decryptingPrivateKey;
+    private String mdnMessageTemplate;
 
     private VelocityEngine velocityEngine;
 
     public ResponseMDN(String as2Version, String serverFQDN, AS2SignatureAlgorithm signingAlgorithm,
-                       Certificate[] signingCertificateChain, PrivateKey signingPrivateKey, PrivateKey decryptingPrivateKey) {
+                       Certificate[] signingCertificateChain, PrivateKey signingPrivateKey, PrivateKey decryptingPrivateKey,
+                       String mdnMessageTemplate) {
         this.as2Version = as2Version;
         this.serverFQDN = serverFQDN;
         this.signingAlgorithm = signingAlgorithm;
         this.signingCertificateChain = signingCertificateChain;
         this.signingPrivateKey = signingPrivateKey;
         this.decryptingPrivateKey = decryptingPrivateKey;
+        // MDN response is to be sent anyway, so empty or null value will be treated as if
+        // the user doesn't know how to compose their own template and/or is satisfied with default one.
+        if (!StringUtils.isBlank(mdnMessageTemplate)) {
+            this.mdnMessageTemplate = mdnMessageTemplate;
+        } else {
+            this.mdnMessageTemplate = DEFAULT_MDN_MESSAGE_TEMPLATE;
+        }
     }
 
     @Override
@@ -132,7 +142,7 @@ public class ResponseMDN implements HttpResponseInterceptor {
             // Return a failed Message Disposition Notification Receipt in response body
             String mdnMessage = createMdnDescription(httpEntityEnclosingRequest, response,
                     DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY,
-                    AS2DispositionType.FAILED, null, null, null, null, null, AS2Charset.US_ASCII, DEFAULT_MDN_MESSAGE_TEMPLATE);
+                    AS2DispositionType.FAILED, null, null, null, null, null, AS2Charset.US_ASCII, mdnMessageTemplate);
             multipartReportEntity = new DispositionNotificationMultipartReportEntity(
                     httpEntityEnclosingRequest, response, DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY,
                     AS2DispositionType.FAILED, null, null, null, null, null, AS2Charset.US_ASCII, boundary, true,
@@ -141,7 +151,7 @@ public class ResponseMDN implements HttpResponseInterceptor {
             String mdnMessage = createMdnDescription(httpEntityEnclosingRequest, response,
                     DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY,
                     AS2DispositionType.PROCESSED, null, null, null, null, null, AS2Charset.US_ASCII,
-                    DEFAULT_MDN_MESSAGE_TEMPLATE);
+                    mdnMessageTemplate);
             multipartReportEntity = new DispositionNotificationMultipartReportEntity(
                     httpEntityEnclosingRequest, response, DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY,
                     AS2DispositionType.PROCESSED, null, null, null, null, null, AS2Charset.US_ASCII, boundary, true,

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/EntityUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/EntityUtils.java
@@ -25,7 +25,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.camel.component.as2.api.AS2Charset;
 import org.apache.camel.component.as2.api.AS2Header;
 import org.apache.camel.component.as2.api.AS2MediaType;
 import org.apache.camel.component.as2.api.entity.ApplicationEDIConsentEntity;
@@ -189,8 +188,10 @@ public final class EntityUtils {
             throws Exception {
         Args.notNull(ediMessage, "EDI Message");
         Args.notNull(ediMessageContentType, "EDI Message Content Type");
-        String charset = ediMessageContentType.getCharset() == null
-                ? AS2Charset.US_ASCII : ediMessageContentType.getCharset().toString();
+        String charset = null;
+        if (ediMessageContentType.getCharset() != null) {
+            charset = ediMessageContentType.getCharset().toString();
+        }
         switch (ediMessageContentType.getMimeType().toLowerCase()) {
             case AS2MediaType.APPLICATION_EDIFACT:
                 return new ApplicationEDIFACTEntity(ediMessage, charset, contentTransferEncoding, isMainBody);

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -135,6 +135,7 @@ public class AS2MessageTest {
     private static final String DISPOSITION_NOTIFICATION_OPTIONS
             = "signed-receipt-protocol=optional,pkcs7-signature; signed-receipt-micalg=optional,sha1";
     private static final String[] SIGNED_RECEIPT_MIC_ALGORITHMS = new String[] { "sha1", "md5" };
+    private static final String MDN_MESSAGE_TEMPLATE = "TBD";
 
     private static final HttpDateGenerator DATE_GENERATOR = new HttpDateGenerator();
 
@@ -179,7 +180,7 @@ public class AS2MessageTest {
 
         testServer = new AS2ServerConnection(
                 AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, TARGET_PORT, AS2SignatureAlgorithm.SHA256WITHRSA,
-                certList.toArray(new Certificate[0]), signingKP.getPrivate(), decryptingKP.getPrivate());
+                certList.toArray(new Certificate[0]), signingKP.getPrivate(), decryptingKP.getPrivate(), MDN_MESSAGE_TEMPLATE);
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(HttpRequest request, HttpResponse response, HttpContext context)

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/EntityUtilsTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/EntityUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.as2.api.util;
+
+import org.apache.camel.component.as2.api.AS2Charset;
+import org.apache.camel.component.as2.api.AS2MediaType;
+import org.apache.camel.component.as2.api.entity.ApplicationEDIEntity;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EntityUtilsTest {
+
+    @Test
+    public void testCreateEDIEntityContentTypeWithoutEncoding() throws Exception {
+        ContentType ediMessageContentType = ContentType.create(AS2MediaType.APPLICATION_EDIFACT, (String) null);
+        String ediMessage = "whatever";
+        ApplicationEDIEntity applicationEDIEntity = EntityUtils.createEDIEntity(ediMessage, ediMessageContentType, null, false);
+        String actualContentType = applicationEDIEntity.getContentTypeValue();
+        Assertions.assertEquals("application/edifact", actualContentType, "content type matches");
+    }
+
+    @Test
+    public void testCreateEDIEntityContentTypeWithEncoding() throws Exception {
+        ContentType ediMessageContentType = ContentType.create(AS2MediaType.APPLICATION_EDIFACT, AS2Charset.US_ASCII);
+        String ediMessage = "whatever";
+        ApplicationEDIEntity applicationEDIEntity = EntityUtils.createEDIEntity(ediMessage, ediMessageContentType, null, false);
+        String actualContentType = applicationEDIEntity.getContentTypeValue();
+        Assertions.assertEquals("application/edifact; charset=US-ASCII", actualContentType, "content type matches");
+    }
+}

--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/internal/AS2ConnectionHelper.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/internal/AS2ConnectionHelper.java
@@ -72,7 +72,7 @@ public final class AS2ConnectionHelper {
                         configuration.getAs2Version(), configuration.getServer(),
                         configuration.getServerFqdn(), configuration.getServerPortNumber(), configuration.getSigningAlgorithm(),
                         configuration.getSigningCertificateChain(), configuration.getSigningPrivateKey(),
-                        configuration.getDecryptingPrivateKey());
+                        configuration.getDecryptingPrivateKey(), configuration.getMdnMessageTemplate());
                 serverConnections.put(configuration.getServerPortNumber(), serverConnection);
             }
             return serverConnection;

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ClientManagerIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ClientManagerIT.java
@@ -120,6 +120,7 @@ public class AS2ClientManagerIT extends AbstractAS2ITSupport {
 
     private static final String MDN_FROM = "as2Test@server.example.com";
     private static final String MDN_SUBJECT_PREFIX = "MDN Response:";
+    private static final String MDN_MESSAGE_TEMPLATE = "TBD";
 
     private static final String EDI_MESSAGE = "UNB+UNOA:1+005435656:1+006415160:1+060515:1434+00000000000778'\n"
                                               + "UNH+00000000000117+INVOIC:D:97B:UN'\n"
@@ -742,7 +743,8 @@ public class AS2ClientManagerIT extends AbstractAS2ITSupport {
         serverConnection = new AS2ServerConnection(
                 AS2_VERSION, ORIGIN_SERVER_NAME,
                 SERVER_FQDN, PARTNER_TARGET_PORT, AS2SignatureAlgorithm.SHA256WITHRSA,
-                serverCertList.toArray(new Certificate[0]), serverSigningKP.getPrivate(), serverSigningKP.getPrivate());
+                serverCertList.toArray(new Certificate[0]), serverSigningKP.getPrivate(), serverSigningKP.getPrivate(),
+                MDN_MESSAGE_TEMPLATE);
         requestHandler = new RequestHandler();
         serverConnection.listen("/", requestHandler);
     }


### PR DESCRIPTION
Currently there is no means to specify custom mdn template. Here I mean that I can call the corresponding setter, but the specified template isn't passed deeper and I still get hardcoded template DEFAULT_MDN_MESSAGE_TEMPLATE from the class ResponseMDN - I can see it from my testing.
My changes allow tp pick up the template from the class AS2Configuration along with many other settings.