### PR TITLE
feature(camel-aws-ddb): Add BatchGetItems, Query and Scan tests

### DIFF
--- a/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2BatchGetItemsRuleIT.java
+++ b/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2BatchGetItemsRuleIT.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.ddb.localstack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.ddb.Ddb2Constants;
+import org.apache.camel.component.aws2.ddb.Ddb2Operations;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AWS2BatchGetItemsRuleIT extends Aws2DDBBase {
+
+    @EndpointInject("direct:start")
+    private ProducerTemplate template;
+
+    private final String attributeName = "clave";
+    private final String secondaryAttributeName = "secondary_attribute";
+    private final String tableName = "TestTableGetBatch";
+    private final String retrieveValue = "retrieve";
+    private final String notRetrieveValue = "ignore";
+
+    @Override
+    protected void cleanupResources() throws Exception {
+        super.cleanupResources();
+
+        DeleteTableRequest deleteTableRequest = DeleteTableRequest.builder()
+                .tableName(tableName)
+                .build();
+        ddbClient.deleteTable(deleteTableRequest);
+    }
+
+    @Override
+    protected void setupResources() throws Exception {
+        super.setupResources();
+        ddbClient = AWSSDKClientUtils.newDynamoDBClient();
+        CreateTableRequest createTableRequest = CreateTableRequest.builder()
+                .tableName(tableName)
+                .keySchema(
+                        KeySchemaElement.builder()
+                                .attributeName(attributeName)
+                                .keyType(KeyType.HASH)
+                                .build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder()
+                                .attributeType(ScalarAttributeType.S)
+                                .attributeName(attributeName)
+                                .build())
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                        .readCapacityUnits(5L)
+                        .writeCapacityUnits(5L)
+                        .build())
+                .build();
+        ddbClient.createTable(createTableRequest);
+    }
+
+    @Test
+    public void batchGetItems() {
+        putItem(retrieveValue, "1");
+        putItem(notRetrieveValue, "0");
+
+        Exchange exchange = template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.BatchGetItems);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, true);
+
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put(attributeName, AttributeValue.builder().s(retrieveValue).build());
+            Map<String, KeysAndAttributes> keysAndAttributesMap = new HashMap<>();
+            KeysAndAttributes keysAndAttributes = KeysAndAttributes.builder()
+                    .keys(key)
+                    .build();
+            keysAndAttributesMap.put(tableName, keysAndAttributes);
+            e.getIn().setHeader(Ddb2Constants.BATCH_ITEMS, keysAndAttributesMap);
+
+        });
+
+        assertNull(exchange.getIn().getExchange().getException());
+        assertNotNull(exchange.getIn().getHeader(Ddb2Constants.BATCH_RESPONSE));
+        assertNotNull(exchange.getIn().getHeader(Ddb2Constants.UNPROCESSED_KEYS));
+    }
+
+    private void putItem(String value1, String value2) {
+        final Map<String, AttributeValue> attributeMap = new HashMap<>();
+        attributeMap.put(attributeName, AttributeValue.builder().s(value1).build());
+        attributeMap.put(secondaryAttributeName, AttributeValue.builder().s(value2).build());
+
+        template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.BatchGetItems);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, "true");
+            e.getIn().setHeader(Ddb2Constants.RETURN_VALUES, "ALL_OLD");
+            e.getIn().setHeader(Ddb2Constants.ITEM, attributeMap);
+            e.getIn().setHeader(Ddb2Constants.ATTRIBUTE_NAMES, attributeMap.keySet());
+        });
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").to("aws2-ddb://" + tableName);
+            }
+        };
+    }
+}

--- a/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2QueryRuleIT.java
+++ b/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2QueryRuleIT.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.ddb.localstack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.ddb.Ddb2Constants;
+import org.apache.camel.component.aws2.ddb.Ddb2Operations;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AWS2QueryRuleIT extends Aws2DDBBase {
+
+    @EndpointInject("direct:start")
+    private ProducerTemplate template;
+
+    private final String attributeName = "clave";
+    private final String secondaryAttributeName = "secondary_attribute";
+    private final String tableName = "TestTableQuery";
+    private final String retrieveValue = "retrieve";
+    private final String notRetrieveValue = "ignore";
+
+    @Override
+    protected void cleanupResources() throws Exception {
+        super.cleanupResources();
+
+        DeleteTableRequest deleteTableRequest = DeleteTableRequest.builder()
+                .tableName(tableName)
+                .build();
+        ddbClient.deleteTable(deleteTableRequest);
+    }
+
+    @Override
+    protected void setupResources() throws Exception {
+        super.setupResources();
+        ddbClient = AWSSDKClientUtils.newDynamoDBClient();
+        CreateTableRequest createTableRequest = CreateTableRequest.builder()
+                .tableName(tableName)
+                .keySchema(
+                        KeySchemaElement.builder()
+                                .attributeName(attributeName)
+                                .keyType(KeyType.HASH)
+                                .build(),
+                        KeySchemaElement.builder()
+                                .attributeName(secondaryAttributeName)
+                                .keyType(KeyType.RANGE)
+                                .build())
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeType(ScalarAttributeType.S)
+                        .attributeName(secondaryAttributeName)
+                        .build(),
+                        AttributeDefinition.builder()
+                                .attributeType(ScalarAttributeType.S)
+                                .attributeName(attributeName)
+                                .build())
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                        .readCapacityUnits(5L)
+                        .writeCapacityUnits(5L)
+                        .build())
+                .build();
+        ddbClient.createTable(createTableRequest);
+    }
+
+    @Test
+    public void queryItems() {
+
+        putItem(retrieveValue, "uno");
+        putItem(retrieveValue, "dos");
+        putItem(retrieveValue, "tres");
+        putItem(notRetrieveValue, "Ignore me");
+        putItem(notRetrieveValue, "I should not be returned");
+
+        Exchange exchange = template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.Query);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, true);
+            Map<String, Condition> keyConditions = new HashMap<>();
+            keyConditions.put(attributeName, Condition.builder().comparisonOperator(
+                    ComparisonOperator.EQ.toString())
+                    .attributeValueList(AttributeValue.builder().s(retrieveValue).build())
+                    .build());
+            e.getIn().setHeader(Ddb2Constants.KEY_CONDITIONS, keyConditions);
+        });
+
+        assertNotNull(exchange.getIn().getHeader(Ddb2Constants.ITEMS));
+        assertEquals(3, exchange.getIn().getHeader(Ddb2Constants.COUNT));
+    }
+
+    private void putItem(String value1, String value2) {
+        final Map<String, AttributeValue> attributeMap = new HashMap<>();
+        attributeMap.put(attributeName, AttributeValue.builder().s(value1).build());
+        attributeMap.put(secondaryAttributeName, AttributeValue.builder().s(value2).build());
+
+        Exchange ex = template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.PutItem);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, "true");
+            e.getIn().setHeader(Ddb2Constants.RETURN_VALUES, "ALL_OLD");
+            e.getIn().setHeader(Ddb2Constants.ITEM, attributeMap);
+            e.getIn().setHeader(Ddb2Constants.ATTRIBUTE_NAMES, attributeMap.keySet());
+        });
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").to(
+                        "aws2-ddb://" + tableName);
+            }
+        };
+    }
+}

--- a/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2ScanRuleIT.java
+++ b/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/AWS2ScanRuleIT.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.ddb.localstack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.ddb.Ddb2Constants;
+import org.apache.camel.component.aws2.ddb.Ddb2Operations;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AWS2ScanRuleIT extends Aws2DDBBase {
+
+    @EndpointInject("direct:start")
+    private ProducerTemplate template;
+
+    private final String attributeName = "clave";
+    private final String secondaryAttributeName = "secondary_attribute";
+    private final String tableName = "TestTableScan";
+    private final String retrieveValue = "retrieve";
+    private final String notRetrieveValue = "ignore";
+
+    @Override
+    protected void cleanupResources() throws Exception {
+        super.cleanupResources();
+
+        DeleteTableRequest deleteTableRequest = DeleteTableRequest.builder()
+                .tableName(tableName)
+                .build();
+        ddbClient.deleteTable(deleteTableRequest);
+    }
+
+    @Override
+    protected void setupResources() throws Exception {
+        super.setupResources();
+        ddbClient = AWSSDKClientUtils.newDynamoDBClient();
+        CreateTableRequest createTableRequest = CreateTableRequest.builder()
+                .tableName(tableName)
+                .keySchema(
+                        KeySchemaElement.builder()
+                                .attributeName(attributeName)
+                                .keyType(KeyType.HASH)
+                                .build(),
+                        KeySchemaElement.builder()
+                                .attributeName(secondaryAttributeName)
+                                .keyType(KeyType.RANGE)
+                                .build())
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeType(ScalarAttributeType.S)
+                        .attributeName(secondaryAttributeName)
+                        .build(),
+                        AttributeDefinition.builder()
+                                .attributeType(ScalarAttributeType.S)
+                                .attributeName(attributeName)
+                                .build())
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                        .readCapacityUnits(5L)
+                        .writeCapacityUnits(5L)
+                        .build())
+                .build();
+        ddbClient.createTable(createTableRequest);
+    }
+
+    @Test
+    public void scan() {
+
+        putItem(notRetrieveValue, "0");
+        putItem(notRetrieveValue, "4");
+
+        putItem(retrieveValue, "1");
+        putItem(retrieveValue, "2");
+        putItem(retrieveValue, "3");
+
+        Exchange exchange = template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.Scan);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, true);
+            Map<String, Condition> keyConditions = new HashMap<>();
+            keyConditions.put(attributeName, Condition.builder().comparisonOperator(
+                    ComparisonOperator.EQ.toString())
+                    .attributeValueList(AttributeValue.builder().s(retrieveValue).build())
+                    .build());
+            e.getIn().setHeader(Ddb2Constants.SCAN_FILTER, keyConditions);
+        });
+
+        assertNotNull(exchange.getIn().getHeader(Ddb2Constants.ITEMS));
+        assertEquals(3, exchange.getIn().getHeader(Ddb2Constants.COUNT));
+    }
+
+    private void putItem(String value1, String value2) {
+        final Map<String, AttributeValue> attributeMap = new HashMap<>();
+        attributeMap.put(attributeName, AttributeValue.builder().s(value1).build());
+        attributeMap.put(secondaryAttributeName, AttributeValue.builder().s(value2).build());
+
+        template.send("direct:start", e -> {
+            e.getIn().setHeader(Ddb2Constants.OPERATION, Ddb2Operations.PutItem);
+            e.getIn().setHeader(Ddb2Constants.CONSISTENT_READ, "true");
+            e.getIn().setHeader(Ddb2Constants.RETURN_VALUES, "ALL_OLD");
+            e.getIn().setHeader(Ddb2Constants.ITEM, attributeMap);
+            e.getIn().setHeader(Ddb2Constants.ATTRIBUTE_NAMES, attributeMap.keySet());
+        });
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").to("aws2-ddb://" + tableName);
+            }
+        };
+    }
+}

--- a/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/Aws2DDBBase.java
+++ b/components/camel-aws/camel-aws2-ddb/src/test/java/org/apache/camel/component/aws2/ddb/localstack/Aws2DDBBase.java
@@ -24,6 +24,7 @@ import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Aws2DDBBase extends CamelTestSupport {
@@ -31,11 +32,16 @@ public class Aws2DDBBase extends CamelTestSupport {
     @RegisterExtension
     public static AWSService service = AWSServiceFactory.createDynamodbService();
 
+    protected DynamoDbClient ddbClient;
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
         Ddb2Component ddb2Component = context.getComponent("aws2-ddb", Ddb2Component.class);
-        ddb2Component.getConfiguration().setAmazonDDBClient(AWSSDKClientUtils.newDynamoDBClient());
+        if (ddbClient == null) {
+            ddbClient = AWSSDKClientUtils.newDynamoDBClient();
+        }
+        ddb2Component.getConfiguration().setAmazonDDBClient(ddbClient);
         return context;
     }
 }


### PR DESCRIPTION
These tests needed specific table creation, so added a table create before and a table delete after the test.

They are very simple tests, but at least they make sure we can do a basic operation on BatchGetItems, Query and Scan.