### PR TITLE
Deprecated Elastic methods removed

### DIFF
--- a/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
+++ b/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
@@ -316,10 +316,8 @@ MultiSearch on specific field(s)
 ----
 SearchRequest req = new SearchRequest();
 req.indices("twitter");
-req.types("tweet");
 SearchRequest req1 = new SearchRequest();
 req.indices("twitter");
-req.types("tweets");
 MultiSearchRequest request = new MultiSearchRequest().add(req1).add(req);
 Item[] response = template.requestBody("direct:search", request, Item[].class);
 ----


### PR DESCRIPTION
types method was removed in 7 version at 2018 november 