### PR TITLE
Elasticsearch-rest empty index name problem

### DIFF
--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -162,14 +162,22 @@ public final class ElasticsearchActionRequestConverter {
 
     @Converter
     public static SearchRequest toSearchRequest(Object queryObject, Exchange exchange) throws IOException {
+         
+        String indexName = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class);
+
         if (queryObject instanceof SearchRequest) {
-            return (SearchRequest) queryObject;
+            SearchRequest searchRequest = (SearchRequest) queryObject;
+            String[] indices = searchRequest.indices();
+            if (indices == null || indices.length == 0) {
+                searchRequest.indices(indexName);
+            }
+            return searchRequest;
         }
         SearchRequest searchRequest = new SearchRequest();
 
         // Only setup the indexName and indexType if the message header has the
         // setting
-        String indexName = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class);
+        
         Integer size = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_SIZE, Integer.class);
         Integer from = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_FROM, Integer.class);
         if (ObjectHelper.isNotEmpty(indexName)) {

--- a/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
+++ b/components/camel-elasticsearch-rest/src/main/java/org/apache/camel/component/elasticsearch/converter/ElasticsearchActionRequestConverter.java
@@ -162,7 +162,6 @@ public final class ElasticsearchActionRequestConverter {
 
     @Converter
     public static SearchRequest toSearchRequest(Object queryObject, Exchange exchange) throws IOException {
-         
         String indexName = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_INDEX_NAME, String.class);
 
         if (queryObject instanceof SearchRequest) {
@@ -177,7 +176,7 @@ public final class ElasticsearchActionRequestConverter {
 
         // Only setup the indexName and indexType if the message header has the
         // setting
-        
+
         Integer size = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_SIZE, Integer.class);
         Integer from = exchange.getIn().getHeader(ElasticsearchConstants.PARAM_FROM, Integer.class);
         if (ObjectHelper.isNotEmpty(indexName)) {


### PR DESCRIPTION
When a specific index is not given in the searchrequest object, the index name in camel dsl should be taken.

`.setBody(constant(new SearchRequest())) .to("elasticsearch-rest://elasticsearch?operation=Search&indexName=camel&useScroll=true&scrollKeepAliveMs=30000")`

In this scenario, a query is made with an empty index and documents related to the index are sent to me. If we change the code like this, it will search the camel index.