### PR TITLE
CAMEL-16832: camel-kafka - file descriptor leak

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -535,7 +535,7 @@ public class KafkaConsumer extends DefaultConsumer {
                 }
             } finally {
                 // only close if not retry or re-connecting
-                if (!retry.get() && !reconnect.get()) {
+                if (!retry.get()) {
                     LOG.debug("Closing consumer {}", threadId);
                     IOHelper.close(consumer);
                 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -534,7 +534,7 @@ public class KafkaConsumer extends DefaultConsumer {
                     }
                 }
             } finally {
-                // only close if not retry or re-connecting
+                // only close if not retry
                 if (!retry.get()) {
                     LOG.debug("Closing consumer {}", threadId);
                     IOHelper.close(consumer);


### PR DESCRIPTION
closing the consumer in case of reconnect. the consumer is re-instantiated in the following doInit() and the "old" consumer needs to be closed to release file descriptor resources.