### PR TITLE
(chores) camel-kafka: cleanups related to CAMEL-16949

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessor.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessor.java
@@ -159,7 +159,7 @@ public class KafkaRecordProcessor {
         return new ProcessResult(false, record.offset());
     }
 
-    public boolean processException(
+    private boolean processException(
             Exchange exchange, TopicPartition partition, long partitionLastOffset,
             ExceptionHandler exceptionHandler) {
 
@@ -170,7 +170,7 @@ public class KafkaRecordProcessor {
             LOG.warn("Will seek consumer to offset {} and start polling again.", partitionLastOffset);
 
             // force commit, so we resume on next poll where we failed
-            commitOffset(partition, partitionLastOffset, false, true, threadId);
+            commitOffset(partition, partitionLastOffset, false, true);
 
             // continue to next partition
             return true;
@@ -183,7 +183,7 @@ public class KafkaRecordProcessor {
     }
 
     public void commitOffset(
-            TopicPartition partition, long partitionLastOffset, boolean stopping, boolean forceCommit, String threadId) {
+            TopicPartition partition, long partitionLastOffset, boolean stopping, boolean forceCommit) {
         commitOffset(configuration, consumer, partition, partitionLastOffset, stopping, forceCommit, threadId);
     }
 


### PR DESCRIPTION
- avoid rebuilding the processor for every polled record
- make the exception processor method private
- remove unused variables
- make the reconnect variable not volatile as it is unnecessary and
  local to the thread
- make the retry variable not volatile as it is unnecessary
- avoid recreating the poll duration variable
- stop creating the lock in the inner loop and move it to the main loop
- remove unnecessary parameter thread ID in some methods as it is already available as a member variable to the record processors
- stop overwriting the local lastResult parameter
- fix an incorrect point of commit


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->