### PR TITLE
camel-docker - Remove unnecessary deps to jnr (java native runtime)

### DIFF
--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -32,12 +32,6 @@
     <name>Camel :: Docker</name>
     <description>Camel Docker Support</description>
 
-
-    <properties>
-        <jffi.version>1.2.7</jffi.version>
-        <jnr-x86asm.version>1.0.2</jnr-x86asm.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -49,27 +43,6 @@
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
             <version>${docker-java-version}</version>
-        </dependency>
-
-        <!-- need to avoid the snapshot dependency -->
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>${jffi.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>${jffi.version}</version>
-            <scope>runtime</scope>
-            <classifier>native</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jnr-x86asm</artifactId>
-            <version>${jnr-x86asm.version}</version>
         </dependency>
 
         <!-- logging -->


### PR DESCRIPTION
In the latest docker-java `com.github.jnr:*` deps seem to be no longer used. So now it's not only just superfluous but also brings unnecessary pseudo dep to a x86 native lib `com.github.jnr:jnr-x86asm`. Let's remove them.