### PR TITLE
Fix message router example description

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
@@ -16,7 +16,7 @@ on the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] e
 == Examples
 
 The following example shows how to route a request from an input
-*seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
+*direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
 the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
 
 [source,java]


### PR DESCRIPTION
Fix message router example description so that it refers to the same endpoint as the example's code