### PR TITLE
CAMEL-17037: added for sftp producer chmodDirectory functionality

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConfiguration.java
@@ -75,6 +75,8 @@ public class SftpConfiguration extends RemoteFileConfiguration {
     private boolean existDirCheckUsingLs = true;
     @UriParam(label = "security")
     private String keyExchangeProtocols;
+    @UriParam(label = "producer, advanced")
+    private String chmodDirectory;
 
     public SftpConfiguration() {
         setProtocol("sftp");
@@ -247,6 +249,17 @@ public class SftpConfiguration extends RemoteFileConfiguration {
 
     public String getChmod() {
         return chmod;
+    }
+
+    /**
+     * Allows you to set chmod during path creation. For example chmod=640.
+     */
+    public void setChmodDirectory(String chmodDirectory) {
+        this.chmodDirectory = chmodDirectory;
+    }
+
+    public String getChmodDirectory() {
+        return chmodDirectory;
     }
 
     /**

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpEndpoint.java
@@ -34,7 +34,7 @@ import org.apache.camel.spi.UriParam;
              syntax = "sftp:host:port/directoryName", label = "file")
 @Metadata(excludeProperties = "appendChars,bufferSize,siteCommand,"
                               + "directoryMustExist,extendedAttributes,probeContentType,startingDirectoryMustExist,"
-                              + "startingDirectoryMustHaveAccess,chmodDirectory,forceWrites,copyAndDeleteOnRenameFail,"
+                              + "startingDirectoryMustHaveAccess,forceWrites,copyAndDeleteOnRenameFail,"
                               + "renameUsingCopy")
 public class SftpEndpoint extends RemoteFileEndpoint<SftpRemoteFile> {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote.sftp.integration;
+
+import java.io.File;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIf(value = "org.apache.camel.component.file.remote.services.SftpEmbeddedService#hasRequiredAlgorithms")
+public class SftpChmodIT extends SftpServerTestSupport {
+
+    @Test
+    public void testSftpChmod() {
+        template.sendBodyAndHeader(
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&chmod=777",
+                "Hello World", Exchange.FILE_NAME,
+                "hello.txt");
+
+        File file = ftpFile("hello.txt").toFile();
+        assertTrue(file.exists(), "File should exist: " + file);
+        assertEquals("Hello World", context.getTypeConverter().convertTo(String.class, file));
+    }
+
+}

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
@@ -30,13 +30,12 @@ public class SftpChmodDirectoryIT extends SftpServerTestSupport {
     @Test
     public void testSftpChmodDirectoryWriteable() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/testFolder1" +
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/folder" +
                                    "?username=admin&password=admin&chmod=777&chmodDirectory=770",
                 "Hello World", Exchange.FILE_NAME,
                 "hello.txt");
 
-        //File file = ftpFile("testFolder/hello.txt").toFile();
-        File path = ftpFile("testFolder/hello.txt").getParent().toFile();
+        File path = ftpFile("folder/hello.txt").getParent().toFile();
         assertTrue(path.canRead(), "Path should have permission readable: " + path);
         assertTrue(path.canWrite(), "Path should have permission writeable: " + path);
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
@@ -22,22 +22,23 @@ import org.apache.camel.Exchange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnabledIf(value = "org.apache.camel.component.file.remote.services.SftpEmbeddedService#hasRequiredAlgorithms")
-public class SftpChmodIT extends SftpServerTestSupport {
+public class SftpChmodDirectoryIT extends SftpServerTestSupport {
 
     @Test
-    public void testSftpChmod() {
+    public void testSftpChmodDirectoryWriteable() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&chmod=777",
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/testFolder1" +
+                                   "?username=admin&password=admin&chmod=777&chmodDirectory=770",
                 "Hello World", Exchange.FILE_NAME,
                 "hello.txt");
 
-        File file = ftpFile("hello.txt").toFile();
-        assertTrue(file.exists(), "File should exist: " + file);
-        assertEquals("Hello World", context.getTypeConverter().convertTo(String.class, file));
+        //File file = ftpFile("testFolder/hello.txt").toFile();
+        File path = ftpFile("testFolder/hello.txt").getParent().toFile();
+        assertTrue(path.canRead(), "Path should have permission readable: " + path);
+        assertTrue(path.canWrite(), "Path should have permission writeable: " + path);
     }
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/spi/ManagementStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/ManagementStrategy.java
@@ -25,12 +25,13 @@ import org.apache.camel.StaticService;
 /**
  * Strategy for management.
  * <p/>
- * This is totally pluggable allowing to use a custom or 3rd party management implementation with Camel.
+ * If JMX is detected (camel-management JAR on the classpath) then org.apache.camel.management.JmxManagementStrategy is
+ * in use. Otherwise, the DefaultManagementStrategy is in use.
+ * <p/>
+ * You can also plugin and use a 3rd party management implementation with Camel.
  *
  * @see org.apache.camel.spi.EventNotifier
  * @see org.apache.camel.spi.EventFactory
- * @see ManagementObjectNameStrategy
- * @see org.apache.camel.spi.ManagementAgent
  */
 public interface ManagementStrategy extends StaticService {
 


### PR DESCRIPTION
For the sftp component a possibility to set the permission (chmod) also on an new created path.
Only for the producer.
SFTP api feature: channel.chmod(permissions, directory);

Implemented within an helper method

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
