### PR TITLE
Use an existing bean from the registry if a single candidate of the given type is available, rather than creating a new one

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/ConstantTypeBeanHolder.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/ConstantTypeBeanHolder.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.bean;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -79,7 +80,12 @@ public class ConstantTypeBeanHolder implements BeanTypeHolder {
 
     @Override
     public Object getBean(Exchange exchange) {
-        // only create a bean if we have a default no-arg constructor
+        //  try to get the bean from registry first if there is a single candidate for the type. 
+        Set<?> beans = beanInfo.getCamelContext().getRegistry().findByType(type);
+        if (beans.size() == 1) {
+            return beans.iterator().next();
+        }
+        // only create a bean if we have a default no-arg constructor and not present in the registry
         if (beanInfo.hasPublicNoArgConstructors()) {
             Object bean = getBeanInfo().getCamelContext().getInjector().newInstance(type, false);
             if (options != null && !options.isEmpty()) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallByTypeRefExistingBeanTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MethodCallByTypeRefExistingBeanTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Handler;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Registry;
+import org.junit.jupiter.api.Test;
+
+public class MethodCallByTypeRefExistingBeanTest extends ContextTestSupport {
+
+    @Override
+    protected Registry createRegistry() throws Exception {
+        Registry jndi = super.createRegistry();
+        jndi.bind("foo", new MyBean("Type Ref "));
+        return jndi;
+    }
+
+    @Test
+    public void testRefOrBeanPrefix() throws Exception {
+        getMockEndpoint("mock:a").expectedBodiesReceived("Hello Type Ref A");
+        getMockEndpoint("mock:b").expectedBodiesReceived("Hello Type Ref B");
+
+        template.sendBody("direct:a", "A");
+        template.sendBody("direct:b", "B");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:a").transform().method(MyBean.class).to("mock:a");
+
+                from("direct:b").transform().method(MyBean.class).to("mock:b");
+            }
+        };
+    }
+
+    private static class MyBean {
+
+        private final String field;
+
+        //No default constructor available
+        public MyBean(String field) {
+            this.field = field;
+        }
+
+        @Handler
+        public String hello(String text) {
+            return "Hello " + field + text;
+        }
+
+    }
+}


### PR DESCRIPTION

Fixing https://issues.apache.org/jira/browse/CAMEL-16733. 

Search the registry and if single bean is found matching the given type, then use it rather than creating a new instance.
