### PR TITLE
Setting custom MLLP ack using HL7 ack example

### DIFF
--- a/components/camel-hl7/src/main/docs/hl7terser-language.adoc
+++ b/components/camel-hl7/src/main/docs/hl7terser-language.adoc
@@ -138,4 +138,20 @@ from("direct:test1")
   .transform(ack())
 ----
 
+=== Custom Acknowledgement for MLLP
+
+In particural situations you may want to set a custom acknowledgement without using Exceptions.
+This can be achieved using the `ack` expression:
+
+[source,java]
+----
+import org.apache.camel.component.mllp.MllpConstants;
+import ca.uhn.hl7v2.AcknowledgmentCode;
+import ca.uhn.hl7v2.ErrorCode;
+
+// In process block
+exchange.setProperty(MllpConstants.MLLP_ACKNOWLEDGEMENT,
+  ack(AcknowledgmentCode.AR, "Server didn't accept this message", ErrorCode.UNKNOWN_KEY_IDENTIFIER).evaluate(exchange, Object.class)
+----
+
 include::{page-component-version}@camel-spring-boot::page$hl7-starter.adoc[]


### PR DESCRIPTION
The "HL7 Acknowledgement expression" example can make it look like this negative ack  will be used for MLLP to send back. 
I had a difficult finding a way to set a custom ack without going low-level into HL7 itself. This example demonstrates you can reuse what Camel already provides but have to set it explicitly. 
<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
