### PR TITLE
implement logging mdc support CAMEL-12879

### DIFF
--- a/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
+++ b/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
@@ -51,3 +51,6 @@ otelTracer.init(camelContext);
 --------------------------------------------------------------------------------------------------
 
 include::{page-component-version}@camel-spring-boot::page$opentelemetry-starter.adoc[]
+
+== MDC Logging
+When MDC Logging is enabled for the active Camel context the Trace ID and Span ID will be added and removed from the MDC for each route, the keys are `traceId` and `spanId`, respectively.

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -98,6 +98,16 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
         span.addEvent(getEventNameFromFields(fields), convertToAttributes(fields));
     }
 
+    @Override
+    public String traceId() {
+        return span.getSpanContext().getTraceId();
+    }
+
+    @Override
+    public String spanId() {
+        return span.getSpanContext().getSpanId();
+    }
+
     String getEventNameFromFields(Map<String, ?> fields) {
         Object eventValue = fields == null ? null : fields.get("event");
         if (eventValue != null) {

--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -135,3 +135,8 @@ Where the value of header "request-header" is "foo", the resulting trace from ex
 and the resulting message would contain:
 
 * Header "baggage-header" of value "foo"
+
+== MDC Logging
+When MDC Logging is enabled for the active Camel context the Trace ID and Span ID will be added and removed from the MDC for each route or processor (depending on the tracing strategy configured), the keys are `traceId` and `spanId`, respectively.
+
+If the `OpenTracingTracingStrategy` is enabled the span ID will be the one for the current processor that logs an entry, otherwise it will be the one for the current route.

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingSpanAdapter.java
@@ -90,4 +90,14 @@ public class OpenTracingSpanAdapter implements SpanAdapter {
         this.span.log(fields);
     }
 
+    @Override
+    public String traceId() {
+        return this.span.context().toTraceId();
+    }
+
+    @Override
+    public String spanId() {
+        return this.span.context().toSpanId();
+    }
+
 }

--- a/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
+++ b/components/camel-opentracing/src/main/java/org/apache/camel/opentracing/OpenTracingTracer.java
@@ -88,9 +88,7 @@ public class OpenTracingTracer extends org.apache.camel.tracing.Tracer {
 
         if (tracer != null) {
             try { // Take care NOT to import GlobalTracer as it is an optional dependency and may not be on the classpath.
-                if (!io.opentracing.util.GlobalTracer.isRegistered()) {
-                    io.opentracing.util.GlobalTracer.register(tracer);
-                }
+                io.opentracing.util.GlobalTracer.registerIfAbsent(tracer);
             } catch (NoClassDefFoundError globalTracerNotInClasspath) {
                 LOG.trace("GlobalTracer is not found on the classpath.");
             }

--- a/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MDCSupportTest.java
+++ b/components/camel-opentracing/src/test/java/org/apache/camel/opentracing/MDCSupportTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentracing;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MDCSupportTest extends CamelOpenTracingTestSupport {
+
+    private static SpanTestData[] testdata = {
+            new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
+                    .setParentId(1),
+            new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
+    };
+
+    public MDCSupportTest() {
+        super(testdata);
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        camelContext.setUseMDCLogging(true);
+        return camelContext;
+    }
+
+    @Test
+    public void testRoute() throws Exception {
+        template.requestBody("direct:start", "Hello");
+
+        verify();
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").to("seda:a").routeId("start");
+
+                from("seda:a").routeId("a")
+                        .process(new Processor() {
+                            public void process(Exchange exchange) throws Exception {
+                                assertNotNull(MDC.get("traceId"));
+                                assertNotNull(MDC.get("spanId"));
+                            }
+                        });
+            }
+        };
+    }
+}

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
@@ -17,12 +17,15 @@
 package org.apache.camel.tracing;
 
 import org.apache.camel.Exchange;
+import org.slf4j.MDC;
 
 /**
  * Utility class for managing active spans as a stack associated with an exchange.
  */
 public final class ActiveSpanManager {
 
+    public static final String MDC_TRACE_ID = "traceId";
+    public static final String MDC_SPAN_ID = "spanId";
     private static final String ACTIVE_SPAN_PROPERTY = "OpenTracing.activeSpan";
 
     private ActiveSpanManager() {
@@ -52,6 +55,11 @@ public final class ActiveSpanManager {
     public static void activate(Exchange exchange, SpanAdapter span) {
         exchange.setProperty(ACTIVE_SPAN_PROPERTY,
                 new Holder((Holder) exchange.getProperty(ACTIVE_SPAN_PROPERTY), span));
+
+        if (exchange.getContext().isUseMDCLogging()) {
+            MDC.put(MDC_TRACE_ID, "" + span.traceId());
+            MDC.put(MDC_SPAN_ID, "" + span.spanId());
+        }
     }
 
     /**
@@ -65,6 +73,18 @@ public final class ActiveSpanManager {
         Holder holder = (Holder) exchange.getProperty(ACTIVE_SPAN_PROPERTY);
         if (holder != null) {
             exchange.setProperty(ACTIVE_SPAN_PROPERTY, holder.getParent());
+
+            if (exchange.getContext().isUseMDCLogging()) {
+                Holder parent = holder.getParent();
+                if (parent != null) {
+                    SpanAdapter span = holder.getParent().getSpan();
+                    MDC.put(MDC_TRACE_ID, "" + span.traceId());
+                    MDC.put(MDC_SPAN_ID, "" + span.spanId());
+                } else {
+                    MDC.remove(MDC_TRACE_ID);
+                    MDC.remove(MDC_SPAN_ID);
+                }
+            }
         }
     }
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
@@ -34,4 +34,8 @@ public interface SpanAdapter {
     void setTag(String key, Boolean value);
 
     void log(Map<String, String> log);
+
+    String traceId();
+
+    String spanId();
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
@@ -25,6 +25,8 @@ public class MockSpanAdapter implements SpanAdapter {
 
     private List<LogEntry> logEntries = new ArrayList<>();
     private HashMap<String, Object> tags = new HashMap<>();
+    private String traceId;
+    private String spanId;
 
     static long nowMicros() {
         return System.currentTimeMillis() * 1000;
@@ -73,9 +75,27 @@ public class MockSpanAdapter implements SpanAdapter {
         this.tags.put(key, value);
     }
 
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    public void setSpanId(String spanId) {
+        this.spanId = spanId;
+    }
+
     @Override
     public void log(Map<String, String> fields) {
         this.logEntries.add(new LogEntry(nowMicros(), fields));
+    }
+
+    @Override
+    public String traceId() {
+        return this.traceId;
+    }
+
+    @Override
+    public String spanId() {
+        return this.spanId;
     }
 
     public List<LogEntry> logEntries() {


### PR DESCRIPTION
Adds traceId and spanId string methods to SpanAdapter
Adds and removes MDC fields when activating, deactivating a span

Rebased version of #4914 