### PR TITLE
CAMEL-16837: Remove reference to non-functional aws2-ddbstream batch consumers

### DIFF
--- a/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddbstream-component.adoc
+++ b/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddbstream-component.adoc
@@ -64,14 +64,6 @@ It is an error to provide a sequence number that is greater than the
 largest sequence number in the describe-streams result, as this will
 lead to the AWS call returning an HTTP 400.
 
-== Batch Consumer
-
-This component implements the Batch Consumer.
-
-This allows you for instance to know how many messages exists in this
-batch and for instance let the Aggregator
-aggregate this number of messages.
-
 == Usage
 
 === Static credentials vs Default Credential Provider


### PR DESCRIPTION
If I've understood CAMEL-16837 correctly, the 'batch consumers' stuff in `aws2-ddbstream` is not currently functional.

There was a proposal to mention this in the CQ extension docs. But I figured it made more sense to remove it from the compoent docs, until it's fully implemented / supported.