### PR TITLE
CAMEL-16184: marked juint 4 tests as deprecated and updated pom.xml file

### DIFF
--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/AvailablePortFinderTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/AvailablePortFinderTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AvailablePortFinderTest {
 
+    @Deprecated
     @Test
     public void testNotAvailableTcpPort() throws Exception {
         int p1 = AvailablePortFinder.getNextAvailable();
@@ -39,6 +40,7 @@ public class AvailablePortFinderTest {
         socket.close();
     }
 
+    @Deprecated
     @Test
     public void testNotAvailableUdpPort() throws Exception {
         int p1 = AvailablePortFinder.getNextAvailable();
@@ -48,6 +50,7 @@ public class AvailablePortFinderTest {
         socket.close();
     }
 
+    @Deprecated
     @Test
     public void testNotAvailableMulticastPort() throws Exception {
         int p1 = AvailablePortFinder.getNextAvailable();
@@ -59,6 +62,7 @@ public class AvailablePortFinderTest {
         socket.close();
     }
 
+    @Deprecated
     @Test
     public void testPortRange() throws Exception {
         int p1 = AvailablePortFinder.getNextAvailable(49152, 65535);
@@ -69,6 +73,7 @@ public class AvailablePortFinderTest {
         socket2.close();
     }
 
+    @Deprecated
     @Test
     public void testAvailablePortFinderPropertiesFunction() throws Exception {
         AvailablePortFinderPropertiesFunction function = new AvailablePortFinderPropertiesFunction();
@@ -78,6 +83,7 @@ public class AvailablePortFinderTest {
         assertThat(function.apply(null)).isNull();
     }
 
+    @Deprecated
     @Test
     public void testAvailablePortFinderPropertiesFunctionWithRange() throws Exception {
         // range

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/CamelTestSupportTest.java
@@ -32,6 +32,7 @@ public class CamelTestSupportTest extends CamelTestSupport {
         super.setUp();
     }
 
+    @Deprecated
     @Test
     public void replacesFromEndpoint() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");
@@ -41,16 +42,19 @@ public class CamelTestSupportTest extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Test(expected = NoSuchEndpointException.class)
     public void exceptionThrownWhenEndpointNotFoundAndNoCreate() {
         getMockEndpoint("mock:bogus", false);
     }
 
+    @Deprecated
     @Test(expected = NoSuchEndpointException.class)
     public void exceptionThrownWhenEndpointNotAMockEndpoint() {
         getMockEndpoint("direct:something", false);
     }
 
+    @Deprecated
     @Test
     public void autoCreateNoneExisting() {
         MockEndpoint mock = getMockEndpoint("mock:bogus2", true);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternExcludeTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternExcludeTest.java
@@ -27,6 +27,7 @@ public class RouteFilterPatternExcludeTest extends CamelTestSupport {
         return "bar*";
     }
 
+    @Deprecated
     @Test
     public void testRouteFilter() throws Exception {
         assertEquals(1, context.getRoutes().size());

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternIncludeExcludeTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternIncludeExcludeTest.java
@@ -32,6 +32,7 @@ public class RouteFilterPatternIncludeExcludeTest extends CamelTestSupport {
         return "jms:*";
     }
 
+    @Deprecated
     @Test
     public void testRouteFilter() throws Exception {
         assertEquals(1, context.getRoutes().size());

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternIncludeTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/RouteFilterPatternIncludeTest.java
@@ -27,6 +27,7 @@ public class RouteFilterPatternIncludeTest extends CamelTestSupport {
         return "foo*";
     }
 
+    @Deprecated
     @Test
     public void testRouteFilter() throws Exception {
         assertEquals(1, context.getRoutes().size());
@@ -40,6 +41,7 @@ public class RouteFilterPatternIncludeTest extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AdviceWithLambdaTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AdviceWithLambdaTest.java
@@ -29,6 +29,7 @@ public class AdviceWithLambdaTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testAdviceWith() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AdviceWithNotStartedTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AdviceWithNotStartedTest.java
@@ -33,6 +33,7 @@ public class AdviceWithNotStartedTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testNotStarted() throws Exception {
         AdviceWith.adviceWith(context.getRouteDefinition("foo"), context, new AdviceWithRouteBuilder() {

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AsyncSendMockTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/AsyncSendMockTest.java
@@ -30,6 +30,7 @@ public class AsyncSendMockTest extends CamelTestSupport {
         return "seda*";
     }
 
+    @Deprecated
     @Test
     public void testmakeAsyncApiCall() {
         try {

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestFalseTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestFalseTest.java
@@ -62,6 +62,7 @@ public class CreateCamelContextPerTestFalseTest extends CamelTestSupport {
         super.doPostTearDown();
     }
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -75,6 +76,7 @@ public class CreateCamelContextPerTestFalseTest extends CamelTestSupport {
         assertTrue("Should create 1 or more CamelContext per test class", CREATED_CONTEXTS.get() >= 1);
     }
 
+    @Deprecated
     @Test
     public void testSendAnotherMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -88,6 +90,7 @@ public class CreateCamelContextPerTestFalseTest extends CamelTestSupport {
         assertTrue("Should create 1 or more CamelContext per test class", CREATED_CONTEXTS.get() >= 1);
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         resultEndpoint.expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestTrueTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/CreateCamelContextPerTestTrueTest.java
@@ -67,6 +67,7 @@ public class CreateCamelContextPerTestTrueTest extends CamelTestSupport {
         LATCH.await(5, TimeUnit.SECONDS);
     }
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -81,6 +82,7 @@ public class CreateCamelContextPerTestTrueTest extends CamelTestSupport {
         assertEquals("Should not call postTearDown yet", 0, POST_TEAR_DOWN.get());
     }
 
+    @Deprecated
     @Test
     public void testSendAnotherMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -95,6 +97,7 @@ public class CreateCamelContextPerTestTrueTest extends CamelTestSupport {
         assertEquals("Should not call postTearDown yet", 0, POST_TEAR_DOWN.get());
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         resultEndpoint.expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugJUnit4Test.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugJUnit4Test.java
@@ -42,6 +42,7 @@ public class DebugJUnit4Test extends CamelTestSupport {
     }
     // END SNIPPET: e1
 
+    @Deprecated
     @Test
     public void testDebugger() throws Exception {
         // set mock expectations
@@ -55,6 +56,7 @@ public class DebugJUnit4Test extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testTwo() throws Exception {
         // set mock expectations

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugNoLazyTypeConverterTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugNoLazyTypeConverterTest.java
@@ -47,6 +47,7 @@ public class DebugNoLazyTypeConverterTest extends CamelTestSupport {
     }
     // END SNIPPET: e1
 
+    @Deprecated
     @Test
     public void testDebugger() throws Exception {
         // set mock expectations
@@ -60,6 +61,7 @@ public class DebugNoLazyTypeConverterTest extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testTwo() throws Exception {
         // set mock expectations

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/DebugTest.java
@@ -42,6 +42,7 @@ public class DebugTest extends CamelTestSupport {
     }
     // END SNIPPET: e1
 
+    @Deprecated
     @Test
     public void testDebugger() throws Exception {
         // set mock expectations
@@ -55,6 +56,7 @@ public class DebugTest extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testTwo() throws Exception {
         // set mock expectations

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterCreateCamelContextPerClassTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterCreateCamelContextPerClassTest.java
@@ -34,6 +34,7 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -45,6 +46,7 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
         assertMockEndpointsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterFluentTemplateTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterFluentTemplateTest.java
@@ -42,6 +42,7 @@ public class FilterFluentTemplateTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -53,6 +54,7 @@ public class FilterFluentTemplateTest extends CamelTestSupport {
         resultEndpoint.assertIsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         resultEndpoint.expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterJUnit4Test.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterJUnit4Test.java
@@ -36,6 +36,7 @@ public class FilterJUnit4Test extends CamelTestSupport {
     @Produce("direct:start")
     protected ProducerTemplate template;
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -47,6 +48,7 @@ public class FilterJUnit4Test extends CamelTestSupport {
         resultEndpoint.assertIsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         resultEndpoint.expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/FilterTest.java
@@ -42,6 +42,7 @@ public class FilterTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testSendMatchingMessage() throws Exception {
         String expectedBody = "<matched/>";
@@ -53,6 +54,7 @@ public class FilterTest extends CamelTestSupport {
         resultEndpoint.assertIsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void testSendNotMatchingMessage() throws Exception {
         resultEndpoint.expectedMessageCount(0);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/GetMockEndpointTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/GetMockEndpointTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 public class GetMockEndpointTest extends CamelTestSupport {
 
+    @Deprecated
     @Test
     public void testMock() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsAndSkipJUnit4Test.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsAndSkipJUnit4Test.java
@@ -32,6 +32,7 @@ public class IsMockEndpointsAndSkipJUnit4Test extends CamelTestSupport {
         return "direct:foo";
     }
 
+    @Deprecated
     @Test
     public void testMockEndpointAndSkip() throws Exception {
         // notice we have automatic mocked the direct:foo endpoints and the name of the endpoints is "mock:uri"

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsFileTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsFileTest.java
@@ -39,6 +39,7 @@ public class IsMockEndpointsFileTest extends CamelTestSupport {
         return "file:target*";
     }
 
+    @Deprecated
     @Test
     public void testMockFileEndpoints() throws Exception {
         // notice we have automatic mocked all endpoints and the name of the endpoints is "mock:uri"

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsJUnit4Test.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsJUnit4Test.java
@@ -31,6 +31,7 @@ public class IsMockEndpointsJUnit4Test extends CamelTestSupport {
         return "*";
     }
 
+    @Deprecated
     @Test
     public void testMockAllEndpoints() throws Exception {
         // notice we have automatic mocked all endpoints and the name of the endpoints is "mock:uri"

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/IsMockEndpointsTest.java
@@ -27,6 +27,7 @@ public class IsMockEndpointsTest extends CamelTestSupport {
         return "*";
     }
 
+    @Deprecated
     @Test
     public void testMockAllEndpoints() throws Exception {
         getMockEndpoint("mock:direct:start").expectedBodiesReceived("Hello World");

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/MockEndpointFailNoHeaderTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/MockEndpointFailNoHeaderTest.java
@@ -37,6 +37,7 @@ public class MockEndpointFailNoHeaderTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void withHeaderTestCase() throws InterruptedException {
         String expectedBody = "<matched/>";
@@ -45,6 +46,7 @@ public class MockEndpointFailNoHeaderTest extends CamelTestSupport {
         resultEndpoint.assertIsSatisfied();
     }
 
+    @Deprecated
     @Test
     public void noHeaderTestCase() throws InterruptedException {
         resultEndpoint.expectedHeaderReceived("foo", "bar");

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/ProduceBeanTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/ProduceBeanTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
  */
 public class ProduceBeanTest extends CamelTestSupport {
 
+    @Deprecated
     @Test
     public void testProduceBean() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/RouteBuilderConfigureExceptionTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/RouteBuilderConfigureExceptionTest.java
@@ -37,6 +37,7 @@ public class RouteBuilderConfigureExceptionTest extends CamelTestSupport {
         }
     }
 
+    @Deprecated
     @Test
     public void testFoo() throws Exception {
     }

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/RouteProcessorDumpRouteCoverageTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/RouteProcessorDumpRouteCoverageTest.java
@@ -29,6 +29,7 @@ public class RouteProcessorDumpRouteCoverageTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testProcessor() throws Exception {
         String out = template.requestBody("direct:start", "Hello World", String.class);

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleMockEndpointsTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleMockEndpointsTest.java
@@ -28,6 +28,7 @@ public class SimpleMockEndpointsTest extends CamelTestSupport {
         return "seda:queue";
     }
 
+    @Deprecated
     @Test
     public void testMockAndSkip() throws Exception {
         getMockEndpoint("mock:seda:queue").expectedBodiesReceived("Bye Camel");

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleMockTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleMockTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 public class SimpleMockTest extends CamelTestSupport {
 
+    @Deprecated
     @Test
     public void testMock() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleNotifyBuilderTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleNotifyBuilderTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 public class SimpleNotifyBuilderTest extends CamelTestSupport {
 
+    @Deprecated
     @Test
     public void testNotifyBuilder() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context)

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleWeaveAddMockLastTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/SimpleWeaveAddMockLastTest.java
@@ -30,6 +30,7 @@ public class SimpleWeaveAddMockLastTest extends CamelTestSupport {
         return true;
     }
 
+    @Deprecated
     @Test
     public void testWeaveAddMockLast() throws Exception {
         AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {

--- a/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/UseOverridePropertiesWithPropertiesComponentTest.java
+++ b/components/camel-test/camel-test/src/test/java/org/apache/camel/test/patterns/UseOverridePropertiesWithPropertiesComponentTest.java
@@ -55,6 +55,7 @@ public class UseOverridePropertiesWithPropertiesComponentTest extends CamelTestS
         return pc;
     }
 
+    @Deprecated
     @Test
     public void testOverride() throws Exception {
         context.start();


### PR DESCRIPTION
CAMEL-16184: marked juint 4 tests as deprecated and updated pom.xml file.

https://issues.apache.org/jira/browse/CAMEL-16184
