### PR TITLE
Fix incorrect example class links in xpath documentation

### DIFF
--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -228,14 +228,14 @@ shown:
 == Examples
 
 Here is a simple
-https://github.com/apache/camel/blob/main/camel-core/src/test/java/org/apache/camel/processor/XPathFilterTest.java[example]
+https://github.com/apache/camel/blob/main/core/camel-core/src/test/java/org/apache/camel/processor/XPathFilterTest.java[example]
 using an XPath expression as a predicate in a
 Message Filter
 
 If you have a standard set of namespaces you wish to work with and wish
 to share them across many different XPath expressions you can use the
 NamespaceBuilder as shown
-https://github.com/apache/camel/blob/main/camel-core/src/test/java/org/apache/camel/processor/XPathWithNamespaceBuilderFilterTest.java[in
+https://github.com/apache/camel/blob/main/core/camel-core/src/test/java/org/apache/camel/processor/XPathWithNamespaceBuilderFilterTest.java[in
 this example]
 
 In this sample we have a choice construct. The first choice evaulates if


### PR DESCRIPTION
Trivial change to documentation only
