### PR TITLE
[CAMEL-16992] Camel 3.11.x stay in version

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/bean-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/bean-language.adoc
@@ -20,7 +20,7 @@ using the type of the message body and using any annotations on the bean
 methods.
 
 The xref:manual::bean-binding.adoc[Bean Binding] rules are used to bind the
-xref:{eip-vc}:eips:message.adoc[Message] Exchange to the method parameters; so you can
+xref:eips:message.adoc[Message] Exchange to the method parameters; so you can
 annotate the bean to extract headers or other expressions such as
 xref:xpath-language.adoc[XPath] or xref:xquery-language.adoc[XQuery] from the message.
 
@@ -113,7 +113,7 @@ public boolean isGoldCustomer(@Header(name = "foo") Integer fooHeader) {...}
 ----
 
 So you can bind parameters of the method to the Exchange, the
-xref:{eip-vc}:eips:message.adoc[Message] or individual headers, properties, the body
+xref:eips:message.adoc[Message] or individual headers, properties, the body
 or other expressions.
 
 [[BeanLanguage-Non-RegistryBeans]]
@@ -184,7 +184,7 @@ We have some test cases you can look at if it'll help
 is a JUnit test case showing the Java xref:manual::dsl.adoc[DSL] use of the bean
 expression being used in a filter
 * https://github.com/apache/camel/blob/main/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator.xml[aggregator.xml]
-is a Spring XML test case for the xref:{eip-vc}:eips:aggregate-eip.adoc[Aggregator] which
+is a Spring XML test case for the xref:eips:aggregate-eip.adoc[Aggregator] which
 uses a bean method call to test for the completion of the aggregation.
 
 include::{page-component-version}@camel-spring-boot::page$bean-starter.adoc[]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/beanstalk-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/beanstalk-component.adoc
@@ -163,7 +163,7 @@ Be careful when specifying `release`, as the failed job will immediately
 become available in the same tube and your consumer will try to acquire
 it again. You can `release` and specify _jobDelay_ though.
 
-The beanstalk consumer is a Scheduled xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+The beanstalk consumer is a Scheduled xref:eips:polling-consumer.adoc[Polling
 Consumer] which means there is more options you can configure, such as
 how frequent the consumer should poll. For more details
 see Polling Consumer.

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/dataset-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/dataset-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/dataset-test-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/dataset-test-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/datasonnet-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/datasonnet-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use DataSonnet to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a DataSonnet expression use the following Java code:
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/disruptor-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/disruptor-component.adoc
@@ -199,7 +199,7 @@ without incurring significant latency spikes.
 
 == Use of Request Reply
 
-The Disruptor component supports using xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+The Disruptor component supports using xref:eips:requestReply-eip.adoc[Request
 Reply], where the caller will wait for the Async route to complete. For
 instance:
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/elasticsearch-rest-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/elasticsearch-rest-component.adoc
@@ -278,7 +278,7 @@ try (ElasticsearchScrollRequestIterator response = template.requestBody("direct:
 }
 ----
 
-xref:{eip-vc}:eips:split-eip.adoc[Split EIP] can also be used.
+xref:eips:split-eip.adoc[Split EIP] can also be used.
 
 [source,java]
 ----

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/elsql-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/elsql-component.adoc
@@ -20,7 +20,7 @@ This component uses `spring-jdbc` behind the scenes for the actual SQL
 handling.
 
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/facebook-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/facebook-component.adoc
@@ -327,7 +327,7 @@ facebook4j.PostUpdate body.
         .to("facebook://postFeed/inBody=postUpdate);
 ----------------------------------------------------
 
-To poll, every 5 sec (You can set the xref:{eip-vc}:eips:polling-consumer.adoc[polling
+To poll, every 5 sec (You can set the xref:eips:polling-consumer.adoc[polling
 consumer] options by adding a prefix of "consumer"), all statuses on
 your home feed:
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovy-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovy-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use Groovy to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a Groovy expression use the following Java code
 
@@ -26,7 +26,7 @@ groovy("someGroovyExpression")
 ---------------------------------------
 
 For example you could use the *groovy* function to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message Filter] or as an Expression for a
+Predicate in a xref:eips:filter-eip.adoc[Message Filter] or as an Expression for a
 Recipient List
 
 == Groovy Options

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jms-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jms-component.adoc
@@ -510,7 +510,7 @@ the documentation.
 
 Normally, when using xref:jms-component.adoc[JMS] as the transport, it only
 transfers the body and headers as the payload. If you want to use
-xref:jms-component.adoc[JMS] with a xref:{eip-vc}:eips:dead-letter-channel.adoc[Dead Letter
+xref:jms-component.adoc[JMS] with a xref:eips:dead-letter-channel.adoc[Dead Letter
 Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
@@ -1217,7 +1217,7 @@ Transactions and [Request Reply] over JMS
 When using Request Reply over JMS you cannot
 use a single transaction; JMS will not send any messages until a commit
 is performed, so the server side won't receive anything at all until the
-transaction commits. Therefore to use xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+transaction commits. Therefore to use xref:eips:requestReply-eip.adoc[Request
 Reply] you must commit a transaction after sending the request and then
 use a separate transaction for receiving the response.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jta.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jta.adoc
@@ -11,4 +11,4 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jta.adoc[opts=
 
 The `camel-jta` component is used for integrating Camel's transaction support with JTA.
 
-See more details in the xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client] documentation.
+See more details in the xref:eips:transactional-client.adoc[Transactional Client] documentation.

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/language-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/language-component.adoc
@@ -18,7 +18,7 @@ to an endpoint which executes a script by any of the supported
 Languages in Camel. +
  By having a component to execute language scripts, it allows more
 dynamic routing capabilities. For example by using the
-Routing Slip or xref:{eip-vc}:eips:dynamicRouter-eip.adoc[Dynamic
+Routing Slip or xref:eips:dynamicRouter-eip.adoc[Dynamic
 Router] EIPs you can send messages to `language` endpoints where the
 script is dynamic defined as well.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/mock-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/mock-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/mvel-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/mvel-language.adoc
@@ -73,7 +73,7 @@ The MVEL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use Mvel inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use Mvel inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ognl-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ognl-language.adoc
@@ -77,7 +77,7 @@ The OGNL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use OGNL inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use OGNL inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/quartz-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/quartz-component.adoc
@@ -375,7 +375,7 @@ but it does not want to be fired now.
 
 The xref:quartz-component.adoc[Quartz] component provides a
 Polling Consumer scheduler which allows to
-use cron based scheduling for xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+use cron based scheduling for xref:eips:polling-consumer.adoc[Polling
 Consumer] such as the File and FTP
 consumers.
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sjms-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sjms-component.adoc
@@ -187,7 +187,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -236,7 +236,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sjms2-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sjms2-component.adoc
@@ -190,7 +190,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -239,7 +239,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS2 endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spel-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spel-language.adoc
@@ -126,8 +126,8 @@ can invoke the "bar" method on this bean like this:
 
 === SpEL in enterprise integration patterns
 
-You can use SpEL as an expression for xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient
-List] or as a predicate inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+You can use SpEL as an expression for xref:eips:recipientList-eip.adoc[Recipient
+List] or as a predicate inside a xref:eips:filter-eip.adoc[Message
 Filter]:
 
 [source,xml]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-event-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-event-component.adoc
@@ -18,8 +18,8 @@ The Spring Event component provides access to the Spring
 `ApplicationEvent` objects. This allows you to publish
 `ApplicationEvent` objects to a Spring `ApplicationContext` or to
 consume them. You can then use
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
-Patterns] to process them such as xref:{eip-vc}:eips:filter-eip.adoc[Message
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns] to process them such as xref:eips:filter-eip.adoc[Message
 Filter].
 
 == URI format

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-rabbitmq-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-rabbitmq-component.adoc
@@ -265,7 +265,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different exchanges. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
 
 You can specify using the following headers:
 
@@ -315,7 +315,7 @@ another RabbitMQ endpoint).
 
 If you need to send messages to a lot of different exchanges, it
 makes sense to reuse a endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to exchanges with order types,
 then using toD could for example be done as follows:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-summary.adoc
@@ -25,7 +25,7 @@ components like xref:jms-component.adoc[JMS] and xref:jms-component.adoc[JPA]
 Type Converter support for Spring Resources etc
 * Allows you to reuse the Spring Testing
 framework to simplify your unit and integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful xref:mock-component.adoc[Mock] and
 xref:others:test.adoc[Test] endpoints
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sql-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/sql-component.adoc
@@ -46,7 +46,7 @@ pattern. See further below.
 [TIP]
 ====
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 ====
 
 The SQL component uses the following endpoint URI notation:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/xpath-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/xpath-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XPath to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 *Streams*
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/xquery-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/xquery-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XQuery to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 == XQuery Language options
 

--- a/components/camel-bean/src/main/docs/bean-language.adoc
+++ b/components/camel-bean/src/main/docs/bean-language.adoc
@@ -20,7 +20,7 @@ using the type of the message body and using any annotations on the bean
 methods.
 
 The xref:manual::bean-binding.adoc[Bean Binding] rules are used to bind the
-xref:{eip-vc}:eips:message.adoc[Message] Exchange to the method parameters; so you can
+xref:eips:message.adoc[Message] Exchange to the method parameters; so you can
 annotate the bean to extract headers or other expressions such as
 xref:xpath-language.adoc[XPath] or xref:xquery-language.adoc[XQuery] from the message.
 
@@ -113,7 +113,7 @@ public boolean isGoldCustomer(@Header(name = "foo") Integer fooHeader) {...}
 ----
 
 So you can bind parameters of the method to the Exchange, the
-xref:{eip-vc}:eips:message.adoc[Message] or individual headers, properties, the body
+xref:eips:message.adoc[Message] or individual headers, properties, the body
 or other expressions.
 
 [[BeanLanguage-Non-RegistryBeans]]
@@ -184,7 +184,7 @@ We have some test cases you can look at if it'll help
 is a JUnit test case showing the Java xref:manual::dsl.adoc[DSL] use of the bean
 expression being used in a filter
 * https://github.com/apache/camel/blob/main/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator.xml[aggregator.xml]
-is a Spring XML test case for the xref:{eip-vc}:eips:aggregate-eip.adoc[Aggregator] which
+is a Spring XML test case for the xref:eips:aggregate-eip.adoc[Aggregator] which
 uses a bean method call to test for the completion of the aggregation.
 
 include::{page-component-version}@camel-spring-boot::page$bean-starter.adoc[]

--- a/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
+++ b/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
@@ -163,7 +163,7 @@ Be careful when specifying `release`, as the failed job will immediately
 become available in the same tube and your consumer will try to acquire
 it again. You can `release` and specify _jobDelay_ though.
 
-The beanstalk consumer is a Scheduled xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+The beanstalk consumer is a Scheduled xref:eips:polling-consumer.adoc[Polling
 Consumer] which means there is more options you can configure, such as
 how frequent the consumer should poll. For more details
 see Polling Consumer.

--- a/components/camel-dataset/src/main/docs/dataset-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-dataset/src/main/docs/dataset-test-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-test-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
+++ b/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use DataSonnet to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a DataSonnet expression use the following Java code:
 

--- a/components/camel-disruptor/src/main/docs/disruptor-component.adoc
+++ b/components/camel-disruptor/src/main/docs/disruptor-component.adoc
@@ -199,7 +199,7 @@ without incurring significant latency spikes.
 
 == Use of Request Reply
 
-The Disruptor component supports using xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+The Disruptor component supports using xref:eips:requestReply-eip.adoc[Request
 Reply], where the caller will wait for the Async route to complete. For
 instance:
 

--- a/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
+++ b/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
@@ -278,7 +278,7 @@ try (ElasticsearchScrollRequestIterator response = template.requestBody("direct:
 }
 ----
 
-xref:{eip-vc}:eips:split-eip.adoc[Split EIP] can also be used.
+xref:eips:split-eip.adoc[Split EIP] can also be used.
 
 [source,java]
 ----

--- a/components/camel-elsql/src/main/docs/elsql-component.adoc
+++ b/components/camel-elsql/src/main/docs/elsql-component.adoc
@@ -20,7 +20,7 @@ This component uses `spring-jdbc` behind the scenes for the actual SQL
 handling.
 
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:

--- a/components/camel-facebook/src/main/docs/facebook-component.adoc
+++ b/components/camel-facebook/src/main/docs/facebook-component.adoc
@@ -327,7 +327,7 @@ facebook4j.PostUpdate body.
         .to("facebook://postFeed/inBody=postUpdate);
 ----------------------------------------------------
 
-To poll, every 5 sec (You can set the xref:{eip-vc}:eips:polling-consumer.adoc[polling
+To poll, every 5 sec (You can set the xref:eips:polling-consumer.adoc[polling
 consumer] options by adding a prefix of "consumer"), all statuses on
 your home feed:
 

--- a/components/camel-groovy/src/main/docs/groovy-language.adoc
+++ b/components/camel-groovy/src/main/docs/groovy-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use Groovy to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a Groovy expression use the following Java code
 
@@ -26,7 +26,7 @@ groovy("someGroovyExpression")
 ---------------------------------------
 
 For example you could use the *groovy* function to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message Filter] or as an Expression for a
+Predicate in a xref:eips:filter-eip.adoc[Message Filter] or as an Expression for a
 Recipient List
 
 == Groovy Options

--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -510,7 +510,7 @@ the documentation.
 
 Normally, when using xref:jms-component.adoc[JMS] as the transport, it only
 transfers the body and headers as the payload. If you want to use
-xref:jms-component.adoc[JMS] with a xref:{eip-vc}:eips:dead-letter-channel.adoc[Dead Letter
+xref:jms-component.adoc[JMS] with a xref:eips:dead-letter-channel.adoc[Dead Letter
 Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
@@ -1217,7 +1217,7 @@ Transactions and [Request Reply] over JMS
 When using Request Reply over JMS you cannot
 use a single transaction; JMS will not send any messages until a commit
 is performed, so the server side won't receive anything at all until the
-transaction commits. Therefore to use xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+transaction commits. Therefore to use xref:eips:requestReply-eip.adoc[Request
 Reply] you must commit a transaction after sending the request and then
 use a separate transaction for receiving the response.
 

--- a/components/camel-jta/src/main/docs/jta.adoc
+++ b/components/camel-jta/src/main/docs/jta.adoc
@@ -11,4 +11,4 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jta.adoc[opts=
 
 The `camel-jta` component is used for integrating Camel's transaction support with JTA.
 
-See more details in the xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client] documentation.
+See more details in the xref:eips:transactional-client.adoc[Transactional Client] documentation.

--- a/components/camel-language/src/main/docs/language-component.adoc
+++ b/components/camel-language/src/main/docs/language-component.adoc
@@ -18,7 +18,7 @@ to an endpoint which executes a script by any of the supported
 Languages in Camel. +
  By having a component to execute language scripts, it allows more
 dynamic routing capabilities. For example by using the
-Routing Slip or xref:{eip-vc}:eips:dynamicRouter-eip.adoc[Dynamic
+Routing Slip or xref:eips:dynamicRouter-eip.adoc[Dynamic
 Router] EIPs you can send messages to `language` endpoints where the
 script is dynamic defined as well.
 

--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -18,7 +18,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/components/camel-mvel/src/main/docs/mvel-language.adoc
+++ b/components/camel-mvel/src/main/docs/mvel-language.adoc
@@ -73,7 +73,7 @@ The MVEL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use Mvel inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use Mvel inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/components/camel-ognl/src/main/docs/ognl-language.adoc
+++ b/components/camel-ognl/src/main/docs/ognl-language.adoc
@@ -77,7 +77,7 @@ The OGNL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use OGNL inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use OGNL inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/components/camel-quartz/src/main/docs/quartz-component.adoc
+++ b/components/camel-quartz/src/main/docs/quartz-component.adoc
@@ -375,7 +375,7 @@ but it does not want to be fired now.
 
 The xref:quartz-component.adoc[Quartz] component provides a
 Polling Consumer scheduler which allows to
-use cron based scheduling for xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+use cron based scheduling for xref:eips:polling-consumer.adoc[Polling
 Consumer] such as the File and FTP
 consumers.
 

--- a/components/camel-saxon/src/main/docs/xquery-language.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XQuery to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 == XQuery Language options
 

--- a/components/camel-sjms/src/main/docs/sjms-component.adoc
+++ b/components/camel-sjms/src/main/docs/sjms-component.adoc
@@ -187,7 +187,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -236,7 +236,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/components/camel-sjms2/src/main/docs/sjms2-component.adoc
+++ b/components/camel-sjms2/src/main/docs/sjms2-component.adoc
@@ -190,7 +190,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -239,7 +239,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS2 endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -265,7 +265,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different exchanges. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
 
 You can specify using the following headers:
 
@@ -315,7 +315,7 @@ another RabbitMQ endpoint).
 
 If you need to send messages to a lot of different exchanges, it
 makes sense to reuse a endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to exchanges with order types,
 then using toD could for example be done as follows:

--- a/components/camel-spring/src/main/docs/spel-language.adoc
+++ b/components/camel-spring/src/main/docs/spel-language.adoc
@@ -126,8 +126,8 @@ can invoke the "bar" method on this bean like this:
 
 === SpEL in enterprise integration patterns
 
-You can use SpEL as an expression for xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient
-List] or as a predicate inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+You can use SpEL as an expression for xref:eips:recipientList-eip.adoc[Recipient
+List] or as a predicate inside a xref:eips:filter-eip.adoc[Message
 Filter]:
 
 [source,xml]

--- a/components/camel-spring/src/main/docs/spring-event-component.adoc
+++ b/components/camel-spring/src/main/docs/spring-event-component.adoc
@@ -18,8 +18,8 @@ The Spring Event component provides access to the Spring
 `ApplicationEvent` objects. This allows you to publish
 `ApplicationEvent` objects to a Spring `ApplicationContext` or to
 consume them. You can then use
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
-Patterns] to process them such as xref:{eip-vc}:eips:filter-eip.adoc[Message
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns] to process them such as xref:eips:filter-eip.adoc[Message
 Filter].
 
 == URI format

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -25,7 +25,7 @@ components like xref:jms-component.adoc[JMS] and xref:jms-component.adoc[JPA]
 Type Converter support for Spring Resources etc
 * Allows you to reuse the Spring Testing
 framework to simplify your unit and integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful xref:mock-component.adoc[Mock] and
 xref:others:test.adoc[Test] endpoints
 

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -46,7 +46,7 @@ pattern. See further below.
 [TIP]
 ====
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 ====
 
 The SQL component uses the following endpoint URI notation:

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -14,9 +14,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XPath to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 *Streams*
 

--- a/docs/components/modules/ROOT/pages/beanstalk-component.adoc
+++ b/docs/components/modules/ROOT/pages/beanstalk-component.adoc
@@ -165,7 +165,7 @@ Be careful when specifying `release`, as the failed job will immediately
 become available in the same tube and your consumer will try to acquire
 it again. You can `release` and specify _jobDelay_ though.
 
-The beanstalk consumer is a Scheduled xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+The beanstalk consumer is a Scheduled xref:eips:polling-consumer.adoc[Polling
 Consumer] which means there is more options you can configure, such as
 how frequent the consumer should poll. For more details
 see Polling Consumer.

--- a/docs/components/modules/ROOT/pages/dataset-component.adoc
+++ b/docs/components/modules/ROOT/pages/dataset-component.adoc
@@ -20,7 +20,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/docs/components/modules/ROOT/pages/dataset-test-component.adoc
+++ b/docs/components/modules/ROOT/pages/dataset-test-component.adoc
@@ -20,7 +20,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/docs/components/modules/ROOT/pages/disruptor-component.adoc
+++ b/docs/components/modules/ROOT/pages/disruptor-component.adoc
@@ -201,7 +201,7 @@ without incurring significant latency spikes.
 
 == Use of Request Reply
 
-The Disruptor component supports using xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+The Disruptor component supports using xref:eips:requestReply-eip.adoc[Request
 Reply], where the caller will wait for the Async route to complete. For
 instance:
 

--- a/docs/components/modules/ROOT/pages/elasticsearch-rest-component.adoc
+++ b/docs/components/modules/ROOT/pages/elasticsearch-rest-component.adoc
@@ -280,7 +280,7 @@ try (ElasticsearchScrollRequestIterator response = template.requestBody("direct:
 }
 ----
 
-xref:{eip-vc}:eips:split-eip.adoc[Split EIP] can also be used.
+xref:eips:split-eip.adoc[Split EIP] can also be used.
 
 [source,java]
 ----

--- a/docs/components/modules/ROOT/pages/elsql-component.adoc
+++ b/docs/components/modules/ROOT/pages/elsql-component.adoc
@@ -22,7 +22,7 @@ This component uses `spring-jdbc` behind the scenes for the actual SQL
 handling.
 
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 
 Maven users will need to add the following dependency to their `pom.xml`
 for this component:

--- a/docs/components/modules/ROOT/pages/facebook-component.adoc
+++ b/docs/components/modules/ROOT/pages/facebook-component.adoc
@@ -329,7 +329,7 @@ facebook4j.PostUpdate body.
         .to("facebook://postFeed/inBody=postUpdate);
 ----------------------------------------------------
 
-To poll, every 5 sec (You can set the xref:{eip-vc}:eips:polling-consumer.adoc[polling
+To poll, every 5 sec (You can set the xref:eips:polling-consumer.adoc[polling
 consumer] options by adding a prefix of "consumer"), all statuses on
 your home feed:
 

--- a/docs/components/modules/ROOT/pages/jms-component.adoc
+++ b/docs/components/modules/ROOT/pages/jms-component.adoc
@@ -512,7 +512,7 @@ the documentation.
 
 Normally, when using xref:jms-component.adoc[JMS] as the transport, it only
 transfers the body and headers as the payload. If you want to use
-xref:jms-component.adoc[JMS] with a xref:{eip-vc}:eips:dead-letter-channel.adoc[Dead Letter
+xref:jms-component.adoc[JMS] with a xref:eips:dead-letter-channel.adoc[Dead Letter
 Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
@@ -1219,7 +1219,7 @@ Transactions and [Request Reply] over JMS
 When using Request Reply over JMS you cannot
 use a single transaction; JMS will not send any messages until a commit
 is performed, so the server side won't receive anything at all until the
-transaction commits. Therefore to use xref:{eip-vc}:eips:requestReply-eip.adoc[Request
+transaction commits. Therefore to use xref:eips:requestReply-eip.adoc[Request
 Reply] you must commit a transaction after sending the request and then
 use a separate transaction for receiving the response.
 

--- a/docs/components/modules/ROOT/pages/language-component.adoc
+++ b/docs/components/modules/ROOT/pages/language-component.adoc
@@ -20,7 +20,7 @@ to an endpoint which executes a script by any of the supported
 Languages in Camel. +
  By having a component to execute language scripts, it allows more
 dynamic routing capabilities. For example by using the
-Routing Slip or xref:{eip-vc}:eips:dynamicRouter-eip.adoc[Dynamic
+Routing Slip or xref:eips:dynamicRouter-eip.adoc[Dynamic
 Router] EIPs you can send messages to `language` endpoints where the
 script is dynamic defined as well.
 

--- a/docs/components/modules/ROOT/pages/mock-component.adoc
+++ b/docs/components/modules/ROOT/pages/mock-component.adoc
@@ -20,7 +20,7 @@ notoriously difficult. The xref:mock-component.adoc[Mock], xref:mock-component.a
 and xref:dataset-component.adoc[DataSet] endpoints work great with the
 Camel Testing Framework to simplify your unit and
 integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's large range of Components
 together with the powerful Bean Integration.
 

--- a/docs/components/modules/ROOT/pages/quartz-component.adoc
+++ b/docs/components/modules/ROOT/pages/quartz-component.adoc
@@ -377,7 +377,7 @@ but it does not want to be fired now.
 
 The xref:quartz-component.adoc[Quartz] component provides a
 Polling Consumer scheduler which allows to
-use cron based scheduling for xref:{eip-vc}:eips:polling-consumer.adoc[Polling
+use cron based scheduling for xref:eips:polling-consumer.adoc[Polling
 Consumer] such as the File and FTP
 consumers.
 

--- a/docs/components/modules/ROOT/pages/sjms-component.adoc
+++ b/docs/components/modules/ROOT/pages/sjms-component.adoc
@@ -189,7 +189,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -238,7 +238,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/docs/components/modules/ROOT/pages/sjms2-component.adoc
+++ b/docs/components/modules/ROOT/pages/sjms2-component.adoc
@@ -192,7 +192,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different destinations. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with a header
 
 You can specify the destination in the following headers:
 
@@ -241,7 +241,7 @@ another JMS endpoint).
 
 If you need to send messages to a lot of different JMS destinations, it
 makes sense to reuse a SJMS2 endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to queues with order types,
 then using toD could for example be done as follows:

--- a/docs/components/modules/ROOT/pages/spring-event-component.adoc
+++ b/docs/components/modules/ROOT/pages/spring-event-component.adoc
@@ -20,8 +20,8 @@ The Spring Event component provides access to the Spring
 `ApplicationEvent` objects. This allows you to publish
 `ApplicationEvent` objects to a Spring `ApplicationContext` or to
 consume them. You can then use
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
-Patterns] to process them such as xref:{eip-vc}:eips:filter-eip.adoc[Message
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+Patterns] to process them such as xref:eips:filter-eip.adoc[Message
 Filter].
 
 == URI format

--- a/docs/components/modules/ROOT/pages/spring-rabbitmq-component.adoc
+++ b/docs/components/modules/ROOT/pages/spring-rabbitmq-component.adoc
@@ -267,7 +267,7 @@ a message header. This allows Camel to reuse the same endpoint, but send
 to different exchanges. This greatly reduces the number of endpoints
 created and economizes on memory and thread resources.
 
-TIP: Using xref:{eip-vc}:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
+TIP: Using xref:eips:toD-eip.adoc[toD] is easier than specifying the dynamic destination with headers
 
 You can specify using the following headers:
 
@@ -317,7 +317,7 @@ another RabbitMQ endpoint).
 
 If you need to send messages to a lot of different exchanges, it
 makes sense to reuse a endpoint and specify the dynamic destinations
-with simple language using xref:{eip-vc}:eips:toD-eip.adoc[toD].
+with simple language using xref:eips:toD-eip.adoc[toD].
 
 For example suppose you need to send messages to exchanges with order types,
 then using toD could for example be done as follows:

--- a/docs/components/modules/ROOT/pages/spring-summary.adoc
+++ b/docs/components/modules/ROOT/pages/spring-summary.adoc
@@ -27,7 +27,7 @@ components like xref:jms-component.adoc[JMS] and xref:jms-component.adoc[JPA]
 Type Converter support for Spring Resources etc
 * Allows you to reuse the Spring Testing
 framework to simplify your unit and integration testing using
-xref:{eip-vc}:eips:enterprise-integration-patterns.adoc[Enterprise Integration
+xref:eips:enterprise-integration-patterns.adoc[Enterprise Integration
 Patterns] and Camel's powerful xref:mock-component.adoc[Mock] and
 xref:others:test.adoc[Test] endpoints
 

--- a/docs/components/modules/ROOT/pages/sql-component.adoc
+++ b/docs/components/modules/ROOT/pages/sql-component.adoc
@@ -48,7 +48,7 @@ pattern. See further below.
 [TIP]
 ====
 This component can be used as a
-xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client].
+xref:eips:transactional-client.adoc[Transactional Client].
 ====
 
 The SQL component uses the following endpoint URI notation:

--- a/docs/components/modules/languages/pages/bean-language.adoc
+++ b/docs/components/modules/languages/pages/bean-language.adoc
@@ -22,7 +22,7 @@ using the type of the message body and using any annotations on the bean
 methods.
 
 The xref:manual::bean-binding.adoc[Bean Binding] rules are used to bind the
-xref:{eip-vc}:eips:message.adoc[Message] Exchange to the method parameters; so you can
+xref:eips:message.adoc[Message] Exchange to the method parameters; so you can
 annotate the bean to extract headers or other expressions such as
 xref:xpath-language.adoc[XPath] or xref:xquery-language.adoc[XQuery] from the message.
 
@@ -115,7 +115,7 @@ public boolean isGoldCustomer(@Header(name = "foo") Integer fooHeader) {...}
 ----
 
 So you can bind parameters of the method to the Exchange, the
-xref:{eip-vc}:eips:message.adoc[Message] or individual headers, properties, the body
+xref:eips:message.adoc[Message] or individual headers, properties, the body
 or other expressions.
 
 [[BeanLanguage-Non-RegistryBeans]]
@@ -186,7 +186,7 @@ We have some test cases you can look at if it'll help
 is a JUnit test case showing the Java xref:manual::dsl.adoc[DSL] use of the bean
 expression being used in a filter
 * https://github.com/apache/camel/blob/main/components/camel-spring/src/test/resources/org/apache/camel/spring/processor/aggregator.xml[aggregator.xml]
-is a Spring XML test case for the xref:{eip-vc}:eips:aggregate-eip.adoc[Aggregator] which
+is a Spring XML test case for the xref:eips:aggregate-eip.adoc[Aggregator] which
 uses a bean method call to test for the completion of the aggregation.
 
 include::{page-component-version}@camel-spring-boot::page$bean-starter.adoc[]

--- a/docs/components/modules/languages/pages/datasonnet-language.adoc
+++ b/docs/components/modules/languages/pages/datasonnet-language.adoc
@@ -16,9 +16,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use DataSonnet to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a DataSonnet expression use the following Java code:
 

--- a/docs/components/modules/languages/pages/groovy-language.adoc
+++ b/docs/components/modules/languages/pages/groovy-language.adoc
@@ -16,9 +16,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use Groovy to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 To use a Groovy expression use the following Java code
 
@@ -28,7 +28,7 @@ groovy("someGroovyExpression")
 ---------------------------------------
 
 For example you could use the *groovy* function to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message Filter] or as an Expression for a
+Predicate in a xref:eips:filter-eip.adoc[Message Filter] or as an Expression for a
 Recipient List
 
 == Groovy Options

--- a/docs/components/modules/languages/pages/mvel-language.adoc
+++ b/docs/components/modules/languages/pages/mvel-language.adoc
@@ -75,7 +75,7 @@ The MVEL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use Mvel inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use Mvel inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/docs/components/modules/languages/pages/ognl-language.adoc
+++ b/docs/components/modules/languages/pages/ognl-language.adoc
@@ -79,7 +79,7 @@ The OGNL language supports 1 options, which are listed below.
 
 == Samples
 
-For example you could use OGNL inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+For example you could use OGNL inside a xref:eips:filter-eip.adoc[Message
 Filter] in XML
 
 [source,java]

--- a/docs/components/modules/languages/pages/spel-language.adoc
+++ b/docs/components/modules/languages/pages/spel-language.adoc
@@ -128,8 +128,8 @@ can invoke the "bar" method on this bean like this:
 
 === SpEL in enterprise integration patterns
 
-You can use SpEL as an expression for xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient
-List] or as a predicate inside a xref:{eip-vc}:eips:filter-eip.adoc[Message
+You can use SpEL as an expression for xref:eips:recipientList-eip.adoc[Recipient
+List] or as a predicate inside a xref:eips:filter-eip.adoc[Message
 Filter]:
 
 [source,xml]

--- a/docs/components/modules/languages/pages/xpath-language.adoc
+++ b/docs/components/modules/languages/pages/xpath-language.adoc
@@ -16,9 +16,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XPath to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 *Streams*
 

--- a/docs/components/modules/languages/pages/xquery-language.adoc
+++ b/docs/components/modules/languages/pages/xquery-language.adoc
@@ -16,9 +16,9 @@ xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicat
 used in the xref:manual::dsl.adoc[DSL].
 
 For example you could use XQuery to create an
-Predicate in a xref:{eip-vc}:eips:filter-eip.adoc[Message
+Predicate in a xref:eips:filter-eip.adoc[Message
 Filter] or as an Expression for a
-xref:{eip-vc}:eips:recipientList-eip.adoc[Recipient List].
+xref:eips:recipientList-eip.adoc[Recipient List].
 
 == XQuery Language options
 

--- a/docs/components/modules/others/pages/jta.adoc
+++ b/docs/components/modules/others/pages/jta.adoc
@@ -13,4 +13,4 @@ include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jta.adoc[opts=
 
 The `camel-jta` component is used for integrating Camel's transaction support with JTA.
 
-See more details in the xref:{eip-vc}:eips:transactional-client.adoc[Transactional Client] documentation.
+See more details in the xref:eips:transactional-client.adoc[Transactional Client] documentation.

--- a/docs/components/modules/others/pages/yaml-dsl.adoc
+++ b/docs/components/modules/others/pages/yaml-dsl.adoc
@@ -169,7 +169,7 @@ Support for Endpoint DSL auto completion https://github.com/apache/camel-k-runti
 
 == Defining beans
 
-In addition to the general support for creating beans provided by xref:latest@components:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
+In addition to the general support for creating beans provided by xref:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
 
 [source,yaml]
 ----

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
@@ -167,7 +167,7 @@ Support for Endpoint DSL auto completion https://github.com/apache/camel-k-runti
 
 == Defining beans
 
-In addition to the general support for creating beans provided by xref:latest@components:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
+In addition to the general support for creating beans provided by xref:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Removes use of eip-vc attribute and latest@components literal from components component.