### PR TITLE
CAMEL-16832: camel-kafka - file descriptor leak contd.

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -240,6 +240,8 @@ public class KafkaConsumer extends DefaultConsumer {
                 first = false;
 
                 if (!isRunAllowed() || isStoppingOrStopped() || isSuspendingOrSuspended()) {
+                    LOG.debug("Closing consumer {}", threadId);
+                    IOHelper.close(consumer);
                     return;
                 }
 
@@ -277,6 +279,8 @@ public class KafkaConsumer extends DefaultConsumer {
                 doReconnectRun();
                 // set reconnect to false as its done now
                 reconnect.set(false);
+                // set retry to true to continue polling
+                retry.set(true);
             }
             // polling
             doPollRun(retry, reconnect);
@@ -502,6 +506,7 @@ public class KafkaConsumer extends DefaultConsumer {
                         }
                         // re-connect so the consumer can try the same message again
                         reconnect.set(true);
+                        retry.set(false); // to close the current consumer
                     } else if (PollOnError.ERROR_HANDLER == onError) {
                         // use bridge error handler to route with exception
                         bridge.handleException(e);


### PR DESCRIPTION
Both retry & reconnect states need to be set carefully. Prior this change, retry=true is always true (unless PollOnError is set to STOP) and this retry state still avoids that the consumer is closed in the finally block. I temporarily set it to false in the RECONNECT case (so the consumer is closed) and reset it later to continue polling. Probably better to merge those states into a single enum (potential future improvement).
Also I recognized that the consumer may leak if the service is being stopped, while not being in the poll routine (i.e. while retrying/reconnecting/sleeping).

Best regards
Jens
