### PR TITLE
camel-jdbc: auto-closing the statement prevents post-processing

### DIFF
--- a/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/JdbcProducer.java
+++ b/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/JdbcProducer.java
@@ -195,7 +195,10 @@ public class JdbcProducer extends DefaultProducer {
         ResultSet rs = null;
         boolean shouldCloseResources = true;
 
-        try (Statement stmt = conn.createStatement()) {
+        try {
+            // We might need to leave it open to allow post-processing of the result set. This is why we
+            // are not using try-with-resources here.
+            Statement stmt = conn.createStatement();
 
             if (parameters != null && !parameters.isEmpty()) {
                 Map<String, Object> copy = new HashMap<>(parameters);


### PR DESCRIPTION
Although it would be advisable to have the statement auto-closing, in
this case it prevents the result set from being post-processed. This
causes a failure subsequently, when the result set from the statement is
used to iterate over the results.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->