### PR TITLE
camel-websocket: safe extension of endpoint

### DIFF
--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
@@ -284,48 +284,7 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
-        SSLContextParameters sslContextParameters
-                = resolveAndRemoveReferenceParameter(parameters, "sslContextParameters", SSLContextParameters.class);
-
-        Boolean enableJmx = getAndRemoveParameter(parameters, "enableJmx", Boolean.class);
-        String staticResources = getAndRemoveParameter(parameters, "staticResources", String.class);
-        int port = extractPortNumber(remaining);
-        String host = extractHostName(remaining);
-
-        WebsocketEndpoint endpoint = new WebsocketEndpoint(this, uri, remaining, parameters);
-
-        if (enableJmx != null) {
-            endpoint.setEnableJmx(enableJmx);
-        } else {
-            endpoint.setEnableJmx(isEnableJmx());
-        }
-
-        // prefer to use endpoint configured over component configured
-        if (sslContextParameters == null) {
-            // fallback to component configured
-            sslContextParameters = getSslContextParameters();
-        }
-        if (sslContextParameters == null) {
-            sslContextParameters = retrieveGlobalSslContextParameters();
-        }
-
-        // prefer to use endpoint configured over component configured
-        if (staticResources == null) {
-            // fallback to component configured
-            staticResources = getStaticResources();
-        }
-
-        if (staticResources != null) {
-            endpoint.setStaticResources(staticResources);
-        }
-
-        endpoint.setSslContextParameters(sslContextParameters);
-        endpoint.setPort(port);
-        endpoint.setHost(host);
-        endpoint.setSubprotocol(subprotocol);
-
-        setProperties(endpoint, parameters);
-        return endpoint;
+        return new WebsocketEndpoint(this, uri, remaining, parameters);
     }
 
     protected void setWebSocketComponentServletInitialParameter(ServletContextHandler context, WebsocketEndpoint endpoint) {
@@ -569,27 +528,6 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
             return remaining.substring(index, remaining.length());
         } else {
             return "/" + remaining;
-        }
-    }
-
-    private int extractPortNumber(String remaining) {
-        int index1 = remaining.indexOf(':');
-        int index2 = remaining.indexOf('/');
-
-        if (index1 != -1 && index2 != -1) {
-            String result = remaining.substring(index1 + 1, index2);
-            return Integer.parseInt(result);
-        } else {
-            return port;
-        }
-    }
-
-    private String extractHostName(String remaining) {
-        int index = remaining.indexOf(':');
-        if (index != -1) {
-            return remaining.substring(0, index);
-        } else {
-            return host;
         }
     }
 

--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
@@ -292,7 +292,7 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
         int port = extractPortNumber(remaining);
         String host = extractHostName(remaining);
 
-        WebsocketEndpoint endpoint = new WebsocketEndpoint(this, uri, remaining, parameters);
+        WebsocketEndpoint endpoint = newEndpoint(uri, remaining, parameters);
 
         if (enableJmx != null) {
             endpoint.setEnableJmx(enableJmx);
@@ -326,6 +326,10 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
 
         setProperties(endpoint, parameters);
         return endpoint;
+    }
+
+    protected WebsocketEndpoint newEndpoint(String uri, String remaining, Map<String, Object> parameters) {
+        return new WebsocketEndpoint(this, uri, remaining, parameters);
     }
 
     protected void setWebSocketComponentServletInitialParameter(ServletContextHandler context, WebsocketEndpoint endpoint) {

--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketComponent.java
@@ -284,7 +284,48 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
-        return new WebsocketEndpoint(this, uri, remaining, parameters);
+        SSLContextParameters sslContextParameters
+                = resolveAndRemoveReferenceParameter(parameters, "sslContextParameters", SSLContextParameters.class);
+
+        Boolean enableJmx = getAndRemoveParameter(parameters, "enableJmx", Boolean.class);
+        String staticResources = getAndRemoveParameter(parameters, "staticResources", String.class);
+        int port = extractPortNumber(remaining);
+        String host = extractHostName(remaining);
+
+        WebsocketEndpoint endpoint = new WebsocketEndpoint(this, uri, remaining, parameters);
+
+        if (enableJmx != null) {
+            endpoint.setEnableJmx(enableJmx);
+        } else {
+            endpoint.setEnableJmx(isEnableJmx());
+        }
+
+        // prefer to use endpoint configured over component configured
+        if (sslContextParameters == null) {
+            // fallback to component configured
+            sslContextParameters = getSslContextParameters();
+        }
+        if (sslContextParameters == null) {
+            sslContextParameters = retrieveGlobalSslContextParameters();
+        }
+
+        // prefer to use endpoint configured over component configured
+        if (staticResources == null) {
+            // fallback to component configured
+            staticResources = getStaticResources();
+        }
+
+        if (staticResources != null) {
+            endpoint.setStaticResources(staticResources);
+        }
+
+        endpoint.setSslContextParameters(sslContextParameters);
+        endpoint.setPort(port);
+        endpoint.setHost(host);
+        endpoint.setSubprotocol(subprotocol);
+
+        setProperties(endpoint, parameters);
+        return endpoint;
     }
 
     protected void setWebSocketComponentServletInitialParameter(ServletContextHandler context, WebsocketEndpoint endpoint) {
@@ -528,6 +569,27 @@ public class WebsocketComponent extends DefaultComponent implements SSLContextPa
             return remaining.substring(index, remaining.length());
         } else {
             return "/" + remaining;
+        }
+    }
+
+    private int extractPortNumber(String remaining) {
+        int index1 = remaining.indexOf(':');
+        int index2 = remaining.indexOf('/');
+
+        if (index1 != -1 && index2 != -1) {
+            String result = remaining.substring(index1 + 1, index2);
+            return Integer.parseInt(result);
+        } else {
+            return port;
+        }
+    }
+
+    private String extractHostName(String remaining) {
+        int index = remaining.indexOf(':');
+        if (index != -1) {
+            return remaining.substring(0, index);
+        } else {
+            return host;
         }
     }
 

--- a/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketEndpoint.java
+++ b/components/camel-websocket/src/main/java/org/apache/camel/component/websocket/WebsocketEndpoint.java
@@ -93,66 +93,6 @@ public class WebsocketEndpoint extends DefaultEndpoint {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-
-        SSLContextParameters sslContextParameters
-                = component.resolveAndRemoveReferenceParameter(parameters, "sslContextParameters", SSLContextParameters.class);
-
-        Boolean enableJmx = component.getAndRemoveParameter(parameters, "enableJmx", Boolean.class);
-        String staticResources = component.getAndRemoveParameter(parameters, "staticResources", String.class);
-        int port = extractPortNumber(resourceUri);
-        String host = extractHostName(resourceUri);
-
-        if (enableJmx != null) {
-            setEnableJmx(enableJmx);
-        } else {
-            setEnableJmx(component.isEnableJmx());
-        }
-
-        // prefer to use endpoint configured over component configured
-        if (sslContextParameters == null) {
-            // fallback to component configured
-            sslContextParameters = component.getSslContextParameters();
-        }
-        if (sslContextParameters == null) {
-            sslContextParameters = component.retrieveGlobalSslContextParameters();
-        }
-
-        // prefer to use endpoint configured over component configured
-        if (staticResources == null) {
-            // fallback to component configured
-            staticResources = component.getStaticResources();
-        }
-        if (staticResources != null) {
-            setStaticResources(staticResources);
-        }
-
-        setSslContextParameters(sslContextParameters);
-        setPort(port);
-        setHost(host);
-        setSubprotocol(component.getSubprotocol());
-
-        configureProperties(parameters);
-    }
-
-    private int extractPortNumber(String remaining) {
-        int index1 = remaining.indexOf(':');
-        int index2 = remaining.indexOf('/');
-
-        if (index1 != -1 && index2 != -1) {
-            String result = remaining.substring(index1 + 1, index2);
-            return Integer.parseInt(result);
-        } else {
-            return component.getPort();
-        }
-    }
-
-    private String extractHostName(String remaining) {
-        int index = remaining.indexOf(':');
-        if (index != -1) {
-            return remaining.substring(0, index);
-        } else {
-            return component.getHost();
-        }
     }
 
     @Override


### PR DESCRIPTION
Moving the endpoint initialization code from the component into the endpoint constructor makes it considerably easier to extend WebsocketEndpoint with your own customized endpoint.