### PR TITLE
[CAMEL-16795] Fix read-lock behavior

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
@@ -87,8 +87,8 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
             LOG.trace("Previous length: {}, new length: {}", length, newLength);
             LOG.trace("New older than threshold: {}", newOlderThan);
 
-            if (newLength >= minLength && minAge == 0 && newLastModified == lastModified && newLength == length
-                    || minAge != 0 && newLastModified < newOlderThan) {
+            if (newLength >= minLength && ((minAge == 0 && newLastModified == lastModified && newLength == length)
+                    || (minAge != 0 && newLastModified < newOlderThan))) {
                 LOG.trace("Read lock acquired.");
                 exclusive = true;
             } else {


### PR DESCRIPTION
This reverts parts of the commit [1] which broke the read-lock behavior for files.

[1] https://github.com/apache/camel/commit/c5bbbd5b58569fbbd00d2936223f4d52ed23f78d