### PR TITLE
https://issues.apache.org/jira/browse/CAMEL-16807 : Fixed a problem w…

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -343,6 +343,7 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
     public KafkaConfiguration copy() {
         try {
             KafkaConfiguration copy = (KafkaConfiguration) clone();
+            copy.additionalProperties = new HashMap<>(this.additionalProperties);
             return copy;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeCamelException(e);


### PR DESCRIPTION
…ith KafkaConfiguration:copy()

OK so I'm not sure if this is the right thing.  Please review the JIRA issue for more details.  I've made a change based on what I think the semantics of `copy()` should be.  I don't know enough about Kafka or Kafka-camel to know if this is right.

But ultimately the issue is that the `additionalProperties` map is not cloned (the default impl. of Java's `clone()` only does a shallow copy).  So as a result a call to `copy()` will create a second instance of `KafkaConfiguration` that shares the same `HashMap` for the `additionalProperties` field.

Making a copy of that field seems like the solution.

My concern is over the fact that the config is copied when creating a second connector at all - I would have expected a new empty configuration to be used rather than a clone of an existing one (in the use case documented in the Jira).