### PR TITLE
(trivial) camel-jt400: add message severity and message object

### DIFF
--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -228,13 +228,15 @@ The following headers are potentially available. If the values could not
 be determined, the headers will not be set
 [width="100%",cols="2m,2m,1m,5",options="header"]
 |===
-| Header constant                          | Header value                      | Type    | Description
-| Jt400Constants.MESSAGE_ID                | "CamelJt400MessageID"             | String  | The message identifier
-| Jt400Constants.MESSAGE_FILE              | "CamelJt400MessageFile"           | String  | The message file name
-| Jt400Constants.MESSAGE_TYPE              | "CamelJt400MessageType"           | Integer | The message type (corresponds to constants defined in the AS400Message class)
-| Jt400Constants.MESSAGE_DFT_RPY           | "CamelJt400MessageDefaultReply"   | String  | The default message reply, when the message is an inquiry message
-| Jt400Constants.MESSAGE_REPLYTO_KEY       | "CamelJt400MessageReplyToKey"     | byte[]  | The key of the message that will be replied to (if the `sendingReply` parameter is set to `true`)
-| Jt400Constants.SENDER_INFORMATION        | "SENDER_INFORMATION"              | String  | The job identifier of the sending job
+| Header constant                          | Header value                      | Type           | Description
+| Jt400Constants.MESSAGE                   | "CamelJt400Message"               | QueuedMessage  | The message received
+| Jt400Constants.MESSAGE_ID                | "CamelJt400MessageID"             | String         | The message identifier
+| Jt400Constants.MESSAGE_FILE              | "CamelJt400MessageFile"           | String         | The message file name
+| Jt400Constants.MESSAGE_TYPE              | "CamelJt400MessageType"           | Integer        | The message type (corresponds to constants defined in the AS400Message class)
+| Jt400Constants.MESSAGE_SEVERITY          | "CamelJt400MessageSeverity"       | Integer        | The message severity (Valid values are between 0 and 99, or -1 if it is not set)
+| Jt400Constants.MESSAGE_DFT_RPY           | "CamelJt400MessageDefaultReply"   | String         | The default message reply, when the message is an inquiry message
+| Jt400Constants.MESSAGE_REPLYTO_KEY       | "CamelJt400MessageReplyToKey"     | byte[]         | The key of the message that will be replied to (if the `sendingReply` parameter is set to `true`)
+| Jt400Constants.SENDER_INFORMATION        | "SENDER_INFORMATION"              | String         | The job identifier of the sending job
 |===
 
 === Producer headers when sending to message queues

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Constants.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Constants.java
@@ -25,9 +25,11 @@ public interface Jt400Constants {
     public static final String KEY = "KEY";
 
     // Used only for message queue support
+    public static final String MESSAGE = "CamelJt400Message";
     public static final String MESSAGE_ID = "CamelJt400MessageID";
     public static final String MESSAGE_FILE = "CamelJt400MessageFile";
     public static final String MESSAGE_TYPE = "CamelJt400MessageType";
+    public static final String MESSAGE_SEVERITY = "CamelJt400MessageSeverity";
     public static final String MESSAGE_DFT_RPY = "CamelJt400MessageDefaultReply";
     public static final String MESSAGE_REPLYTO_KEY = "CamelJt400MessageReplyToKey";
 

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400MsgQueueConsumer.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400MsgQueueConsumer.java
@@ -128,6 +128,8 @@ public class Jt400MsgQueueConsumer extends ScheduledPollConsumer {
         setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE_ID, entry.getID());
         setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE_FILE, entry.getFileName());
         setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE_TYPE, entry.getType());
+        setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE_SEVERITY, entry.getSeverity());
+        setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE, entry);
         if (AS400Message.INQUIRY == entry.getType()) {
             setHeaderIfValueNotNull(exchange.getIn(), Jt400Constants.MESSAGE_DFT_RPY, entry.getDefaultReply());
             if (getEndpoint().isSendingReply()) {


### PR DESCRIPTION
Added some more enhancements to the message queue receiving capability of the JT400 component:
 - Added message severity to the headers, as that has been a commonly-requested filter criteria
- Added the `QueuedMessage` object to the headers, so if a processor wants to do more involved operations, like loading the message from the message file to retrieve help text, that option is available
