### PR TITLE
add eip back to eip models labels

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/batch-config.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/batch-config.json
@@ -5,7 +5,7 @@
     "title": "Batch-config",
     "description": "Configures batch-processing resequence eip.",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.config.BatchResequencerConfig",
     "input": false,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/faultToleranceConfiguration.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/faultToleranceConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Fault Tolerance Configuration",
     "description": "MicroProfile Fault Tolerance Circuit Breaker EIP configuration",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.FaultToleranceConfigurationDefinition",
     "input": false,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/hystrixConfiguration.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/hystrixConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Hystrix Configuration",
     "description": "Hystrix Circuit Breaker EIP configuration",
     "deprecated": true,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.HystrixConfigurationDefinition",
     "input": false,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/resilience4jConfiguration.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/resilience4jConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Resilience4j Configuration",
     "description": "Resilience4j Circuit Breaker EIP configuration",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.Resilience4jConfigurationDefinition",
     "input": false,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/stream-config.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/stream-config.json
@@ -5,7 +5,7 @@
     "title": "Stream-config",
     "description": "Configures stream-processing resequence eip.",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.config.StreamResequencerConfig",
     "input": false,
     "output": false

--- a/core/camel-core-engine/src/main/docs/modules/eips/examples/json/batch-config.json
+++ b/core/camel-core-engine/src/main/docs/modules/eips/examples/json/batch-config.json
@@ -1,0 +1,1 @@
+../../../../../../../../camel-core-model/src/generated/resources/org/apache/camel/model/config/batch-config.json

--- a/core/camel-core-engine/src/main/docs/modules/eips/examples/json/faultToleranceConfiguration.json
+++ b/core/camel-core-engine/src/main/docs/modules/eips/examples/json/faultToleranceConfiguration.json
@@ -1,0 +1,1 @@
+../../../../../../../../camel-core-model/src/generated/resources/org/apache/camel/model/faultToleranceConfiguration.json

--- a/core/camel-core-engine/src/main/docs/modules/eips/examples/json/hystrixConfiguration.json
+++ b/core/camel-core-engine/src/main/docs/modules/eips/examples/json/hystrixConfiguration.json
@@ -1,0 +1,1 @@
+../../../../../../../../camel-core-model/src/generated/resources/org/apache/camel/model/hystrixConfiguration.json

--- a/core/camel-core-engine/src/main/docs/modules/eips/examples/json/resilience4jConfiguration.json
+++ b/core/camel-core-engine/src/main/docs/modules/eips/examples/json/resilience4jConfiguration.json
@@ -1,0 +1,1 @@
+../../../../../../../../camel-core-model/src/generated/resources/org/apache/camel/model/resilience4jConfiguration.json

--- a/core/camel-core-engine/src/main/docs/modules/eips/examples/json/stream-config.json
+++ b/core/camel-core-engine/src/main/docs/modules/eips/examples/json/stream-config.json
@@ -1,0 +1,1 @@
+../../../../../../../../camel-core-model/src/generated/resources/org/apache/camel/model/config/stream-config.json

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/config/batch-config.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/config/batch-config.json
@@ -5,7 +5,7 @@
     "title": "Batch-config",
     "description": "Configures batch-processing resequence eip.",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.config.BatchResequencerConfig",
     "input": false,
     "output": false

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/config/stream-config.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/config/stream-config.json
@@ -5,7 +5,7 @@
     "title": "Stream-config",
     "description": "Configures stream-processing resequence eip.",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.config.StreamResequencerConfig",
     "input": false,
     "output": false

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/faultToleranceConfiguration.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/faultToleranceConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Fault Tolerance Configuration",
     "description": "MicroProfile Fault Tolerance Circuit Breaker EIP configuration",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.FaultToleranceConfigurationDefinition",
     "input": false,
     "output": false

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/hystrixConfiguration.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/hystrixConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Hystrix Configuration",
     "description": "Hystrix Circuit Breaker EIP configuration",
     "deprecated": true,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.HystrixConfigurationDefinition",
     "input": false,
     "output": false

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/resilience4jConfiguration.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/resilience4jConfiguration.json
@@ -5,7 +5,7 @@
     "title": "Resilience4j Configuration",
     "description": "Resilience4j Circuit Breaker EIP configuration",
     "deprecated": false,
-    "label": "configuration",
+    "label": "configuration,eip",
     "javaType": "org.apache.camel.model.Resilience4jConfigurationDefinition",
     "input": false,
     "output": false

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/FaultToleranceConfigurationDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/FaultToleranceConfigurationDefinition.java
@@ -27,7 +27,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * MicroProfile Fault Tolerance Circuit Breaker EIP configuration
  */
-@Metadata(label = "configuration")
+@Metadata(label = "configuration,eip")
 @XmlRootElement(name = "faultToleranceConfiguration")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Configurer(extended = true)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/HystrixConfigurationDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/HystrixConfigurationDefinition.java
@@ -29,7 +29,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Hystrix Circuit Breaker EIP configuration
  */
-@Metadata(label = "configuration")
+@Metadata(label = "configuration,eip")
 @XmlRootElement(name = "hystrixConfiguration")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Configurer(extended = true)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/Resilience4jConfigurationDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/Resilience4jConfigurationDefinition.java
@@ -29,7 +29,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Resilience4j Circuit Breaker EIP configuration
  */
-@Metadata(label = "configuration")
+@Metadata(label = "configuration,eip")
 @XmlRootElement(name = "resilience4jConfiguration")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Configurer(extended = true)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/config/BatchResequencerConfig.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/config/BatchResequencerConfig.java
@@ -26,7 +26,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Configures batch-processing resequence eip.
  */
-@Metadata(label = "configuration")
+@Metadata(label = "configuration,eip")
 @XmlRootElement(name = "batch-config")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class BatchResequencerConfig extends ResequencerConfig {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/config/StreamResequencerConfig.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/config/StreamResequencerConfig.java
@@ -28,7 +28,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Configures stream-processing resequence eip.
  */
-@Metadata(label = "configuration")
+@Metadata(label = "configuration,eip")
 @XmlRootElement(name = "stream-config")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class StreamResequencerConfig extends ResequencerConfig {


### PR DESCRIPTION
This fixes the website build, broken with some of the recent "Polished EIPs and make their categorization simpler for tooling." work. With  the 'eip' label restored, the json files are symlinked so they can be used in the corresponding eip pages.
