### PR TITLE
update to new indexer and jsonpath syntax

### DIFF
--- a/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
+++ b/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
@@ -8,7 +8,7 @@
 :component-header: Both producer and consumer are supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/avro.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: avro
+:camel-spring-boot-name: avro-rpc
 
 *Since Camel {since}*
 

--- a/components/camel-aws/src/main/docs/aws-summary.adoc
+++ b/components/camel-aws/src/main/docs/aws-summary.adoc
@@ -11,4 +11,4 @@ storage service, email and queue services. The main reason to use AWS is its clo
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]

--- a/components/camel-azure/src/main/docs/azure-summary.adoc
+++ b/components/camel-azure/src/main/docs/azure-summary.adoc
@@ -9,5 +9,5 @@ provide connectivity to Azure services from Camel.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 

--- a/components/camel-debezium/src/main/docs/debezium-summary.adoc
+++ b/components/camel-debezium/src/main/docs/debezium-summary.adoc
@@ -10,4 +10,4 @@ Camel includes individual components for each Debezium connector which allows fo
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]

--- a/components/camel-google/src/main/docs/google-summary.adoc
+++ b/components/camel-google/src/main/docs/google-summary.adoc
@@ -11,4 +11,4 @@ drive . The main reason to use Google is the G Suite features.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]

--- a/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
@@ -24,7 +24,7 @@ http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-huawei/src/main/docs/hwcloud-summary.adoc
+++ b/components/camel-huawei/src/main/docs/hwcloud-summary.adoc
@@ -7,4 +7,4 @@ The Camel components for https://www.huaweicloud.com/intl/en-us/[Huawei Cloud Se
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]

--- a/components/camel-ignite/src/main/docs/ignite-summary.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-summary.adoc
@@ -16,7 +16,7 @@ image::apache-ignite.png[]
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-jsonapi/src/main/docs/jsonApi-dataformat.adoc
+++ b/components/camel-jsonapi/src/main/docs/jsonApi-dataformat.adoc
@@ -7,7 +7,7 @@
 :supportlevel: Stable
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/jsonApi.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: jsonApi
+:camel-spring-boot-name: jsonapi
 
 *Since Camel {since}*
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
@@ -14,7 +14,7 @@ The Kubernetes components integrate your application with Kubernetes standalone 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-openstack/src/main/docs/openstack-summary.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-summary.adoc
@@ -14,7 +14,7 @@ https://www.openstack.org//[OpenStack] applications.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
+++ b/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
@@ -8,7 +8,7 @@
 :component-header: Both producer and consumer are supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/paho-mqtt5.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: paho
+:camel-spring-boot-name: paho-mqtt5
 
 *Since Camel {since}*
 

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -8,7 +8,7 @@
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]
 
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.

--- a/core/camel-core-engine/src/main/docs/antora.yml
+++ b/core/camel-core-engine/src/main/docs/antora.yml
@@ -16,8 +16,4 @@
 #
 
 name: components
-#title: Enterprise Integration Patterns
 version: latest
-#start_page: eips:enterprise-integration-patterns.adoc
-#nav:
-#- modules/eips/nav.adoc

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -174,18 +174,18 @@ The aggregator provides a pluggable repository which you can implement
 your own `org.apache.camel.spi.AggregationRepository`.
 
 If you need persistent repository then Camel provides numerous implementations, such as from the
-xref:components::caffeine-cache-component.adoc[Caffeine],
-xref:components::cql-component.adoc[CassandraQL],
-xref:components::ehcache-component.adoc[EHCache],
-xref:components::infinispan-component.adoc[Infinispan],
-xref:components::jcache-component.adoc[JCache],
-xref:components:others:leveldb.adoc[LevelDB],
-xref:components:others:redis.adoc[Redis],
-or xref:components::sql-component.adoc[SQL] components.
+xref:ROOT:caffeine-cache-component.adoc[Caffeine],
+xref:ROOT:cql-component.adoc[CassandraQL],
+xref:ROOT:ehcache-component.adoc[EHCache],
+xref:ROOT:infinispan-component.adoc[Infinispan],
+xref:ROOT:jcache-component.adoc[JCache],
+xref:others:leveldb.adoc[LevelDB],
+xref:others:redis.adoc[Redis],
+or xref:ROOT:sql-component.adoc[SQL] components.
 
 == Completion
 
-When aggregation xref:latest@manual:ROOT:exchange.adoc[Exchange]s at some point you need to
+When aggregation xref:manual::exchange.adoc[Exchange]s at some point you need to
 indicate that the aggregated exchanges is complete, so they can be sent
 out of the aggregator. Camel allows you to indicate completion in
 various ways as follows:
@@ -197,7 +197,7 @@ key within the period.
 exchanges are completed.
 * _completionSize_ - Is a number indicating that after X aggregated
 exchanges its complete.
-* _completionPredicate_ - Runs a xref:latest@manual:ROOT:predicate.adoc[Predicate] when a new
+* _completionPredicate_ - Runs a xref:manual::predicate.adoc[Predicate] when a new
 exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
@@ -206,7 +206,7 @@ override the `preComplete` method and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * _completionFromBatchConsumer_ - Special option for
-xref:latest@manual:ROOT:batch-consumer.adoc[Batch Consumer] which allows you to complete
+xref:manual::batch-consumer.adoc[Batch Consumer] which allows you to complete
 when all the messages from the batch has been aggregated.
 * _forceCompletionOnStop_ - Indicates to complete all current
 aggregated exchanges when the context is stopped
@@ -224,9 +224,9 @@ Completion is mandatory and must be configured on the aggregation.
 === Pre-completion mode
 
 There can be use-cases where you want the incoming
-xref:latest@manual:ROOT:exchange.adoc[Exchange] to determine if the correlation group
+xref:manual::exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch.
+xref:manual::exchange.adoc[Exchange] is starting a new group from scratch.
 The pre-completion mode must be enabled by the `AggregationStrategy` by overriding the `canPreComplete` method
 to return a `true` value.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
@@ -8,7 +8,7 @@
 The Bean EIP is used for invoking a method on a bean, and the returned value
 is the new message body.
 
-The Bean EIP is similar to the xref:components::bean-component.adoc[Bean] component
+The Bean EIP is similar to the xref:ROOT:bean-component.adoc[Bean] component
 which also is used for invoking beans, but in the form as a Camel component.
 
 == URI Format
@@ -19,7 +19,7 @@ bean:beanID[?options]
 ----
 
 Where *beanID* can be any string which is used to look up the bean in
-the xref:latest@manual:ROOT:registry.adoc[Registry].
+the xref:manual::registry.adoc[Registry].
 
 == EIP options
 
@@ -115,6 +115,6 @@ In XML DSL this is also possible using `beanType`:
 How bean methods to be invoked are chosen (if they are not specified
 explicitly through the *method* parameter) and how parameter values are
 constructed from the xref:message.adoc[Message] are all defined by the
-xref:latest@manual:ROOT:bean-binding.adoc[Bean Binding] mechanism which is used throughout
-all the various xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration]
+xref:manual::bean-binding.adoc[Bean Binding] mechanism which is used throughout
+all the various xref:manual::bean-integration.adoc[Bean Integration]
 mechanisms in Camel.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/channel-adapter.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/channel-adapter.adoc
@@ -19,7 +19,7 @@ of the component, which allows applications to easily send and receive data.
 == Example
 
 An application must receive messages from a Kafka topic, which can be done by using the
-xref:components::kafka-component.adoc[Kafka] component.
+xref:ROOT:kafka-component.adoc[Kafka] component.
 
 One solution is to use a Camel route which consumes from the Kafka topic which calls a bean with the data.
 
@@ -41,7 +41,7 @@ public class CheeseBean {
 }
 ----
 
-You can also use xref:latest@manual:ROOT:pojo-consuming.adoc[POJO consuming] with `@Consume` annotation.
+You can also use xref:manual::pojo-consuming.adoc[POJO consuming] with `@Consume` annotation.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
@@ -21,7 +21,7 @@ include::partial$eip-options.adoc[]
 
 == Example
 
-The Camel xref:components:languages:simple-language.adoc[Simple] language
+The Camel xref:languages:simple-language.adoc[Simple] language
 is great to use with the Choice EIP when routing is based on the content of the message,
 such as checking message headers.
 
@@ -106,7 +106,7 @@ from("direct:start")
 However, the code will still not compile.
 
 The reason is we have stretched how far we can take the good old Java language in terms of
-xref:latest@manual:ROOT:dsl.adoc[DSL]. In a more dynamic or modern language such as Kotlin or Groovy
+xref:manual::dsl.adoc[DSL]. In a more dynamic or modern language such as Kotlin or Groovy
 you would be able to let it be stack based, so the `.end()` will pop the last type of the
 stack, and you would return to the scope of the Choice EIP.
 
@@ -137,7 +137,7 @@ to the Choice EIP.
 ==== Still problems
 
 If there are still problems, then you can split your route into multiple
-routes, and link them together using the xref:components::direct-component.adoc[Direct]
+routes, and link them together using the xref:ROOT:direct-component.adoc[Direct]
 component.
 
 There can be some combinations of xref:eips:enterprise-integration-patterns.adoc[EIP]s

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/competing-consumers.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/competing-consumers.adoc
@@ -9,8 +9,8 @@ For example from SEDA, JMS, Kafka, and various AWS components.
 
 image::eip/CompetingConsumers.gif[image]
 
-- xref:components::seda-component.adoc[SEDA] for SEDA based concurrent processing using a thread pool
-- xref:components::jms-component.adoc[JMS] for distributed SEDA based concurrent processing with queues which support reliable load balancing, failover and clustering.
+- xref:ROOT:seda-component.adoc[SEDA] for SEDA based concurrent processing using a thread pool
+- xref:ROOT:jms-component.adoc[JMS] for distributed SEDA based concurrent processing with queues which support reliable load balancing, failover and clustering.
 
 For components which does not allow concurrent consumers, then Camel allows routeing from the consumer
 to a thread-pool which can then further process the message concurrently,

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
@@ -11,7 +11,7 @@ In Camel the Content Enricher can be done in several ways:
 
 * Using xref:enrich-eip.adoc[Enrich] EIP
 * Using a xref:message-translator.adoc[Message Translator]
-* Using a xref:latest@manual:ROOT:processor.adoc[Processor] with the enrichment programmed in Java
+* Using a xref:manual::processor.adoc[Processor] with the enrichment programmed in Java
 * Using a xref:bean-eip.adoc[Bean] EIP with the enrichment programmed in Java
 
 The most natural Camel approach is using xref:enrich-eip.adoc[Enrich] EIP.
@@ -21,8 +21,8 @@ The most natural Camel approach is using xref:enrich-eip.adoc[Enrich] EIP.
 
 You can consume a message from
 one destination, transform it with something like
-xref:components::velocity-component.adoc[Velocity], xref:components::xquery-component.adoc[XQuery],
-or xref:components::atlasmap-component.adoc[AtlasMap]
+xref:ROOT:velocity-component.adoc[Velocity], xref:ROOT:xquery-component.adoc[XQuery],
+or xref:ROOT:atlasmap-component.adoc[AtlasMap]
 and then send it on to another destination.
 
 [source,java]
@@ -44,7 +44,7 @@ And in XML
 ----
 
 You can also enrich the message in Java DSL directly (using fluent builder) as an
-xref:latest@manual:ROOT:expression.adoc[Expression]. In the example below the message
+xref:manual::expression.adoc[Expression]. In the example below the message
 is enriched by appending ` World!` to the message body:
 
 [source,java]
@@ -55,7 +55,7 @@ from("direct:start")
 ----
 
 The fluent builder is not available in XML or YAML DSL, instead you can use
-xref:components:languages:simple-language.adoc[Simple] language:
+xref:languages:simple-language.adoc[Simple] language:
 
 [source,xml]
 ----
@@ -70,7 +70,7 @@ xref:components:languages:simple-language.adoc[Simple] language:
 
 == Content enrichment using a Processor
 
-In this example we add our own xref:latest@manual:ROOT:processor.adoc[Processor] using
+In this example we add our own xref:manual::processor.adoc[Processor] using
 explicit Java to enrich the message:
 
 [source,java]
@@ -118,6 +118,6 @@ It is usually used for xref:requestReply-eip.adoc[Request Reply] messaging, for 
 * xref:pollEnrich-eip.adoc[Poll Enrich] EIP - Uses a xref:polling-consumer.adoc[Polling
 Consumer] to obtain the additional data. It is usually used for
 xref:event-message.adoc[Event Message] messaging, for instance to read a
-file or download a xref:components::ftp-component.adoc[FTP] file.
+file or download a xref:ROOT:ftp-component.adoc[FTP] file.
 
 For more details see xref:enrich-eip.adoc[Enrich] EIP and xref:pollEnrich-eip.adoc[Poll Enrich] EIP.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
@@ -11,12 +11,12 @@ image::eip/ContentFilter.gif[image]
 
 * Using a xref:message-translator.adoc[Message Translator]
 * Invoking a xref:bean-eip.adoc[Bean] with the filtering programmed in Java
-* Using a xref:latest@manual:ROOT:processor.adoc[Processor] with the filtering programmed in Java
-* Using an xref:latest@manual:ROOT:expression.adoc[Expression]
+* Using a xref:manual::processor.adoc[Processor] with the filtering programmed in Java
+* Using an xref:manual::expression.adoc[Expression]
 
 == Message Content filtering using a Processor
 
-In this example we add our own xref:latest@manual:ROOT:processor.adoc[Processor] using
+In this example we add our own xref:manual::processor.adoc[Processor] using
 explicit Java to filter the message:
 
 [source,java]
@@ -58,7 +58,7 @@ And in XML DSL:
 
 == Message Content filtering using expression
 
-Some languages like xref:components:languages:xpath-language.adoc[XPath], and xref:components:languages:xquery-language.adoc[XQuery]
+Some languages like xref:languages:xpath-language.adoc[XPath], and xref:languages:xquery-language.adoc[XQuery]
 can be used to transform and filter content from messages.
 
 In the example we use xpath to filter a XML message to select all the `<foo><bar>` elements:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
@@ -5,11 +5,11 @@ http://www.enterpriseintegrationpatterns.com/CorrelationIdentifier.html[Correlat
 Identifier] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] by getting or setting a header on the xref:message.adoc[Message].
 
-When working with the xref:components::activemq-component.adoc[ActiveMQ] or xref:components::jms-component.adoc[JMS]
+When working with the xref:ROOT:activemq-component.adoc[ActiveMQ] or xref:ROOT:jms-component.adoc[JMS]
 components the correlation identifier header is called
 *JMSCorrelationID*, and they handle the correlation automatically.
 
-Other messaging systems, such as xref:components::rabbitmq-component.adoc[RabbitMQ] also handles this automatic,
+Other messaging systems, such as xref:ROOT:rabbitmq-component.adoc[RabbitMQ] also handles this automatic,
 and you should generally not have a need for using custom correlation IDs with these systems.
 
 image::eip/CorrelationIdentifierSolution.gif[image]
@@ -18,18 +18,18 @@ You can use your own correlation identifier to any
 message exchange to help correlate messages together to a single
 conversation (or business process). For example if you need to correlation messages when using web services.
 
-The use of a correlation identifier is key to working with xref:components:others:tracing.adoc[Distributed Tracing]
+The use of a correlation identifier is key to working with xref:others:tracing.adoc[Distributed Tracing]
 and be useful when using xref:latest@manual::tracer.adoc[Tracer] messages to log,
-or testing with simulation or canned data such as with the xref:components::mock-component.adoc[Mock] testing framework.
+or testing with simulation or canned data such as with the xref:ROOT:mock-component.adoc[Mock] testing framework.
 
 
 == EIPs using correlation identifiers
 
 Some xref:enterprise-integration-patterns.adoc[EIP] patterns will spin off a sub message, and in
 those cases, Camel will add a correlation id on the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] as a property with they key
+xref:manual::exchange.adoc[Exchange] as a property with they key
 `Exchange.CORRELATION_ID`, which links back to the source
-xref:latest@manual:ROOT:exchange.adoc[Exchange] and its exchange id.
+xref:manual::exchange.adoc[Exchange] and its exchange id.
 
 The following EIPs does this:
 
@@ -42,7 +42,7 @@ The following EIPs does this:
 == Example
 
 The following example uses a request/reply pattern in
-the xref:components::jms-component.adoc[JMS] component, where correlation identifiers are automatically handled:
+the xref:ROOT:jms-component.adoc[JMS] component, where correlation identifiers are automatically handled:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
@@ -5,11 +5,11 @@ http://www.enterpriseintegrationpatterns.com/DeadLetterChannel.html[Dead
 Letter Channel] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the
 https://www.javadoc.io/doc/org.apache.camel/camel-core-processor/current/org/apache/camel/processor/errorhandler/DeadLetterChannel.html[DeadLetterChannel]
-processor which is an xref:latest@manual:ROOT:error-handler.adoc[Error Handler].
+processor which is an xref:manual::error-handler.adoc[Error Handler].
 
 image::eip/DeadLetterChannelSolution.gif[image]
 
-The Dead Letter Channel is an xref:latest@manual:ROOT:error-handler.adoc[Error Handler]
+The Dead Letter Channel is an xref:manual::error-handler.adoc[Error Handler]
 that implements the principles from the Dead Letter Channel EIP.
 From the illustration above we can see the pattern is that if a message cannot be processed or fails during sending, it should be moved to a dead letter queue.
 The dead letter queue, is based on a Camel
@@ -66,7 +66,7 @@ which means this error handler is used globally. You can override this per route
 individual routes used another error handler.
 
 NOTE: The DSLs is planned to be improved in the near future to have a unified
-way of configuring error handling across all DSLs, with xref:latest@manual:ROOT:route-configuration.adoc[Route Configuration].
+way of configuring error handling across all DSLs, with xref:manual::route-configuration.adoc[Route Configuration].
 When fully implemented then configuring error handler in Java and XML DSL would be much more similar than currently.
 
 === Redelivery
@@ -133,7 +133,7 @@ If you do not want this behaviour you can configure `deadLetterHandleNewExceptio
 === What happens when an Exchange is moved to the dead letter queue
 
 When all attempts of redelivery have failed the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is moved to the dead letter queue.
+xref:manual::exchange.adoc[Exchange] is moved to the dead letter queue.
 The exchange is then complete, and from the client point of view, the message is done being processed.
 
 For instance configuring the dead letter channel as:
@@ -154,8 +154,8 @@ And in XML:
 </errorHandler>
 ----
 
-The Dead Letter error handler will clear the caused exception (`setException(null)`), by moving the caused exception to a property on the xref:latest@manual:ROOT:exchange.adoc[Exchange], with the key `Exchange.EXCEPTION_CAUGHT`.
-Then the xref:latest@manual:ROOT:exchange.adoc[Exchange]
+The Dead Letter error handler will clear the caused exception (`setException(null)`), by moving the caused exception to a property on the xref:manual::exchange.adoc[Exchange], with the key `Exchange.EXCEPTION_CAUGHT`.
+Then the xref:manual::exchange.adoc[Exchange]
 is moved to the `jms:queue:dead` destination, and the client will not notice the failure.
 
 === Moving the original message to the dead letter queue
@@ -173,7 +173,7 @@ from("jms:queue:order:input")
 -----
 
 The route listen for JMS messages and validates, transforms and handle it.
-During this the xref:latest@manual:ROOT:exchange.adoc[Exchange] payload is transformed/modified in the various bean stages.
+During this the xref:manual::exchange.adoc[Exchange] payload is transformed/modified in the various bean stages.
 
 Now suppose that if an exception is thrown we want to move the message to the dead letter queue.
 However the message that is moved to the dead letter queue (by default) is the current message.
@@ -221,7 +221,7 @@ combining with the parent unit of work and ends up usinguse the parent original 
 
 === Calling a processor before redelivery using OnRedelivery
 
-When the Dead Letter Channel is doing redeliver its possible to configure a xref:latest@manual:ROOT:processor.adoc[Processor]
+When the Dead Letter Channel is doing redeliver its possible to configure a xref:manual::processor.adoc[Processor]
 that is executed just _before_ every redelivery attempt.
 This can be used for the situations where you need to alter the message before its redelivered.
 
@@ -246,9 +246,9 @@ And in XML DSL, you specify a bean id via `onRedeliveryRef` on the `<errorHandle
 </errorHandler>
 ----
 
-TIP: Camel also supports xref:latest@manual:ROOT:exception-clause.adoc[onException] to use `onRedeliver`.
+TIP: Camel also supports xref:manual::exception-clause.adoc[onException] to use `onRedeliver`.
 This means you can do special on redelivery for different exceptions, as opposed to `onRedelivery` set on
-Dead Letter Channel (or xref:latest@manual:ROOT:defaulterrorhandler.adoc[Default Error Handler]) can be viewed as global scoped.
+Dead Letter Channel (or xref:manual::defaulterrorhandler.adoc[Default Error Handler]) can be viewed as global scoped.
 
 
 === Calling a processor before sending message to the dead letter queue using OnPrepareFailure
@@ -408,8 +408,8 @@ The `Exchange.TO_ENDPOINT` have the constant value `CamelToEndpoint`.
 
 This information is updated when Camel sends a message to any endpoint.
 
-When for example processing the xref:latest@manual:ROOT:exchange.adoc[Exchange] at a given
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and the message is to be moved into the dead letter queue, then Camel also decorates the Exchange with another property that contains that *last* endpoint:
+When for example processing the xref:manual::exchange.adoc[Exchange] at a given
+xref:manual::endpoint.adoc[Endpoint] and the message is to be moved into the dead letter queue, then Camel also decorates the Exchange with another property that contains that *last* endpoint:
 
 [source,java]
 ----
@@ -425,7 +425,7 @@ endpoint uri would be stored as information.
 
 This information is kept on the Exchange even if the message was successfully processed by a given endpoint,
 and then later fails for example in a local xref:bean-eip.adoc[Bean] EIP processing instead.
-So beware that this is a hint that helps pinpoint errors to xref:latest@manual:ROOT:endpoint.adoc[Endpoints], and not EIPs.
+So beware that this is a hint that helps pinpoint errors to xref:manual::endpoint.adoc[Endpoints], and not EIPs.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
@@ -37,10 +37,10 @@ And in XML:
 </route>
 ----
 
-The delayed value can be a dynamic xref:latest@manual:ROOT:expression.adoc[Expression].
+The delayed value can be a dynamic xref:manual::expression.adoc[Expression].
 
 For example to delay a random between 1 and 5 seconds, we can use
-the xref:components:languages:simple-language.adoc[Simple] language:
+the xref:languages:simple-language.adoc[Simple] language:
 
 [source,java]
 ----
@@ -62,7 +62,7 @@ And in XML DSL:
 </route>
 ----
 
-You can also call a xref:components:languages:bean-language.adoc[Bean Method] to compute the
+You can also call a xref:languages:bean-language.adoc[Bean Method] to compute the
 delayed value from Java code:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/durable-subscriber.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/durable-subscriber.adoc
@@ -5,8 +5,8 @@ https://www.enterpriseintegrationpatterns.com/patterns/messaging/DurableSubscrip
 from the xref:enterprise-integration-patterns.adoc[EIP patterns] book.
 
 Camel supports the Durable Subscriber from the EIP patterns
-using components, such as the xref:components::jms-component.adoc[JMS] or
-xref:components::kafka-component.adoc[Kafka] component, which supports publish & subscribe
+using components, such as the xref:ROOT:jms-component.adoc[JMS] or
+xref:ROOT:kafka-component.adoc[Kafka] component, which supports publish & subscribe
 using topics with support for non-durable and durable subscribers.
 
 image::eip/DurableSubscriptionSolution.gif[image]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
@@ -52,7 +52,7 @@ And in XML:
 </route>
 ----
 
-Which will call a xref:components:languages:bean-language.adoc[Bean Method] to compute the slip
+Which will call a xref:languages:bean-language.adoc[Bean Method] to compute the slip
 _on-the-fly_. The bean could be implemented as follows:
 
 [source,java]
@@ -138,7 +138,7 @@ Exchange are.
 
 == @DynamicRouter annotation
 
-You can also use xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] with the `@DynamicRouter` annotation,
+You can also use xref:manual::bean-integration.adoc[Bean Integration] with the `@DynamicRouter` annotation,
 on a Java bean method.
 
 In the example below the `route` method would
@@ -161,4 +161,4 @@ public class MyDynamicRouter {
 ----
 
 The parameters on the `route` method is bound to information from the Exchange using
-xref:latest@manual:ROOT:bean-binding.adoc[Bean Parameter Binding].
+xref:manual::bean-binding.adoc[Bean Parameter Binding].

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/enrich-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/enrich-eip.adoc
@@ -16,7 +16,7 @@ In Camel the Content Enricher can be done in several ways:
 
 * Using xref:enrich-eip.adoc[Enrich] EIP or xref:pollEnrich-eip.adoc[Poll Enrich] EIP
 * Using a xref:message-translator.adoc[Message Translator]
-* Using a xref:latest@manual:ROOT:processor.adoc[Processor] with the enrichment programmed in Java
+* Using a xref:manual::processor.adoc[Processor] with the enrichment programmed in Java
 * Using a xref:bean-eip.adoc[Bean] EIP with the enrichment programmed in Java
 
 The most natural Camel approach is using xref:enrich-eip.adoc[Enrich] EIP,
@@ -28,7 +28,7 @@ It is usually used for xref:requestReply-eip.adoc[Request Reply] messaging, for 
 * xref:pollEnrich-eip.adoc[Poll Enrich] EIP - Uses a xref:polling-consumer.adoc[Polling
 Consumer] to obtain the additional data. It is usually used for
 xref:event-message.adoc[Event Message] messaging, for instance to read a
-file or download a xref:components::ftp-component.adoc[FTP] file.
+file or download a xref:ROOT:ftp-component.adoc[FTP] file.
 
 NOTE: This page documents the Enrich EIP.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/enterprise-integration-patterns.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/enterprise-integration-patterns.adoc
@@ -299,7 +299,7 @@ and via non-messaging techniques?
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
 a|image::eip/ControlBusIcon.gif[image]
-|xref:components::controlbus-component.adoc[ControlBus] |How can we effectively administer a
+|xref:ROOT:controlbus-component.adoc[ControlBus] |How can we effectively administer a
 messaging system that is distributed across multiple platforms and a
 wide geographic area?
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
@@ -10,16 +10,16 @@ image::eip/EventMessageSolution.gif[image]
 
 Use an Event Message for reliable, asynchronous event notification between applications.
 
-Camel supports Event Message by the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+Camel supports Event Message by the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 on a xref:message.adoc[Message] which can be set to `InOnly` to indicate
-a oneway event message. Camel xref:components::index.adoc[Components] then
+a oneway event message. Camel xref:ROOT:index.adoc[Components] then
 implement this pattern using the underlying transport or protocols.
 
-The default behaviour of many xref:components::index.adoc[Components] is `InOnly`
-such as for xref:components::jms-component.adoc[JMS], xref:components::jms-component.adoc[File] or
-xref:components::seda-component.adoc[SEDA].
+The default behaviour of many xref:ROOT:index.adoc[Components] is `InOnly`
+such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:jms-component.adoc[File] or
+xref:ROOT:seda-component.adoc[SEDA].
 
-Some components support both `InOnly` and `InOut` and act accordingly. For example the xref:components::jms-component.adoc[JMS]
+Some components support both `InOnly` and `InOut` and act accordingly. For example the xref:ROOT:jms-component.adoc[JMS]
 can send messages as one-way (`InOnly`) or use request/reply messaging (`InOut`).
 
 TIP: See the related xref:requestReply-eip.adoc[Request Reply] message.
@@ -27,7 +27,7 @@ TIP: See the related xref:requestReply-eip.adoc[Request Reply] message.
 == Using endpoint URI
 
 If you are using a component which defaults to `InOut` you can override
-the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] for a *consumer* endpoint using
+the xref:manual::exchange-pattern.adoc[Exchange Pattern] for a *consumer* endpoint using
 the pattern property.
 
 [source,text]
@@ -59,7 +59,7 @@ And with XML:
 == Using setExchangePattern EIP
 
 You can specify the
-xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] using `setExchangePattern` in the DSL.
+xref:manual::exchange-pattern.adoc[Exchange Pattern] using `setExchangePattern` in the DSL.
 
 [source,java]
 ----
@@ -79,8 +79,8 @@ And with XML:
 </route>
 ----
 
-When using `setExchangePattern` then the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
-on the xref:latest@manual:ROOT:exchange.adoc[Exchange] is changed from this point onwards in the route.
+When using `setExchangePattern` then the xref:manual::exchange-pattern.adoc[Exchange Pattern]
+on the xref:manual::exchange.adoc[Exchange] is changed from this point onwards in the route.
 
 This means you can change the pattern back again at a later point:
 
@@ -94,16 +94,16 @@ from("mq:someQueue")
   .log("InOut MEP received ${body}")
 ----
 
-NOTE: Using `setExchangePattern` to change the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+NOTE: Using `setExchangePattern` to change the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 is often only used in special use-cases where you must
 force to be using either `InOnly` or `InOut` mode when using components that support both modes (such as messaging components like ActiveMQ, JMS, RabbitMQ etc.)
 
 == JMS component and InOnly vs InOut
 
-When consuming messages from xref:components::jms-component.adoc[JMS] a Request Reply is
+When consuming messages from xref:ROOT:jms-component.adoc[JMS] a Request Reply is
 indicated by the presence of the `JMSReplyTo` header. This means the JMS component automatic
 detects whether to use `InOnly` or `InOut` in the consumer.
 
-Likewise, the JMS producer will check the current xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
-on the xref:latest@manual:ROOT:exchange.adoc[Exchange] to know whether to use `InOnly` or `InOut` mode (i.e. one-way vs request/reply messaging)
+Likewise, the JMS producer will check the current xref:manual::exchange-pattern.adoc[Exchange Pattern]
+on the xref:manual::exchange.adoc[Exchange] to know whether to use `InOnly` or `InOut` mode (i.e. one-way vs request/reply messaging)
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
@@ -21,7 +21,7 @@ when a xref:message.adoc[Message] is available for processing.
 == Example
 
 The following demonstrates a xref:bean-eip.adoc[Bean] being invoked when
-an event occurs from a xref:components::jms-component.adoc[JMS] queue.
+an event occurs from a xref:ROOT:jms-component.adoc[JMS] queue.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/fault-tolerance-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/fault-tolerance-eip.adoc
@@ -1,7 +1,7 @@
 = Fault Tolerance EIP
 
 This component supports the xref:circuitBreaker-eip.adoc[Circuit Breaker] EIP with the
-xref:components:others:microprofile-fault-tolerance.adoc[MicroProfile Fault Tolerance] library.
+xref:others:microprofile-fault-tolerance.adoc[MicroProfile Fault Tolerance] library.
 
 == Options
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
@@ -22,7 +22,7 @@ include::partial$eip-options.adoc[]
 
 == Example
 
-The Camel xref:components:languages:simple-language.adoc[Simple] language
+The Camel xref:languages:simple-language.adoc[Simple] language
 is great to use with the Filter EIP when routing is based on the content of the message,
 such as checking message headers.
 
@@ -49,7 +49,7 @@ And in XML:
 </route>
 ----
 
-You can use many languages as the predicate, such as xref:components:languages:xpath-language.adoc[XPath]:
+You can use many languages as the predicate, such as xref:languages:xpath-language.adoc[XPath]:
 
 [source,java]
 ----
@@ -71,7 +71,7 @@ And in XML:
 </route>
 ----
 
-Here is another example of calling a xref:components:languages:bean-language.adoc[method on a bean]
+Here is another example of calling a xref:languages:bean-language.adoc[method on a bean]
 to define the filter behavior:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/from-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/from-eip.adoc
@@ -5,7 +5,7 @@
 :since: 
 :supportlevel: Stable
 
-Every Camel xref:latest@manual:ROOT:routes.adoc[route] starts from an xref:latest@manual:ROOT:endpoint.adoc[Endpoint]
+Every Camel xref:manual::routes.adoc[route] starts from an xref:manual::endpoint.adoc[Endpoint]
 as the input (source) to the route.
 
 The From EIP is the input.
@@ -19,7 +19,7 @@ include::partial$eip-options.adoc[]
 == Example
 
 In the route below the route starts from
-a xref:components::file-component.adoc[File] endpoint.
+a xref:ROOT:file-component.adoc[File] endpoint.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/guaranteed-delivery.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/guaranteed-delivery.adoc
@@ -5,15 +5,15 @@ http://www.enterpriseintegrationpatterns.com/GuaranteedMessaging.html[Guaranteed
 Delivery] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using among others the following components:
 
-* xref:components::file-component.adoc[File] for using file systems as a persistent store of
+* xref:ROOT:file-component.adoc[File] for using file systems as a persistent store of
 messages
-* xref:components::activemq-component.adoc[ActiveMQ] or xref:components::jms-component.adoc[JMS] when using persistent delivery (the default) for
+* xref:ROOT:activemq-component.adoc[ActiveMQ] or xref:ROOT:jms-component.adoc[JMS] when using persistent delivery (the default) for
 working with JMS queues and topics for high performance, clustering and load balancing
-* xref:components::kafka-component.adoc[Kafka] when using persistent delivery for
+* xref:ROOT:kafka-component.adoc[Kafka] when using persistent delivery for
 working with streaming events for high performance, clustering and load balancing
-* xref:components::jpa-component.adoc[JPA] for using a database as a persistence layer, or use
-any of the other database component such as xref:components::sql-component.adoc[SQL],
-xref:components::jdbc-component.adoc[JDBC], or xref:components::mybatis-component.adoc[MyBatis]
+* xref:ROOT:jpa-component.adoc[JPA] for using a database as a persistence layer, or use
+any of the other database component such as xref:ROOT:sql-component.adoc[SQL],
+xref:ROOT:jdbc-component.adoc[JDBC], or xref:ROOT:mybatis-component.adoc[MyBatis]
 
 image::eip/GuaranteedMessagingSolution.gif[image]
 
@@ -21,7 +21,7 @@ image::eip/GuaranteedMessagingSolution.gif[image]
 
 The following example demonstrates illustrates the use
 of http://www.enterpriseintegrationpatterns.com/GuaranteedMessaging.html[Guaranteed
-Delivery] within the xref:components::jms-component.adoc[JMS] component.
+Delivery] within the xref:ROOT:jms-component.adoc[JMS] component.
 
 By default, a message
 is not considered successfully delivered until the recipient has

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/idempotentConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/idempotentConsumer-eip.adoc
@@ -14,9 +14,9 @@ The Idempotent Consumer essentially acts like a
 xref:filter-eip.adoc[Message Filter] to filter out duplicates.
 
 Camel will add the message id eagerly to the repository to detect
-duplication also for xref:latest@manual:ROOT:exchange.adoc[Exchange]'s' currently in progress.
+duplication also for xref:manual::exchange.adoc[Exchange]'s' currently in progress.
 On completion Camel will remove the message id from the repository if
-the xref:latest@manual:ROOT:exchange.adoc[Exchange] failed, otherwise it stays there.
+the xref:manual::exchange.adoc[Exchange] failed, otherwise it stays there.
 
 == Options
 
@@ -32,24 +32,24 @@ your own `org.apache.camel.spi.IdempotentRepository`.
 Camel provides the following Idempotent Consumer implementations:
 
 * MemoryIdempotentRepository from `camel-support` JAR
-* xref:components::caffeine-cache-component.adoc[CaffeineIdempotentRepository]
-* xref:components::cql-component.adoc[CassandraIdempotentRepository]
-xref:components::cql-component.adoc[NamedCassandraIdempotentRepository]
-* xref:components::ehcache-component.adoc[EHCacheIdempotentRepository]
-* xref:components::hazelcast-summary.adoc[HazelcastIdempotentRepository]
-* xref:components::hbase-component.adoc[HBaseIdempotentRepository]
-* xref:components::infinispan-component.adoc[InfinispanIdempotentRepository]
-xref:components::infinispan-component.adoc[InfinispanEmbeddedIdempotentRepository]
-xref:components::infinispan-component.adoc[InfinispanRemoteIdempotentRepository]
-* xref:components::jcache-component.adoc[JCacheIdempotentRepository]
-* xref:components::jpa-component.adoc[JpaMessageIdRepository]
-* xref:components::kafka-component.adoc[KafkaIdempotentRepository]
-* xref:components::mongodb-component.adoc[MongoDbIdempotentRepository]
-* xref:components::spring-redis-component.adoc[RedisIdempotentRepository]
-xref:components::spring-redis-component.adoc[RedisStringIdempotentRepository]
-* xref:latest@manual:ROOT:spring.adoc[SpringCacheIdempotentRepository]
-* xref:components::sql-component.adoc[JdbcMessageIdRepository]
-xref:components::sql-component.adoc[JdbcOrphanLockAwareIdempotentRepository]
+* xref:ROOT:caffeine-cache-component.adoc[CaffeineIdempotentRepository]
+* xref:ROOT:cql-component.adoc[CassandraIdempotentRepository]
+xref:ROOT:cql-component.adoc[NamedCassandraIdempotentRepository]
+* xref:ROOT:ehcache-component.adoc[EHCacheIdempotentRepository]
+* xref:ROOT:hazelcast-summary.adoc[HazelcastIdempotentRepository]
+* xref:ROOT:hbase-component.adoc[HBaseIdempotentRepository]
+* xref:ROOT:infinispan-component.adoc[InfinispanIdempotentRepository]
+xref:ROOT:infinispan-component.adoc[InfinispanEmbeddedIdempotentRepository]
+xref:ROOT:infinispan-component.adoc[InfinispanRemoteIdempotentRepository]
+* xref:ROOT:jcache-component.adoc[JCacheIdempotentRepository]
+* xref:ROOT:jpa-component.adoc[JpaMessageIdRepository]
+* xref:ROOT:kafka-component.adoc[KafkaIdempotentRepository]
+* xref:ROOT:mongodb-component.adoc[MongoDbIdempotentRepository]
+* xref:ROOT:spring-redis-component.adoc[RedisIdempotentRepository]
+xref:ROOT:spring-redis-component.adoc[RedisStringIdempotentRepository]
+* xref:manual::spring.adoc[SpringCacheIdempotentRepository]
+* xref:ROOT:sql-component.adoc[JdbcMessageIdRepository]
+xref:ROOT:sql-component.adoc[JdbcOrphanLockAwareIdempotentRepository]
 
 == Example
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
@@ -1,7 +1,7 @@
 = Intercept
 
 The intercept feature in Camel supports intercepting
-xref:latest@manual:ROOT:exchange.adoc[Exchange]'s' while they are being routed.
+xref:manual::exchange.adoc[Exchange]'s' while they are being routed.
 
 == Kinds of interceptors
 
@@ -10,7 +10,7 @@ Camel supports three kinds of interceptors:
 * `intercept` that intercepts every processing step as they happen during routing
 * `interceptFrom` that intercepts only the incoming step (i.e. xref:from-eip.adoc[from])
 * `interceptSendToEndpoint` that intercepts only when an
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is about to be sent to the given xref:message-endpoint.adoc[endpoint].
+xref:manual::exchange.adoc[Exchange] is about to be sent to the given xref:message-endpoint.adoc[endpoint].
 
 The `interceptSendToEndpoint` is dynamic hence it will also trigger if a
 dynamic URI is constructed that Camel was not aware of at startup
@@ -24,7 +24,7 @@ messages from this endpoint, then the `interceptFrom` is not triggered.
 === Interceptor scopes
 
 All the interceptors can be configured on global, route scope, or with
-xref:latest@manual:ROOT:route-configuration.adoc[Route Configuration].
+xref:manual::route-configuration.adoc[Route Configuration].
 
 This means multiple interceptors can be _triggered_.
 
@@ -59,7 +59,7 @@ And in XML:
 
 All these interceptors support the following features:
 
-* xref:latest@manual:ROOT:predicate.adoc[Predicate] using `when` to only trigger the interceptor in certain conditions
+* xref:manual::predicate.adoc[Predicate] using `when` to only trigger the interceptor in certain conditions
 * `stop` forces stopping continue routing the Exchange and mark it as completed successful (it's actually the xref:stop-eip.adoc[Stop] EIP).
 * `skip` when used with `interceptSendToEndpoint` will *skip* sending the message to the original intended endpoint.
 * `afterUri` when used with `interceptSendToEndpoint` allows to send
@@ -71,7 +71,7 @@ URI pattern matching by: exact uri, wildcard, regular expression. See further be
 
 === Using intercept
 
-The `Intercept` is intercepting the xref:latest@manual:ROOT:exchange.adoc[Exchange]
+The `Intercept` is intercepting the xref:manual::exchange.adoc[Exchange]
 on every processing steps during routing.
 
 Given the following example:
@@ -117,7 +117,7 @@ The example is as follows in XML:
 
 === Controlling when to intercept using a predicate
 
-If you only want to intercept "sometimes", then you can use a xref:latest@manual:ROOT:predicate.adoc[predicate].
+If you only want to intercept "sometimes", then you can use a xref:manual::predicate.adoc[predicate].
 
 For instance in the sample below we only intercept if the message body
 contains the string word Hello:
@@ -203,7 +203,7 @@ applies for that particular route.
 
 So lets start with the logging example. We want to log all the
 incoming messages, so we use `interceptFrom` to route to the
-xref:components::log-component.adoc[Log] component.
+xref:ROOT:log-component.adoc[Log] component.
 
 [source,java]
 ----
@@ -288,7 +288,7 @@ message is sent to the intended destination.
 The interceptor can also be configured to not send to the destination (skip)
 which means the message is detoured instead.
 
-A xref:latest@manual:ROOT:predicate.adoc[Predicate] can also be used
+A xref:manual::predicate.adoc[Predicate] can also be used
 to control when to intercept, which has been previously covered.
 
 The `afterUri` option, is used when you need to process
@@ -296,7 +296,7 @@ the response message from the intended destination. This functionality
 was added later to the interceptor, in a form of sending to yet another xref:message-endpoint.adoc[endpoint].
 
 Let start with a basic example, where we want to intercept when a
-message is being sent to xref:components::kafka-component.adoc[kafka]:
+message is being sent to xref:ROOT:kafka-component.adoc[kafka]:
 
 [source,java]
 ----
@@ -369,7 +369,7 @@ And in XML:
 Sometimes you want to *intercept and skip* sending messages to a specific endpoint.
 
 For example to avoid sending any message to kafka, but detour them to a
-xref:components::mock-component.adoc[mock] endpoint, can be done as follows:
+xref:ROOT:mock-component.adoc[mock] endpoint, can be done as follows:
 
 [source,java]
 ----
@@ -404,7 +404,7 @@ And in XML:
 
 === Conditional skipping sending to endpoint
 
-You can combine both a xref:latest@manual:ROOT:predicate.adoc[predicate] and skip sending to the original endpoint.
+You can combine both a xref:manual::predicate.adoc[predicate] and skip sending to the original endpoint.
 For example suppose you have some "test" messages that sometimes occur, and that you
 want to avoid sending these message to a downstream kafka system, then this can be done as shown:
 
@@ -464,7 +464,7 @@ interceptSendToEndpoint("jms:queue:cheese").to("log:smelly");
 === Intercepting when matching endpoints by wildcard
 
 Match by wildcard allows you to match a range of endpoint or all of a
-given type. For instance use `file:*` will match all xref:components::file-component.adoc[file] based endpoints.
+given type. For instance use `file:*` will match all xref:ROOT:file-component.adoc[file] based endpoints.
 
 [source,java]
 -------------------------------------

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
@@ -8,7 +8,7 @@
 Kamelets (Kamel route snippets) allow users to connect to external systems via a simplified interface,
 hiding all the low level details about how those connections are implemented.
 
-The Kamelet EIP allows calling Kamelets (i.e. xref:latest@manual:ROOT:route-template.adoc[Route Template]).
+The Kamelet EIP allows calling Kamelets (i.e. xref:manual::route-template.adoc[Route Template]).
 When calling a Kamelet you may just refer to the name (template id) of the Kamelet in the EIP as shown below:
 
 == Options
@@ -38,8 +38,8 @@ And in XML
 
 Camel will then, when starting:
 
-* Lookup the xref:latest@manual:ROOT:route-template.adoc[Route Template] with the given id (in the example above its foo) from the `CamelContext`
-* Create a new route based on the xref:latest@manual:ROOT:route-template.adoc[Route Template]
+* Lookup the xref:manual::route-template.adoc[Route Template] with the given id (in the example above its foo) from the `CamelContext`
+* Create a new route based on the xref:manual::route-template.adoc[Route Template]
 
 == Dependency
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/loadBalance-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/loadBalance-eip.adoc
@@ -18,7 +18,7 @@ Camel provides the following policies out-of-the-box:
 | xref:failover-eip.adoc[Failover Load Balancer] | In case of failures the exchange will be tried on the next endpoint.
 | xref:roundRobin-eip.adoc[Round Robin Load Balancer] | The destination endpoints are selected in a round-robin fashion. This is a well known and classic policy, which spreads the load evenly.
 | xref:random-eip.adoc[Random Load Balancer] |  The destination endpoints are selected by random.
-| xref:sticky-eip.adoc[Sticky Load Balancer] | Sticky load balancing using an xref:latest@manual:ROOT:expression.adoc[Expression] to calculate a correlation key to perform the sticky load balancing.
+| xref:sticky-eip.adoc[Sticky Load Balancer] | Sticky load balancing using an xref:manual::expression.adoc[Expression] to calculate a correlation key to perform the sticky load balancing.
 | xref:topic-eip.adoc[Topic Load Balancer] | Topic which sends to all destinations.
 | xref:weighted-eip.adoc[Weighted Loader Balancer] | Uses a weighted load distribution ratio for each server with respect to others.
 |=======================================================================

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
@@ -9,9 +9,9 @@ How can I log the processing of a xref:message.adoc[Message]?
 
 Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
 
-* You can use the xref:components::log-component.adoc[Log] component which logs the Message content.
-* You can use the xref:latest@manual:ROOT:tracer.adoc[Tracer] which trace logs message flow.
-* You can also use a xref:latest@manual:ROOT:processor.adoc[Processor] or xref:latest@manual:ROOT:bean-binding.adoc[Bean] and log from Java code.
+* You can use the xref:ROOT:log-component.adoc[Log] component which logs the Message content.
+* You can use the xref:manual::tracer.adoc[Tracer] which trace logs message flow.
+* You can also use a xref:manual::processor.adoc[Processor] or xref:manual::bean-binding.adoc[Bean] and log from Java code.
 * You can use this log EIP.
 
 == Options
@@ -23,14 +23,14 @@ include::partial$eip-options.adoc[]
 === Difference between Log EIP and Log component
 
 This log EIP is much lighter and meant for logging human logs such as `Starting to do ...` etc.
-It can only log a message based on the xref:components:languages:simple-language.adoc[Simple] language.
+It can only log a message based on the xref:languages:simple-language.adoc[Simple] language.
 
-The xref:components::log-component.adoc[log] component is meant for logging the message content (body, headers, etc.).
+The xref:ROOT:log-component.adoc[log] component is meant for logging the message content (body, headers, etc.).
 There are many options on the log component to configure what content to log.
 
 == Example
 
-You can use the log EIP which allows you to use xref:components:languages:simple-language.adoc[Simple] language to construct a dynamic message which gets logged.
+You can use the log EIP which allows you to use xref:languages:simple-language.adoc[Simple] language to construct a dynamic message which gets logged.
 
 For example, you can do
 
@@ -52,7 +52,7 @@ And in XML:
 </route>
 ----
 
-This will be evaluated using the xref:components:languages:simple-language.adoc[Simple]
+This will be evaluated using the xref:languages:simple-language.adoc[Simple]
 to construct the `String` containg the message to be logged.
 
 === Logging message body with streaming
@@ -156,7 +156,7 @@ And in XML:
 ==== Using custom logger from the Registry
 
 If the Log EIP has not been configured with a specific logger to use,
-then Camel will will lookup in the xref:latest@manual:ROOT:registry.adoc[Registry]
+then Camel will will lookup in the xref:manual::registry.adoc[Registry]
 if there is a single instance of `org.slf4j.Logger`.
 
 If such an instance exists then this logger is used,
@@ -188,7 +188,7 @@ And in XML:
 == Masking sensitive information like password
 
 You can enable security masking for logging by setting `logMask` flag to `true`.
-Note that this option also affects xref:components::log-component.adoc[Log] component.
+Note that this option also affects xref:ROOT:log-component.adoc[Log] component.
 
 To enable mask in Java DSL at CamelContext level:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/loop-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/loop-eip.adoc
@@ -45,7 +45,7 @@ then send the message repetitively to mock:result.
 The number of times the message is sent is either passed as an argument to `loop`,
 or determined at runtime by evaluating an expression.
 
-The xref:latest@manual:ROOT:expression.adoc[Expression] *must* evaluate to an `int`,
+The xref:manual::expression.adoc[Expression] *must* evaluate to an `int`,
 otherwise a `RuntimeCamelException` is thrown.
 
 Pass loop count as an argument:
@@ -66,7 +66,7 @@ from("direct:b")
         .to("mock:result");
 ----
 
-And with the xref:components:languages:xpath-language.adoc[XPath] language:
+And with the xref:languages:xpath-language.adoc[XPath] language:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
@@ -8,7 +8,7 @@ One such technique is xref:components:dataformats:index.adoc[Data Formats],
 where marshal and unmarshal comes from.
 
 So in other words the xref:marshal-eip.adoc[Marshal] and xref:unmarshal-eip.adoc[Unmarshal] EIPs
-are used with xref:components:dataformats:index.adoc[Data Formats].
+are used with xref:dataformats:index.adoc[Data Formats].
 
 - _Marshal_ - Transforms the message body (such as Java object) into a binary or textual format, ready to be wired over the network.
 - _Unmarshal_ - Transforms data in some binary or textual format (such as received over the network)
@@ -18,10 +18,10 @@ into a Java object; or some other representation according to the data format be
 
 The following example reads XML files from the inbox/xml directory.
 Each file is then transformed into Java Objects using xref:dataformats:jaxb-dataformat.adoc[JAXB].
-Then a xref:components::bean-component.adoc[Bean] is invoked that takes in the Java object.
+Then a xref:ROOT:bean-component.adoc[Bean] is invoked that takes in the Java object.
 
 Then the reverse operation happens to transform the Java objects back into XML also via JAXB,
-but using the `unmarshal` operation. And finally the message is routed to a xref:components::jms-component.adoc[JMS] queue.
+but using the `unmarshal` operation. And finally the message is routed to a xref:ROOT:jms-component.adoc[JMS] queue.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-broker.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-broker.adoc
@@ -11,9 +11,9 @@ image::eip/MessageBroker.gif[image]
 Use a central Message Broker that can receive messages from multiple destinations,
 determine the correct destination and route the message to the correct channel.
 
-Camel supports integration with existing message broker systems such as xref:components::activemq-component.adoc[ActiveMQ],
-xref:components::kafka-component.adoc[Kafka], xref:components::spring-rabbitmq-component.adoc[RabbitMQ],
-and cloud queue systems such as xref:components::aws2-s3-component.adoc[AWS SQS], and others.
+Camel supports integration with existing message broker systems such as xref:ROOT:activemq-component.adoc[ActiveMQ],
+xref:ROOT:kafka-component.adoc[Kafka], xref:ROOT:spring-rabbitmq-component.adoc[RabbitMQ],
+and cloud queue systems such as xref:ROOT:aws2-s3-component.adoc[AWS SQS], and others.
 
 These Camel components allows to both send and receive data from message brokers.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-bus.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-bus.adoc
@@ -13,7 +13,7 @@ A messaging system such as Apache ActiveMQ can be used as Message Bus.
 == Example
 
 The following demonstrates how the Camel message bus can be used to
-ingest message into the bus with the xref:components::jms-component.adoc[JMS] component.
+ingest message into the bus with the xref:ROOT:jms-component.adoc[JMS] component.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-channel.adoc
@@ -13,7 +13,7 @@ image::eip/MessageChannelSolution.gif[image]
 
 == Example
 
-In xref:components::jms-component.adoc[JMS], Message Channels are represented by topics and queues such as
+In xref:ROOT:jms-component.adoc[JMS], Message Channels are represented by topics and queues such as
 the following:
 
 [source,text]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-dispatcher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-dispatcher.adoc
@@ -8,7 +8,7 @@ image::eip/MessageDispatcher.gif[image]
 
 In Camel the Message Dispatcher can be archived in different ways such as:
 
-* You can use a component like xref:components::jms-component.adoc[JMS] with selectors
+* You can use a component like xref:ROOT:jms-component.adoc[JMS] with selectors
 to implement a xref:selective-consumer.adoc[Selective Consumer] as the Message Dispatcher implementation.
 
 * Or you can use a xref:message-endpoint.adoc[Message Endpoint] as the Message Dispatcher itself, or

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-endpoint.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-endpoint.adoc
@@ -13,19 +13,19 @@ image::eip/MessageEndpointSolution.gif[image]
 
 Connect an application to a messaging channel using a Message Endpoint, a client of the messaging system that the application can then use to send or receive messages.
 
-When using the xref:latest@manual:ROOT:dsl.adoc[DSL] to create xref:latest@manual:ROOT:routes.adoc[Routes] you
-typically refer to Message Endpoints by their xref:latest@manual:ROOT:uris.adoc[URIs]
+When using the xref:manual::dsl.adoc[DSL] to create xref:manual::routes.adoc[Routes] you
+typically refer to Message Endpoints by their xref:manual::uris.adoc[URIs]
 rather than directly using the
 https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. It's then a responsibility of the
 https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/CamelContext.html[CamelContext]
 to create and activate the necessary `Endpoint` instances using the
-available xref:components::index.adoc[Components].
+available xref:ROOT:index.adoc[Components].
 
 == Example
 
-The following example route demonstrates the use of a xref:components::file-component.adoc[File] consumer endpoint and a xref:components::jms-component.adoc[JMS] producer endpoint,
-by their xref:latest@manual:ROOT:uris.adoc[URIs]:
+The following example route demonstrates the use of a xref:ROOT:file-component.adoc[File] consumer endpoint and a xref:ROOT:jms-component.adoc[JMS] producer endpoint,
+by their xref:manual::uris.adoc[URIs]:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
@@ -10,7 +10,7 @@ image::eip/MessageExpirationSolution.gif[image]
 
 Set the Message Expiration to specify a time limit how long the message is viable.
 
-Message expiration is supported by some Camel components such as xref:components::jms-component.adoc[JMS],
+Message expiration is supported by some Camel components such as xref:ROOT:jms-component.adoc[JMS],
 which uses _time-to-live_ to specify for how long the message is valid.
 
 IMPORTANT: When using message expiration then mind about keeping clock's synchronized among the systems.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
@@ -95,7 +95,7 @@ And in XML:
 == Route stack-trace in exceptions logged by error handler
 
 If Message History is enabled, then Camel will include this information,
-when the xref:latest@manual:ROOT:error-handler.adoc[Error Handler] logs exhausted exceptions,
+when the xref:manual::error-handler.adoc[Error Handler] logs exhausted exceptions,
 where you can see the message history; you may think this as a "route stacktrace".
 
 And example is provided below:
@@ -182,14 +182,14 @@ where the exception occurred (process1).
 === Configuring route stack-trace from error handler
 
 You can turn off logging Message History with `logExhaustedMessageHistory`
-from the xref:latest@manual:ROOT:error-handler.adoc[Error Handler] using:
+from the xref:manual::error-handler.adoc[Error Handler] using:
 
 [source,java]
 ----
 errorHandler(defaultErrorHandler().logExhaustedMessageHistory(false));
 ----
 
-The xref:latest@manual:ROOT:error-handler.adoc[Error Handler] does not log the
+The xref:manual::error-handler.adoc[Error Handler] does not log the
 message body/header details (to avoid logging sensitive message body details).
 You can enable this with `logExhaustedMessageBody` on the error handler as shown:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
@@ -24,7 +24,7 @@ to choose where the message should go.
 
 The following example shows how to route a request from an input
 direct:a endpoint to either direct:b, direct:c, or direct:d depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate]:
+the evaluation of various xref:manual::predicate.adoc[Predicate]:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-translator.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-translator.adoc
@@ -10,10 +10,10 @@ image::eip/MessageTranslator.gif[image]
 The Message Translator can be done in different ways in Camel:
 
 * Using xref:transform-eip.adoc[Transform] or xref:setBody-eip.adoc[Set Body] in the DSL
-* Calling a xref:latest@manual:ROOT:processor.adoc[Processor] or xref:latest@manual:ROOT:bean-integration.adoc[bean]
+* Calling a xref:manual::processor.adoc[Processor] or xref:manual::bean-integration.adoc[bean]
   to perform the transformation
-* Using template-based xref:components::index.adoc[Components], with the template being the source for how the message is translated
-* Messages can also be transformed using xref:latest@manual:ROOT:data-format.adoc[Data Format]
+* Using template-based xref:ROOT:index.adoc[Components], with the template being the source for how the message is translated
+* Messages can also be transformed using xref:manual::data-format.adoc[Data Format]
   to marshal and unmarshal messages in different encodings.
 
 == Example
@@ -23,7 +23,7 @@ Each of above approaches is documented in the following examples:
 === Message Translator with Transform EIP
 
 You can use a xref:transform-eip.adoc[Transform] which uses an
-xref:latest@manual:ROOT:expression.adoc[Expression] to do the transformation:
+xref:manual::expression.adoc[Expression] to do the transformation:
 
 In the example below we prepend Hello to the message body using the
 xref:components:languages:simple-language.adoc[Simple] language:
@@ -51,7 +51,7 @@ And in XML DSL:
 === Message Translator with Bean
 
 You can transform a message using Camels
-xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to call any method on a bean
+xref:manual::bean-integration.adoc[Bean Integration] to call any method on a bean
 that performs the message translation:
 
 [source,java]
@@ -74,7 +74,7 @@ And in XML:
 
 === Message Translator with Processor
 
-You can also use a xref:latest@manual:ROOT:processor.adoc[Processor] to do
+You can also use a xref:manual::processor.adoc[Processor] to do
 the transformation:
 
 [source,java]
@@ -98,7 +98,7 @@ And in XML:
 === Message Translator using Templating Components
 
 You can also consume a message from one destination, transform it with something like
-xref:components::velocity-component.adoc[Velocity] or xref:components::xquery-component.adoc[XQuery] and then send
+xref:ROOT:velocity-component.adoc[Velocity] or xref:ROOT:xquery-component.adoc[XQuery] and then send
 it on to another destination.
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message.adoc
@@ -9,7 +9,7 @@ interface.
 image::eip/MessageSolution.gif[image]
 
 The `org.apache.camel.Message` is the _data record_ that represents the message part
-of the xref:latest@manual:ROOT:exchange.adoc[Exchange].
+of the xref:manual::exchange.adoc[Exchange].
 
 The message contains the following information:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-bridge.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-bridge.adoc
@@ -10,14 +10,14 @@ image::eip/MessagingBridge.gif[image]
 
 Use a Messaging Bridge, a connection between messaging systems, to replicate messages between systems.
 
-You can use Camel to bridge different systems using Camel xref:components::index.adoc[Components]
-and bridge the endpoints together in a xref:latest@manual:ROOT:routes.adoc[Route].
+You can use Camel to bridge different systems using Camel xref:ROOT:index.adoc[Components]
+and bridge the endpoints together in a xref:manual::routes.adoc[Route].
 
 Another alternative is to bridge systems using xref:change-data-capture.adoc[Change Data Capture].
 
 == Example
 
-A basic bridge between two messaging systems (such as WebsphereMQ and xref:components::activemq-component.adoc[ActiveMQ])
+A basic bridge between two messaging systems (such as WebsphereMQ and xref:ROOT:activemq-component.adoc[ActiveMQ])
 can be done with a single Camel route:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-gateway.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-gateway.adoc
@@ -11,7 +11,7 @@ image::eip/MessagingGatewaySolution.gif[image]
 Use a Messaging Gateway, a class than wraps messaging-specific method calls and exposes domain-specific methods to the application.
 
 Camel has several endpoint components that support the Messaging Gateway from the EIP patterns.
-Components like xref:components::bean-component.adoc[Bean] provides a way to bind a Java interface to the message exchange.
+Components like xref:ROOT:bean-component.adoc[Bean] provides a way to bind a Java interface to the message exchange.
 
-Another approach is to use `@Produce` annotations (xref:latest@manual:ROOT:pojo-producing.adoc[POJO Producing])
+Another approach is to use `@Produce` annotations (xref:manual::pojo-producing.adoc[POJO Producing])
 which also can be used to hide Camel APIs and thereby encapsulate access, acting as a Messaging Gateway EIP solution.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-mapper.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-mapper.adoc
@@ -17,9 +17,9 @@ Since the Messaging Mapper is implemented as a separate class that references th
 and the messaging layer, neither layer is aware of the other. The layers don't even know about the Messaging Mapper.
 
 With Camel this pattern is often implemented directly via Camel components that provides
-xref:latest@manual:ROOT:type-converter.adoc[Type Converter]'s from the messaging infrastructure to common Java types or
+xref:manual::type-converter.adoc[Type Converter]'s from the messaging infrastructure to common Java types or
 Java Objects representing the data model of the component in question. Combining this with the
 xref:message-translator.adoc[Message Translator] to have the Messaging Mapper EIP pattern.
 
-Camel also integrates with external mapping software such as xref:components::atlasmap-component.adoc[AtlasMap].
+Camel also integrates with external mapping software such as xref:ROOT:atlasmap-component.adoc[AtlasMap].
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/multicast-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/multicast-eip.adoc
@@ -5,7 +5,7 @@
 :since: 
 :supportlevel: Stable
 
-The Multicast EIP allows to route *the same* message to a number of xref:latest@manual:ROOT:endpoint.adoc[endpoints]
+The Multicast EIP allows to route *the same* message to a number of xref:manual::endpoint.adoc[endpoints]
 and process them in a different way.
 
 image::eip/RecipientListIcon.gif[image]
@@ -183,7 +183,7 @@ process the remainder destinations. You have the chance to deal with the excepti
 when aggregating using an `AggregationStrategy`.
 
 But sometimes you just want Camel to stop and let the exception be
-propagated back, and let the Camel xref:latest@manual:ROOT:error-handler.adoc[Error Handler]
+propagated back, and let the Camel xref:manual::error-handler.adoc[Error Handler]
 handle it. You can do this by specifying that it should stop in case of an
 exception occurred. This is done by the `stopOnException` option as
 shown below:
@@ -249,7 +249,7 @@ use a deep clone copy then you need to use a custom `onPrepare` which
 allows you to create a deep copy of the message body in the `Processor`.
 
 Notice the `onPrepare` can be used for any kind of custom logic which
-you would like to execute before the xref:latest@manual:ROOT:exchange.adoc[Exchange] is
+you would like to execute before the xref:manual::exchange.adoc[Exchange] is
 being multicasted.
 
 == See Also

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/normalizer.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/normalizer.adoc
@@ -29,7 +29,7 @@ from("direct:start")
     .to("mock:result");
 ----
 
-In this case we're using a Java xref:components::bean-component.adoc[Bean] as the normalizer.
+In this case we're using a Java xref:ROOT:bean-component.adoc[Bean] as the normalizer.
 
 The class looks like this:
 
@@ -78,5 +78,5 @@ The same example in XML:
 
 In case there are many incoming formats, then the xref:choice-eip.adoc[Content Based Router]
 may end up with too many choices. In this situation then an alternative is to use xref:toD-eip.adoc[Dynamic to]
-that computes a xref:components::bean-component.adoc[Bean] endpoint, to be called that acts as
+that computes a xref:ROOT:bean-component.adoc[Bean] endpoint, to be called that acts as
 xref:message-translator.adoc[Message Translator].

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/pipeline-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/pipeline-eip.adoc
@@ -11,7 +11,7 @@ from the xref:enterprise-integration-patterns.adoc[EIP patterns] in various ways
 image::eip/PipesAndFilters.gif[image]
 
 With Camel, you can separate your processing across multiple independent
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint]'s which can then be chained
+xref:manual::endpoint.adoc[Endpoint]'s which can then be chained
 together.
 
 == Options
@@ -23,7 +23,7 @@ include::partial$eip-options.adoc[]
 == Using pipeline
 
 You can create pipelines of logic using multiple
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint] or
+xref:manual::endpoint.adoc[Endpoint] or
 xref:message-translator.adoc[Message Translator] instances as follows:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/point-to-point-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/point-to-point-channel.adoc
@@ -12,12 +12,12 @@ image::eip/PointToPointSolution.gif[image]
 
 Send the message on a Point-to-Point Channel, which ensures that only one receiver will receive a particular message.
 
-The Point to Point Channel is supported in Camel by messaging based xref:components::index.adoc[Components], such as:
+The Point to Point Channel is supported in Camel by messaging based xref:ROOT:index.adoc[Components], such as:
 
-* xref:components::amqp-component.adoc[AMQP] for working with AMQP Queues
-* xref:components::jms-component.adoc[ActiveMQ], or xref:components::jms-component.adoc[JMS] for working with JMS Queues
-* xref:components::seda-component.adoc[SEDA] for internal Camel seda queue based messaging
-* xref:components::spring-rabbitmq-component.adoc[Spring RabbitMQ] for working with AMQP Queues (RabbitMQ)
+* xref:ROOT:amqp-component.adoc[AMQP] for working with AMQP Queues
+* xref:ROOT:jms-component.adoc[ActiveMQ], or xref:ROOT:jms-component.adoc[JMS] for working with JMS Queues
+* xref:ROOT:seda-component.adoc[SEDA] for internal Camel seda queue based messaging
+* xref:ROOT:spring-rabbitmq-component.adoc[Spring RabbitMQ] for working with AMQP Queues (RabbitMQ)
 
 There are also messaging based in the cloud from cloud providers such as Amazon, Google and Azure.
 
@@ -26,7 +26,7 @@ TIP: See also the related xref:publish-subscribe-channel.adoc[Publish Scribe Cha
 == Example
 
 The following example demonstrates point to point messaging using
-the xref:components::jms-component.adoc[JMS] component:
+the xref:ROOT:jms-component.adoc[JMS] component:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/pollEnrich-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/pollEnrich-eip.adoc
@@ -16,7 +16,7 @@ In Camel the Content Enricher can be done in several ways:
 
 * Using xref:enrich-eip.adoc[Enrich] EIP or xref:pollEnrich-eip.adoc[Poll Enrich] EIP
 * Using a xref:message-translator.adoc[Message Translator]
-* Using a xref:latest@manual:ROOT:processor.adoc[Processor] with the enrichment programmed in Java
+* Using a xref:manual::processor.adoc[Processor] with the enrichment programmed in Java
 * Using a xref:bean-eip.adoc[Bean] EIP with the enrichment programmed in Java
 
 The most natural Camel approach is using xref:enrich-eip.adoc[Enrich] EIP,
@@ -28,7 +28,7 @@ It is usually used for xref:requestReply-eip.adoc[Request Reply] messaging, for 
 * xref:pollEnrich-eip.adoc[Poll Enrich] EIP - Uses a xref:polling-consumer.adoc[Polling
 Consumer] to obtain the additional data. It is usually used for
 xref:event-message.adoc[Event Message] messaging, for instance to read a
-file or download a xref:components::ftp-component.adoc[FTP] file.
+file or download a xref:ROOT:ftp-component.adoc[FTP] file.
 
 NOTE: This page documents the Poll Enrich EIP.
 
@@ -127,8 +127,8 @@ In XML DSL you use `pollEnrich` as follows:
 
 === Using Poll Enrich with Rest DSL
 
-You can also use `pollEnrich` with xref:latest@manual:ROOT:rest-dsl.adoc[Rest DSL] to
-for example download a file from xref:components::aws2-s3-component.adoc[AWS S3] as the response of an API call.
+You can also use `pollEnrich` with xref:manual::rest-dsl.adoc[Rest DSL] to
+for example download a file from xref:ROOT:aws2-s3-component.adoc[AWS S3] as the response of an API call.
 
 [source,xml]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/polling-consumer.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/polling-consumer.adoc
@@ -25,14 +25,14 @@ You can get hold of a `PollingConsumer` in several ways in Camel:
 https://github.com/apache/camel/blob/main/core/camel-api/src/main/java/org/apache/camel/Endpoint.java[Endpoint.createPollingConsumer()]
 method.
 
-- Use the xref:latest@manual:ROOT:consumertemplate.adoc[ConsumerTemplate] to poll on demand.
+- Use the xref:manual::consumertemplate.adoc[ConsumerTemplate] to poll on demand.
 
 == Using Polling Consumer
 
 If you need to use Polling Consumer from within a route, then the xref:pollEnrich-eip.adoc[Poll Enrich] EIP can be used.
 
 On the other hand if you need to use Polling Consumer programmatically,
-then using xref:latest@manual:ROOT:consumertemplate.adoc[ConsumerTemplate] is a good choice.
+then using xref:manual::consumertemplate.adoc[ConsumerTemplate] is a good choice.
 
 And if you want to use the lower level Camel APIs then you can create the `PollingConsumer` instance to be used.
 
@@ -88,7 +88,7 @@ if the internal queue is full. If the value is `0` or negative then no timeout i
 timeout is triggered then a `ExchangeTimedOutException` is thrown.
 |=======================================================================
 
-You can configure these options in endpoints xref:latest@manual:ROOT:uris.adoc[URIs], such
+You can configure these options in endpoints xref:manual::uris.adoc[URIs], such
 as shown below:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
@@ -6,7 +6,7 @@
 :supportlevel: Stable
 
 The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
-is used for processing message xref:latest@manual:ROOT:exchange.adoc[Exchanges].
+is used for processing message xref:manual::exchange.adoc[Exchanges].
 
 The processor is a core Camel concept that represents a node capable of using, creating,
 or modifying an incoming exchange. During routing, exchanges flow from one processor
@@ -20,7 +20,7 @@ image::eip/message_flow_in_route.png[image]
 A route first starts with a consumer (think `from` in the DSL) that populates the initial
 exchange. At each processor step, the out message from the previous step is the in
 message of the next. In many cases, processors don’t set an out message, so in this case
-the in message is reused. At the end of a route, the xref:latest@manual:ROOT:exchange-pattern.adoc[Messageg Exchange Pattern] (MEP)
+the in message is reused. At the end of a route, the xref:manual::exchange-pattern.adoc[Messageg Exchange Pattern] (MEP)
 of the exchange determines whether a reply needs to be sent back to the caller of the route. If the MEP is `InOnly`,
 no reply will be sent back. If it’s `InOut`, Camel will take the out message from the last
 step and return it.
@@ -70,7 +70,7 @@ from("activemq:myQueue")
 ----
 
 You can also call a processor by its bean id, if the processor
-has been enlisted in the xref:latest@manual:ROOT:registry.adoc[Registry], such as with the id `myProcessor`:
+has been enlisted in the xref:manual::registry.adoc[Registry], such as with the id `myProcessor`:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/publish-subscribe-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/publish-subscribe-channel.adoc
@@ -10,12 +10,12 @@ image::eip/PublishSubscribeSolution.gif[image]
 
 Send the event on a Publish-Subscribe Channel, which delivers a copy of a particular event to each receiver.
 
-The Publish-Subscribe Channel is supported in Camel by messaging based xref:components::index.adoc[Components], such as:
+The Publish-Subscribe Channel is supported in Camel by messaging based xref:ROOT:index.adoc[Components], such as:
 
-* xref:components::amqp-component.adoc[AMQP] for working with AMQP Queues
-* xref:components::jms-component.adoc[ActiveMQ], or xref:components::jms-component.adoc[JMS] for working with JMS Queues
-* xref:components::seda-component.adoc[SEDA] for internal Camel seda queue based messaging
-* xref:components::spring-rabbitmq-component.adoc[Spring RabbitMQ] for working with AMQP Queues (RabbitMQ)
+* xref:ROOT:amqp-component.adoc[AMQP] for working with AMQP Queues
+* xref:ROOT:jms-component.adoc[ActiveMQ], or xref:ROOT:jms-component.adoc[JMS] for working with JMS Queues
+* xref:ROOT:seda-component.adoc[SEDA] for internal Camel seda queue based messaging
+* xref:ROOT:spring-rabbitmq-component.adoc[Spring RabbitMQ] for working with AMQP Queues (RabbitMQ)
 
 There are also messaging based in the cloud from cloud providers such as Amazon, Google and Azure.
 
@@ -24,7 +24,7 @@ TIP: See also the related xref:point-to-point-channel.adoc[Point to Point Channe
 == Example
 
 The following example demonstrates publish sbuscriber messaging using
-the xref:components::jms-component.adoc[JMS] component with JMS topics:
+the xref:ROOT:jms-component.adoc[JMS] component with JMS topics:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
@@ -36,7 +36,7 @@ The following exchange properties are set on each `Exchange` that are sent by th
 
 == Using Recipient List
 
-The Recipient List EIP allows to route *the same* message to a number of xref:latest@manual:ROOT:endpoint.adoc[endpoints]
+The Recipient List EIP allows to route *the same* message to a number of xref:manual::endpoint.adoc[endpoints]
 and process them in a different way.
 
 There can be 1 or more destinations, and Camel will execute them sequentially (by default).
@@ -74,7 +74,7 @@ And in XML:
 Usually one of the main reasons for using the Recipient List pattern is that the list of recipients is dynamic and
 calculated at runtime.
 
-The following example demonstrates how to create a dynamic recipient list using an xref:latest@manual:ROOT:expression.adoc[Expression]
+The following example demonstrates how to create a dynamic recipient list using an xref:manual::expression.adoc[Expression]
 (which in this case extracts a named header value dynamically) to calculate the list of endpoints; which are either
 of type `Endpoint` or are converted to a `String` and then resolved using the endpoint URIs (separated by comma).
 
@@ -178,7 +178,7 @@ process the remainder destinations. You have the chance to deal with the excepti
 when aggregating using an `AggregationStrategy`.
 
 But sometimes you just want Camel to stop and let the exception be
-propagated back, and let the Camel xref:latest@manual:ROOT:error-handler.adoc[Error Handler]
+propagated back, and let the Camel xref:manual::error-handler.adoc[Error Handler]
 handle it. You can do this by specifying that it should stop in case of an
 exception occurred. This is done by the `stopOnException` option as
 shown below:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
@@ -10,12 +10,12 @@ image::eip/RequestReply.gif[image]
 
 Send a pair of Request-Reply messages, each on its own channel.
 
-Camel supports Request Reply by the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+Camel supports Request Reply by the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 on a xref:message.adoc[Message] which can be set to `InOut` to indicate a
-request/reply message. Camel xref:components::index.adoc[Components] then
+request/reply message. Camel xref:ROOT:index.adoc[Components] then
 implement this pattern using the underlying transport or protocols.
 
-For example when using xref:components::jms-component.adoc[JMS] with `InOut` the component will
+For example when using xref:ROOT:jms-component.adoc[JMS] with `InOut` the component will
 by default perform these actions:
 
 * create by default a temporary inbound queue
@@ -24,14 +24,14 @@ by default perform these actions:
 * send the request message
 * consume the response and associate the inbound message to the belonging request
 using the `JMSCorrelationID` (as you may be performing many concurrent request/responses).
-* continue routing when the reply is received and populated on the xref:latest@manual:ROOT:exchange.adoc[Exchange]
+* continue routing when the reply is received and populated on the xref:manual::exchange.adoc[Exchange]
 
 TIP: See the related xref:eips:event-message.adoc[Event Message].
 
 == Using endpoint URI
 
 If you are using a component which defaults to `InOnly` you can override
-the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] for a *consumer* endpoint using
+the xref:manual::exchange-pattern.adoc[Exchange Pattern] for a *consumer* endpoint using
 the pattern property.
 
 [source,text]
@@ -63,7 +63,7 @@ And with XML:
 == Using setExchangePattern EIP
 
 You can specify the
-xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] using `setExchangePattern` in the DSL.
+xref:manual::exchange-pattern.adoc[Exchange Pattern] using `setExchangePattern` in the DSL.
 
 [source,java]
 ----
@@ -83,8 +83,8 @@ And with XML:
 </route>
 ----
 
-When using `setExchangePattern` then the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
-on the xref:latest@manual:ROOT:exchange.adoc[Exchange] is changed from this point onwards in the route.
+When using `setExchangePattern` then the xref:manual::exchange-pattern.adoc[Exchange Pattern]
+on the xref:manual::exchange.adoc[Exchange] is changed from this point onwards in the route.
 
 This means you can change the pattern back again at a later point:
 
@@ -98,17 +98,17 @@ from("direct:foo")
   .log("InOut MEP received ${body}")
 ----
 
-NOTE: Using `setExchangePattern` to change the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+NOTE: Using `setExchangePattern` to change the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 is often only used in special use-cases where you must
 force to be using either `InOnly` or `InOut` mode when using components that support both modes (such as messaging components like ActiveMQ, JMS, RabbitMQ etc.)
 
 == JMS component and InOnly vs InOut
 
-When consuming messages from xref:components::jms-component.adoc[JMS] a Request Reply is
+When consuming messages from xref:ROOT:jms-component.adoc[JMS] a Request Reply is
 indicated by the presence of the `JMSReplyTo` header. This means the JMS component automatic
 detects whether to use `InOnly` or `InOut` in the consumer.
 
-Likewise, the JMS producer will check the current xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
-on the xref:latest@manual:ROOT:exchange.adoc[Exchange] to know whether to use `InOnly` or `InOut` mode (i.e. one-way vs request/reply messaging)
+Likewise, the JMS producer will check the current xref:manual::exchange-pattern.adoc[Exchange Pattern]
+on the xref:manual::exchange.adoc[Exchange] to know whether to use `InOnly` or `InOut` mode (i.e. one-way vs request/reply messaging)
 
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/resequence-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/resequence-eip.adoc
@@ -15,7 +15,7 @@ image::eip/Resequencer.gif[image]
 
 Use a stateful filter, a Resequencer, to collect and re-order messages so that they can be published to the output channel in a specified order.
 
-The Resequencer implementation in Camel uses an xref:latest@manual:ROOT:expression.adoc[Expression]
+The Resequencer implementation in Camel uses an xref:manual::expression.adoc[Expression]
 as the `Comparator` to re-order the messages. By using the expression then the messages
 can easily be re-ordered by a message header or another piece of the message.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
@@ -11,8 +11,8 @@ image::eip/ReturnAddressSolution.gif[image]
 
 The request message should contain a Return Address that indicates where to send the reply message.
 
-Camel supports Return Address by messaging xref:components::index.adoc[Components]
-that provides this functionality such as the xref:components::jms-component.adoc[JMS]
+Camel supports Return Address by messaging xref:ROOT:index.adoc[Components]
+that provides this functionality such as the xref:ROOT:jms-component.adoc[JMS]
 component via the `JMSReplyTo` header.
 
 == Example

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/rollback-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/rollback-eip.adoc
@@ -5,7 +5,7 @@
 :since: 
 :supportlevel: Stable
 
-The Rollback EIP is used for marking an xref:latest@manual:ROOT:exchange.adoc[Exchange]
+The Rollback EIP is used for marking an xref:manual::exchange.adoc[Exchange]
 to rollback and stop continue routing the message.
 
 == Options

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/routingSlip-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/routingSlip-eip.adoc
@@ -36,14 +36,14 @@ The following exchange properties are set on each `Exchange` that are sent by th
 
 == Using Routing Slip
 
-The Routing Slip EIP allows to route a message through a series of xref:latest@manual:ROOT:endpoint.adoc[endpoints] (the slip).
+The Routing Slip EIP allows to route a message through a series of xref:manual::endpoint.adoc[endpoints] (the slip).
 
-There can be 1 or more endpoint xref:latest@manual:ROOT:uris.adoc[uris] in the slip.
+There can be 1 or more endpoint xref:manual::uris.adoc[uris] in the slip.
 
 TIP: A slip can be empty, meaning that the message will not be routed anywhere.
 
 The following route will take any messages sent to the Apache ActiveMQ queue cheese
-and use the header with key "whereTo" that is used to compute the slip (endpoint xref:latest@manual:ROOT:uris.adoc[uris]).
+and use the header with key "whereTo" that is used to compute the slip (endpoint xref:manual::uris.adoc[uris]).
 
 [source,java]
 ---------------------
@@ -74,7 +74,7 @@ The same example in XML is simply just:
 
 === How is the slip computed
 
-The Routing Slip uses an xref:latest@manual:ROOT:expression.adoc[Expression] to compute the value for the slip.
+The Routing Slip uses an xref:manual::expression.adoc[Expression] to compute the value for the slip.
 The result of the expression can be one of:
 
 - `String`

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
@@ -153,7 +153,7 @@ And are loaded up in XML like this:
 Each bean is loaded with a different price for beer. When the message is sent to each bean endpoint,
 it will arrive at the `MyVendor.quote` method. This method does a simple check whether this quote
 request is for beer and then sets the price of beer on the exchange for retrieval at a later step.
-The message is forwarded on to the next step using xref:latest@manual:ROOT:pojo-producing.adoc[POJO Producing]
+The message is forwarded on to the next step using xref:manual::pojo-producing.adoc[POJO Producing]
 (see the `@Produce` annotation).
 
 At the next step we want to take the beer quotes from all vendors and find out which one was the best

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/service-activator.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/service-activator.adoc
@@ -10,19 +10,19 @@ image::eip/MessagingAdapterSolution.gif[image]
 
 Design a Service Activator that connects the messages on the channel to the service being accessed.
 
-Camel has several xref:components::index.adoc[Components] that support the Service Activator EIP.
+Camel has several xref:ROOT:index.adoc[Components] that support the Service Activator EIP.
 
-Components like xref:components::bean-component.adoc[Bean] and xref:components::bean-component.adoc[CXF]
-provide a way to bind the message xref:latest@manual:ROOT:exchange.adoc[Exchange] to a Java interface/service
+Components like xref:ROOT:bean-component.adoc[Bean] and xref:ROOT:bean-component.adoc[CXF]
+provide a way to bind the message xref:manual::exchange.adoc[Exchange] to a Java interface/service
 where the route defines the endpoints and wires it up to the bean.
 
-In addition, you can use the xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to wire messages
+In addition, you can use the xref:manual::bean-integration.adoc[Bean Integration] to wire messages
 to a bean using Java annotation.
 
 == Example
 
-Here is a simple example of using a xref:components::direct-component.adoc[Direct] endpoint
-to create a messaging interface to a POJO xref:components::bean-component.adoc[Bean] service.
+Here is a simple example of using a xref:ROOT:direct-component.adoc[Direct] endpoint
+to create a messaging interface to a POJO xref:ROOT:bean-component.adoc[Bean] service.
 
 Using Java DSL:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setBody-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setBody-eip.adoc
@@ -15,10 +15,10 @@ image::eip/MessageTranslator.gif[image]
 The xref:message-translator.adoc[Message Translator] can be done in different ways in Camel:
 
 * Using xref:transform-eip.adoc[Transform] or xref:setBody-eip.adoc[Set Body] in the DSL
-* Calling a xref:latest@manual:ROOT:processor.adoc[Processor] or xref:latest@manual:ROOT:bean-integration.adoc[bean]
+* Calling a xref:manual::processor.adoc[Processor] or xref:manual::bean-integration.adoc[bean]
 to perform the transformation
-* Using template-based xref:components::index.adoc[Components], with the template being the source for how the message is translated
-* Messages can also be transformed using xref:latest@manual:ROOT:data-format.adoc[Data Format]
+* Using template-based xref:ROOT:index.adoc[Components], with the template being the source for how the message is translated
+* Messages can also be transformed using xref:manual::data-format.adoc[Data Format]
 to marshal and unmarshal messages in different encodings.
 
 This page is documenting the first approach by using Set Body EIP.
@@ -34,7 +34,7 @@ include::partial$eip-options.adoc[]
 === Using Set Body EIP
 
 You can use a xref:setBody-eip.adoc[Set Body] which uses an
-xref:latest@manual:ROOT:expression.adoc[Expression] to do the transformation:
+xref:manual::expression.adoc[Expression] to do the transformation:
 
 In the example below we prepend Hello to the message body using the
 xref:components:languages:simple-language.adoc[Simple] language:
@@ -63,5 +63,5 @@ And in XML DSL:
 
 The Transform EIP always sets the result on the OUT message body.
 
-Set Body sets the result accordingly to the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+Set Body sets the result accordingly to the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 on the `Exchange`.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/sort-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/sort-eip.adoc
@@ -24,7 +24,7 @@ or uses the `String` representation.
 
 You can also configure a custom `Comparator` to control the sorting.
 
-An xref:latest@manual:ROOT:expression.adoc[Expression] can also be used, which performs the sorting, and return the sorted message body.
+An xref:manual::expression.adoc[Expression] can also be used, which performs the sorting, and return the sorted message body.
 The value returned from the `Expression` must be convertible to `java.util.List` as this is required by the JDK sort operation.
 
 === Using Sort EIP

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/sticky-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/sticky-eip.adoc
@@ -7,7 +7,7 @@
 
 Sticky mode for the xref:loadBalance-eip.adoc[Load Balancer] EIP.
 
-A stick mode means that a correlation key (calculated as xref:latest@manual:ROOT:expression.adoc[Expression])
+A stick mode means that a correlation key (calculated as xref:manual::expression.adoc[Expression])
 is used to determine the destination. This allows to route all messages with the same key to the same destination.
 
 == Options

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/to-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/to-eip.adoc
@@ -40,8 +40,8 @@ the dynamic endpoint URI.
 
 == Using To
 
-The following example route demonstrates the use of a xref:components::file-component.adoc[File] consumer endpoint and a xref:components::jms-component.adoc[JMS] producer endpoint,
-by their xref:latest@manual:ROOT:uris.adoc[URIs]:
+The following example route demonstrates the use of a xref:ROOT:file-component.adoc[File] consumer endpoint and a xref:ROOT:jms-component.adoc[JMS] producer endpoint,
+by their xref:manual::uris.adoc[URIs]:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
@@ -20,7 +20,7 @@ Connect an application to a messaging channel using a Message Endpoint, a client
 
 In Camel the ToD EIP is used for sending xref:message.adoc[messages] to dynamic xref:message-endpoint.adoc[endpoints].
 
-The xref:to-eip.adoc[To] and ToD EIPs are the most common patterns to use in Camel xref:latest@manual:ROOT:routes.adoc[routes].
+The xref:to-eip.adoc[To] and ToD EIPs are the most common patterns to use in Camel xref:manual::routes.adoc[routes].
 
 == Options
 
@@ -34,8 +34,8 @@ The `to` is used for sending messages to a static xref:message-endpoint.adoc[end
 In other words `to` sends message only to the *same* endpoint.
 
 The `toD` is used for sending message to a dynamic xref:message-endpoint.adoc[endpoint].
-The dynamic endpoint is evaluated _on-demand_ by an xref:latest@manual:ROOT:expression.adoc[Expression].
-By default, the xref:components:languages:simple-language.adoc[Simple] expression is used to compute
+The dynamic endpoint is evaluated _on-demand_ by an xref:manual::expression.adoc[Expression].
+By default, the xref:languages:simple-language.adoc[Simple] expression is used to compute
 the dynamic endpoint URI.
 
 == Using ToD
@@ -59,8 +59,8 @@ And in XML:
 </route>
 ----
 
-You can also prefix the uri with a value because the endpoint xref:latest@manual:ROOT:uris.adoc[URI] is
-evaluated using the xref:components:languages:simple-language.adoc[Simple] language:
+You can also prefix the uri with a value because the endpoint xref:manual::uris.adoc[URI] is
+evaluated using the xref:languages:simple-language.adoc[Simple] language:
 
 [source,java]
 ----
@@ -84,7 +84,7 @@ value order, then the endpoint is computed as "mock:order".
 
 === Using other languages with toD
 
-You can also use other languages such as xref:components:languages:xpath-language.adoc[XPath].
+You can also use other languages such as xref:languages:xpath-language.adoc[XPath].
 Doing this requires to start with `language:` as shown below. If you do not
 specify `language:` then the endpoint is a component name. And in some
 cases there is both a component and language with the same name such as
@@ -189,7 +189,7 @@ A number of non-HTTP components has been optimised as well:
 For the optimisation to work, then:
 
 . The optimisation is detected and activated during startup of the Camel routes with `toD`.
-. The dynamic uri in `toD` must provide the component name as either static or resolved via xref:latest@manual:ROOT:using-propertyplaceholder.adoc[property placeholders].
+. The dynamic uri in `toD` must provide the component name as either static or resolved via xref:manual::using-propertyplaceholder.adoc[property placeholders].
 . The supported components must be on the classpath.
 
 The HTTP based components will be optimised to use the same hostname:port for each endpoint, and the dynamic values

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
@@ -19,18 +19,18 @@ a 3rd-party JTA transaction manager can be embedded and used.
 
 In Camel transactions are supported by JMS messaging components:
 
-- xref:components::activemq-component.adoc[ActiveMQ]
-- xref:components::jms-component.adoc[JMS]
-- xref:components::sjms-component.adoc[Simple JMS]
-- xref:components::sjms2-component.adoc[Simple JMS 2.x]
+- xref:ROOT:activemq-component.adoc[ActiveMQ]
+- xref:ROOT:jms-component.adoc[JMS]
+- xref:ROOT:sjms-component.adoc[Simple JMS]
+- xref:ROOT:sjms2-component.adoc[Simple JMS 2.x]
 
 And all the SQL database components, such as:
 
-- xref:components::elsql-component.adoc[ElSQL]
-- xref:components::jdbc-component.adoc[JDBC]
-- xref:components::jpa-component.adoc[JPA]
-- xref:components::sql-component.adoc[SQL]
-- xref:components::mybatis-component.adoc[MyBatis]
+- xref:ROOT:elsql-component.adoc[ElSQL]
+- xref:ROOT:jdbc-component.adoc[JDBC]
+- xref:ROOT:jpa-component.adoc[JPA]
+- xref:ROOT:sql-component.adoc[SQL]
+- xref:ROOT:mybatis-component.adoc[MyBatis]
 
 == Understanding Transactions
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/transform-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/transform-eip.adoc
@@ -19,10 +19,10 @@ Use a special filter, a Message Translator, between other filters or application
 The xref:message-translator.adoc[Message Translator] can be done in different ways in Camel:
 
 * Using xref:transform-eip.adoc[Transform] or xref:setBody-eip.adoc[Set Body] in the DSL
-* Calling a xref:latest@manual:ROOT:processor.adoc[Processor] or xref:latest@manual:ROOT:bean-integration.adoc[bean]
+* Calling a xref:manual::processor.adoc[Processor] or xref:manual::bean-integration.adoc[bean]
 to perform the transformation
-* Using template-based xref:components::index.adoc[Components], with the template being the source for how the message is translated
-* Messages can also be transformed using xref:latest@manual:ROOT:data-format.adoc[Data Format]
+* Using template-based xref:ROOT:index.adoc[Components], with the template being the source for how the message is translated
+* Messages can also be transformed using xref:manual::data-format.adoc[Data Format]
 to marshal and unmarshal messages in different encodings.
 
 This page is documenting the first approach by using Transform EIP.
@@ -36,7 +36,7 @@ include::partial$eip-options.adoc[]
 === Using Transform EIP
 
 You can use a xref:transform-eip.adoc[Transform] which uses an
-xref:latest@manual:ROOT:expression.adoc[Expression] to do the transformation:
+xref:manual::expression.adoc[Expression] to do the transformation:
 
 In the example below we prepend Hello to the message body using the
 xref:components:languages:simple-language.adoc[Simple] language:
@@ -65,5 +65,5 @@ And in XML DSL:
 
 The Transform EIP always sets the result on the OUT message body.
 
-Set Body sets the result accordingly to the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+Set Body sets the result accordingly to the xref:manual::exchange-pattern.adoc[Exchange Pattern]
 on the `Exchange`.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
@@ -4,11 +4,11 @@ The xref:marshal-eip.adoc[Marshal] and xref:unmarshal-eip.adoc[Unmarshal] EIPs a
 for xref:message-translator.adoc[Message Transformation].
 
 Camel has support for message transformation using several techniques.
-One such technique is xref:components:dataformats:index.adoc[Data Formats],
+One such technique is xref:dataformats:index.adoc[Data Formats],
 where marshal and unmarshal comes from.
 
 So in other words the xref:marshal-eip.adoc[Marshal] and xref:unmarshal-eip.adoc[Unmarshal] EIPs
-are used with xref:components:dataformats:index.adoc[Data Formats].
+are used with xref:dataformats:index.adoc[Data Formats].
 
 - _Marshal_ - Transforms the message body (such as Java object) into a binary or textual format, ready to be wired over the network.
 - _Unmarshal_ - Transforms data in some binary or textual format (such as received over the network)
@@ -18,10 +18,10 @@ into a Java object; or some other representation according to the data format be
 
 The following example reads XML files from the inbox/xml directory.
 Each file is then transformed into Java Objects using xref:dataformats:jaxb-dataformat.adoc[JAXB].
-Then a xref:components::bean-component.adoc[Bean] is invoked that takes in the Java object.
+Then a xref:ROOT:bean-component.adoc[Bean] is invoked that takes in the Java object.
 
 Then the reverse operation happens to transform the Java objects back into XML also via JAXB,
-but using the `unmarshal` operation. And finally the message is routed to a xref:components::jms-component.adoc[JMS] queue.
+but using the `unmarshal` operation. And finally the message is routed to a xref:ROOT:jms-component.adoc[JMS] queue.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/validate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/validate-eip.adoc
@@ -5,7 +5,7 @@
 :since: 
 :supportlevel: Stable
 
-The Validate EIP uses an xref:latest@manual:ROOT:expression.adoc[Expression] or xref:latest@manual:ROOT:predicate.adoc[Predicate]
+The Validate EIP uses an xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicate]
 to validate the contents of a message.
 
 image::eip/MessageSelectorIcon.gif[image]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/wireTap-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/wireTap-eip.adoc
@@ -21,20 +21,20 @@ include::partial$eip-options.adoc[]
 == WireTap Nodes
 
 Camel's Wire Tap node supports two modes when wire tapping an
-xref:latest@manual:ROOT:exchange.adoc[Exchange]:
+xref:manual::exchange.adoc[Exchange]:
 
 - _Default mode_: Camel will copy the original
-xref:latest@manual:ROOT:exchange.adoc[Exchange] and set its
-xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
-the tapped xref:latest@manual:ROOT:exchange.adoc[Exchange] to be sent in a fire and forget
-style. The tapped xref:latest@manual:ROOT:exchange.adoc[Exchange] is then sent in a
+xref:manual::exchange.adoc[Exchange] and set its
+xref:manual::exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
+the tapped xref:manual::exchange.adoc[Exchange] to be sent in a fire and forget
+style. The tapped xref:manual::exchange.adoc[Exchange] is then sent in a
 separate thread, so it can run in parallel with the original. Beware that
 only the `Exchange` is copied - Wire Tap won't do a deep clone (unless you
 specify a custom processor via *`onPrepareRef`* which does that). So all
 copies could share objects from the original `Exchange`.
 
 - _New mode_: Camel also provides an option of sending a new
-xref:latest@manual:ROOT:exchange.adoc[Exchange] allowing you to populate it with new
+xref:manual::exchange.adoc[Exchange] allowing you to populate it with new
 values.
 
 === Using Wire Tap
@@ -155,7 +155,7 @@ to construct the message, instead of using a `Processor`:
 
 The WireTap uses a thread pool to process the
 tapped messages. This thread pool will by default use the settings
-detailed at xref:latest@manual:ROOT:threading-model.adoc[Threading Model].
+detailed at xref:manual::threading-model.adoc[Threading Model].
 
 In particular, when the pool is exhausted (with all threads utilized), further wiretaps
 will be executed synchronously by the calling thread. To remedy this,
@@ -165,8 +165,8 @@ a different rejection policy, a larger worker queue, or more worker threads.
 == Wire tapping Streaming based messages
 
 If you Wire Tap a stream message body then you
-should consider enabling xref:latest@manual:ROOT:stream-caching.adoc[Stream caching] to
+should consider enabling xref:manual::stream-caching.adoc[Stream caching] to
 ensure the message body can be read at each endpoint.
 
-See more details at xref:latest@manual:ROOT:stream-caching.adoc[Stream caching].
+See more details at xref:manual::stream-caching.adoc[Stream caching].
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-options.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-options.adoc
@@ -18,6 +18,6 @@ The {doctitle} eip supports {optioncount} options, which are listed below.
 | Name | Description | Default | Type
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
 endif::[]
 

--- a/docs/components/modules/ROOT/pages/index.adoc
+++ b/docs/components/modules/ROOT/pages/index.adoc
@@ -9,24 +9,24 @@ services that can not only resolve easy messaging and transferring data but also
 
 Below is the list of core components that are provided by Apache Camel.
 
-Number of Core Components: indexCount:[attributes=core] in indexUniqueCount:[attributes=core,unique=artifactid] JAR artifacts (indexCount:[attributes="core,deprecated"] deprecated)
+Number of Core Components: indexCount:[attributes=core] in indexUniqueCount:[attributes=core,format=artifactid] JAR artifacts (indexCount:[attributes="core,deprecated"] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
-indexTable::[attributes=core,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[attributes=core,cellformats="$xref|artifactid|supportlevel|since|description"]
 
 == Components
 
 Below is the list of non-core components that are provided by Apache Camel.
 
-Number of Non-Core Components: indexCount:[attributes=!core] in indexUniqueCount:[attributes=!core,unique=artifactid] JAR artifacts (indexCount:[attributes="!core,deprecated"] deprecated)
+Number of Non-Core Components: indexCount:[attributes=!core] in indexUniqueCount:[attributes=!core,format=artifactid] JAR artifacts (indexCount:[attributes="!core,deprecated"] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
 //'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,attributes=!core,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[relative=!nav.adoc,attributes=!core,cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/ROOT/partials/component-endpoint-options.adoc
+++ b/docs/components/modules/ROOT/partials/component-endpoint-options.adoc
@@ -5,21 +5,21 @@
 :endpoint-path-option-name: util.boldLink(path[2], "endpoint_path_option", value.group)
 :endpoint-query-option-name: util.boldLink(path[2], "endpoint_query_option", value.group)
 :last-cell-formats: |util.description(value) \
-|util.defaultValue(value.defaultValue) \
+|util.valueAsString(value.defaultValue) \
 |util.javaSimpleName(value.javaType)
 include::jsonpath$example$json/{shortname}.json[query='$.component',formats='name,scheme,pascalcasescheme=util.pascalCase(scheme),syntax,apiSyntax', requires={requires}]
-include::jsonpathcount$example$json/{shortname}.json[queries='pathparametercount=nodes$.properties[?(@.kind=="path")],queryparametercount=nodes$.properties[?(@.kind=="parameter")],apicount=nodes$.apis.*']
+include::jsonpathcount$example$json/{shortname}.json[queries='propertycount=nodes$.componentProperties.*,pathparametercount=nodes$.properties[?(@.kind=="path")],queryparametercount=nodes$.properties[?(@.kind=="parameter")],apicount=nodes$.apis.*']
 
 == Component Options
 
-The {doctitle} component supports jsonpathCount:example$json/{shortname}.json['nodes$.componentProperties.*'] options, which are listed below.
+The {doctitle} component supports {propertycount} options, which are listed below.
 
 [{tablespec}]
 |===
 | Name | Description | Default | Type
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.componentProperties.*','{component-option-name}{last-cell-formats}',{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.componentProperties.*','{component-option-name}{last-cell-formats}',{requires}]
 
 
 // endpoint options: START
@@ -46,7 +46,7 @@ ifeval::[{pathparametercount} != 0]
 | Name | Description | Default | Type
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.properties[?(@.kind=="path")]','{endpoint-path-option-name}{last-cell-formats}',{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.kind=="path")]','{endpoint-path-option-name}{last-cell-formats}',{requires}]
 
 endif::[]
 
@@ -63,7 +63,7 @@ ifeval::[{queryparametercount} != 0]
 | Name | Description | Default | Type
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.properties[?(@.kind=="parameter")]','{endpoint-query-option-name}{last-cell-formats}',{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.kind=="parameter")]','{endpoint-query-option-name}{last-cell-formats}',{requires}]
 endif::[]
 
 ifeval::[{apicount} != 0]
@@ -85,11 +85,11 @@ There are {apicount} API names as listed in the table below:
 | API Name | Type | Description
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.apis.*','`<<#_api_${path[2]},*${path[2]}*>>`| value.consumerOnly ? "Consumer" : value.producerOnly ? "Producer" : "Both" | value.description']
+jsonpathTable::example$json/{shortname}.json['nodes$.apis.*','`<<#_api_${path[2]},*${path[2]}*>>`| value.consumerOnly ? "Consumer" : value.producerOnly ? "Producer" : "Both" | value.description']
 
 Each API is documented in the following sections to come.
 
-[jsonpathBlock2, example$json/{shortname}.json, 'nodes$.apis.*','apiname=path[2], producer-consumer = util.producerConsumerLong(value.consumerOnly\, value.producerOnly), methodcount=Object.keys(value.methods).length, aliases=value.aliases', {requires}]
+[jsonpathBlock, example$json/{shortname}.json, 'nodes$.apis.*','apiname=path[2], producer-consumer = util.producerConsumerLong(value.consumerOnly\, value.producerOnly), methodcount=Object.keys(value.methods).length, aliases=value.aliases', {requires}]
 ----
 
 [#_api_{apiname}]
@@ -118,16 +118,16 @@ The {methodcount} method(s) is listed in the table below, followed by detailed s
 | Method | Alias | Description
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.apis["{apiname}"].methods.*','`<<#_api_{apiname}_method_${path[4]},*${path[4]}*>>`|util.alias(path[4], "{aliases}")|value.description', {requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.apis["{apiname}"].methods.*','`<<#_api_{apiname}_method_${path[4]},*${path[4]}*>>`|util.alias(path[4], "{aliases}")|value.description', {requires}]
 
-[jsonpathBlock2, example$json/{shortname}.json, 'nodes$.apis["{apiname}"].methods.*','methodname=path[4]', {requires}]
+[jsonpathBlock, example$json/{shortname}.json, 'nodes$.apis["{apiname}"].methods.*','methodname=path[4]', {requires}]
 ------
 [#_api_{apiname}_method_{methodname}]
 ==== Method {methodname}
 
 Signatures:
 
-jsonpathList2::example$json/{shortname}.json['nodes$.apis["{apiname}"].methods["{methodname}"].signatures.*','util.formatSignature(value)', {requires}]
+jsonpathList::example$json/{shortname}.json['nodes$.apis["{apiname}"].methods["{methodname}"].signatures.*','util.formatSignature(value)', {requires}]
 
 The {name}/{methodname} API method has the parameters listed in the table below:
 
@@ -136,7 +136,7 @@ The {name}/{methodname} API method has the parameters listed in the table below:
 | Parameter | Description | Type
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.apiProperties["{apiname}"].methods["{methodname}"].properties.*','`*${path[6]}*`|`${util.strong(value, "Required")} ${value.description}`|util.javaSimpleName(value.javaType)', {requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.apiProperties["{apiname}"].methods["{methodname}"].properties.*','`*${path[6]}*`|`${util.strong(value, "Required")} ${value.description}`|util.javaSimpleName(value.javaType)', {requires}]
 
 ------
 

--- a/docs/components/modules/dataformats/pages/index.adoc
+++ b/docs/components/modules/dataformats/pages/index.adoc
@@ -1,14 +1,12 @@
-[list-of-camel-data-formats]
 = Data Formats
 
 Below is the list of data formats that are provided by Apache Camel.
 
-Number of Data Formats: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Data Formats: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Data Format | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/dataformats/partials/dataformat-options.adoc
+++ b/docs/components/modules/dataformats/partials/dataformat-options.adoc
@@ -17,6 +17,6 @@ The {doctitle} dataformat supports {optioncount} options, which are listed below
 | Name | Default | Java Type | Description
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
 endif::[]
 

--- a/docs/components/modules/languages/pages/index.adoc
+++ b/docs/components/modules/languages/pages/index.adoc
@@ -1,14 +1,12 @@
-[list-of-camel-expression-languages]
 = Expression Languages
 
 Below is the list of expression languages that are provided by Apache Camel.
 
-Number of Languages: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Languages: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Language | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/languages/partials/language-options.adoc
+++ b/docs/components/modules/languages/partials/language-options.adoc
@@ -17,6 +17,6 @@ The {doctitle} language supports {optioncount} options, which are listed below.
 | Name | Default | Java Type | Description
 |===
 
-jsonpathTable2::example$json/{shortname}.json['nodes$.properties[?(@.kind=="attribute" && @.displayName!="Id")]',{cellformats},{requires}]
+jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.kind=="attribute" && @.displayName!="Id")]',{cellformats},{requires}]
 endif::[]
 

--- a/docs/components/modules/others/pages/index.adoc
+++ b/docs/components/modules/others/pages/index.adoc
@@ -1,18 +1,16 @@
-[list-of-camel-components]
 = Miscellaneous Components
 
 Component references are references used to place a component in an assembly. Apache Component references 
 provides various references that offers services for messaging, sending data, notifications and various other 
 services that can not only resolve easy messaging and transferring data but also provide securing of data.
 
-Number of Miscellaneous Components: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Miscellaneous Components: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 
 
 

--- a/dsl/src/main/docs/dsl.adoc
+++ b/dsl/src/main/docs/dsl.adoc
@@ -5,4 +5,4 @@
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={doctitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={doctitle}',descriptionformat=description]


### PR DESCRIPTION
point to current version, not latest from eip docs

fix avra-rpc and paho-mqtt5 spring boot metadata

fix case of jsonapi in camel-spring-boot-name

See apache/camel-website#648.