### PR TITLE
CAMEL-16927 fixes spring creating multiple camel contexts resulting in deadlock

### DIFF
--- a/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/CamelContextFactoryBean.java
@@ -525,13 +525,14 @@ public class CamelContextFactoryBean extends AbstractCamelContextFactoryBean<Spr
     }
 
     protected SpringCamelContext newCamelContext() {
-        return new SpringCamelContext(getApplicationContext());
+        return new SpringCamelContext();
     }
 
     @Override
     public SpringCamelContext getContext(boolean create) {
         if (context == null && create) {
             context = createContext();
+            context.setApplicationContext(getApplicationContext());
             configure(context);
             context.build();
         }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/CamelProxyDeadlockTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/CamelProxyDeadlockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.spring.config;
 
-import org.apache.camel.Exchange;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.spring.SpringTestSupport;
@@ -39,12 +39,16 @@ public class CamelProxyDeadlockTest extends SpringTestSupport {
         DefaultProducerTemplate producer = new DefaultProducerTemplate(scc);
         producer.start();
 
-        Object reply = producer.requestBody("direct-vm:start", "Hello!");
+        MockEndpoint result = resolveMandatoryEndpoint(scc, "mock:result", MockEndpoint.class);
+        result.expectedBodiesReceived("Camel");
 
-        assertEquals("Hello from Piotr Klimczak", reply);
+        String reply = (String) producer.requestBody("direct-vm:start", "Camel");
+
+        result.assertIsSatisfied();
+        assertEquals("Camel", reply);
     }
 
     interface TestProcessor {
-        Object test(Exchange exchange);
+        String test(String body);
     }
 }

--- a/components/camel-spring/src/test/java/org/apache/camel/spring/config/CamelProxyDeadlockTest.java
+++ b/components/camel-spring/src/test/java/org/apache/camel/spring/config/CamelProxyDeadlockTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.config;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+import org.apache.camel.spring.SpringCamelContext;
+import org.apache.camel.spring.SpringTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CamelProxyDeadlockTest extends SpringTestSupport {
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/config/CamelProxyDeadlockTest.xml");
+    }
+
+    @Test
+    public void testCamelProxy() throws Exception {
+        SpringCamelContext scc = context.adapt(SpringCamelContext.class);
+        DefaultProducerTemplate producer = new DefaultProducerTemplate(scc);
+        producer.start();
+
+        Object reply = producer.requestBody("direct-vm:start", "Hello!");
+
+        assertEquals("Hello from Piotr Klimczak", reply);
+    }
+
+    interface TestProcessor {
+        Object test(Exchange exchange);
+    }
+}

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/config/CamelProxyDeadlockTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/config/CamelProxyDeadlockTest.xml
@@ -35,18 +35,13 @@
             <from uri="direct-vm:start"/>
 
             <bean ref="c"/> <!-- This must be proxy "c" to trigger CAMEL-16927 -->
-
-            <to uri="mock:result"/>
         </route>
 
-        <route id="a">
+        <route id="routeBehindProxy">
             <from uri="direct-vm:a"/>
 
             <!-- With CAMEL-16927 unfixed, this route would never be reached -->
-            <setBody>
-                <constant>Hello from Piotr Klimczak</constant>
-            </setBody>
-            <log message="CAMEL-16927 is fixed if you see this"/>
+            <to uri="mock:result"/>
         </route>
     </camelContext>
 

--- a/components/camel-spring/src/test/resources/org/apache/camel/spring/config/CamelProxyDeadlockTest.xml
+++ b/components/camel-spring/src/test/resources/org/apache/camel/spring/config/CamelProxyDeadlockTest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+    <!-- This test covers CAMEL-16927 deadlock case -->
+    <camelContext id="testCamel" xmlns="http://camel.apache.org/schema/spring">
+
+        <proxy id="a" serviceUrl="direct-vm:a" serviceInterface="org.apache.camel.spring.config.CamelProxyDeadlockTest.TestProcessor"/>
+        <proxy id="b" serviceUrl="direct-vm:a" serviceInterface="org.apache.camel.spring.config.CamelProxyDeadlockTest.TestProcessor"/>
+        <proxy id="c" serviceUrl="direct-vm:a" serviceInterface="org.apache.camel.spring.config.CamelProxyDeadlockTest.TestProcessor"/>
+
+        <route id="test">
+            <from uri="direct-vm:start"/>
+
+            <bean ref="c"/> <!-- This must be proxy "c" to trigger CAMEL-16927 -->
+
+            <to uri="mock:result"/>
+        </route>
+
+        <route id="a">
+            <from uri="direct-vm:a"/>
+
+            <!-- With CAMEL-16927 unfixed, this route would never be reached -->
+            <setBody>
+                <constant>Hello from Piotr Klimczak</constant>
+            </setBody>
+            <log message="CAMEL-16927 is fixed if you see this"/>
+        </route>
+    </camelContext>
+
+</beans>


### PR DESCRIPTION

Fixes spring creating multiple camel contexts, affecting DefaultReactiveExecutor/Worker resulting in deadlock