### PR TITLE
[camel-nats] Fix headers mapping when doing a round trip to nats

### DIFF
--- a/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConsumer.java
+++ b/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConsumer.java
@@ -173,7 +173,13 @@ public class NatsConsumer extends DefaultConsumer {
                                 .getHeaderFilterStrategy();
                         msg.getHeaders().entrySet().forEach(entry -> {
                             if (!strategy.applyFilterToExternalHeaders(entry.getKey(), entry.getValue(), exchange)) {
-                                exchange.getIn().setHeader(entry.getKey(), entry.getValue());
+                                if (entry.getValue().size() == 1) {
+                                    // going from camel to nats add all headers in lists, so we extract them in the opposite
+                                    // way if it contains a single value
+                                    exchange.getIn().setHeader(entry.getKey(), entry.getValue().get(0));
+                                } else {
+                                    exchange.getIn().setHeader(entry.getKey(), entry.getValue());
+                                }
                             } else {
                                 LOG.debug("Excluding header {} as per strategy", entry.getKey());
                             }

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerHeadersSupportIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerHeadersSupportIT.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.nats.integration;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.nats.client.Connection;
 import io.nats.client.Nats;
@@ -46,11 +48,11 @@ class NatsConsumerHeadersSupportIT extends NatsITSupport {
     @Test
     void testConsumerShouldForwardHeaders() throws IOException, InterruptedException {
 
-        final String[] firstHeader = { HEADER_VALUE_1 };
-        final String[] secondHeader = { HEADER_VALUE_2, HEADER_VALUE_3 };
-        this.mockResultEndpoint.expectedHeaderReceived(HEADER_KEY_1, firstHeader);
-        this.mockResultEndpoint.expectedHeaderReceived(HEADER_KEY_2,
-                secondHeader);
+        List<String> secondHeaders = new ArrayList<String>();
+        secondHeaders.add(HEADER_VALUE_2);
+        secondHeaders.add(HEADER_VALUE_3);
+        this.mockResultEndpoint.expectedHeaderReceived(HEADER_KEY_1, HEADER_VALUE_1);
+        this.mockResultEndpoint.expectedHeaderReceived(HEADER_KEY_2, secondHeaders);
 
         final Options options = new Options.Builder().server("nats://" + service.getServiceAddress()).build();
         final Connection connection = Nats.connect(options);


### PR DESCRIPTION
Camel headers are defined as Map<String, Object>, and Nats headers as Map<String, List<Object>>.

When doing a round trip to nats via camel, the following header:
Header 1 - Value 1
becomes
Header 1 - [Value 1].

The best way I could find to remove this invalid behavior is to transform the singleton lists in their first element when mapping the headers from nats header to camel header.