### PR TITLE
Set pulsar redelivery count in exchange headers

### DIFF
--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageHeaders.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageHeaders.java
@@ -31,4 +31,5 @@ public interface PulsarMessageHeaders {
     String KEY_OUT = "CamelPulsarProducerMessageKey";
     String PROPERTIES_OUT = "CamelPulsarProducerMessageProperties";
     String EVENT_TIME_OUT = "CamelPulsarProducerMessageEventTime";
+    String PULSAR_REDELIVERY_COUNT = "pulsar_redelivery_count";
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageHeaders.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageHeaders.java
@@ -31,5 +31,5 @@ public interface PulsarMessageHeaders {
     String KEY_OUT = "CamelPulsarProducerMessageKey";
     String PROPERTIES_OUT = "CamelPulsarProducerMessageProperties";
     String EVENT_TIME_OUT = "CamelPulsarProducerMessageEventTime";
-    String PULSAR_REDELIVERY_COUNT = "pulsar_redelivery_count";
+    String PULSAR_REDELIVERY_COUNT = "CamelPulsarRedeliveryCount";
 }

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageUtils.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/utils/message/PulsarMessageUtils.java
@@ -32,6 +32,7 @@ import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeade
 import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.PRODUCER_NAME;
 import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.PROPERTIES;
 import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.PUBLISH_TIME;
+import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.PULSAR_REDELIVERY_COUNT;
 import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.SEQUENCE_ID;
 import static org.apache.camel.component.pulsar.utils.message.PulsarMessageHeaders.TOPIC_NAME;
 
@@ -53,6 +54,7 @@ public final class PulsarMessageUtils {
         msg.setHeader(TOPIC_NAME, message.getTopicName());
         msg.setHeader(SEQUENCE_ID, message.getSequenceId());
         msg.setHeader(PUBLISH_TIME, message.getPublishTime());
+        msg.setHeader(PULSAR_REDELIVERY_COUNT, message.getRedeliveryCount());
         msg.setHeader(PROPERTIES, message.getProperties());
         msg.setHeader(Exchange.MESSAGE_TIMESTAMP, message.getPublishTime());
 


### PR DESCRIPTION
<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

Pulsar tracks message redelivery to its consumers as a property on their `Message`. It would be helpful to know about the redelivery count in Camel. This adds a new `PulsarMessageHeader` to track the Pulsar redelivery count. This is a separate redelivery than the redelivery that Camel itself would handle and thus is a different property than the `Excange.REDELIVERY_COUNTER` property