### PR TITLE
Added support for initializing Kamelet bindings from Camel JBang

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -73,7 +73,7 @@ The same behavior also works for all the other search commands. The table below 
 
 
 [[CamelJBang-Init-Kamets]]
-== Search Init
+== Init Kamelets
 
 The init sub-command can be used to simplify creating Kamelets. Through this command, it is possible to create new Kamelets through pre-configured templates. It works in two steps: first it is necessary to bootstrap the Kamelet by creating a properties file with the parameters necessary to create the Kamelet. Once the properties file is correctly set, then it is possible to create a pre-filled Kamelet by processing that properties file.
 
@@ -98,6 +98,28 @@ CamelJBang init kamelet --properties-path work/init-template.properties
 Running this command will create a new file in the `work` directory. The name of the generated file is determined by the `kameletMetadataName` property in the properties file. As such, parsing the default properties file would generate a file named `my-sample-sink.kamelet.yaml` in the directory.
 
 After the file is generated, it may still need to require final adjustments, such as correctly setting the name, the icon and other requirements for official Kamelets. Please consult the Kamelet development documentation for updated details.
+
+
+[[CamelJBang-Init-Bindings]]
+== Init Bindings
+
+The init sub-command can also be used to simplify creating Kamelets bindings. Through this command, it is possible to create new bindings through pre-configured templates. Use the  `--kamelet` option (you can list the available ones using the search command) to set the Kamelet to generate the binding for.
+
+To execute this feature run:
+
+[source,bash]
+----
+CamelJBang init binding --destination /path/to/destination/directory/ --kamelet sftp-source
+----
+
+This will create a new sample YAML binding file that can be modified and used in Camel K.
+
+You can also generate bindings that can be run by CamelJBang or Camel Core, but setting the `--project` option:
+
+[source,bash]
+----
+CamelJBang init binding --destination /path/to/destination/directory/ --kamelet sftp-source --project core
+----
 
 
 [[CamelJBang-Running]]

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -532,7 +532,54 @@ class InitKamelet extends AbstractInitKamelet implements Callable<Integer> {
             return 1;
         }
     }
+}
 
+@Command(name = "binding", description = "Provide init templates for kamelet bindings")
+class InitBinding extends AbstractInitKamelet implements Callable<Integer> {
+    @Option(names = { "-h", "--help" }, usageHelp = true, description = "Display the help and sub-commands")
+    private boolean helpRequested = false;
+
+    @Option(names = { "--base-resource-location" }, defaultValue = "github:apache", hidden = true,
+            description = "Where to download the resources from (used for development/testing)")
+    private String baseResourceLocation;
+
+    @Option(names = { "--branch" }, defaultValue = "main", hidden = true,
+            description = "The branch to use when downloading resources from (used for development/testing)")
+    private String branch;
+
+    @Option(names = { "--destination" }, defaultValue = "work",
+            description = "The destination directory where to download the files")
+    private String destination;
+
+    @Option(names = { "--kamelet" }, defaultValue = "",
+            description = "The kamelet to create a binding for")
+    private String kamelet;
+
+    @Option(names = { "--project" }, defaultValue = "camel-k",
+            description = "The project to create a binding for (either camel-k or core)")
+    private String project;
+
+    private int downloadSample() throws IOException, CamelException {
+        setBranch(branch);
+
+        String resourcePath = String.format("camel-kamelets:templates/bindings/%s/%s-binding.yaml", project, kamelet);
+
+        setResourceLocation(baseResourceLocation, resourcePath);
+
+        try {
+            resolveResource(new File(destination));
+        } catch (ResourceAlreadyExists e) {
+            System.err.println(e.getMessage());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return downloadSample();
+    }
 }
 
 @Command(name = "CamelJBang", mixinStandardHelpOptions = true, version = "CamelJBang ${camel.jbang.version}",
@@ -553,7 +600,8 @@ public class CamelJBang implements Callable<Integer> {
                         .addSubcommand("languages", new SearchLanguages())
                         .addSubcommand("others", new SearchOthers()))
                 .addSubcommand("init", new CommandLine(new Init())
-                        .addSubcommand("kamelet", new InitKamelet()));
+                        .addSubcommand("kamelet", new InitKamelet())
+                        .addSubcommand("binding", new InitBinding()));
 
         int exitCode = commandLine.execute(args);
         System.exit(exitCode);


### PR DESCRIPTION
This depends on apache/camel-kamelets#465

Basically it simplifies initializing new bindings from the CLI using Camel JBang. 

[![asciicast](https://asciinema.org/a/431329.svg)](https://asciinema.org/a/431329)

*Note*: the arguments on the screencast are slightly different, but the functionality is the same.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->