### PR TITLE
Using custom Content-Type headers with RestDSL

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
@@ -317,6 +317,13 @@ to specify a custom content-type if the message body should not attempt to be
 marshalled using the binding. For example if the message body is a
 custom binary payload etc.
 
+When automatic binding from POJO to JSon/JAXB takes place the existing `content-type` header will by default be replaced with either `application/json` or `application/xml`. To disable the default behavior and be able to produce JSon/JAXB responses with custom `content-type` headers (e.g. `application/user.v2+json`) you configure this in Java DSL as shown below:
+
+[source,java]
+----
+restConfiguration().dataFormatProperty("contentTypeHeader", "false");
+----
+
 To use binding you must include the necessary data formats on the
 classpath, such as `camel-jaxb` and/or `camel-jackson`. And then enable
 the binding mode. You can configure the binding mode globally on the


### PR DESCRIPTION
Added information about how to allow custom XML/JSon Content-Type headers when automatic binding from POJO to JSon/JAXB takes place.

Changes to documentation based on discussion in the following thread:
https://lists.apache.org/thread.html/r5e82fecd501a3b5ed25844fded1124bf2f3d48a8fdb97556dd5d0f70%40%3Cusers.camel.apache.org%3E

Not sure if the information is placed at the best position in the documentation but I couldn't figure out a better place.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
