### PR TITLE
CAMEL-16718: fix camel-netty-http test case

### DIFF
--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSSLHandshakeErrorTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSSLHandshakeErrorTest.java
@@ -60,8 +60,8 @@ public class NettyHttpSSLHandshakeErrorTest extends BaseNettyTest {
         Exception ex = response.getException();
 
         assertTrue(response.isFailed(), "should have failed");
-        assertNotNull(ex.getCause());
-        assertEquals(javax.net.ssl.SSLHandshakeException.class, ex.getCause().getClass(), "exception expected");
+        assertNotNull(ex);
+        assertEquals(javax.net.ssl.SSLHandshakeException.class, ex.getClass(), "SSLHandshakeException expected");
 
         assertMockEndpointsSatisfied();
     }


### PR DESCRIPTION
The fix for the CAMEL-16718 changed the exception returned
(commit ref: 4845cf938e423355ea96ed7a3e1942fcceac2de3), so now the
SSLHandshakeException is not on the cause of the original exception, but
instead is the exception itself.

-- 

This one was failing for a while on CI. I think this will fix it.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->