### PR TITLE
CAMEL-16877: camel-salesforce: Fix timeouts occurring in synchronous/transacted routes

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceComponent.java
@@ -838,7 +838,7 @@ public class SalesforceComponent extends DefaultComponent implements SSLContextP
         SecurityUtils.adaptToIBMCipherNames(sslContextFactory);
 
         final SalesforceHttpClient httpClient = new SalesforceHttpClient(
-                context.getExecutorServiceManager().newThreadPool(source, "SalesforceHttpClient", workerPoolSize,
+                context, context.getExecutorServiceManager().newThreadPool(source, "SalesforceHttpClient", workerPoolSize,
                         workerPoolMaxSize),
                 sslContextFactory);
         // default settings, use httpClientProperties to set other

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceHttpClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceHttpClient.java
@@ -113,6 +113,12 @@ public class SalesforceHttpClient extends HttpClient {
         super.doStart();
     }
 
+    @Override
+    protected void doStop() throws Exception {
+        workerPool.shutdown();
+        super.doStop();
+    }
+
     public SalesforceSession getSession() {
         return session;
     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
@@ -200,13 +200,13 @@ public abstract class AbstractClientBase extends ServiceSupport
                         // from SalesforceSecurityHandler
                         Throwable failure = result.getFailure();
                         if (failure instanceof SalesforceException) {
-                            httpClient.getExecutor()
+                            httpClient.getWorkerPool()
                                     .execute(() -> callback.onResponse(null, headers, (SalesforceException) failure));
                         } else {
                             final String msg = String.format("Unexpected error {%s:%s} executing {%s:%s}", response.getStatus(),
                                     response.getReason(), request.getMethod(),
                                     request.getURI());
-                            httpClient.getExecutor().execute(() -> callback.onResponse(null, headers,
+                            httpClient.getWorkerPool().execute(() -> callback.onResponse(null, headers,
                                     new SalesforceException(msg, response.getStatus(), failure)));
                         }
                     } else {
@@ -226,13 +226,13 @@ public abstract class AbstractClientBase extends ServiceSupport
                                 session.parseLoginResponse(contentResponse, getContentAsString());
                                 final String msg = String.format("Unexpected Error {%s:%s} executing {%s:%s}", status,
                                         response.getReason(), request.getMethod(), request.getURI());
-                                httpClient.getExecutor()
+                                httpClient.getWorkerPool()
                                         .execute(() -> callback.onResponse(null, headers, new SalesforceException(msg, null)));
                             } catch (SalesforceException e) {
 
                                 final String msg = String.format("Error {%s:%s} executing {%s:%s}", status,
                                         response.getReason(), request.getMethod(), request.getURI());
-                                httpClient.getExecutor().execute(() -> callback.onResponse(null, headers,
+                                httpClient.getWorkerPool().execute(() -> callback.onResponse(null, headers,
                                         new SalesforceException(msg, response.getStatus(), e)));
                             }
                         } else if (status < HttpStatus.OK_200 || status >= HttpStatus.MULTIPLE_CHOICES_300) {
@@ -241,12 +241,12 @@ public abstract class AbstractClientBase extends ServiceSupport
 
                             // for APIs that return body on status 400, such as
                             // Composite API we need content as well
-                            httpClient.getExecutor()
+                            httpClient.getWorkerPool()
                                     .execute(() -> callback.onResponse(getContentAsInputStream(), headers, exception));
                         } else {
 
                             // Success!!!
-                            httpClient.getExecutor()
+                            httpClient.getWorkerPool()
                                     .execute(() -> callback.onResponse(getContentAsInputStream(), headers, null));
                         }
                     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
@@ -200,12 +200,14 @@ public abstract class AbstractClientBase extends ServiceSupport
                         // from SalesforceSecurityHandler
                         Throwable failure = result.getFailure();
                         if (failure instanceof SalesforceException) {
-                            callback.onResponse(null, headers, (SalesforceException) failure);
+                            httpClient.getExecutor()
+                                    .execute(() -> callback.onResponse(null, headers, (SalesforceException) failure));
                         } else {
                             final String msg = String.format("Unexpected error {%s:%s} executing {%s:%s}", response.getStatus(),
                                     response.getReason(), request.getMethod(),
                                     request.getURI());
-                            callback.onResponse(null, headers, new SalesforceException(msg, response.getStatus(), failure));
+                            httpClient.getExecutor().execute(() -> callback.onResponse(null, headers,
+                                    new SalesforceException(msg, response.getStatus(), failure)));
                         }
                     } else {
 
@@ -224,14 +226,14 @@ public abstract class AbstractClientBase extends ServiceSupport
                                 session.parseLoginResponse(contentResponse, getContentAsString());
                                 final String msg = String.format("Unexpected Error {%s:%s} executing {%s:%s}", status,
                                         response.getReason(), request.getMethod(), request.getURI());
-                                callback.onResponse(null, headers, new SalesforceException(msg, null));
-
+                                httpClient.getExecutor()
+                                        .execute(() -> callback.onResponse(null, headers, new SalesforceException(msg, null)));
                             } catch (SalesforceException e) {
 
                                 final String msg = String.format("Error {%s:%s} executing {%s:%s}", status,
                                         response.getReason(), request.getMethod(), request.getURI());
-                                callback.onResponse(null, headers, new SalesforceException(msg, response.getStatus(), e));
-
+                                httpClient.getExecutor().execute(() -> callback.onResponse(null, headers,
+                                        new SalesforceException(msg, response.getStatus(), e)));
                             }
                         } else if (status < HttpStatus.OK_200 || status >= HttpStatus.MULTIPLE_CHOICES_300) {
                             // Salesforce HTTP failure!
@@ -239,11 +241,13 @@ public abstract class AbstractClientBase extends ServiceSupport
 
                             // for APIs that return body on status 400, such as
                             // Composite API we need content as well
-                            callback.onResponse(getContentAsInputStream(), headers, exception);
+                            httpClient.getExecutor()
+                                    .execute(() -> callback.onResponse(getContentAsInputStream(), headers, exception));
                         } else {
 
                             // Success!!!
-                            callback.onResponse(getContentAsInputStream(), headers, null);
+                            httpClient.getExecutor()
+                                    .execute(() -> callback.onResponse(getContentAsInputStream(), headers, null));
                         }
                     }
                 } finally {

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/RestApiIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/RestApiIntegrationTest.java
@@ -471,6 +471,12 @@ public class RestApiIntegrationTest extends AbstractSalesforceTestBase {
     }
 
     @Test
+    public void querySyncAsyncDoesntTimeout() throws Exception {
+        final Object result = template.requestBody("direct:querySyncAsync", "");
+        assertNotNull(result);
+    }
+
+    @Test
     public void testParentRelationshipQuery() throws Exception {
         try {
             createAccountAndContact();
@@ -751,6 +757,16 @@ public class RestApiIntegrationTest extends AbstractSalesforceTestBase {
                 from("direct:queryAll")
                         .to("salesforce:queryAll?sObjectQuery=SELECT name from Line_Item__c&sObjectClass="
                             + QueryRecordsLine_Item__c.class.getName() + "&format=" + format);
+
+                from("direct:querySyncAsync")
+                        .to("direct:querySync")
+                        .to("direct:queryAsync");
+
+                from("direct:querySync?synchronous=false").routeId("r.querySync")
+                        .to("salesforce:query?rawPayload=true&sObjectQuery=Select Id From Contact Where Name = 'Sync'");
+
+                from("direct:queryAsync?synchronous=true").routeId("r.queryAsync")
+                        .to("salesforce:query?rawPayload=true&sObjectQuery=Select Id From Contact  Where Name = 'Sync'");
 
                 // testSearch
                 from("direct:search").to("salesforce:search?sObjectSearch=FIND {Wee}&format=" + format);

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.salesforce.internal.client;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -148,6 +149,9 @@ public class AbstractClientBaseTest {
 
         when(conversation.getAttribute(SalesforceSecurityHandler.AUTHENTICATION_REQUEST_ATTRIBUTE))
                 .thenReturn(salesforceRequest);
+
+        final Executor executor = mock(Executor.class);
+        when(client.httpClient.getExecutor()).thenReturn(executor);
 
         // completes the request
         listener.getValue().onComplete(result);

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBaseTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.salesforce.internal.client;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -150,8 +150,8 @@ public class AbstractClientBaseTest {
         when(conversation.getAttribute(SalesforceSecurityHandler.AUTHENTICATION_REQUEST_ATTRIBUTE))
                 .thenReturn(salesforceRequest);
 
-        final Executor executor = mock(Executor.class);
-        when(client.httpClient.getExecutor()).thenReturn(executor);
+        final ExecutorService executor = mock(ExecutorService.class);
+        when(client.httpClient.getWorkerPool()).thenReturn(executor);
 
         // completes the request
         listener.getValue().onComplete(result);


### PR DESCRIPTION
This issue is caused by the fact that the Jetty client uses a single thread to invoke completion listeners, and camel reuses that thread (if in synchronous mode) for subsequent operations before returning from AsyncCallback.done(). Result is a deadlock.

I solved this by quickly passing the Jetty response to another thread, using Jetty's thread pool. Would like some eyeballs on this please.
