### PR TITLE
[CAMEL-16992] Main stay in version

### DIFF
--- a/components/camel-bean/src/main/docs/bean-language.adoc
+++ b/components/camel-bean/src/main/docs/bean-language.adoc
@@ -82,7 +82,7 @@ public boolean isGoldCustomer(@Header(name = "foo") Integer fooHeader) {...}
 ----
 
 So you can bind parameters of the method to the `Exchange`, the
-xref:{eip-vc}:eips:message.adoc[Message] or individual headers, properties, the body
+xref:eips:message.adoc[Message] or individual headers, properties, the body
 or other expressions.
 
 === Non-Registry Beans

--- a/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
+++ b/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
@@ -97,7 +97,7 @@ Be careful when specifying `release`, as the failed job will immediately
 become available in the same tube and your consumer will try to acquire
 it again. You can `release` and specify _jobDelay_ though.
 
-The beanstalk consumer is a Scheduled xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+The beanstalk consumer is a Scheduled xref:eips:polling-consumer.adoc[Polling
 Consumer] which means there is more options you can configure, such as
 how frequent the consumer should poll. For more details
 see Polling Consumer.

--- a/components/camel-dataset/src/main/docs/dataset-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-dataset/src/main/docs/dataset-test-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-test-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
+++ b/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example, you could use DataSonnet to create a
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a DataSonnet expression use the following Java code:
 

--- a/components/camel-disruptor/src/main/docs/disruptor-component.adoc
+++ b/components/camel-disruptor/src/main/docs/disruptor-component.adoc
@@ -118,7 +118,7 @@ without incurring significant latency spikes.
 
 == Use of Request Reply
 
-The Disruptor component supports using xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+The Disruptor component supports using xref:eips:requestReply-eip.adoc[Request
 Reply], where the caller will wait for the Async route to complete. For
 instance:
 

--- a/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
+++ b/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
@@ -214,7 +214,7 @@ try (ElasticsearchScrollRequestIterator response = template.requestBody("direct:
 }
 ----
 
-xref:{eip-vc}:eips:split-eip.adoc[Split EIP] can also be used.
+xref:eips:split-eip.adoc[Split EIP] can also be used.
 
 [source,java]
 ----

--- a/components/camel-elsql/src/main/docs/elsql-component.adoc
+++ b/components/camel-elsql/src/main/docs/elsql-component.adoc
@@ -20,7 +20,7 @@ This component uses `spring-jdbc` behind the scenes for the actual SQL
 handling.
 
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:

--- a/components/camel-facebook/src/main/docs/facebook-component.adoc
+++ b/components/camel-facebook/src/main/docs/facebook-component.adoc
@@ -159,7 +159,7 @@ from("direct:foo")
     .to("facebook://postFeed/inBody=postUpdate);
 ----------------------------------------------------
 
-To poll, every 5 sec (You can set the xref:{eip-vc}:eips:polling-consumer.adoc[polling
+To poll, every 5 sec (You can set the xref:eips:polling-consumer.adoc[polling
 consumer] options by adding a prefix of "consumer"), all statuses on
 your home feed:
 

--- a/components/camel-groovy/src/main/docs/groovy-language.adoc
+++ b/components/camel-groovy/src/main/docs/groovy-language.adoc
@@ -12,7 +12,7 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/groovy.adoc
 Camel has support for using http://www.groovy-lang.org/[Groovy].
 
 For example, you can use Groovy in a xref:manual::predicate.adoc[Predicate]
-with the xref:{eip-vc}:eips:filter-eip.adoc[Message
+with the xref:eips:filter-eip.adoc[Message
 Filter] EIP.
 
 [source,java]

--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -261,7 +261,7 @@ the documentation.
 
 Normally, when using xref:jms-component.adoc[JMS] as the transport, it only
 transfers the body and headers as the payload. If you want to use
-xref:jms-component.adoc[JMS] with a xref:{eip-vc}:eips:dead-letter-channel.adoc[Dead Letter
+xref:jms-component.adoc[JMS] with a xref:eips:dead-letter-channel.adoc[Dead Letter
 Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
@@ -961,7 +961,7 @@ Transactions and [Request Reply] over JMS
 When using Request Reply over JMS you cannot
 use a single transaction; JMS will not send any messages until a commit
 is performed, so the server side won't receive anything at all until the
-transaction commits. Therefore to use xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+transaction commits. Therefore to use xref:eips:requestReply-eip.adoc[Request
 Reply] you must commit a transaction after sending the request and then
 use a separate transaction for receiving the response.
 

--- a/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
+++ b/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
@@ -23,7 +23,7 @@ include::partial$language-options.adoc[]
 == Examples
 
 For example, you can use JSONPath in a xref:manual::predicate.adoc[Predicate]
-with the xref:{eip-vc}:eips:choice-eip.adoc[Content Based Router] EIP.
+with the xref:eips:choice-eip.adoc[Content Based Router] EIP.
 
 [source,java]
 ----

--- a/components/camel-jta/src/main/docs/jta.adoc
+++ b/components/camel-jta/src/main/docs/jta.adoc
@@ -11,4 +11,4 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jta.adoc[opts=
 
 The `camel-jta` component is used for integrating Camel's transaction support with JTA.
 
-See more details in the xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client] documentation.
+See more details in the xref:eips:transactional-client.adoc[Transactional Client] documentation.

--- a/components/camel-language/src/main/docs/language-component.adoc
+++ b/components/camel-language/src/main/docs/language-component.adoc
@@ -18,7 +18,7 @@ to an endpoint which executes a script by any of the supported
 Languages in Camel. +
  By having a component to execute language scripts, it allows more
 dynamic routing capabilities. For example by using the
-Routing Slip or xref:{eip-vc}:eips:dynamicRouter-eip.adoc[Dynamic
+Routing Slip or xref:eips:dynamicRouter-eip.adoc[Dynamic
 Router] EIPs you can send messages to `language` endpoints where the
 script is dynamic defined as well.
 

--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-mvel/src/main/docs/mvel-language.adoc
+++ b/components/camel-mvel/src/main/docs/mvel-language.adoc
@@ -16,7 +16,7 @@ MVEL is powerful for templates, but can also be used for
 xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicate]
 
 For example, you can use MVEL in a xref:manual::predicate.adoc[Predicate]
-with the xref:{eip-vc}:eips:choice-eip.adoc[Content Based Router] EIP.
+with the xref:eips:choice-eip.adoc[Content Based Router] EIP.
 
 You can use MVEL dot notation to invoke operations. If you for instance
 have a body that contains a POJO that has a `getFamilyName` method then
@@ -65,7 +65,7 @@ The following Camel related variables are made available:
 
 == Example
 
-For example, you could use MVEL inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example, you could use MVEL inside a xref:eips:filter-eip.adoc[Message
 Filter]
 
 [source,java]

--- a/components/camel-ognl/src/main/docs/ognl-language.adoc
+++ b/components/camel-ognl/src/main/docs/ognl-language.adoc
@@ -14,7 +14,7 @@ used as an xref:manual::expression.adoc[Expression] or xref:manual::predicate.ad
 in Camel routes.
 
 For example, you can use MVEL in a xref:manual::predicate.adoc[Predicate]
-with the xref:{eip-vc}:eips:choice-eip.adoc[Content Based Router] EIP.
+with the xref:eips:choice-eip.adoc[Content Based Router] EIP.
 
 You can use OGNL dot notation to invoke operations. If you for instance
 have a body that contains a POJO that has a `getFamilyName` method then
@@ -64,7 +64,7 @@ include::partial$language-options.adoc[]
 
 == Example
 
-For example, you could use OGNL inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example, you could use OGNL inside a xref:eips:filter-eip.adoc[Message
 Filter]
 
 [source,java]

--- a/components/camel-quartz/src/main/docs/quartz-component.adoc
+++ b/components/camel-quartz/src/main/docs/quartz-component.adoc
@@ -280,7 +280,7 @@ but it does not want to be fired now.
 
 The xref:quartz-component.adoc[Quartz] component provides a
 Polling Consumer scheduler which allows to
-use cron based scheduling for xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+use cron based scheduling for xref:eips:polling-consumer.adoc[Polling
 Consumer] such as the File and FTP
 consumers.
 

--- a/components/camel-saxon/src/main/docs/xquery-language.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-language.adoc
@@ -14,8 +14,8 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example, you could use XQuery to create a
-predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message Filter]
-or as an expression for a xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+predicate in a xref:eips:filter-eip.adoc[Message Filter]
+or as an expression for a xref:eips:recipientList-eip.adoc[Recipient List].
 
 == XQuery Language options
 

--- a/components/camel-sjms/src/main/docs/sjms-component.adoc
+++ b/components/camel-sjms/src/main/docs/sjms-component.adoc
@@ -94,7 +94,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -143,7 +143,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/components/camel-sjms2/src/main/docs/sjms2-component.adoc
+++ b/components/camel-sjms2/src/main/docs/sjms2-component.adoc
@@ -96,7 +96,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -145,7 +145,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS2 endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -177,7 +177,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different exchanges. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
 
 You can specify using the following headers:
 
@@ -227,7 +227,7 @@ another RabbitMQ endpoint).
 
 If you need to send messages to a lot of different exchanges, it
 makes sense to reuse a endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to exchanges with order types,
 then using toD could for example be done as follows:

--- a/components/camel-spring/src/main/docs/spel-language.adoc
+++ b/components/camel-spring/src/main/docs/spel-language.adoc
@@ -49,8 +49,8 @@ The following Camel related variables are made available:
 
 == Example
 
-You can use SpEL as an expression for xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient
-List] or as a predicate inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+You can use SpEL as an expression for xref:eips:recipientList-eip.adoc[Recipient
+List] or as a predicate inside a xref:eips:filter-eip.adoc[Message
 Filter]:
 
 [source,xml]

--- a/components/camel-spring/src/main/docs/spring-event-component.adoc
+++ b/components/camel-spring/src/main/docs/spring-event-component.adoc
@@ -18,8 +18,8 @@ The Spring Event component provides access to the Spring
 `ApplicationEvent` objects. This allows you to publish
 `ApplicationEvent` objects to a Spring `ApplicationContext` or to
 consume them. You can then use
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
-Patterns] to process them such as xref:{eip-vc}:eips:filter-eip.adoc[Message
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns] to process them such as xref:eips:filter-eip.adoc[Message
 Filter].
 
 == URI format

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -24,7 +24,7 @@ components like xref:jms-component.adoc[JMS] and xref:jms-component.adoc[JPA]
 Type Converter support for Spring Resources etc
 * Allows you to reuse the Spring Testing
 framework to simplify your unit and integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful xref:mock-component.adoc[Mock] and
 xref:others:test.adoc[Test] endpoints
 

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -46,7 +46,7 @@ pattern. See further below.
 [TIP]
 ====
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 ====
 
 The SQL component uses the following endpoint URI notation:

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -14,8 +14,8 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example, you could use XPath to create a
-predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message Filter]
-or as an expression for a xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+predicate in a xref:eips:filter-eip.adoc[Message Filter]
+or as an expression for a xref:eips:recipientList-eip.adoc[Recipient List].
 
 == XPath Language options
 
@@ -82,7 +82,7 @@ exchange:
 |===
 
 CAUTION: `function:properties` and `function:simple` is not supported
-when the return type is a `NodeSet`, such as when using with a xref:{eip-vc}:eips:split-eip.adoc[Split] EIP.
+when the return type is a `NodeSet`, such as when using with a xref:eips:split-eip.adoc[Split] EIP.
 
 Here's an example showing some of these functions in use.
 
@@ -195,7 +195,7 @@ xpath("/invoice/@orderType = 'premium'", "invoiceDetails")
 
 
 Here is a simple example using an XPath expression as a predicate in a
-xref:{eip-vc}:eips:filter-eip.adoc[Message Filter]:
+xref:eips:filter-eip.adoc[Message Filter]:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
@@ -127,7 +127,7 @@ from("direct:start")
 ----
 
 You only need to use `.endChoice()` when using certain
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[EIP]s which often have additional
+xref:eips:enterprise-integration-patterns.adoc[EIP]s which often have additional
 methods to configure or as part of the EIP itself. For example the
 xref:split-eip.adoc[Split] EIP has a sub-route which denotes the
 routing of each _splitted_ message. You would also have to use
@@ -140,6 +140,6 @@ If there are still problems, then you can split your route into multiple
 routes, and link them together using the xref:components::direct-component.adoc[Direct]
 component.
 
-There can be some combinations of xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[EIP]s
+There can be some combinations of xref:eips:enterprise-integration-patterns.adoc[EIP]s
 that can hit limits in how far we can take the fluent builder DSL with
 generics you can do in Java programming language.

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/tokenize-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/tokenize-language.adoc
@@ -10,7 +10,7 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/tokenize.ad
 *Since Camel {since}*
 
 The tokenizer language is a built-in language in `camel-core`, which is
-most often used with the xref:{eip-vc}:eips:split-eip.adoc[Split] EIP
+most often used with the xref:eips:split-eip.adoc[Split] EIP
 to split a message using a token-based strategy.
 
 The tokenizer language is intended to tokenize text documents using a
@@ -54,4 +54,4 @@ from("direct:a")
         .to("direct:b");
 ----
 
-For more examples see xref:{eip-vc}:eips:split-eip.adoc[Split] EIP.
+For more examples see xref:eips:split-eip.adoc[Split] EIP.

--- a/core/camel-xml-jaxp/src/main/docs/modules/languages/pages/xtokenize-language.adoc
+++ b/core/camel-xml-jaxp/src/main/docs/modules/languages/pages/xtokenize-language.adoc
@@ -10,7 +10,7 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/xtokenize.a
 *Since Camel {since}*
 
 The XML Tokenize language is a built-in language in `camel-xml-jaxp`, which
-is a truly XML-aware tokenizer that can be used with the xref:{eip-vc}:eips:split-eip.adoc[Split] EIP
+is a truly XML-aware tokenizer that can be used with the xref:eips:split-eip.adoc[Split] EIP
 as the conventional xref:tokenize-language.adoc[Tokenize] to efficiently and
 effectively tokenize XML documents.
 
@@ -25,4 +25,4 @@ include::partial$language-options.adoc[]
 
 == Example
 
-See xref:{eip-vc}:eips:split-eip.adoc[Split] EIP which has examples using the XML Tokenize language.
+See xref:eips:split-eip.adoc[Split] EIP which has examples using the XML Tokenize language.

--- a/docs/components/antora.yml
+++ b/docs/components/antora.yml
@@ -18,12 +18,16 @@
 name: components
 title: Camel Components
 version: latest
+prerelease: true
+display-version: 3.12.0 (Prerelease)
+
 nav:
   - modules/ROOT/nav.adoc
   - modules/dataformats/nav.adoc
   - modules/languages/nav.adoc
   - modules/others/nav.adoc
   - modules/eips/nav.adoc
+
 asciidoc:
   attributes:
     index-table-format: width="100%",cols="4,3,3,3,6",options="header"

--- a/docs/user-manual/antora.yml
+++ b/docs/user-manual/antora.yml
@@ -22,3 +22,7 @@ nav:
 - modules/ROOT/nav.adoc
 - modules/faq/nav.adoc
 - modules/ROOT/references.adoc
+
+asciidoc:
+  attributes:
+    eip-vc: latest@components

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
@@ -168,7 +168,7 @@ Support for Endpoint DSL auto completion https://github.com/apache/camel-k-runti
 
 == Defining beans
 
-In addition to the general support for creating beans provided by xref:latest@components:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
+In addition to the general support for creating beans provided by xref:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
 
 [source,yaml]
 ----


### PR DESCRIPTION
- removes use of eip-vc attribute and latest@component literal from components component
- adds eip-vc attribute to user-manual playbook
- marks `components` component as prerelease and sets display version to '3.12.0 (Prerelease)'. Note that the URI version segment is still 'latest'.