### PR TITLE
(trivial) tiny tweak to jt400 component doc

### DIFF
--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -199,7 +199,7 @@ Inquiry messages or messages requiring a message ID are not supported.
 You can explicit configure a connection pool on the Jt400Component, or as an uri option
 on the endpoint.
 
-=== Program call
+== Program call
 
 This endpoint expects the input to be an `Object[]`, whose object types are
 `int`, `long`, `CharSequence` (such as `String`), or `byte[]`. All other


### PR DESCRIPTION
The `Program Call` section should be a peer of the sections above and below it, not a subheading for connection pooling. Sorry for missing in my last round of updates. 