### PR TITLE
CAMEL-16763: Fixes JMS Correlation ID bug in camel-sjms

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsProducer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsProducer.java
@@ -490,7 +490,7 @@ public class SjmsProducer extends DefaultAsyncProducer {
      * @throws JMSException can be thrown
      */
     protected String determineCorrelationId(Message message) throws JMSException {
-        String cid = getJMSCorrelationIDAsBytes(message);
+        String cid = getJMSCorrelationID(message);
         if (ObjectHelper.isEmpty(cid)) {
             cid = getJMSMessageID(message);
         }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
@@ -385,6 +385,22 @@ public final class JmsMessageHelper {
     }
 
     /**
+     * Gets the JMSCorrelationID from the message.
+     *
+     * @param  message the message
+     * @return         the JMSCorrelationID, or <tt>null</tt> if not able to get
+     */
+    public static String getJMSCorrelationID(Message message) {
+        try {
+            return message.getJMSCorrelationID();
+        } catch (JMSException e) {
+            // ignore
+        }
+
+        return null;
+    }
+
+    /**
      * Gets the JMSCorrelationIDAsBytes from the message.
      *
      * @param  message the message

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/ReplyManagerSupport.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/ReplyManagerSupport.java
@@ -41,7 +41,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.camel.component.sjms.jms.JmsMessageHelper.getJMSCorrelationIDAsBytes;
+import static org.apache.camel.component.sjms.jms.JmsMessageHelper.getJMSCorrelationID;
 
 /**
  * Base class for {@link ReplyManager} implementations.
@@ -127,7 +127,7 @@ public abstract class ReplyManagerSupport extends ServiceSupport implements Repl
 
     @Override
     public void onMessage(Message message, Session session) throws JMSException {
-        String correlationID = getJMSCorrelationIDAsBytes(message);
+        String correlationID = getJMSCorrelationID(message);
 
         if (correlationID == null) {
             log.warn("Ignoring message with no correlationID: {}", message);


### PR DESCRIPTION
Addresses issue [CAMEL-16763](https://issues.apache.org/jira/browse/CAMEL-16763).

This PR replaces `getJMSCorrelationIDAsBytes()` calls with `getJMSCorrelationID`. Using `getJMSCorrelationIDAsBytes()` to determine correlation ID is not compatible with Artemis JMS Client as the Artemis implementation of `Message` only returns a correlation ID from `getJMSCorrelationIDAsBytes()` if the correlation ID is a byte array, otherwise it returns null. Because camel sets the correlation ID explicitly as a string, the correlation ID retrieved from `getJMSCorrelationIDAsBytes()` was always null.


