### PR TITLE
Update direct-vm-component.adoc : DirectVmEndpoint / bad default value for failIfNoConsumers

### DIFF
--- a/camel-core/src/main/docs/modules/ROOT/pages/direct-vm-component.adoc
+++ b/camel-core/src/main/docs/modules/ROOT/pages/direct-vm-component.adoc
@@ -94,7 +94,7 @@ with the following path and query parameters:
 | *exceptionHandler* (consumer) | To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this options is not in use. By default the consumer will deal with exceptions, that will be logged at WARN/ERROR level and ignored. |  | ExceptionHandler
 | *exchangePattern* (consumer) | Sets the default exchange pattern when creating an exchange. |  | ExchangePattern
 | *block* (producer) | If sending a message to a direct endpoint which has no active consumer, then we can tell the producer to block and wait for the consumer to become active. | true | boolean
-| *failIfNoConsumers* (producer) | Whether the producer should fail by throwing an exception, when sending to a Direct-VM endpoint with no active consumers. | false | boolean
+| *failIfNoConsumers* (producer) | Whether the producer should fail by throwing an exception, when sending to a Direct-VM endpoint with no active consumers. | true | boolean
 | *timeout* (producer) | The timeout value to use if block is enabled. | 30000 | long
 | *headerFilterStrategy* (producer) | Sets a HeaderFilterStrategy that will only be applied on producer endpoints (on both directions: request and response). Default value: none. |  | HeaderFilterStrategy
 | *propagateProperties* (advanced) | Whether to propagate or not properties from the producer side to the consumer side, and vice versa. Default value: true. | true | boolean


### PR DESCRIPTION
DirectVmEndpoint:43 "failIfNoConsumers" is at "true" but doc for 2.x says the default is "false" :

https://github.com/apache/camel/blob/camel-2.x/camel-core/src/main/java/org/apache/camel/component/directvm/DirectVmEndpoint.java
https://github.com/apache/camel/blob/camel-2.25.x/camel-core/src/main/java/org/apache/camel/component/directvm/DirectVmEndpoint.java
