### PR TITLE
CAMEL-16874: fix bug with sendEmptyMessages and pollEnrich

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFilePollingConsumer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFilePollingConsumer.java
@@ -146,6 +146,8 @@ public class GenericFilePollingConsumer extends EventDrivenPollingConsumer {
                         if (polledMessages == 0 && sendEmptyMessageWhenIdle) {
                             // send an "empty" exchange
                             processEmptyMessage();
+                            // set polledMessages=1 since the empty message is queued
+                            polledMessages = 1;
                         } else if (polledMessages == 0 && timeout > 0) {
                             // if we did not poll a file and we are using
                             // timeout then try to poll again

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileIdleEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileIdleEventTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+public class FileConsumePollEnrichFileIdleEventTest extends ContextTestSupport {
+
+    @Test
+    public void testPollEnrich() throws Exception {
+        //        getMockEndpoint("mock:start").expectedBodiesReceived("Event1");
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        //        mock.expectedMinimumMessageCount(2);
+        mock.expectedBodiesReceived("Event1", "EnrichData");
+
+        mock.expectedFileExists(testFile("enrich/.done/Event1.txt"));
+        mock.expectedFileExists(testFile("enrich/.done/Event2.txt"));
+        mock.expectedFileExists(testFile("enrichdata/.done/AAA.dat"));
+
+        template.sendBodyAndHeader(fileUri("enrich"), "Event1", Exchange.FILE_NAME,
+                "Event1.txt");
+
+        log.info("Sleeping for 1 sec before writing enrichdata file");
+        Thread.sleep(1000);
+        template.sendBodyAndHeader(fileUri("enrichdata"), "EnrichData",
+                Exchange.FILE_NAME, "AAA.dat");
+        // Trigger second event
+        //        Thread.sleep(1000);
+        template.sendBodyAndHeader(fileUri("enrich"), "Event2", Exchange.FILE_NAME,
+                "Event2.txt");
+        log.info("... write done");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testPollEmptyEnrich() throws Exception {
+        //        getMockEndpoint("mock:start").expectedBodiesReceived("Event1");
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedBodiesReceived("Event1");
+
+        mock.expectedFileExists(testFile("enrich/.done/Event1.txt"));
+
+        template.sendBodyAndHeader(fileUri("enrich"), "Event1", Exchange.FILE_NAME,
+                "Event1.txt");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(fileUri("enrich?initialDelay=0&delay=10&move=.done"))
+                        .to("mock:start")
+                        .pollEnrich(
+                                fileUri("enrichdata?initialDelay=0&delay=10&move=.done&sendEmptyMessageWhenIdle=true"), 1000)
+                        .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileIdleEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileIdleEventTest.java
@@ -25,13 +25,11 @@ import org.junit.jupiter.api.Test;
 public class FileConsumePollEnrichFileIdleEventTest extends ContextTestSupport {
 
     @Test
-    public void testPollEnrich() throws Exception {
-        //        getMockEndpoint("mock:start").expectedBodiesReceived("Event1");
+    public void testNonEmptyAfterEmpty() throws Exception {
+        getMockEndpoint("mock:start").expectedBodiesReceived("Event1", "Event2");
 
         MockEndpoint mock = getMockEndpoint("mock:result");
-        //        mock.expectedMinimumMessageCount(2);
         mock.expectedBodiesReceived("Event1", "EnrichData");
-
         mock.expectedFileExists(testFile("enrich/.done/Event1.txt"));
         mock.expectedFileExists(testFile("enrich/.done/Event2.txt"));
         mock.expectedFileExists(testFile("enrichdata/.done/AAA.dat"));
@@ -43,8 +41,7 @@ public class FileConsumePollEnrichFileIdleEventTest extends ContextTestSupport {
         Thread.sleep(1000);
         template.sendBodyAndHeader(fileUri("enrichdata"), "EnrichData",
                 Exchange.FILE_NAME, "AAA.dat");
-        // Trigger second event
-        //        Thread.sleep(1000);
+        // Trigger second event which should find the EnrichData file
         template.sendBodyAndHeader(fileUri("enrich"), "Event2", Exchange.FILE_NAME,
                 "Event2.txt");
         log.info("... write done");
@@ -54,11 +51,10 @@ public class FileConsumePollEnrichFileIdleEventTest extends ContextTestSupport {
 
     @Test
     public void testPollEmptyEnrich() throws Exception {
-        //        getMockEndpoint("mock:start").expectedBodiesReceived("Event1");
+        getMockEndpoint("mock:start").expectedBodiesReceived("Event1");
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Event1");
-
         mock.expectedFileExists(testFile("enrich/.done/Event1.txt"));
 
         template.sendBodyAndHeader(fileUri("enrich"), "Event1", Exchange.FILE_NAME,


### PR DESCRIPTION
When the  file endpoint is used with option sendEmptyMessageWhenIdle=true in pollEnrich, an empty event is queued but is never read. So on the next call, even if a real file is present, the empty event is returned. The correction forces the empty event to be consumed. I also added a unit test.