### PR TITLE
CAMEL-16905: remove obsolete code from MockEndpoint

### DIFF
--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
@@ -802,15 +802,7 @@ public class MockEndpoint extends DefaultEndpoint implements BrowsableEndpoint, 
             return null;
         }
 
-        if (actualValue instanceof Expression) {
-            Class<?> clazz = Object.class;
-            if (expectedValue != null) {
-                clazz = expectedValue.getClass();
-            }
-            actualValue = ((Expression) actualValue).evaluate(exchange, clazz);
-        } else if (actualValue instanceof Predicate) {
-            actualValue = ((Predicate) actualValue).matches(exchange);
-        } else if (expectedValue != null) {
+        if (expectedValue != null) {
             String from = actualValue.getClass().getName();
             String to = expectedValue.getClass().getName();
             actualValue = getCamelContext().getTypeConverter().convertTo(expectedValue.getClass(), exchange, actualValue);

--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
@@ -288,8 +288,7 @@ public class MockEndpointTest extends ContextTestSupport {
         resultEndpoint.reset();
 
         resultEndpoint.expectedHeaderReceived("number", 123);
-        template.sendBodyAndHeader("direct:a", "<foo><id>123</id></foo>", "number",
-                XPathBuilder.xpath("/foo/id", Integer.class));
+        template.sendBody("direct:xpathexprs", "<foo><id>123</id></foo>");
         resultEndpoint.assertIsSatisfied();
     }
 
@@ -299,8 +298,7 @@ public class MockEndpointTest extends ContextTestSupport {
         resultEndpoint.reset();
 
         resultEndpoint.expectedPropertyReceived("number", 123);
-        template.sendBodyAndProperty("direct:a", "<foo><id>123</id></foo>", "number",
-                XPathBuilder.xpath("/foo/id", Integer.class));
+        template.sendBody("direct:xpathexprs", "<foo><id>123</id></foo>");
         resultEndpoint.assertIsSatisfied();
     }
 
@@ -1080,9 +1078,8 @@ public class MockEndpointTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived(987);
 
-        // start with 0 (zero) to have it converted to the number and match 987
-        // and since its an expression it would be evaluated first as well
-        template.sendBody("direct:a", ExpressionBuilder.constantExpression("0987"));
+        // Route contains: setBody(ExpressionBuilder.constantExpression("0987"))
+        template.sendBody("direct:bodyexpr", "");
 
         assertMockEndpointsSatisfied();
     }
@@ -1296,6 +1293,15 @@ public class MockEndpointTest extends ContextTestSupport {
                 from("direct:a").to("mock:result");
 
                 from("direct:b").transform(body().append(" World")).to("mock:result");
+
+                from("direct:xpathexprs")
+                        .setHeader("number", XPathBuilder.xpath("/foo/id", Integer.class))
+                        .setProperty("number", XPathBuilder.xpath("/foo/id", Integer.class))
+                        .to("mock:result");
+
+                from("direct:bodyexpr")
+                        .setBody(ExpressionBuilder.constantExpression("0987"))
+                        .to("mock:result");
             }
         };
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
@@ -29,9 +29,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
-import org.apache.camel.builder.ExpressionBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.language.xpath.XPathBuilder;
 import org.apache.camel.spi.Registry;
 import org.junit.jupiter.api.Test;
 
@@ -279,26 +277,6 @@ public class MockEndpointTest extends ContextTestSupport {
         // assert we can assert using other than string, eg numbers
         resultEndpoint.expectedHeaderReceived("number", 123);
         sendHeader("number", 123);
-        resultEndpoint.assertIsSatisfied();
-    }
-
-    @Test
-    public void testExpressionExpectationOfHeader() throws InterruptedException {
-        MockEndpoint resultEndpoint = getMockEndpoint("mock:result");
-        resultEndpoint.reset();
-
-        resultEndpoint.expectedHeaderReceived("number", 123);
-        template.sendBody("direct:xpathexprs", "<foo><id>123</id></foo>");
-        resultEndpoint.assertIsSatisfied();
-    }
-
-    @Test
-    public void testExpressionExpectationOfProperty() throws InterruptedException {
-        MockEndpoint resultEndpoint = getMockEndpoint("mock:result");
-        resultEndpoint.reset();
-
-        resultEndpoint.expectedPropertyReceived("number", 123);
-        template.sendBody("direct:xpathexprs", "<foo><id>123</id></foo>");
         resultEndpoint.assertIsSatisfied();
     }
 
@@ -1074,17 +1052,6 @@ public class MockEndpointTest extends ContextTestSupport {
     }
 
     @Test
-    public void testExpectedBodyExpression() throws Exception {
-        MockEndpoint mock = getMockEndpoint("mock:result");
-        mock.expectedBodiesReceived(987);
-
-        // Route contains: setBody(ExpressionBuilder.constantExpression("0987"))
-        template.sendBody("direct:bodyexpr", "");
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
     public void testResetDefaultProcessor() throws Exception {
         final AtomicInteger counter = new AtomicInteger();
 
@@ -1293,15 +1260,6 @@ public class MockEndpointTest extends ContextTestSupport {
                 from("direct:a").to("mock:result");
 
                 from("direct:b").transform(body().append(" World")).to("mock:result");
-
-                from("direct:xpathexprs")
-                        .setHeader("number", XPathBuilder.xpath("/foo/id", Integer.class))
-                        .setProperty("number", XPathBuilder.xpath("/foo/id", Integer.class))
-                        .to("mock:result");
-
-                from("direct:bodyexpr")
-                        .setBody(ExpressionBuilder.constantExpression("0987"))
-                        .to("mock:result");
             }
         };
     }


### PR DESCRIPTION
Remove the code which evaluates Expression or Predicate values.
Modify MockEndpointTest cases which checked for this (TBD if these cases should simply be removed instead.)
Checked other core and component tests which might have relied on this and didn't find any.
