### PR TITLE
(aws2-ddb) Set exclusive start key only once.

### DIFF
--- a/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/QueryCommand.java
+++ b/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/QueryCommand.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.apache.camel.Exchange;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
@@ -36,9 +35,8 @@ public class QueryCommand extends AbstractDdbCommand {
     public void execute() {
         QueryRequest.Builder query = QueryRequest.builder().tableName(determineTableName())
                 .attributesToGet(determineAttributeNames()).consistentRead(determineConsistentRead())
-                .exclusiveStartKey(determineStartKey()).keyConditions(determineKeyConditions())
-                .exclusiveStartKey(determineStartKey()).limit(determineLimit())
-                .scanIndexForward(determineScanIndexForward());
+                .keyConditions(determineKeyConditions()).exclusiveStartKey(determineExclusiveStartKey())
+                .limit(determineLimit()).scanIndexForward(determineScanIndexForward());
 
         // Check if we have set an Index Name
         if (exchange.getIn().getHeader(Ddb2Constants.INDEX_NAME, String.class) != null) {
@@ -53,11 +51,6 @@ public class QueryCommand extends AbstractDdbCommand {
         tmp.put(Ddb2Constants.CONSUMED_CAPACITY, result.consumedCapacity());
         tmp.put(Ddb2Constants.COUNT, result.count());
         addToResults(tmp);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, AttributeValue> determineStartKey() {
-        return exchange.getIn().getHeader(Ddb2Constants.START_KEY, Map.class);
     }
 
     private Boolean determineScanIndexForward() {


### PR DESCRIPTION
Switch to use the existing parent class's method to determine the exclusive start key, only set it once in the builder.

---

Side note, the following line will set the LAST_EVALUATED_KEY to an SdkAutoConstructMap when no last evaluated key is present.

```java
tmp.put(Ddb2Constants.LAST_EVALUATED_KEY, result.lastEvaluatedKey());
```

I'm not sure if this is intentional, or the component should check for this and return null. Currently, dependent applications have to reimplement this logic available in the sdk.

```java
public final boolean hasLastEvaluatedKey() {
    return lastEvaluatedKey != null && !(lastEvaluatedKey instanceof SdkAutoConstructMap);
}
```

If an always-null if not present is desired, I could put up another pull request.