### PR TITLE
fix(dataformat): conversion to ByteBuffer 

### DIFF
--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jackson.converter;
 import java.io.File;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 
@@ -107,6 +108,9 @@ public final class JacksonTypeConverters {
             } else if (byte[].class.isAssignableFrom(type)) {
                 byte[] out = mapper.writeValueAsBytes(value);
                 return type.cast(out);
+            } else if (ByteBuffer.class.isAssignableFrom(type)) {
+                byte[] out = mapper.writeValueAsBytes(value);
+                return type.cast(ByteBuffer.wrap(out));
             } else if (mapper.canSerialize(type) && !Enum.class.isAssignableFrom(type)) {
                 // if the source value type is readable by the mapper then use
                 // its read operation

--- a/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/converter/JacksonConversionsBufferTest.java
+++ b/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/converter/JacksonConversionsBufferTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson.converter;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jackson.JacksonConstants;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JacksonConversionsBufferTest extends CamelTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        // enable jackson type converter by setting this property on
+        // CamelContext
+        context.getGlobalOptions().put(JacksonConstants.ENABLE_TYPE_CONVERTER, "true");
+        return context;
+    }
+
+    @Test
+    public void shouldConvertMapToByteBuffer() {
+        String name = "someName";
+        Map<String, String> pojoAsMap = new HashMap<>();
+        pojoAsMap.put("name", name);
+
+        ByteBuffer testByteBuffer = (ByteBuffer) template.requestBody("direct:test", pojoAsMap);
+
+        assertEquals("{\"name\":\"someName\"}", StandardCharsets.UTF_8.decode(testByteBuffer).toString());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:test").convertBodyTo(ByteBuffer.class);
+            }
+        };
+    }
+
+}

--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
@@ -180,7 +180,7 @@ public final class VertxPlatformHttpSupport {
             response.end((Buffer) body);
         } else {
             final TypeConverter tc = camelExchange.getContext().getTypeConverter();
-            final ByteBuffer bb = tc.mandatoryConvertTo(ByteBuffer.class, body);
+            final ByteBuffer bb = tc.mandatoryConvertTo(ByteBuffer.class, camelExchange, body);
             final Buffer b = Buffer.buffer(bb.capacity());
 
             b.setBytes(0, bb);


### PR DESCRIPTION
With this PR we're fixing the problem described in [CAMEL-16906](https://issues.apache.org/jira/browse/CAMEL-16906) and we'll be able to use `jackson` dataformat unmarshal with `platform-http`. If we're happy with the approach, the solution will have to be replicated to all dataformats, as, each of them know how to convert the body `Map` (or the object that is used by the marshal process) into the `ByteBuffer` as expected by the `platform-http`.

I've tried to look for a generic solution directly on the platform-http component to minimize the impact, but I doubt there is a way to know beforehand how all the dataformats will work (unless we assume they always unmarshal the body to a `Map`).

Ref [CAMEL-16906](https://issues.apache.org/jira/browse/CAMEL-16906)

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
