### PR TITLE
ResourceHelper.hasScheme() now recognizes "https:" scheme

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/ResourceHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ResourceHelper.java
@@ -70,7 +70,7 @@ public final class ResourceHelper {
             return false;
         }
 
-        return uri.startsWith("file:") || uri.startsWith("classpath:") || uri.startsWith("http:");
+        return uri.startsWith("file:") || uri.startsWith("classpath:") || uri.startsWith("http:") || uri.startsWith("https:");
     }
 
     /**


### PR DESCRIPTION
I noticed that isHttpUri() recognizes "https:" as a scheme, so it seems to me that hasScheme() ought to recognise it as well.