### PR TITLE
[CAMEL-16992] Camel 2.x cant stay in version

### DIFF
--- a/docs/components/antora.yml
+++ b/docs/components/antora.yml
@@ -27,3 +27,4 @@ asciidoc:
   attributes:
     index-table-format: width="100%",cols="4,3,3,3,6",options="header"
 #  | Data Format | Artifact | Support Level | Since | Description
+    eip-vc: latest@components


### PR DESCRIPTION
Camel 2.x eips module is not part of components component so eip references need to go to latest.  eip-vc attribute added to components component descriptor.