### PR TITLE
(chores) camel-grpc: fix version conflict causing CI failures

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -235,7 +235,7 @@
     <grpc-google-auth-library-version>0.26.0</grpc-google-auth-library-version>
     <grpc-guava-version>28.2-jre</grpc-guava-version>
     <grpc-java-jwt-version>3.16.0</grpc-java-jwt-version>
-    <grpc-netty-tcnative-boringssl-static-version>2.0.39.Final</grpc-netty-tcnative-boringssl-static-version>
+    <grpc-netty-tcnative-boringssl-static-version>2.0.44.Final</grpc-netty-tcnative-boringssl-static-version>
     <grpc-version>1.38.0</grpc-version>
     <gson-version>2.8.7</gson-version>
     <guava-eventbus-version>28.2-jre</guava-eventbus-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -215,7 +215,7 @@
         <grpc-google-auth-library-version>0.26.0</grpc-google-auth-library-version>
         <grpc-guava-version>28.2-jre</grpc-guava-version>
         <grpc-java-jwt-version>3.16.0</grpc-java-jwt-version>
-        <grpc-netty-tcnative-boringssl-static-version>2.0.39.Final</grpc-netty-tcnative-boringssl-static-version>
+        <grpc-netty-tcnative-boringssl-static-version>2.0.44.Final</grpc-netty-tcnative-boringssl-static-version>
         <gson-version>2.8.7</gson-version>
         <guava-eventbus-version>28.2-jre</guava-eventbus-version>
         <guice3-version>3.0</guice3-version>


### PR DESCRIPTION
The reordering of the Netty dependencies from
b8ca24ee853275ad5cf9fa0ca61fa5e72a9b891b is bringing a newer version of
the io.netty:netty-tcnative-boringssl-static (2.0.44.Final). Forcing the
camel-grpc to use the older one (2.0.39.Final) causes a failure because the class
AsyncSSLPrivateKeyMethod is not present on the older one.

This causes the GrpcProducerSecurityTest test to fail.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->