### PR TITLE
CAMEL-16946:  bean-validator,  validate all elements if body is of type Iterable

### DIFF
--- a/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidatorProducer.java
+++ b/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidatorProducer.java
@@ -40,13 +40,13 @@ public class BeanValidatorProducer extends DefaultProducer {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        Object bean = exchange.getIn().getBody();
         Set<ConstraintViolation<Object>> constraintViolations = new HashSet<>();
 
-        if (bean instanceof Iterable) {
-            ((Iterable) bean).forEach(b -> constraintViolations.addAll(getConstraintViolationsForSingleBean(b, this.group)));
+        if (exchange.getIn().getBody() instanceof Iterable) {
+            Iterable<?> body = exchange.getIn().getBody(Iterable.class);
+            body.forEach(b -> constraintViolations.addAll(getConstraintViolationsForSingleBean(b, this.group)));
         } else {
-            constraintViolations.addAll(getConstraintViolationsForSingleBean(bean, this.group));
+            constraintViolations.addAll(getConstraintViolationsForSingleBean(exchange.getIn().getBody(), this.group));
         }
 
         if (!constraintViolations.isEmpty()) {

--- a/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidatorProducer.java
+++ b/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidatorProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.bean.validator;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -40,12 +41,12 @@ public class BeanValidatorProducer extends DefaultProducer {
     @Override
     public void process(Exchange exchange) throws Exception {
         Object bean = exchange.getIn().getBody();
-        Set<ConstraintViolation<Object>> constraintViolations;
+        Set<ConstraintViolation<Object>> constraintViolations = new HashSet<>();
 
-        if (this.group != null) {
-            constraintViolations = validatorFactory.getValidator().validate(bean, group);
+        if (bean instanceof Iterable) {
+            ((Iterable) bean).forEach(b -> constraintViolations.addAll(getConstraintViolationsForSingleBean(b, this.group)));
         } else {
-            constraintViolations = validatorFactory.getValidator().validate(bean);
+            constraintViolations.addAll(getConstraintViolationsForSingleBean(bean, this.group));
         }
 
         if (!constraintViolations.isEmpty()) {
@@ -67,6 +68,18 @@ public class BeanValidatorProducer extends DefaultProducer {
 
     public void setGroup(Class<?> group) {
         this.group = group;
+    }
+
+    private Set<ConstraintViolation<Object>> getConstraintViolationsForSingleBean(Object bean, Class<?> group) {
+        Set<ConstraintViolation<Object>> constraintViolations;
+
+        if (this.group != null) {
+            constraintViolations = validatorFactory.getValidator().validate(bean, group);
+        } else {
+            constraintViolations = validatorFactory.getValidator().validate(bean);
+        }
+
+        return constraintViolations;
     }
 
 }


### PR DESCRIPTION
This PR implements CAMEL-16946.
The bean-validator component checks if the body is of type Iterable. If so, then each element will be validated. Otherwise, the single element will be validated.
The corresponding tests have been changed to parameterized tests. Each test is executed with a single bean as well as with a collection of beans.