### PR TITLE
Update otel component to stable API in 3.8.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -451,7 +451,7 @@
     <olingo4-version>4.8.0</olingo4-version>
     <openjpa-version>3.1.2</openjpa-version>
     <openstack4j-version>3.8</openstack4j-version>
-    <opentelemetry-version>0.11.0</opentelemetry-version>
+    <opentelemetry-version>1.6.0</opentelemetry-version>
     <opentracing-tracerresolver-version>0.1.8</opentracing-tracerresolver-version>
     <opentracing-version>0.31.0</opentracing-version>
     <openwebbeans-version>1.7.3</openwebbeans-version>

--- a/components/camel-opentelemetry/pom.xml
+++ b/components/camel-opentelemetry/pom.xml
@@ -64,6 +64,11 @@
       <version>${opentelemetry-version}</version>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-semconv</artifactId>
+      <version>${opentelemetry-version}-alpha</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/components/camel-opentelemetry/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-opentelemetry/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=opentelemetry
 groupId=org.apache.camel
 artifactId=camel-opentelemetry
-version=3.8.0-SNAPSHOT
+version=3.8.1-SNAPSHOT
 projectName=Camel :: OpenTelemetry
 projectDescription=Distributed tracing using OpenTelemetry

--- a/components/camel-opentelemetry/src/generated/resources/opentelemetry.json
+++ b/components/camel-opentelemetry/src/generated/resources/opentelemetry.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel",
     "artifactId": "camel-opentelemetry",
-    "version": "3.8.0-SNAPSHOT"
+    "version": "3.8.1-SNAPSHOT"
   }
 }

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -21,17 +21,15 @@ import java.util.Map;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageBuilder;
-import io.opentelemetry.api.baggage.EntryMetadata;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.trace.attributes.SemanticAttributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.Tag;
 
 public class OpenTelemetrySpanAdapter implements SpanAdapter {
     private static final String DEFAULT_EVENT_NAME = "log";
-    private static EnumMap<Tag, String> tagMap = new EnumMap<>(Tag.class);
+    private static final EnumMap<Tag, String> tagMap = new EnumMap<>(Tag.class);
 
     static {
         tagMap.put(Tag.COMPONENT, "component");
@@ -45,7 +43,7 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
     }
 
     private Baggage baggage;
-    private io.opentelemetry.api.trace.Span span;
+    private final io.opentelemetry.api.trace.Span span;
 
     OpenTelemetrySpanAdapter(io.opentelemetry.api.trace.Span span) {
         this.span = span;
@@ -145,9 +143,9 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
     public void setCorrelationContextItem(String key, String value) {
         BaggageBuilder builder = Baggage.builder();
         if (baggage != null) {
-            builder = builder.setParent(Context.current().with(baggage));
+            builder = Baggage.current().toBuilder();
         }
-        baggage = builder.put(key, value, EntryMetadata.EMPTY).build();
+        baggage = builder.put(key, value).build();
     }
 
     public String getContextPropagationItem(String key) {

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -18,10 +18,12 @@ package org.apache.camel.opentelemetry;
 
 import java.util.Set;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import org.apache.camel.Exchange;
@@ -32,7 +34,6 @@ import org.apache.camel.tracing.ExtractAdapter;
 import org.apache.camel.tracing.InjectAdapter;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
-import org.apache.camel.tracing.SpanKind;
 import org.apache.camel.tracing.decorators.AbstractInternalSpanDecorator;
 
 @ManagedResource(description = "OpenTelemetryTracer")
@@ -53,18 +54,18 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         this.instrumentationName = instrumentationName;
     }
 
-    private Span.Kind mapToSpanKind(SpanKind kind) {
+    private SpanKind mapToSpanKind(org.apache.camel.tracing.SpanKind kind) {
         switch (kind) {
             case SPAN_KIND_CLIENT:
-                return Span.Kind.CLIENT;
+                return SpanKind.CLIENT;
             case SPAN_KIND_SERVER:
-                return Span.Kind.SERVER;
+                return SpanKind.SERVER;
             case CONSUMER:
-                return Span.Kind.CONSUMER;
+                return SpanKind.CONSUMER;
             case PRODUCER:
-                return Span.Kind.PRODUCER;
+                return SpanKind.PRODUCER;
             default:
-                return Span.Kind.SERVER;
+                return SpanKind.SERVER;
         }
     }
 
@@ -78,17 +79,18 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         }
 
         if (tracer == null) {
-            tracer = OpenTelemetry.get().getTracer(instrumentationName);
+            tracer = GlobalOpenTelemetry.get().getTracer(instrumentationName);
         }
 
         if (tracer == null) {
             // No tracer is available, so setup NoopTracer
-            tracer = Tracer.getDefault();
+            tracer = OpenTelemetry.noop().getTracer(instrumentationName);
         }
     }
 
     @Override
-    protected SpanAdapter startSendingEventSpan(String operationName, SpanKind kind, SpanAdapter parent) {
+    protected SpanAdapter startSendingEventSpan(
+            String operationName, org.apache.camel.tracing.SpanKind kind, SpanAdapter parent) {
         Baggage baggage = null;
         SpanBuilder builder = tracer.spanBuilder(operationName).setSpanKind(mapToSpanKind(kind));
         if (parent != null) {
@@ -102,7 +104,8 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
 
     @Override
     protected SpanAdapter startExchangeBeginSpan(
-            Exchange exchange, SpanDecorator sd, String operationName, SpanKind kind, SpanAdapter parent) {
+            Exchange exchange, SpanDecorator sd, String operationName, org.apache.camel.tracing.SpanKind kind,
+            SpanAdapter parent) {
         SpanBuilder builder = tracer.spanBuilder(operationName);
         Baggage baggage;
         if (parent != null) {
@@ -111,7 +114,7 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
             baggage = spanFromExchange.getBaggage();
         } else {
             ExtractAdapter adapter = sd.getExtractAdapter(exchange.getIn().getHeaders(), encoding);
-            Context ctx = OpenTelemetry.get().getPropagators().getTextMapPropagator().extract(Context.current(), adapter,
+            Context ctx = GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator().extract(Context.current(), adapter,
                     new OpenTelemetryGetter(adapter));
             Span span = Span.fromContext(ctx);
             baggage = Baggage.fromContext(ctx);
@@ -136,7 +139,7 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         OpenTelemetrySpanAdapter spanFromExchange = (OpenTelemetrySpanAdapter) span;
         Span otelSpan = spanFromExchange.getOpenTelemetrySpan();
         Context ctx = Context.current().with(otelSpan).with(spanFromExchange.getBaggage());
-        OpenTelemetry.get().getPropagators().getTextMapPropagator().inject(ctx, adapter, new OpenTelemetrySetter());
+        GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator().inject(ctx, adapter, new OpenTelemetrySetter());
     }
 
 }

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/propagators/OpenTelemetryGetter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/propagators/OpenTelemetryGetter.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.opentelemetry.propagators;
 
-import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import org.apache.camel.tracing.ExtractAdapter;
 
-public class OpenTelemetryGetter implements TextMapPropagator.Getter<ExtractAdapter> {
+public class OpenTelemetryGetter implements TextMapGetter<ExtractAdapter> {
 
     ExtractAdapter adapter;
 

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/propagators/OpenTelemetrySetter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/propagators/OpenTelemetrySetter.java
@@ -18,10 +18,10 @@ package org.apache.camel.opentelemetry.propagators;
 
 import javax.annotation.Nullable;
 
-import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
 import org.apache.camel.tracing.InjectAdapter;
 
-public class OpenTelemetrySetter implements TextMapPropagator.Setter<InjectAdapter> {
+public class OpenTelemetrySetter implements TextMapSetter<InjectAdapter> {
     @Override
     public void set(@Nullable InjectAdapter adapter, String key, String value) {
         adapter.put(key, value);

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/SpanTestData.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/SpanTestData.java
@@ -17,24 +17,21 @@
 package org.apache.camel.opentelemetry;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 
 public class SpanTestData {
 
     private String label;
     private String uri;
     private String operation;
-    private Span.Kind kind = Span.Kind.INTERNAL;
+    private SpanKind kind = SpanKind.INTERNAL;
     private int parentId = -1;
-    private List<String> logMessages = new ArrayList<>();
-    private Map<String, String> tags = new HashMap<>();
-    private ArrayList<SpanTestData> childs = new ArrayList<>();
-    private Map<String, String> baggage = new HashMap<>();
+    private final List<String> logMessages = new ArrayList<>();
+    private final Map<String, String> tags = new HashMap<>();
 
     public String getLabel() {
         return label;
@@ -63,11 +60,11 @@ public class SpanTestData {
         return this;
     }
 
-    public Span.Kind getKind() {
+    public SpanKind getKind() {
         return kind;
     }
 
-    public SpanTestData setKind(Span.Kind kind) {
+    public SpanTestData setKind(SpanKind kind) {
         this.kind = kind;
         return this;
     }
@@ -98,10 +95,4 @@ public class SpanTestData {
     public Map<String, String> getTags() {
         return tags;
     }
-
-    public SpanTestData setChilds(SpanTestData[] childs) {
-        Collections.addAll(this.childs, childs);
-        return this;
-    }
-
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -441,7 +441,7 @@
         <ognl-version>3.1.12</ognl-version>
         <openjpa-version>3.1.2</openjpa-version>
         <openstack4j-version>3.8</openstack4j-version>
-        <opentelemetry-version>0.11.0</opentelemetry-version>
+        <opentelemetry-version>1.6.0</opentelemetry-version>
         <!-- cannot upgrade opentracing until https://github.com/eclipse/microprofile-opentracing v2 is released -->
         <opentracing-version>0.31.0</opentracing-version>
         <opentracing-tracerresolver-version>0.1.8</opentracing-tracerresolver-version>


### PR DESCRIPTION
Updates OpenTelemetry to stable version (>= 1.0.0) in the 3.8.x stream.
Reasons for the change:
- some Camel users are tied to AWS SDK v1 which was deprecated past 3.8.x
- camel OTeL component in 3.8.x uses OTeL SDK prior to first stable release (1.0.0)
- since stable release, OTeL guarantees that agent release will be compatible with any SDK version

Long story short - updating OTeL SDK >= 1.0.0 in 3.8.x enables customers using AWS SDK v1 to deploy Camel with newest OTeL Java Agent.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
