### PR TITLE
[CAMEL-16931] Change DefaultMaskingFormatter to preserve quotes in keyValue data

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/processor/DefaultMaskingFormatterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/processor/DefaultMaskingFormatterTest.java
@@ -27,7 +27,7 @@ public class DefaultMaskingFormatterTest {
         DefaultMaskingFormatter formatter = new DefaultMaskingFormatter();
         String answer
                 = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
-        assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+        assertEquals("key=value, myPassword=xxxxx,\n myPassphrase=\"xxxxx\", secretKey='xxxxx'", answer);
 
         answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
         assertEquals("<xmlPassword>\n xxxxx \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
@@ -61,7 +61,7 @@ public class DefaultMaskingFormatterTest {
         DefaultMaskingFormatter formatter = new DefaultMaskingFormatter(true, false, true);
         String answer
                 = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo bar\", secretKey='!@#$%^&*() -+[]{};:'");
-        assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+        assertEquals("key=value, myPassword=xxxxx,\n myPassphrase=\"xxxxx\", secretKey='xxxxx'", answer);
 
         answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
         assertEquals("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
@@ -78,7 +78,7 @@ public class DefaultMaskingFormatterTest {
         DefaultMaskingFormatter formatter = new DefaultMaskingFormatter(true, true, false);
         String answer
                 = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
-        assertEquals("key=value, myPassword=\"xxxxx\",\n myPassphrase=\"xxxxx\", secretKey=\"xxxxx\"", answer);
+        assertEquals("key=value, myPassword=xxxxx,\n myPassphrase=\"xxxxx\", secretKey='xxxxx'", answer);
 
         answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
         assertEquals("<xmlPassword>\n xxxxx \n</xmlPassword>\n<user password=\"xxxxx\"/>", answer);
@@ -96,7 +96,7 @@ public class DefaultMaskingFormatterTest {
         formatter.setMaskString("**********");
         String answer
                 = formatter.format("key=value, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
-        assertEquals("key=value, myPassword=\"**********\",\n myPassphrase=\"**********\", secretKey=\"**********\"", answer);
+        assertEquals("key=value, myPassword=**********,\n myPassphrase=\"**********\", secretKey='**********'", answer);
 
         answer = formatter.format("<xmlPassword>\n foo bar \n</xmlPassword>\n<user password=\"asdf qwert\"/>");
         assertEquals("<xmlPassword>\n ********** \n</xmlPassword>\n<user password=\"**********\"/>", answer);
@@ -113,7 +113,7 @@ public class DefaultMaskingFormatterTest {
         DefaultMaskingFormatter formatter = new DefaultMaskingFormatter();
         String answer
                 = formatter.format("key=value, myAccessKey=foo,\n authkey=\"foo bar\", refreshtoken='!@#$%^&*() -+[]{};:'");
-        assertEquals("key=value, myAccessKey=\"xxxxx\",\n authkey=\"xxxxx\", refreshtoken=\"xxxxx\"", answer);
+        assertEquals("key=value, myAccessKey=xxxxx,\n authkey=\"xxxxx\", refreshtoken='xxxxx'", answer);
 
         answer = formatter.format("<subscribeKey>\n foo bar \n</subscribeKey>\n<user verificationCode=\"asdf qwert\"/>");
         assertEquals("<subscribeKey>\n xxxxx \n</subscribeKey>\n<user verificationCode=\"xxxxx\"/>", answer);
@@ -134,7 +134,7 @@ public class DefaultMaskingFormatterTest {
                 = formatter.format(
                         "key=value, Cheese=gauda, myPassword=foo,\n myPassphrase=\"foo　bar\", secretKey='!@#$%^&*() -+[]{};:'");
         assertEquals(
-                "key=value, Cheese=\"**********\", myPassword=\"**********\",\n myPassphrase=\"**********\", secretKey=\"**********\"",
+                "key=value, Cheese=**********, myPassword=**********,\n myPassphrase=\"**********\", secretKey='**********'",
                 answer);
 
         answer = formatter

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultMaskingFormatter.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultMaskingFormatter.java
@@ -36,7 +36,7 @@ public class DefaultMaskingFormatter implements MaskingFormatter {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMaskingFormatter.class);
 
-    private Set<String> keywords;
+    private final Set<String> keywords;
     private boolean maskKeyValue;
     private boolean maskXmlElement;
     private boolean maskJson;
@@ -109,13 +109,13 @@ public class DefaultMaskingFormatter implements MaskingFormatter {
             answer = xmlElementMaskPattern.matcher(answer).replaceAll("$1" + maskString + "$3");
             if (maskKeyValue) {
                 // used for the attributes in the XML tags
-                answer = keyValueMaskPattern.matcher(answer).replaceAll("$1\"" + maskString + "\"");
+                answer = keyValueMaskPattern.matcher(answer).replaceAll("$1" + maskString);
             }
         } else if (json) {
             answer = jsonMaskPattern.matcher(answer).replaceAll("\"$1\"$2:$3\"" + maskString + "\"");
         } else if (maskKeyValue) {
             // key=value paris
-            answer = keyValueMaskPattern.matcher(answer).replaceAll("$1\"" + maskString + "\"");
+            answer = keyValueMaskPattern.matcher(answer).replaceAll("$1" + maskString);
         }
 
         return answer;
@@ -169,7 +169,7 @@ public class DefaultMaskingFormatter implements MaskingFormatter {
             return null;
         }
         regex.insert(0, "([\\w]*(?:");
-        regex.append(")[\\w]*[\\s]*?=[\\s]*?)([\\S&&[^'\",\\}\\]\\)]]+[\\S&&[^,\\}\\]\\)>]]*?|\"[^\"]*?\"|'[^']*?')");
+        regex.append(")[\\w]*[\\s]*?=[\\s]*?['\"]?)([^'\",]+)");
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("KeyValue Pattern: {}", regex);


### PR DESCRIPTION
Log masking formatter preserves the quotes used in the source data when masking keyValue pairs. Supported are no quotes, single quotes and normal quotes.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
