### PR TITLE
update to new indexer and jsonpath syntax

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aws-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aws-summary.adoc
@@ -11,4 +11,4 @@ provides streaming for Apache Kafka and more. The main reason to use AWS is its 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aws2-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/aws2-summary.adoc
@@ -11,4 +11,4 @@ storage service, email and queue services. The main reason to use AWS is its clo
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/azure-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/azure-summary.adoc
@@ -11,4 +11,4 @@ provide connectivity to Azure services from Camel.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/google-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/google-summary.adoc
@@ -11,4 +11,4 @@ drive . The main reason to use Google is the G Suite features.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/hazelcast-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/hazelcast-summary.adoc
@@ -25,7 +25,7 @@ http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ignite-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ignite-summary.adoc
@@ -17,7 +17,7 @@ image::apache-ignite.png[]
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/kubernetes-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/kubernetes-summary.adoc
@@ -15,7 +15,7 @@ The Kubernetes components integrate your application with Kubernetes standalone 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/openstack-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/openstack-summary.adoc
@@ -16,7 +16,7 @@ https://www.openstack.org//[OpenStack] applications.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-summary.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-summary.adoc
@@ -10,7 +10,7 @@
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.

--- a/components/camel-avro-rpc/src/main/docs/avro-component.adoc
+++ b/components/camel-avro-rpc/src/main/docs/avro-component.adoc
@@ -9,7 +9,7 @@
 :component-header: Both producer and consumer are supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/avro.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: avro
+:camel-spring-boot-name: avro-rpc
 
 *Since Camel {since}*
 

--- a/components/camel-aws-cw/src/main/docs/aws-summary.adoc
+++ b/components/camel-aws-cw/src/main/docs/aws-summary.adoc
@@ -11,4 +11,4 @@ provides streaming for Apache Kafka and more. The main reason to use AWS is its 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/components/camel-aws2-cw/src/main/docs/aws2-summary.adoc
+++ b/components/camel-aws2-cw/src/main/docs/aws2-summary.adoc
@@ -11,4 +11,4 @@ storage service, email and queue services. The main reason to use AWS is its clo
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/components/camel-azure/src/main/docs/azure-summary.adoc
+++ b/components/camel-azure/src/main/docs/azure-summary.adoc
@@ -11,4 +11,4 @@ provide connectivity to Azure services from Camel.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/components/camel-google-bigquery/src/main/docs/google-summary.adoc
+++ b/components/camel-google-bigquery/src/main/docs/google-summary.adoc
@@ -11,4 +11,4 @@ drive . The main reason to use Google is the G Suite features.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/components/camel-grape/src/main/docs/grape-component.adoc
+++ b/components/camel-grape/src/main/docs/grape-component.adoc
@@ -8,6 +8,8 @@
 :supportLevel: Stable
 :component-header: Only producer is supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/grape.adoc[opts=optional]
+//Manually maintained attributes
+:camel-spring-boot-name: grape
 
 *Since Camel {since}*
 
@@ -253,3 +255,5 @@ command:
         setHeader(GrapeConstats.GRAPE_COMMAND, constant(CamelGrapeCommand.clearPatches)).
         setBody().constant("Installed patches have been deleted."); 
 -----------------------------------------------------------------------------------------
+
+include::spring-boot:partial$starter.adoc[]

--- a/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
@@ -25,7 +25,7 @@ http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-ignite/src/main/docs/ignite-summary.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-summary.adoc
@@ -17,7 +17,7 @@ image::apache-ignite.png[]
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-joor/src/main/docs/joor-language.adoc
+++ b/components/camel-joor/src/main/docs/joor-language.adoc
@@ -8,7 +8,7 @@
 :supportLevel: Preview
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/joor.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: core
+:camel-spring-boot-name: joor
 
 *Since Camel {since}*
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
@@ -15,7 +15,7 @@ The Kubernetes components integrate your application with Kubernetes standalone 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-openstack/src/main/docs/openstack-summary.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-summary.adoc
@@ -16,7 +16,7 @@ https://www.openstack.org//[OpenStack] applications.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/components/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring/src/main/docs/spring-summary.adoc
@@ -10,7 +10,7 @@
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -12,7 +12,7 @@ you to combine a number of messages together into a single message.
 
 image::eip/Aggregator.gif[image]
 
-A correlation xref:latest@manual:ROOT:expression.adoc[Expression] is used to determine the
+A correlation xref:manual:ROOT:expression.adoc[Expression] is used to determine the
 messages which should be aggregated together. If you want to aggregate
 all messages into a single message, just use a constant expression. An
 AggregationStrategy is used to combine all the message exchanges for a
@@ -115,7 +115,7 @@ class ArrayListAggregationStrategy implements AggregationStrategy {
 
 == About completion
 
-When aggregation xref:latest@manual:ROOT:exchange.adoc[Exchange]s at some point you need to
+When aggregation xref:manual:ROOT:exchange.adoc[Exchange]s at some point you need to
 indicate that the aggregated exchanges is complete, so they can be send
 out of the aggregator. Camel allows you to indicate completion in
 various ways as follows:
@@ -127,7 +127,7 @@ key within the period.
 exchanges are completed.
 * completionSize - Is a number indicating that after X aggregated
 exchanges it's complete.
-* completionPredicate - Runs a xref:latest@manual:ROOT:predicate.adoc[Predicate] when a new
+* completionPredicate - Runs a xref:manual:ROOT:predicate.adoc[Predicate] when a new
 exchange is aggregated to determine if we are complete or not.
 The configured aggregationStrategy can implement the
 Predicate interface and will be used as the completionPredicate if no
@@ -136,7 +136,7 @@ override the `preComplete` method and will be used as
 the completionPredicate in pre-complete check mode. See further below
 for more details.
 * completionFromBatchConsumer - Special option for
-xref:latest@manual:ROOT:batch-consumer.adoc[Batch Consumer] which allows you to complete
+xref:manual:ROOT:batch-consumer.adoc[Batch Consumer] which allows you to complete
 when all the messages from the batch has been aggregated.
 * forceCompletionOnStop - Indicates to complete all current
 aggregated exchanges when the context is stopped
@@ -156,9 +156,9 @@ aggregator. If not provided Camel will thrown an Exception on startup.
 == Pre-completion mode
 
 There can be use-cases where you want the incoming
-xref:latest@manual:ROOT:exchange.adoc[Exchange] to determine if the correlation group
+xref:manual:ROOT:exchange.adoc[Exchange] to determine if the correlation group
 should pre-complete, and then the incoming
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch. o
+xref:manual:ROOT:exchange.adoc[Exchange] is starting a new group from scratch. o
 determine this the `AggregationStrategy` must override the `canPreComplete` method
 which has to return `true`.
 
@@ -193,7 +193,7 @@ consumer etc)
 The aggregator provides a pluggable repository which you can implement
 your own `org.apache.camel.spi.AggregationRepository`. +
  If you need persistent repository then you can use either Camel
-xref:components:others:leveldb.adoc[LevelDB], or xref:components::sql-component.adoc[SQL Component] components.
+xref:components:others:leveldb.adoc[LevelDB], or xref:ROOT:sql-component.adoc[SQL Component] components.
 
 == Using TimeoutAwareAggregationStrategy
 
@@ -558,7 +558,7 @@ without using POJOs then you may have `null` as `oldExchange` or
 Aggregate EIP will invoke the
 `AggregationStrategy` with `oldExchange` as null, for the first
 Exchange incoming to the aggregator. And then for
-subsequent xref:latest@manual:ROOT:exchange.adoc[Exchange]s then `oldExchange` and
+subsequent xref:manual:ROOT:exchange.adoc[Exchange]s then `oldExchange` and
 `newExchange` parameters are both not null.
 
 Example with Content Enricher EIP and no data

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
@@ -15,7 +15,7 @@ bean:beanID[?options]
 ----
 
 Where *beanID* can be any string which is used to look up the bean in
-the xref:latest@manual:ROOT:registry.adoc[Registry]
+the xref:manual:ROOT:registry.adoc[Registry]
 
 == EIP options
 
@@ -46,20 +46,20 @@ so when using `prototype` then this depends on the delegated registry.
 
 == Bean as endpoint
 
-Camel also supports invoking xref:components::bean-component.adoc[Bean] as an Endpoint. In the
+Camel also supports invoking xref:ROOT:bean-component.adoc[Bean] as an Endpoint. In the
 route below:
 
 What happens is that when the exchange is routed to the `myBean` Camel
-will use the xref:latest@manual:ROOT:bean-binding.adoc[Bean Binding] to invoke the bean. +
+will use the xref:manual:ROOT:bean-binding.adoc[Bean Binding] to invoke the bean. +
  The source for the bean is just a plain POJO:
 
-Camel will use xref:latest@manual:ROOT:bean-binding.adoc[Bean Binding] to invoke the
+Camel will use xref:manual:ROOT:bean-binding.adoc[Bean Binding] to invoke the
 `sayHello` method, by converting the Exchange's In body to the `String`
 type and storing the output of the method on the Exchange Out body.
 
 == Java DSL bean syntax
 
-Java DSL comes with syntactic sugar for the xref:components::bean-component.adoc[Bean]
+Java DSL comes with syntactic sugar for the xref:ROOT:bean-component.adoc[Bean]
 component. Instead of specifying the bean explicitly as the endpoint
 (i.e. `to("bean:beanName")`) you can use the following syntax:
 
@@ -94,6 +94,6 @@ from("direct:start").bean(ExampleBean.class);
 How bean methods to be invoked are chosen (if they are not specified
 explicitly through the *method* parameter) and how parameter values are
 constructed from the xref:message.adoc[Message] are all defined by the
-xref:latest@manual:ROOT:bean-binding.adoc[Bean Binding] mechanism which is used throughout
-all of the various xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration]
+xref:manual:ROOT:bean-binding.adoc[Bean Binding] mechanism which is used throughout
+all of the various xref:manual:ROOT:bean-integration.adoc[Bean Integration]
 mechanisms in Camel.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/channel-adapter.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/channel-adapter.adoc
@@ -20,7 +20,7 @@ of the component, which allows applications to easily send and receive data.
 == Samples
 
 An application must receive messages from a Kafka topic, which can be done by using the
-xref:components::kafka-component.adoc[Kafka] component.
+xref:ROOT:kafka-component.adoc[Kafka] component.
 
 One solution is to use a Camel route which consumes from the Kafka topic which calls a bean with the data.
 
@@ -41,7 +41,7 @@ public class CheeseBean {
 }
 ----
 
-You can also use xref:latest@manual:ROOT:pojo-consuming.adoc[POJO consuming] with `@Consume` annotation.
+You can also use xref:manual:ROOT:pojo-consuming.adoc[POJO consuming] with `@Consume` annotation.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
@@ -30,7 +30,7 @@ The Choice EIP supports 2 options which are listed below:
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+the evaluation of various xref:manual::predicate.adoc[Predicate] expressions
 
 [source,java]
 ----
@@ -50,7 +50,7 @@ RouteBuilder builder = new RouteBuilder() {
 
 [TIP]
 ====
-See xref:latest@manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
+See xref:manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-based-router-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-based-router-eip.adoc
@@ -11,7 +11,7 @@ image::eip/ContentBasedRouter.gif[image]
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+the evaluation of various xref:manual:ROOT:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----
@@ -34,12 +34,12 @@ RouteBuilder builder = new RouteBuilder() {
 [TIP]
 ====
 See
-xref:latest@manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
+xref:manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 ====
 
-== Using the xref:latest@manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]
+== Using the xref:manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]
 
 [source,java]
 ----
@@ -70,8 +70,8 @@ https://github.com/apache/camel/blob/master/core/camel-core/src/test/java/org/ap
 == Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-xref:latest@manual:ROOT:getting-started.adoc[Getting Started]. You may also find the
-xref:latest@manual:ROOT:architecture.adoc[Architecture] useful particularly the description
-of xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and xref:latest@manual:ROOT:uris.adoc[URIs]. Then you could
-try out some of the xref:latest@manual:ROOT:examples.adoc[Examples] first before trying
+xref:manual:ROOT:getting-started.adoc[Getting Started]. You may also find the
+xref:manual:ROOT:architecture.adoc[Architecture] useful particularly the description
+of xref:manual:ROOT:endpoint.adoc[Endpoint] and xref:manual:ROOT:uris.adoc[URIs]. Then you could
+try out some of the xref:manual:ROOT:examples.adoc[Examples] first before trying
 this pattern out.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
@@ -5,7 +5,7 @@ Camel supports the
 http://www.enterpriseintegrationpatterns.com/DataEnricher.html[Content
 Enricher] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using a xref:message-translator.adoc[Message Translator], an
-arbitrary xref:latest@manual:ROOT:processor.adoc[Processor] in the routing logic, or using
+arbitrary xref:manual:ROOT:processor.adoc[Processor] in the routing logic, or using
 the xref:content-enricher.adoc[enrich] DSL element to enrich the
 message.
 
@@ -16,7 +16,7 @@ image::eip/DataEnricher.gif[image]
 
 You can consume a message from
 one destination, transform it with something like
-xref:components::velocity-component.adoc[Velocity] or xref:components::xquery-component.adoc[XQuery], and then send
+xref:ROOT:velocity-component.adoc[Velocity] or xref:ROOT:xquery-component.adoc[XQuery], and then send
 it on to another destination. For example using InOnly (one way
 messaging)
 
@@ -28,7 +28,7 @@ from("activemq:My.Queue")
 ----
 
 If you want to use InOut (request-reply) semantics to process requests
-on the *My.Queue* queue on xref:components::activemq-component.adoc[ActiveMQ] with a template
+on the *My.Queue* queue on xref:ROOT:activemq-component.adoc[ActiveMQ] with a template
 generated response, then sending responses back to the JMSReplyTo
 Destination you could use this:
 
@@ -38,7 +38,7 @@ from("activemq:My.Queue")
     .to("velocity:com/acme/MyResponse.vm");
 ----
 
-Here is a simple example using the xref:latest@manual:ROOT:dsl.adoc[DSL] directly to
+Here is a simple example using the xref:manual:ROOT:dsl.adoc[DSL] directly to
 transform the message
 
 [source,java]
@@ -48,7 +48,7 @@ from("direct:start")
     .to("mock:result");
 ----
 
-In this example we add our own xref:latest@manual:ROOT:processor.adoc[Processor] using
+In this example we add our own xref:manual:ROOT:processor.adoc[Processor] using
 explicit Java
 
 [source,java]
@@ -63,7 +63,7 @@ from("direct:start")
     .to("mock:result");
 ----
 
-we can use xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to use any Java
+we can use xref:manual:ROOT:bean-integration.adoc[Bean Integration] to use any Java
 method on any bean to act as the transformer
 
 [source,java]
@@ -104,14 +104,14 @@ to invoke an external web service. +
 `pollEnrich` on the other hand uses a xref:polling-consumer.adoc[Polling
 Consumer] to obtain the additional data. It is usually used for
 xref:event-message.adoc[Event Message] messaging, for instance to read a
-file or download a xref:components::ftp-component.adoc[FTP] file.
+file or download a xref:ROOT:ftp-component.adoc[FTP] file.
 
 Camel 2.15 or older - Data from current Exchange not used
 
 `pollEnrich` or `enrich` does *not* access any data from the current
-xref:latest@manual:ROOT:exchange.adoc[Exchange] which means when polling it cannot use any
+xref:manual:ROOT:exchange.adoc[Exchange] which means when polling it cannot use any
 of the existing headers you may have set on the
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. For example you cannot set a filename in
+xref:manual:ROOT:exchange.adoc[Exchange]. For example you cannot set a filename in
 the `Exchange.FILE_NAME` header and use `pollEnrich` to consume only
 that file. For that you *must* set the filename in the endpoint URI.
 
@@ -126,9 +126,9 @@ messages from a seda, ... components using an aggregation strategy. Only
 one response message will be aggregated with the original message.
 
 From *Camel 2.16* onwards both enrich and pollEnrich supports dynamic
-endpoints that uses an xref:latest@manual:ROOT:expression.adoc[Expression] to compute the
+endpoints that uses an xref:manual:ROOT:expression.adoc[Expression] to compute the
 uri, which allows to use data from the current
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. In other words all what is told above no
+xref:manual:ROOT:exchange.adoc[Exchange]. In other words all what is told above no
 longer apply and it just works.
 
 [[ContentEnricher-EnrichOptions]]
@@ -139,25 +139,25 @@ longer apply and it just works.
 |Name |Default Value |Description
 |`uri` |  |The endpoint uri for the external service to enrich from. You
 must use either `uri` or `ref`. *Important:* From Camel 2.16 onwards,
-this option is removed, and you use an xref:latest@manual:ROOT:expression.adoc[Expression]
+this option is removed, and you use an xref:manual:ROOT:expression.adoc[Expression]
 to configure the uri, such as xref:components:languages:simple-language.adoc[Simple] or
 xref:components:languages:constant-language.adoc[Constant] or any other dynamic language that can
 compute the uri dynamically using values from the current
-xref:latest@manual:ROOT:exchange.adoc[Exchange].
+xref:manual:ROOT:exchange.adoc[Exchange].
 
 |`ref` |  |Refers to the endpoint for the external service to enrich
 from. You must use either `uri` or `ref`.  **Important:** From Camel
 2.16 onwards, this option is removed, and you use an
-xref:latest@manual:ROOT:expression.adoc[Expression] to configure the uri, such as
+xref:manual:ROOT:expression.adoc[Expression] to configure the uri, such as
 xref:components:languages:simple-language.adoc[Simple] or xref:components:languages:constant-language.adoc[Constant] or any other
 dynamic language that can compute the uri dynamically using values from
-the current  xref:latest@manual:ROOT:exchange.adoc[Exchange].
+the current  xref:manual:ROOT:exchange.adoc[Exchange].
 
 |expression |  |*Camel 2.16:* Mandatory.
-The xref:latest@manual:ROOT:expression.adoc[Expression] to configure the uri, such as
+The xref:manual:ROOT:expression.adoc[Expression] to configure the uri, such as
 xref:components:languages:simple-language.adoc[Simple] or xref:components:languages:constant-language.adoc[Constant] or any other
 dynamic language that can compute the uri dynamically using values from
-the current  xref:latest@manual:ROOT:exchange.adoc[Exchange].
+the current  xref:manual:ROOT:exchange.adoc[Exchange].
 
 |`strategyRef` |  |Refers to an
 https://github.com/apache/camel/blob/master/core/camel-api/src/main/java/org/apache/camel/AggregationStrategy.java[AggregationStrategy]
@@ -306,8 +306,8 @@ And for Spring DSL:
 
 From Camel 2.16 onwards enrich and pollEnrich supports using dynamic
 uris computed based on information from the
-current xref:latest@manual:ROOT:exchange.adoc[Exchange]. For example to enrich from
-a xref:components::http-component.adoc[HTTP] endpoint where the header with key orderId is
+current xref:manual:ROOT:exchange.adoc[Exchange]. For example to enrich from
+a xref:ROOT:http-component.adoc[HTTP] endpoint where the header with key orderId is
 used as part of the content-path of the HTTP url:
 
 [source,java]
@@ -349,25 +349,25 @@ polling
 |Name |Default Value |Description
 |`uri` |  |The endpoint uri for the external service to enrich from. You
 must use either `uri` or `ref`. **Important:** From Camel 2.16 onwards,
-this option is removed, and you use an xref:latest@manual:ROOT:expression.adoc[Expression]
+this option is removed, and you use an xref:manual:ROOT:expression.adoc[Expression]
 to configure the uri, such as xref:components:languages:simple-language.adoc[Simple] or
 xref:components:languages:constant-language.adoc[Constant] or any other dynamic language that can
 compute the uri dynamically using values from the current
- xref:latest@manual:ROOT:exchange.adoc[Exchange].
+ xref:manual:ROOT:exchange.adoc[Exchange].
 
 |`ref` |  |Refers to the endpoint for the external service to enrich
 from. You must use either `uri` or `ref`. **Important:** From Camel 2.16
 onwards, this option is removed, and you use an
-xref:latest@manual:ROOT:expression.adoc[Expression] to configure the uri, such as
+xref:manual:ROOT:expression.adoc[Expression] to configure the uri, such as
 xref:components:languages:simple-language.adoc[Simple] or xref:components:languages:constant-language.adoc[Constant] or any other
 dynamic language that can compute the uri dynamically using values from
-the current  xref:latest@manual:ROOT:exchange.adoc[Exchange].
+the current  xref:manual:ROOT:exchange.adoc[Exchange].
 
 |`expression` |  |**Camel 2.16:** Mandatory.
-The xref:latest@manual:ROOT:expression.adoc[Expression] to configure the uri, such as
+The xref:manual:ROOT:expression.adoc[Expression] to configure the uri, such as
 xref:components:languages:simple-language.adoc[Simple] or xref:components:languages:constant-language.adoc[Constant] or any other
 dynamic language that can compute the uri dynamically using values from
-the current xref:latest@manual:ROOT:exchange.adoc[Exchange].
+the current xref:manual:ROOT:exchange.adoc[Exchange].
 
 |`strategyRef` |  |Refers to an
 https://github.com/apache/camel/blob/master/core/camel-api/src/main/java/org/apache/camel/AggregationStrategy.java[AggregationStrategy]
@@ -431,16 +431,16 @@ The timeout values is in millis.
 Camel 2.15 or older - Data from current Exchange not used
 
 `pollEnrich` does *not* access any data from the current
-xref:latest@manual:ROOT:exchange.adoc[Exchange] which means when polling it cannot use any
+xref:manual:ROOT:exchange.adoc[Exchange] which means when polling it cannot use any
 of the existing headers you may have set on the
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. For example you cannot set a filename in
+xref:manual:ROOT:exchange.adoc[Exchange]. For example you cannot set a filename in
 the `Exchange.FILE_NAME` header and use `pollEnrich` to consume only
 that file. For that you *must* set the filename in the endpoint URI.
 
 From **Camel 2.16** onwards both enrich and pollEnrich supports dynamic
-endpoints that uses an xref:latest@manual:ROOT:expression.adoc[Expression] to compute the
+endpoints that uses an xref:manual:ROOT:expression.adoc[Expression] to compute the
 uri, which allows to use data from the current
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. In other words all what is told above no
+xref:manual:ROOT:exchange.adoc[Exchange]. In other words all what is told above no
 longer apply and it just works.
 
 [[ContentEnricher-Example]]
@@ -493,8 +493,8 @@ For example to wait up to 5 seconds you can do:
 
 From Camel 2.16 onwards enrich and pollEnrich supports using dynamic
 uris computed based on information from the
-current xref:latest@manual:ROOT:exchange.adoc[Exchange]. For example to pollEnrich from an
-endpoint that uses a header to indicate a xref:components::seda-component.adoc[SEDA] queue
+current xref:manual:ROOT:exchange.adoc[Exchange]. For example to pollEnrich from an
+endpoint that uses a header to indicate a xref:ROOT:seda-component.adoc[SEDA] queue
 name:
 
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
@@ -9,18 +9,18 @@ using one of the following mechanisms in the routing logic to transform
 content from the inbound message.
 
 * xref:message-translator.adoc[Message Translator]
-* invoking a xref:latest@manual:ROOT:bean-integration.adoc[Java bean]
-* xref:latest@manual:ROOT:processor.adoc[Processor] object
+* invoking a xref:manual:ROOT:bean-integration.adoc[Java bean]
+* xref:manual:ROOT:processor.adoc[Processor] object
 
 image::eip/ContentFilter.gif[image]
 
 A common way to filter messages is to use an
-xref:latest@manual:ROOT:expression.adoc[Expression] in the xref:latest@manual:ROOT:dsl.adoc[DSL] like
+xref:manual:ROOT:expression.adoc[Expression] in the xref:manual:ROOT:dsl.adoc[DSL] like
 xref:components:languages:xquery-language.adoc[XQuery].
 
-Here is a simple example using the xref:latest@manual:ROOT:dsl.adoc[DSL] directly
+Here is a simple example using the xref:manual:ROOT:dsl.adoc[DSL] directly
 
-In this example we add our own xref:latest@manual:ROOT:processor.adoc[Processor]
+In this example we add our own xref:manual:ROOT:processor.adoc[Processor]
 
 For further examples of this pattern in use you could look at one of the
 JUnit tests
@@ -55,8 +55,8 @@ interested in:
 == Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-xref:latest@manual:ROOT:getting-started.adoc[Getting Started], you may also find the
-xref:latest@manual:ROOT:architecture.adoc[Architecture] useful particularly the description
-of xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and xref:latest@manual:ROOT:uris.adoc[URIs]. Then you could
-try out some of the xref:latest@manual:ROOT:examples.adoc[Examples] first before trying
+xref:manual:ROOT:getting-started.adoc[Getting Started], you may also find the
+xref:manual:ROOT:architecture.adoc[Architecture] useful particularly the description
+of xref:manual:ROOT:endpoint.adoc[Endpoint] and xref:manual:ROOT:uris.adoc[URIs]. Then you could
+try out some of the xref:manual:ROOT:examples.adoc[Examples] first before trying
 this pattern out.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
@@ -7,7 +7,7 @@ Identifier] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] by getting or setting a header on a
 xref:message.adoc[Message].
 
-When working with the xref:components::activemq-component.adoc[ActiveMQ] or xref:components::jms-component.adoc[JMS]
+When working with the xref:ROOT:activemq-component.adoc[ActiveMQ] or xref:ROOT:jms-component.adoc[JMS]
 components the correlation identifier header is called
 *JMSCorrelationID*. You can add your own correlation identifier to any
 message exchange to help correlate messages together to a single
@@ -17,20 +17,20 @@ image::eip/CorrelationIdentifierSolution.gif[image]
 
 The use of a Correlation Identifier is key to working with xref:components:others:tracing.adoc[Tracing]
 and be useful when testing with simulation or canned data such as
-with the xref:components::mock-component.adoc[Mock testing framework]
+with the xref:ROOT:mock-component.adoc[Mock testing framework]
 
 Some xref:enterprise-integration-patterns.adoc[EIP] patterns will spin off a sub message, and in
 those cases, Camel will add a correlation id on the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] as a property with they key
+xref:manual:ROOT:exchange.adoc[Exchange] as a property with they key
 `Exchange.CORRELATION_ID`, which links back to the source
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. For example the
+xref:manual:ROOT:exchange.adoc[Exchange]. For example the
 xref:split-eip.adoc[Splitter], xref:multicast-eip.adoc[Multicast],
 xref:recipientList-eip.adoc[Recipient List], and xref:wireTap-eip.adoc[Wire
 Tap] EIP does this.
 
 The following example demonstrates using the Camel JMSMessageID as the
 Correlation Identifier within a request/reply pattern in
-the xref:components::jms-component.adoc[JMS] component
+the xref:ROOT:jms-component.adoc[JMS] component
 
 == Samples
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
@@ -6,7 +6,7 @@ http://www.enterpriseintegrationpatterns.com/DeadLetterChannel.html[Dead
 Letter Channel] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the
 https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/DeadLetterChannel.html[DeadLetterChannel]
-processor which is an xref:latest@manual:ROOT:error-handler.adoc[Error Handler].
+processor which is an xref:manual:ROOT:error-handler.adoc[Error Handler].
 
 image::eip/DeadLetterChannelSolution.gif[image]
 
@@ -68,11 +68,11 @@ forwarded to the dead letter queue.
 == About moving Exchange to dead letter queue and using handled
 
 When all attempts of redelivery have failed the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] is moved to the dead letter queue (the dead
+xref:manual:ROOT:exchange.adoc[Exchange] is moved to the dead letter queue (the dead
 letter endpoint). The exchange is then complete and from the client
 point of view it was processed. As such the
 xref:dead-letter-channel.adoc[Dead Letter Channel] have handled the
-xref:latest@manual:ROOT:exchange.adoc[Exchange].
+xref:manual:ROOT:exchange.adoc[Exchange].
 
 For instance configuring the dead letter channel as:
 
@@ -103,8 +103,8 @@ And in XML:
 
 The xref:dead-letter-channel.adoc[Dead Letter Channel] above will clear
 the caused exception (`setException(null)`), by moving the caused
-exception to a property on the xref:latest@manual:ROOT:exchange.adoc[Exchange], with the
-key `Exchange.EXCEPTION_CAUGHT`. Then the xref:latest@manual:ROOT:exchange.adoc[Exchange]
+exception to a property on the xref:manual:ROOT:exchange.adoc[Exchange], with the
+key `Exchange.EXCEPTION_CAUGHT`. Then the xref:manual:ROOT:exchange.adoc[Exchange]
 is moved to the `"jms:queue:dead"` destination and the client will not
 notice the failure.
 
@@ -126,12 +126,12 @@ from("jms:queue:order:input")
 -----
 
 The route listen for JMS messages and validates, transforms and handle
-it. During this the xref:latest@manual:ROOT:exchange.adoc[Exchange] payload is
+it. During this the xref:manual:ROOT:exchange.adoc[Exchange] payload is
 transformed/modified. So in case something goes wrong and we want to
 move the message to another JMS destination, then we can configure our
 xref:dead-letter-channel.adoc[Dead Letter Channel] with the
 *useOriginalMessage* option. But when we move the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] to this destination we do not know in which
+xref:manual:ROOT:exchange.adoc[Exchange] to this destination we do not know in which
 state the message is in. Did the error happen in before the
 transformOrder or after? So to be sure we want to move the original
 input message we received from `jms:queue:order:input`. So we can do
@@ -169,13 +169,13 @@ the parent original message.
 == OnRedelivery
 
 When xref:dead-letter-channel.adoc[Dead Letter Channel] is doing
-redeliver its possible to configure a xref:latest@manual:ROOT:processor.adoc[Processor]
+redeliver its possible to configure a xref:manual:ROOT:processor.adoc[Processor]
 that is executed just *before* every redelivery attempt. This can be
 used for the situations where you need to alter the message before its
 redelivered. See below for sample.
 
 TIP: *onException and onRedeliver*
-We also support for per xref:latest@manual:ROOT:exception-clause.adoc[*onException*] to set
+We also support for per xref:manual:ROOT:exception-clause.adoc[*onException*] to set
 a *onRedeliver*. That means you can do special on redelivery for
 different exceptions, as opposed to onRedelivery set on
 xref:dead-letter-channel.adoc[Dead Letter Channel] can be viewed as a
@@ -302,8 +302,8 @@ Is this header is absent, normal redelivery rules apply.
 *Since Camel 2.1*
 
 When Camel routes messages it will decorate the
-xref:latest@manual:ROOT:exchange.adoc[Exchange] with a property that contains the *last*
-endpoint Camel send the xref:latest@manual:ROOT:exchange.adoc[Exchange] to:
+xref:manual:ROOT:exchange.adoc[Exchange] with a property that contains the *last*
+endpoint Camel send the xref:manual:ROOT:exchange.adoc[Exchange] to:
 
 [source,java]
 ----
@@ -316,8 +316,8 @@ This information is updated when Camel sends a message to any endpoint.
 So if it exists its the *last* endpoint which Camel send the Exchange
 to.
 
-When for example processing the xref:latest@manual:ROOT:exchange.adoc[Exchange] at a given
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and the message is to be moved into the
+When for example processing the xref:manual:ROOT:exchange.adoc[Exchange] at a given
+xref:manual:ROOT:endpoint.adoc[Endpoint] and the message is to be moved into the
 dead letter queue, then Camel also decorates the Exchange with another
 property that contains that *last* endpoint:
 
@@ -337,7 +337,7 @@ failed.
 
 These information is kept on the Exchange even if the message
 was successfully processed by a given endpoint, and then later fails for
-example in a local xref:components::bean-component.adoc[Bean] processing instead. So beware
+example in a local xref:ROOT:bean-component.adoc[Bean] processing instead. So beware
 that this is a hint that helps pinpoint errors.
 
 [source,java]
@@ -399,9 +399,9 @@ The onPrepare is also available using the default error handler.
 
 When Camel error handler handles an error such as
 xref:dead-letter-channel.adoc[Dead Letter Channel] or using
-xref:latest@manual:ROOT:exception-clause.adoc[Exception Clause] with handled=true, then
+xref:manual:ROOT:exception-clause.adoc[Exception Clause] with handled=true, then
 Camel will decorate +
- the xref:latest@manual:ROOT:exchange.adoc[Exchange] with the route id where the error
+ the xref:manual:ROOT:exchange.adoc[Exchange] with the route id where the error
 occurred.
 
 [source,java]
@@ -423,16 +423,16 @@ letter queue and use that for error reporting.
 Prior to Camel 2.10, Camel will perform redelivery while stopping a
 route, or shutting down Camel. This has improved a bit in Camel 2.10
 onwards, as Camel will not perform redelivery attempts when shutting
-down aggressively (eg during xref:latest@manual:ROOT:graceful-shutdown.adoc[Graceful
+down aggressively (eg during xref:manual:ROOT:graceful-shutdown.adoc[Graceful
 Shutdown] and timeout hit). From Camel 2.11 onwards there is a new
 option `allowRedeliveryWhileStopping` which you can use to control if
 redelivery is allowed or not; notice that any in progress redelivery
 will still be executed. This option can only disallow any redelivery to
 be executed *after* the stopping of a route/shutdown of Camel has been
 triggered. If a redelivery is disallowed then a
-`RejectedExecutionException` is set on the xref:latest@manual:ROOT:exchange.adoc[Exchange]
-and the processing of the xref:latest@manual:ROOT:exchange.adoc[Exchange] stops. This means
-any consumer will see the xref:latest@manual:ROOT:exchange.adoc[Exchange] as failed due the
+`RejectedExecutionException` is set on the xref:manual:ROOT:exchange.adoc[Exchange]
+and the processing of the xref:manual:ROOT:exchange.adoc[Exchange] stops. This means
+any consumer will see the xref:manual:ROOT:exchange.adoc[Exchange] as failed due the
 `RejectedExecutionException`.
 
 The default value is `true` to be backwards compatible as before. For
@@ -445,7 +445,7 @@ And the sample with XML DSL
 == Samples
 
 The following example shows how to configure the Dead Letter Channel
-configuration using the xref:latest@manual:ROOT:dsl.adoc[DSL]
+configuration using the xref:manual:ROOT:dsl.adoc[DSL]
 
 You can also configure the
 https://www.javadoc.io/doc/org.apache.camel/camel-base/current/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html[RedeliveryPolicy]
@@ -455,11 +455,11 @@ as this example shows
 == How can I modify the Exchange before redelivery?
 
 We support directly in xref:dead-letter-channel.adoc[Dead Letter
-Channel] to set a xref:latest@manual:ROOT:processor.adoc[Processor] that is executed
+Channel] to set a xref:manual:ROOT:processor.adoc[Processor] that is executed
 *before* each redelivery attempt.
 
 When xref:dead-letter-channel.adoc[Dead Letter Channel] is doing
-redeliver its possible to configure a xref:latest@manual:ROOT:processor.adoc[Processor]
+redeliver its possible to configure a xref:manual:ROOT:processor.adoc[Processor]
 that is executed just *before* every redelivery attempt. This can be
 used for the situations where you need to alter the message before its
 redelivered.
@@ -486,12 +486,12 @@ also http://stackoverflow.com/questions/13711462/logging-camel-exceptions-and-se
 === Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-xref:latest@manual:ROOT:getting-started.adoc[Getting Started], you may also find the
-xref:latest@manual:ROOT:architecture.adoc[Architecture] useful particularly the description
-of xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and xref:latest@manual:ROOT:uris.adoc[URIs]. Then you could
-try out some of the xref:latest@manual:ROOT:examples.adoc[Examples] first before trying
+xref:manual:ROOT:getting-started.adoc[Getting Started], you may also find the
+xref:manual:ROOT:architecture.adoc[Architecture] useful particularly the description
+of xref:manual:ROOT:endpoint.adoc[Endpoint] and xref:manual:ROOT:uris.adoc[URIs]. Then you could
+try out some of the xref:manual:ROOT:examples.adoc[Examples] first before trying
 this pattern out.
 
-* xref:latest@manual:ROOT:error-handler.adoc[Error Handler]
-* xref:latest@manual:ROOT:exception-clause.adoc[Exception Clause]
+* xref:manual:ROOT:error-handler.adoc[Error Handler]
+* xref:manual:ROOT:exception-clause.adoc[Exception Clause]
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
@@ -60,7 +60,7 @@ from("direct:start")
     .dynamicRouter(method(DynamicRouterTest.class, "slip"));
 ----
 
-Which will leverage a xref:components::bean-component.adoc[Bean] to compute the slip
+Which will leverage a xref:ROOT:bean-component.adoc[Bean] to compute the slip
 _on-the-fly_, which could be implemented as follows:
 
 [source,java]
@@ -198,4 +198,4 @@ Bean Integration such as
 
 * POJO Producing
 * Spring Remoting
-* xref:components::bean-component.adoc[Bean] component
+* xref:ROOT:bean-component.adoc[Bean] component

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/enterprise-integration-patterns.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/enterprise-integration-patterns.adoc
@@ -5,7 +5,7 @@ Camel supports most of the
 http://www.eaipatterns.com/toc.html[Enterprise Integration Patterns]
 from the excellent book by Gregor Hohpe and Bobby Woolf.
 
-If you are new to Camel you might want to try the xref:latest@manual:ROOT:getting-started.adoc[Getting Started] in the
+If you are new to Camel you might want to try the xref:manual:ROOT:getting-started.adoc[Getting Started] in the
 User Guide before attempting to implement these patterns.
 
 [[EnterpriseIntegrationPatterns-MessagingSystems]]
@@ -299,7 +299,7 @@ and via non-messaging techniques?
 [width="100%",cols="10%,10%,80%",]
 |=======================================================================
 a|image::eip/ControlBusIcon.gif[image]
-|xref:components::controlbus-component.adoc[ControlBus] |How can we effectively administer a
+|xref:ROOT:controlbus-component.adoc[ControlBus] |How can we effectively administer a
 messaging system that is distributed across multiple platforms and a
 wide geographic area?
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
@@ -4,16 +4,16 @@
 Camel supports the
 http://www.enterpriseintegrationpatterns.com/EventMessage.html[Event
 Message] from the xref:enterprise-integration-patterns.adoc[EIP
-patterns] by supporting the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
+patterns] by supporting the xref:manual:ROOT:exchange-pattern.adoc[Exchange Pattern]
 on a xref:message.adoc[Message] which can be set to *InOnly* to indicate
-a oneway event message. Camel xref:components::index.adoc[Components] then
+a oneway event message. Camel xref:ROOT:index.adoc[Components] then
 implement this pattern using the underlying transport or protocols.
 
 image::eip/EventMessageSolution.gif[image]
 
-The default behaviour of many xref:components::index.adoc[Components] is InOnly
-such as for xref:components::jms-component.adoc[JMS], xref:components::jms-component.adoc[File] or
-xref:components::seda-component.adoc[SEDA]
+The default behaviour of many xref:ROOT:index.adoc[Components] is InOnly
+such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:jms-component.adoc[File] or
+xref:ROOT:seda-component.adoc[SEDA]
 
 TIP: See the related xref:requestReply-eip.adoc[Request Reply] message.
 
@@ -21,7 +21,7 @@ TIP: See the related xref:requestReply-eip.adoc[Request Reply] message.
 == Explicitly specifying InOnly
 
 If you are using a component which defaults to InOut you can override
-the xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] for an endpoint using
+the xref:manual:ROOT:exchange-pattern.adoc[Exchange Pattern] for an endpoint using
 the pattern property.
 
 [source]
@@ -33,7 +33,7 @@ foo:bar?exchangePattern=InOnly
 == Samples
 
 From 2.0 onwards on Camel you can specify the
-xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] using the DSL.
+xref:manual:ROOT:exchange-pattern.adoc[Exchange Pattern] using the DSL.
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
@@ -21,8 +21,8 @@ when a xref:message.adoc[Message] is available for processing.
 
 The following demonstrates a
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
-defined in the Camel xref:latest@manual:ROOT:registry.adoc[Registry] which is
-invoked when an event occurs from a xref:components::jms-component.adoc[JMS] queue.
+defined in the Camel xref:manual:ROOT:registry.adoc[Registry] which is
+invoked when an event occurs from a xref:ROOT:jms-component.adoc[JMS] queue.
 
 [source,java]
 ----
@@ -30,7 +30,7 @@ from("jms:queue:foo")
     .processRef("processor");
 ----
 
-**Using the xref:latest@manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]**
+**Using the xref:manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]**
 
 [source,xml]
 ----
@@ -49,8 +49,8 @@ For more details see:
 == Using This Pattern
 
 If you would like to use this EIP Pattern then please read the
-xref:latest@manual:ROOT:getting-started.adoc[Getting Started], you may also find the
-xref:latest@manual:ROOT:architecture.adoc[Architecture] useful particularly the description
-of xref:latest@manual:ROOT:endpoint.adoc[Endpoint] and xref:latest@manual:ROOT:uris.adoc[URIs]. Then you could
-try out some of the xref:latest@manual:ROOT:examples.adoc[Examples] first before trying
+xref:manual:ROOT:getting-started.adoc[Getting Started], you may also find the
+xref:manual:ROOT:architecture.adoc[Architecture] useful particularly the description
+of xref:manual:ROOT:endpoint.adoc[Endpoint] and xref:manual:ROOT:uris.adoc[URIs]. Then you could
+try out some of the xref:manual:ROOT:examples.adoc[Examples] first before trying
 this pattern out.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
@@ -13,7 +13,7 @@ image::eip/MessageFilter.gif[image]
 
 The following example shows how to create a Message Filter route
 consuming messages from an endpoint called *queue:a*, which if the
-xref:latest@manual:ROOT:predicate.adoc[Predicate] is true will be dispatched to *queue:b*
+xref:manual:ROOT:predicate.adoc[Predicate] is true will be dispatched to *queue:b*
 
 == EIP options
 
@@ -90,15 +90,15 @@ the when predicate by using the `.stop()`.
 == Knowing if Exchange was filtered or not
 
 The xref:filter-eip.adoc[Message Filter] EIP will add a property on
-the xref:latest@manual:ROOT:exchange.adoc[Exchange] that states if it was filtered or not.
+the xref:manual:ROOT:exchange.adoc[Exchange] that states if it was filtered or not.
 
 The property has the key `Exchange.FILTER_MATCHED`, which has the String
 value of `CamelFilterMatched`. Its value is a boolean indicating `true`
-or `false`. If the value is `true` then the xref:latest@manual:ROOT:exchange.adoc[Exchange]
+or `false`. If the value is `true` then the xref:manual:ROOT:exchange.adoc[Exchange]
 was routed in the filter block. This property will be visible within the
 xref:filter-eip.adoc[Message Filter] block who's
-xref:latest@manual:ROOT:predicate.adoc[Predicate] matches (value set to `true`), and to the
+xref:manual:ROOT:predicate.adoc[Predicate] matches (value set to `true`), and to the
 steps immediately following the xref:filter-eip.adoc[Message Filter]
 with the value set based on the results of the last
-xref:filter-eip.adoc[Message Filter] xref:latest@manual:ROOT:predicate.adoc[Predicate]
+xref:filter-eip.adoc[Message Filter] xref:manual:ROOT:predicate.adoc[Predicate]
 evaluated.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/guaranteed-delivery.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/guaranteed-delivery.adoc
@@ -6,15 +6,15 @@ http://www.enterpriseintegrationpatterns.com/GuaranteedMessaging.html[Guaranteed
 Delivery] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using among others the following components:
 
-* xref:components::file-component.adoc[File] for using file systems as a persistent store of
+* xref:ROOT:file-component.adoc[File] for using file systems as a persistent store of
 messages
-* xref:components::jms-component.adoc[JMS] when using persistent delivery (the default) for
+* xref:ROOT:jms-component.adoc[JMS] when using persistent delivery (the default) for
 working with JMS Queues and Topics for high performance, clustering and
 load balancing
-* xref:components::jpa-component.adoc[JPA] for using a database as a persistence layer, or use
-any of the many other database component such as xref:components::sql-component.adoc[SQL],
-xref:components::jdbc-component.adoc[JDBC],
-xref:components::mybatis-component.adoc[MyBatis]
+* xref:ROOT:jpa-component.adoc[JPA] for using a database as a persistence layer, or use
+any of the many other database component such as xref:ROOT:sql-component.adoc[SQL],
+xref:ROOT:jdbc-component.adoc[JDBC],
+xref:ROOT:mybatis-component.adoc[MyBatis]
 
 image::eip/GuaranteedMessagingSolution.gif[image]
 
@@ -23,7 +23,7 @@ image::eip/GuaranteedMessagingSolution.gif[image]
 
 The following example demonstrates illustrates the use
 of http://www.enterpriseintegrationpatterns.com/GuaranteedMessaging.html[Guaranteed
-Delivery] within the xref:components::jms-component.adoc[JMS] component. By default, a message
+Delivery] within the xref:ROOT:jms-component.adoc[JMS] component. By default, a message
 is not considered successfully delivered until the recipient has
 persisted the message locally guaranteeing its receipt in the event the
 destination becomes unavailable.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/idempotentConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/idempotentConsumer-eip.adoc
@@ -21,15 +21,15 @@ the Exchange failed, otherwise it stays there.
 Camel provides the following Idempotent Consumer implementations:
 
 * MemoryIdempotentRepository
-* xref:components::file-component.adoc[FileIdempotentRepository]
-* xref:components::hazelcast-summary.adoc[HazelcastIdempotentRepository]
-* xref:components::sql-component.adoc[JdbcMessageIdRepository]
-* xref:components::jpa-component.adoc[JpaMessageIdRepository]
-* xref:components::infinispan-component.adoc[InfinispanIdempotentRepository]
-* xref:components::jcache-component.adoc[JCacheIdempotentRepository]
-* xref:latest@manual:ROOT:spring.adoc[SpringCacheIdempotentRepository]
-* xref:components::ehcache-component.adoc[EhcacheIdempotentRepository]
-* xref:components::kafka-component.adoc[KafkaIdempotentRepository]
+* xref:ROOT:file-component.adoc[FileIdempotentRepository]
+* xref:ROOT:hazelcast-summary.adoc[HazelcastIdempotentRepository]
+* xref:ROOT:sql-component.adoc[JdbcMessageIdRepository]
+* xref:ROOT:jpa-component.adoc[JpaMessageIdRepository]
+* xref:ROOT:infinispan-component.adoc[InfinispanIdempotentRepository]
+* xref:ROOT:jcache-component.adoc[JCacheIdempotentRepository]
+* xref:manual:ROOT:spring.adoc[SpringCacheIdempotentRepository]
+* xref:ROOT:ehcache-component.adoc[EhcacheIdempotentRepository]
+* xref:ROOT:kafka-component.adoc[KafkaIdempotentRepository]
 
 == Options
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
@@ -113,7 +113,7 @@ particular route.
 
 So lets start with the logging example. We want to log all the
 *incoming* requests so we use `interceptFrom` to route to the
-xref:components::log-component.adoc[Log] component. As `proceed` is default then the
+xref:ROOT:log-component.adoc[Log] component. As `proceed` is default then the
 Exchange will continue its route, and thus it will
 continue to `mock:first`.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
@@ -8,9 +8,9 @@
 How can I log the processing of a xref:message.adoc[Message]?
 
 Camel provides many ways to log the fact that you are processing a message. Here are just a few examples:
-* You can use the xref:components::log-component.adoc[Log] component which logs the Message content.
-* You can use the xref:latest@manual:ROOT:tracer.adoc[Tracer] which trace logs message flow.
-* You can also use a xref:latest@manual:ROOT:processor.adoc[Processor] or xref:latest@manual:ROOT:bean-binding.adoc[Bean] and log from Java code.
+* You can use the xref:ROOT:log-component.adoc[Log] component which logs the Message content.
+* You can use the xref:manual:ROOT:tracer.adoc[Tracer] which trace logs message flow.
+* You can also use a xref:manual:ROOT:processor.adoc[Processor] or xref:manual:ROOT:bean-binding.adoc[Bean] and log from Java code.
 * You can use the log DSL.
 
 == Options
@@ -35,7 +35,7 @@ The log DSL is much lighter and meant for logging human logs such as Starting to
 
 == Samples
 
-You can use the log DSL which allows you to use xref:components:languages:simple-language.adoc[Simple] language to construct a dynamic message which gets logged.
+You can use the log DSL which allows you to use xref:languages:simple-language.adoc[Simple] language to construct a dynamic message which gets logged.
 
 For example you can do
 
@@ -170,7 +170,7 @@ In some scenarios it is required that the bundle associated with logger should b
 == Masking sensitive information like password
 
 You can enable security masking for logging by setting `logMask` flag to `true`.
-Note that this option also affects xref:components::log-component.adoc[Log] component.
+Note that this option also affects xref:ROOT:log-component.adoc[Log] component.
 
 To enable mask in Java DSL at CamelContext level:
 [source,java]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
@@ -1,7 +1,7 @@
 [[marshal-eip]]
 = Marshal EIP
 
-Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel xref:components::index.adoc[Components]. Marshalling is used in the same way as unmarshalling above; in the xref:latest@manual:ROOT:dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the xref:latest@manual:ROOT:registry.adoc[Registry].
+Marshalling is the opposite of unmarshalling, where a bean is marshalled into some binary or textual format for transmission over some transport via a Camel xref:ROOT:index.adoc[Components]. Marshalling is used in the same way as unmarshalling above; in the xref:manual:ROOT:dsl.adoc[DSL] you can use a DataFormat instance, you can configure the DataFormat dynamically using the DSL or you can refer to a named instance of the format in the xref:manual:ROOT:registry.adoc[Registry].
 
 == Options
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-bus.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-bus.adoc
@@ -10,7 +10,7 @@ consumers to be decoupled.
 image::eip/MessageBusSolution.gif[image]
 
 Folks often assume that a Message Bus is a JMS though so you may wish to
-refer to the xref:components::jms-component.adoc[JMS] component for traditional MOM support. +
+refer to the xref:ROOT:jms-component.adoc[JMS] component for traditional MOM support. +
 
 
 [[MessageBus-Example]]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-channel.adoc
@@ -21,7 +21,7 @@ jms:queue:foo
 -------------
 
 This message channel can be then used within the
-xref:components::jms-component.adoc[JMS] component
+xref:ROOT:jms-component.adoc[JMS] component
 
 And the following shows a little Java route snippet:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-endpoint.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-endpoint.adoc
@@ -10,8 +10,8 @@ interface.
 
 image::eip/MessageEndpointSolution.gif[image]
 
-When using the xref:latest@manual:ROOT:dsl.adoc[DSL] to create xref:latest@manual:ROOT:routes.adoc[Routes] you
-typically refer to Message Endpoints by their xref:latest@manual:ROOT:uris.adoc[URIs]
+When using the xref:manual:ROOT:dsl.adoc[DSL] to create xref:manual:ROOT:routes.adoc[Routes] you
+typically refer to Message Endpoints by their xref:manual:ROOT:uris.adoc[URIs]
 rather than directly using the
 https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Endpoint.html[Endpoint]
 interface. Its then a responsibility of the

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
@@ -11,7 +11,7 @@ image::eip/MessageExpirationSolution.gif[image]
 
 Set the Message Expiration to specify a time limit how long the message is viable.
 
-Message expiration is supported by some Camel components such as xref:components::jms-component.adoc[JMS]
+Message expiration is supported by some Camel components such as xref:ROOT:jms-component.adoc[JMS]
 or which allows to set a time-to-live value on messages sent to the broker.
 
 TIP: When using message expiration then mind about keeping clock's synchronized among the systems.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-router.adoc
@@ -11,13 +11,13 @@ image::eip/MessageRouter.gif[image]
 
 The following example shows how to route a request from an input
 *queue:a* endpoint to either *queue:b*, *queue:c* or *queue:d* depending
-on the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+on the evaluation of various xref:manual:ROOT:predicate.adoc[Predicate] expressions
 
 == Examples
 
 The following example shows how to route a request from an input
 *seda:a* endpoint to either *seda:b*, *seda:c* or *seda:d* depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+the evaluation of various xref:manual:ROOT:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----
@@ -35,7 +35,7 @@ RouteBuilder builder = new RouteBuilder() {
 };
 ----
 
-TIP: See xref:latest@manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
+TIP: See xref:manual:faq:why-can-i-not-use-when-or-otherwise-in-a-java-camel-route.adoc[Why
 can I not use when or otherwise in a Java Camel route] if you have
 problems with the Java DSL, accepting using `when` or `otherwise`.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-translator.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-translator.adoc
@@ -4,10 +4,10 @@
 Camel supports the
 http://www.enterpriseintegrationpatterns.com/MessageTranslator.html[Message
 Translator] from the xref:enterprise-integration-patterns.adoc[EIP
-patterns] by using an arbitrary xref:latest@manual:ROOT:processor.adoc[Processor] in the
-routing logic, by using a xref:latest@manual:ROOT:bean-integration.adoc[bean] to perform
+patterns] by using an arbitrary xref:manual:ROOT:processor.adoc[Processor] in the
+routing logic, by using a xref:manual:ROOT:bean-integration.adoc[bean] to perform
 the transformation, or by using transform() in the DSL. You can also use
-a xref:latest@manual:ROOT:data-format.adoc[Data Format] to marshal and unmarshal messages
+a xref:manual:ROOT:data-format.adoc[Data Format] to marshal and unmarshal messages
 in different encodings.
 
 image::eip/MessageTranslator.gif[image]
@@ -15,9 +15,9 @@ image::eip/MessageTranslator.gif[image]
 == Samples
 
 You can transform a message using Camel's
-xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to call any method on a
-bean in your xref:latest@manual:ROOT:registry.adoc[Registry] such as your
-xref:latest@manual:ROOT:spring.adoc[Spring] XML configuration file as follows
+xref:manual:ROOT:bean-integration.adoc[Bean Integration] to call any method on a
+bean in your xref:manual:ROOT:registry.adoc[Registry] such as your
+xref:manual:ROOT:spring.adoc[Spring] XML configuration file as follows
 
 [source,java]
 ----
@@ -28,19 +28,19 @@ from("activemq:SomeQueue")
 
 Where the "myTransformerBean" would be defined in a Spring XML file or
 defined in JNDI etc. You can omit the method name parameter from
-beanRef() and the xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] will try
+beanRef() and the xref:manual:ROOT:bean-integration.adoc[Bean Integration] will try
 to deduce the method to invoke from the message exchange.
 
-or you can add your own explicit xref:latest@manual:ROOT:processor.adoc[Processor] to do
+or you can add your own explicit xref:manual:ROOT:processor.adoc[Processor] to do
 the transformation
 
 or you can use the DSL to explicitly configure the transformation
 
-You can also use xref:latest@manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]
-to do a transformation. Basically any xref:latest@manual:ROOT:expression.adoc[Expression]
+You can also use xref:manual:ROOT:spring-xml-extensions.adoc[Spring XML Extensions]
+to do a transformation. Basically any xref:manual:ROOT:expression.adoc[Expression]
 language can be substituted inside the transform element as shown below
 
-Or you can use the xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to
+Or you can use the xref:manual:ROOT:bean-integration.adoc[Bean Integration] to
 invoke a bean
 
 [source,xml]
@@ -54,7 +54,7 @@ invoke a bean
 
 You can consume a message
 from one destination, transform it with something like
-xref:components::velocity-component.adoc[Velocity] or xref:components::xquery-component.adoc[XQuery] and then send
+xref:ROOT:velocity-component.adoc[Velocity] or xref:ROOT:xquery-component.adoc[XQuery] and then send
 it on to another destination. For example using InOnly (one way
 messaging)
 
@@ -66,7 +66,7 @@ from("activemq:My.Queue")
 ----
 
 If you want to use InOut (request-reply) semantics to process requests
-on the *My.Queue* queue on xref:components::activemq-component.adoc[ActiveMQ] with a template
+on the *My.Queue* queue on xref:ROOT:activemq-component.adoc[ActiveMQ] with a template
 generated response, then sending responses back to the JMSReplyTo
 Destination you could use this.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message.adoc
@@ -9,10 +9,10 @@ interface.
 
 image::eip/MessageSolution.gif[image]
 
-To support various message xref:latest@manual:ROOT:exchange-pattern.adoc[exchange patterns]
+To support various message xref:manual:ROOT:exchange-pattern.adoc[exchange patterns]
 like one way xref:event-message.adoc[Event Message] and
 xref:requestReply-eip.adoc[Request Reply] messages Camel uses an
-xref:latest@manual:ROOT:exchange.adoc[Exchange] interface which has a *pattern* property
+xref:manual:ROOT:exchange.adoc[Exchange] interface which has a *pattern* property
 which can be set to *InOnly* for an xref:event-message.adoc[Event
 Message] which has a single inbound Message, or *InOut* for a
 xref:requestReply-eip.adoc[Request Reply] where there is an inbound and

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-gateway.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-gateway.adoc
@@ -12,8 +12,8 @@ image::eip/MessagingGatewaySolution.gif[image]
 Use a Messaging Gateway, a class than wraps messaging-specific method calls and exposes domain-specific methods to the application.
 
 Camel has several endpoint components that support the Messaging Gateway from the EIP patterns.
-Components like xref:components::bean-component.adoc[Bean] and xref:components::bean-component.adoc[CXF] provide a way
+Components like xref:ROOT:bean-component.adoc[Bean] and xref:ROOT:bean-component.adoc[CXF] provide a way
 to bind a Java interface to the message exchange.
 
-Another approach is to use `@Produce` annotations which you can read about in xref:latest@manual:ROOT:pojo-producing.adoc[POJO Producing]
+Another approach is to use `@Produce` annotations which you can read about in xref:manual:ROOT:pojo-producing.adoc[POJO Producing]
 which also can be used as a Messaging Gateway EIP solution.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-mapper.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/messaging-mapper.adoc
@@ -18,7 +18,7 @@ Since the Messaging Mapper is implemented as a separate class that references th
 and the messaging layer, neither layer is aware of the other. The layers don't even know about the Messaging Mapper.
 
 With Camel this pattern is often implemented directly via Camel components that provides
-xref:latest@manual:ROOT:type-converter.adoc[Type Converter]'s from the messaging infrastructure to common Java types or
+xref:manual:ROOT:type-converter.adoc[Type Converter]'s from the messaging infrastructure to common Java types or
 Java Objects representing the data model of the component in question. Combining this with the
 xref:message-translator.adoc[Message Translator] to have the Messaging Mapper EIP pattern.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/multicast-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/multicast-eip.adoc
@@ -144,5 +144,5 @@ allows you to do this using the processor
 interface.
 
 Notice the `onPrepare` can be used for any kind of custom logic which
-you would like to execute before the xref:latest@manual:ROOT:exchange.adoc[Exchange] is
+you would like to execute before the xref:manual:ROOT:exchange.adoc[Exchange] is
 being multicasted.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/otherwise-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/otherwise-eip.adoc
@@ -21,7 +21,7 @@ The Otherwise EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+the evaluation of various xref:manual:ROOT:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/pipeline-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/pipeline-eip.adoc
@@ -10,7 +10,7 @@ Camel supports the http://www.enterpriseintegrationpatterns.com/PipesAndFilters.
 image::eip/PipesAndFilters.gif[image]
 
 With Camel you can split your processing across multiple independent
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint] instances which can then be chained
+xref:manual:ROOT:endpoint.adoc[Endpoint] instances which can then be chained
 together.
 
 == Options
@@ -23,7 +23,7 @@ The Pipeline EIP has no options.
 == Examples
 
 You can create pipelines of logic using multiple
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint] or xref:message-translator.adoc[Message
+xref:manual:ROOT:endpoint.adoc[Endpoint] or xref:message-translator.adoc[Message
 Translator] instances as follows
 
 Though pipeline is the default mode of operation when you specify

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/point-to-point-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/point-to-point-channel.adoc
@@ -6,18 +6,18 @@ http://www.enterpriseintegrationpatterns.com/PointToPointChannel.html[Point
 to Point Channel] from the xref:enterprise-integration-patterns.adoc[EIP
 patterns] using the following components
 
-* xref:components::seda-component.adoc[SEDA] for in-VM seda based messaging
-* xref:components::jms-component.adoc[JMS] for working with JMS Queues for high performance,
+* xref:ROOT:seda-component.adoc[SEDA] for in-VM seda based messaging
+* xref:ROOT:jms-component.adoc[JMS] for working with JMS Queues for high performance,
 clustering and load balancing
-* xref:components::jpa-component.adoc[JPA] for using a database as a simple message queue
-* xref:components::xmpp-component.adoc[XMPP] for point-to-point communication over XMPP
+* xref:ROOT:jpa-component.adoc[JPA] for using a database as a simple message queue
+* xref:ROOT:xmpp-component.adoc[XMPP] for point-to-point communication over XMPP
 (Jabber)
 * and others
 
 image::eip/PointToPointSolution.gif[image]
 
 The following example demonstrates point to point messaging using
-the xref:components::jms-component.adoc[JMS] component 
+the xref:ROOT:jms-component.adoc[JMS] component
 
 [[PointtoPointChannel-Samples]]
 == Samples

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/polling-consumer.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/polling-consumer.adoc
@@ -62,11 +62,11 @@ full. If the value is *`0`* or negative then no timeout is in use. If a
 timeout is triggered then a *`ExchangeTimedOutException`* is thrown.
 |=======================================================================
 
-Notice that some Camel xref:components::index.adoc[Components] has their own
+Notice that some Camel xref:ROOT:index.adoc[Components] has their own
 implementation of *`PollingConsumer`* and therefore do not support the
 options above.
 
-You can configure these options in endpoints xref:latest@manual:ROOT:uris.adoc[URIs], such
+You can configure these options in endpoints xref:manual:ROOT:uris.adoc[URIs], such
 as shown below:
 
 [source,java]
@@ -83,8 +83,8 @@ Exchange exchange = consumer.receive(5000);
 The *`ConsumerTemplate`* is a template much like
 Spring's *`JmsTemplate`* or *`JdbcTemplate`* supporting the
 xref:polling-consumer.adoc[Polling Consumer] EIP. With the template you
-can consume xref:latest@manual:ROOT:exchange.adoc[Exchange]s from an
-xref:latest@manual:ROOT:endpoint.adoc[Endpoint]. The template supports the three operations
+can consume xref:manual:ROOT:exchange.adoc[Exchange]s from an
+xref:manual:ROOT:endpoint.adoc[Endpoint]. The template supports the three operations
 listed above. However, it also includes convenient methods for returning
 the body, etc *`consumeBody`*.
 
@@ -143,7 +143,7 @@ include::{examplesdir}/components/camel-spring/src/test/java/org/apache/camel/sp
 [[PollingConsumer-TimerBasedPollingConsumer]]
 == Timer Based Polling Consumer
 
-In this sample we use a xref:components::timer-component.adoc[Timer] to schedule a route to be
+In this sample we use a xref:ROOT:timer-component.adoc[Timer] to schedule a route to be
 started every 5th second and invoke our bean *`MyCoolBean`* where we
 implement the business logic for the xref:polling-consumer.adoc[Polling
 Consumer]. Here we want to consume all messages from a JMS queue,
@@ -162,7 +162,7 @@ then fire message exchanges.
 Since this a such a common pattern, polling components can extend the
 https://github.com/apache/camel/blob/master/core/camel-support/src/main/java/org/apache/camel/support/ScheduledPollConsumer.java[ScheduledPollConsumer]
 base class which makes it simpler to implement this pattern. There is
-also the xref:components::quartz-component.adoc[Quartz Component] which provides scheduled
+also the xref:ROOT:quartz-component.adoc[Quartz Component] which provides scheduled
 delivery of messages using the Quartz enterprise scheduler.
 
 For more details see:
@@ -170,17 +170,17 @@ For more details see:
 * https://github.com/apache/camel/blob/master/core/camel-api/src/main/java/org/apache/camel/PollingConsumer.java[PollingConsumer]
 * Scheduled Polling Components
 ** https://github.com/apache/camel/blob/master/core/camel-support/src/main/java/org/apache/camel/support/ScheduledPollConsumer.java[ScheduledPollConsumer]
-** xref:components::scheduler-component.adoc[Scheduler]
-** xref:components::atom-component.adoc[Atom]
-** xref:components::beanstalk-component.adoc[Beanstalk]
-** xref:components::file-component.adoc[File]
-** xref:components::ftp-component.adoc[FTP]
-** xref:components::hbase-component.adoc[hbase]
-** xref:components::jpa-component.adoc[JPA]
-** xref:components::mail-component.adoc[Mail]
-** xref:components::mybatis-component.adoc[MyBatis]
-** xref:components::quartz-component.adoc[Quartz]
-** xref:components::snmp-component.adoc[SNMP]
+** xref:ROOT:scheduler-component.adoc[Scheduler]
+** xref:ROOT:atom-component.adoc[Atom]
+** xref:ROOT:beanstalk-component.adoc[Beanstalk]
+** xref:ROOT:file-component.adoc[File]
+** xref:ROOT:ftp-component.adoc[FTP]
+** xref:ROOT:hbase-component.adoc[hbase]
+** xref:ROOT:jpa-component.adoc[JPA]
+** xref:ROOT:mail-component.adoc[Mail]
+** xref:ROOT:mybatis-component.adoc[MyBatis]
+** xref:ROOT:quartz-component.adoc[Quartz]
+** xref:ROOT:snmp-component.adoc[SNMP]
 
 [[PollingConsumer-ScheduledPollConsumerOptions]]
 === ScheduledPollConsumer Options
@@ -217,7 +217,7 @@ previous run polled 1 or more messages.
 A pluggable *`org.apache.camel.PollingConsumerPollingStrategy`* allowing
 you to provide your custom implementation to control error handling
 usually occurred during the *`poll`* operation _*before*_ an
-xref:latest@manual:ROOT:exchange.adoc[Exchange] has been created and routed in Camel. In
+xref:manual:ROOT:exchange.adoc[Exchange] has been created and routed in Camel. In
 other words the error occurred while the polling was gathering
 information, for instance access to a file network failed so Camel
 cannot access it to scan for files.
@@ -239,20 +239,20 @@ option allows you to share a thread pool among multiple consumers.
 *`org.apache.camel.spi.ScheduledPollConsumerScheduler`* to use as the
 scheduler for firing when the polling consumer runs. The default
 implementation uses the *`ScheduledExecutorService`* and there is a
-xref:components::quartz-component.adoc[Quartz], and xref:latest@manual:ROOT:spring.adoc[Spring] based which
+xref:ROOT:quartz-component.adoc[Quartz], and xref:manual:ROOT:spring.adoc[Spring] based which
 supports CRON expressions. *Notice:* If using a custom scheduler then
 the options for *`initialDelay`, `useFixedDelay`*, *`timeUnit`* and
 *`scheduledExecutorService`* may not be in use. Use the text *`quartz`*
-to refer to use the xref:components::quartz-component.adoc[Quartz] scheduler; and use the
-text `spring` to use the xref:latest@manual:ROOT:spring.adoc[Spring] based; and use the
+to refer to use the xref:ROOT:quartz-component.adoc[Quartz] scheduler; and use the
+text `spring` to use the xref:manual:ROOT:spring.adoc[Spring] based; and use the
 text *`#myScheduler`* to refer to a custom scheduler by its id in the
-xref:latest@manual:ROOT:registry.adoc[Registry].
+xref:manual:ROOT:registry.adoc[Registry].
 
-See xref:components::quartz-component.adoc[Quartz] page for an example.
+See xref:ROOT:quartz-component.adoc[Quartz] page for an example.
 
 |`scheduler.xxx` |`null` |*Camel 2.12:* To configure additional
 properties when using a custom *`scheduler`* or any of the
-xref:components::quartz-component.adoc[Quartz], xref:latest@manual:ROOT:spring.adoc[Spring] based scheduler.
+xref:ROOT:quartz-component.adoc[Quartz], xref:manual:ROOT:spring.adoc[Spring] based scheduler.
 
 |`sendEmptyMessageWhenIdle` |`false` |*Camel 2.9:* If the polling
 consumer did not poll any files, you can enable this option to send an
@@ -316,9 +316,9 @@ is scheduled based and its *`run`* method is invoked periodically based
 on schedule settings. But errors can also occur when a poll is being
 executed. For instance if Camel should poll a file network, and this
 network resource is not available then a *`java.io.IOException`* could
-occur. As this error happens *before* any xref:latest@manual:ROOT:exchange.adoc[Exchange]
+occur. As this error happens *before* any xref:manual:ROOT:exchange.adoc[Exchange]
 has been created and prepared for routing, then the regular
-xref:latest@manual:ROOT:error-handler.adoc[Error handler] does not
+xref:manual:ROOT:error-handler.adoc[Error handler] does not
 apply. So what does the consumer do then? Well the exception is
 propagated back to the *`run`* method where its handled. Camel will by
 default log the exception at *`WARN`* level and then ignore it. At next
@@ -336,7 +336,7 @@ implement a custom scheduler to control when the
 xref:polling-consumer.adoc[Polling Consumer] runs. The default
 implementation is based on the JDKs *`ScheduledExecutorService`* with a
 single thread in the thread pool. There is a CRON based implementation
-in the xref:components::quartz-component.adoc[Quartz], and xref:latest@manual:ROOT:spring.adoc[Spring]
+in the xref:ROOT:quartz-component.adoc[Quartz], and xref:manual:ROOT:spring.adoc[Spring]
 components.
 
 For an example of developing and using a custom scheduler, see the unit
@@ -409,12 +409,12 @@ throwing exceptions as in such a case the *`poll`* operation is not
 invoked and Camel will invoke the *`rollback`* directly.
 
 [[PollingConsumer-ConfiguringantoUsePollingConsumerPollStrategy]]
-=== Configuring an xref:latest@manual:ROOT:endpoint.adoc[Endpoint] to Use `PollingConsumerPollStrategy`
+=== Configuring an xref:manual:ROOT:endpoint.adoc[Endpoint] to Use `PollingConsumerPollStrategy`
 
-To configure an xref:latest@manual:ROOT:endpoint.adoc[Endpoint] to use a custom
+To configure an xref:manual:ROOT:endpoint.adoc[Endpoint] to use a custom
 *`PollingConsumerPollStrategy`* you use the option *`pollStrategy`*. For
 example in the file consumer below we want to use our custom strategy
-defined in the xref:latest@manual:ROOT:registry.adoc[Registry] with the bean id *`myPoll`*:
+defined in the xref:manual:ROOT:registry.adoc[Registry] with the bean id *`myPoll`*:
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
@@ -36,7 +36,7 @@ public class MyProcessor implements Processor {
 
 You can then easily use this inside a route by declaring the bean in
 Spring, say via the XML (or registering it in JNDI if that is your
-xref:latest@manual:ROOT:registry.adoc[Registry])
+xref:manual:ROOT:registry.adoc[Registry])
 
 [source,xml]
 --------------------------------------------------------
@@ -62,7 +62,7 @@ Processor myProcessor = new MyProcessor();
 from("activemq:myQueue").process(myProcessor);
 ----
 
-If you need to lookup the processor in the xref:latest@manual:ROOT:registry.adoc[Registry]
+If you need to lookup the processor in the xref:manual:ROOT:registry.adoc[Registry]
 then you should use the *processRef* DSL:
 
 [source,java]
@@ -93,11 +93,11 @@ refactor it into a separate class.
 
 There is a base class called
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/ProcessorEndpoint.html[ProcessorEndpoint]
-which supports the full xref:latest@manual:ROOT:endpoint.adoc[Endpoint] semantics given a
+which supports the full xref:manual:ROOT:endpoint.adoc[Endpoint] semantics given a
 Processor instance.
 
 So you just need to create a https://github.com/apache/camel/tree/master/components[Component] class by
 deriving from
 http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/impl/DefaultComponent.html[DefaultComponent]
 which returns instances of ProcessorEndpoint. For more details see
-xref:latest@manual:ROOT:writing-components.adoc[Writing Components]
+xref:manual:ROOT:writing-components.adoc[Writing Components]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/publish-subscribe-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/publish-subscribe-channel.adoc
@@ -7,13 +7,13 @@ Subscribe Channel] from the
 xref:enterprise-integration-patterns.adoc[EIP patterns] using for
 example the following components:
 
-* xref:components::jms-component.adoc[JMS] for working with JMS Topics for high performance,
+* xref:ROOT:jms-component.adoc[JMS] for working with JMS Topics for high performance,
 clustering and load balancing
-* xref:components::xmpp-component.adoc[XMPP] when using rooms for group communication
-* xref:components::seda-component.adoc[SEDA] for working with SEDA in the same
-xref:latest@manual:ROOT:camelcontext.adoc[CamelContext] which can work in pub-sub, but
+* xref:ROOT:xmpp-component.adoc[XMPP] when using rooms for group communication
+* xref:ROOT:seda-component.adoc[SEDA] for working with SEDA in the same
+xref:manual:ROOT:camelcontext.adoc[CamelContext] which can work in pub-sub, but
 allowing multiple consumers.
-* xref:components::vm-component.adoc[VM] as SEDA but for intra-JVM.
+* xref:ROOT:vm-component.adoc[VM] as SEDA but for intra-JVM.
 
 image::eip/PublishSubscribeSolution.gif[image]
 
@@ -23,7 +23,7 @@ image::eip/PublishSubscribeSolution.gif[image]
 Another option is to explicitly list the publish-subscribe relationship
 in your routing logic; this keeps the producer and consumer decoupled
 but lets you control the fine grained routing configuration using the
-xref:latest@manual:ROOT:dsl.adoc[DSL].
+xref:manual:ROOT:dsl.adoc[DSL].
 
 In Java code:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
@@ -12,7 +12,7 @@ this pattern using the underlying transport or protocols.
 
 image::eip/RequestReply.gif[image]
 
-For example when using xref:components::jms-component.adoc[JMS] with InOut the component will
+For example when using xref:ROOT:jms-component.adoc[JMS] with InOut the component will
 by default perform these actions
 
 * create by default a temporary inbound queue
@@ -33,7 +33,7 @@ See the related xref:eips:event-message.adoc[Event Message] message
 [[RequestReply-ExplicitlyspecifyingInOut]]
 == Explicitly specifying InOut
 
-When consuming messages from xref:components::jms-component.adoc[JMS] a Request-Reply is
+When consuming messages from xref:ROOT:jms-component.adoc[JMS] a Request-Reply is
 indicated by the presence of the *JMSReplyTo* header.
 
 You can explicitly force an endpoint to be in Request Reply mode by

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/resequence-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/resequence-eip.adoc
@@ -5,7 +5,7 @@
 :since:
 :supportLevel: Stable
 
-The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the xref:components:eips:enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
+The http://www.enterpriseintegrationpatterns.com/Resequencer.html[Resequencer] from the xref:eips:enterprise-integration-patterns.adoc[EIP patterns] allows you to reorganise messages based on some comparator. +
 By default in Camel we use an Expression to create the comparator; so that you can compare by a message header or the body or a piece of a message etc.
 
 image::eip/Resequencer.gif[image]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/resilience4j-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/resilience4j-eip.adoc
@@ -113,7 +113,7 @@ You can find an example with the source code: https://github.com/apache/camel-sp
 
 == Using Resilience4j with Spring Boot
 
-See the xref:components:others:resilience4j.adoc[Resilience4j Component].
+See the xref:others:resilience4j.adoc[Resilience4j Component].
 
 == Camel's Error Handler and Circuit Breaker EIP
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
@@ -7,7 +7,7 @@ patterns] by using the `JMSReplyTo` header.
 
 image::eip/ReturnAddressSolution.gif[image]
 
-For example when using xref:components::jms-component.adoc[JMS] with InOut the component will
+For example when using xref:ROOT:jms-component.adoc[JMS] with InOut the component will
 by default return to the address given in `JMSReplyTo`.
 
 *Requestor Code*

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/rollback-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/rollback-eip.adoc
@@ -12,7 +12,7 @@ using spring transactions.
 
 image::eip/TransactionalClientSolution.gif[image]
 
-Transaction Oriented Endpoints like xref:components::jms-component.adoc[JMS] support using a
+Transaction Oriented Endpoints like xref:ROOT:jms-component.adoc[JMS] support using a
 transaction for both inbound and outbound message exchanges. Endpoints
 that support transactions will participate in the current transaction
 context that they are called from.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/service-activator.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/service-activator.adoc
@@ -13,11 +13,11 @@ Design a Service Activator that connects the messages on the channel to the serv
 
 Camel has several endpoint components that support the Service Activator from the EIP patterns.
 
-Components like  xref:components::bean-component.adoc[Bean] and xref:components::bean-component.adoc[CXF]
+Components like  xref:ROOT:bean-component.adoc[Bean] and xref:ROOT:bean-component.adoc[CXF]
 provide a way to bind the message exchange to a Java interface/service where the route defines the
 endpoints and wires it up to the bean.
 
-In addition you can use the xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] to wire messages
+In addition you can use the xref:manual:ROOT:bean-integration.adoc[Bean Integration] to wire messages
 to a bean using annotation.
 
 == Sample

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
@@ -6,9 +6,9 @@
 :supportLevel: Stable
 
 There is a new `.toD` / `<toD>` that allows to send a message to a dynamic
-computed xref:latest@manual:ROOT:endpoint.adoc[Endpoint] using one or
-more xref:latest@manual:ROOT:expression.adoc[Expression] that are concat together. By
-default the xref:components:languages:simple-language.adoc[Simple] language is used to compute
+computed xref:manual:ROOT:endpoint.adoc[Endpoint] using one or
+more xref:manual:ROOT:expression.adoc[Expression] that are concat together. By
+default the xref:languages:simple-language.adoc[Simple] language is used to compute
 the endpoint.
 
 == Options
@@ -50,7 +50,7 @@ And in XML:
 ----
 
 You can also prefix the uri with a value because by default the uri is
-evaluated using the xref:components:languages:simple-language.adoc[Simple] language
+evaluated using the xref:languages:simple-language.adoc[Simple] language
 
 [source,java]
 ----
@@ -72,8 +72,8 @@ In the example above we compute an endpoint that has prefix "mock:" and
 then the header foo is appended. So for example if the header foo has
 value order, then the endpoint is computed as "mock:order".
 
-You can also use another language than xref:components:languages:simple-language.adoc[Simple] such
-as xref:components:languages:xpath-language.adoc[XPath] - this requires to prefix with language: as
+You can also use another language than xref:languages:simple-language.adoc[Simple] such
+as xref:languages:xpath-language.adoc[XPath] - this requires to prefix with language: as
 shown below (simple language is the default language). If you do not
 specify language: then the endpoint is a component name. And in some
 cases there is both a component and language with the same name such as

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
@@ -8,7 +8,7 @@ using spring transactions.
 
 image::eip/TransactionalClientSolution.gif[image]
 
-Transaction Oriented Endpoints like xref:components::jms-component.adoc[JMS] support using a
+Transaction Oriented Endpoints like xref:ROOT:jms-component.adoc[JMS] support using a
 transaction for both inbound and outbound message exchanges. Endpoints
 that support transactions will participate in the current transaction
 context that they are called from.
@@ -288,9 +288,9 @@ route as transacted using the *transacted* tag.
 
 When a route is marked as transacted using *transacted* Camel will
 automatic use `TransactionErrorHandler` as the
-xref:latest@manual:ROOT:error-handler.adoc[Error Handler]. This error handler supports basically the same
-feature set as the xref:latest@manual:ROOT:defaulterrorhandler.adoc[DefaultErrorHandler],
-so you can for instance use xref:latest@manual:ROOT:exception-clause.adoc[Exception Clause]
+xref:manual:ROOT:error-handler.adoc[Error Handler]. This error handler supports basically the same
+feature set as the xref:manual:ROOT:defaulterrorhandler.adoc[DefaultErrorHandler],
+so you can for instance use xref:manual:ROOT:exception-clause.adoc[Exception Clause]
 as well.
 
 [[TransactionalClient-IntegrationTestingwithSpring]]

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
@@ -1,7 +1,7 @@
 [[unmarshal-eip]]
 = Unmarshal EIP
 
-If you receive a message from one of the Camel xref:components::index.adoc[Components] such as xref:components::file-component.adoc[File], xref:components::http-component.adoc[HTTP] or xref:components::jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some xref:latest@manual:ROOT:bean-integration.adoc[Bean Integration] or perform xref:latest@manual:ROOT:predicate.adoc[Predicate] evaluation and so forth.
+If you receive a message from one of the Camel xref:ROOT:index.adoc[Components] such as xref:ROOT:file-component.adoc[File], xref:ROOT:http-component.adoc[HTTP] or xref:ROOT:jms-component.adoc[JMS] you often want to unmarshal the payload into some bean so that you can process it using some xref:manual:ROOT:bean-integration.adoc[Bean Integration] or perform xref:manual:ROOT:predicate.adoc[Predicate] evaluation and so forth.
 
 
 == Options
@@ -29,11 +29,11 @@ from("activemq:My.Queue").
   to("mqseries:Another.Queue");
 ----
 
-The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your xref:latest@manual:ROOT:registry.adoc[Registry] such as via your xref:components::spring-summary.adoc[Spring] XML file.
+The above uses a named DataFormat of _jaxb_ which is configured with a number of Java package names. You can if you prefer use a named reference to a data format which can then be defined in your xref:manual:ROOT:registry.adoc[Registry] such as via your xref:ROOT:spring-summary.adoc[Spring] XML file.
 
 You can also use the DSL itself to define the data format as you use it.
 For example the following uses Java serialization to unmarshal a binary
-file then send it as an ObjectMessage to xref:components::activemq-component.adoc[ActiveMQ]
+file then send it as an ObjectMessage to xref:ROOT:activemq-component.adoc[ActiveMQ]
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/when-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/when-eip.adoc
@@ -21,7 +21,7 @@ The When EIP has no options.
 
 The following example shows how to route a request from an input
 *direct:a* endpoint to either *direct:b*, *direct:c* or *direct:d* depending on
-the evaluation of various xref:latest@manual:ROOT:predicate.adoc[Predicate] expressions
+the evaluation of various xref:manual:ROOT:predicate.adoc[Predicate] expressions
 
 [source,java]
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/wireTap-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/wireTap-eip.adoc
@@ -15,9 +15,9 @@ image::eip/WireTap.gif[image]
 == Streams
 
 If you xref:wireTap-eip.adoc[Wire Tap] a stream message body then you
-should consider enabling xref:latest@manual:ROOT:stream-caching.adoc[Stream caching] to
+should consider enabling xref:manual:ROOT:stream-caching.adoc[Stream caching] to
 ensure the message body can be read at each endpoint. See more details
-at xref:latest@manual:ROOT:stream-caching.adoc[Stream caching].
+at xref:manual:ROOT:stream-caching.adoc[Stream caching].
 
 TIP: See the `cacheSize` option for more details on _how much cache_ to use depending on how many or few unique endpoints are used.
 
@@ -48,7 +48,7 @@ The Wire Tap EIP supports 12 options which are listed below:
 
 The WireTap uses a thread pool to process the
 tapped messages. This thread pool will by default use the settings
-detailed at xref:latest@manual:ROOT:threading-model.adoc[Threading Model]. In particular,
+detailed at xref:manual:ROOT:threading-model.adoc[Threading Model]. In particular,
 when the pool is exhausted (with all threads utilized), further wiretaps
 will be executed synchronously by the calling thread. To remedy this,
 you can configure an explicit thread pool on the xref:wireTap-eip.adoc[Wire
@@ -58,19 +58,19 @@ or more worker threads.
 == WireTap Node
 
 Camel's Wire Tap node supports two flavors when tapping an
-xref:latest@manual:ROOT:exchange.adoc[Exchange]:
+xref:manual:ROOT:exchange.adoc[Exchange]:
 
 - With the traditional Wire Tap, Camel will copy the original
-xref:latest@manual:ROOT:exchange.adoc[Exchange] and set its
-xref:latest@manual:ROOT:exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
-the tapped xref:latest@manual:ROOT:exchange.adoc[Exchange] to be sent in a fire and forget
-style. The tapped xref:latest@manual:ROOT:exchange.adoc[Exchange] is then sent in a
+xref:manual:ROOT:exchange.adoc[Exchange] and set its
+xref:manual:ROOT:exchange-pattern.adoc[Exchange Pattern] to *`InOnly`*, as we want
+the tapped xref:manual:ROOT:exchange.adoc[Exchange] to be sent in a fire and forget
+style. The tapped xref:manual:ROOT:exchange.adoc[Exchange] is then sent in a
 separate thread so it can run in parallel with the original. Beware that
 only the Exchange is copied - Wire Tap won't do a deep clone (unless you
 specify a custom processor via *`onPrepareRef`* which does that). So all
 copies could share objects from the original Exchange.
 - Camel also provides an option of sending a new
-xref:latest@manual:ROOT:exchange.adoc[Exchange] allowing you to populate it with new
+xref:manual:ROOT:exchange.adoc[Exchange] allowing you to populate it with new
 values.
 
 == Sending a Copy (traditional wiretap)
@@ -98,25 +98,25 @@ values.
     }
 ----
 
-== Sending a New xref:latest@manual:ROOT:exchange.adoc[Exchange]
+== Sending a New xref:manual:ROOT:exchange.adoc[Exchange]
 
 Camel supports either a processor or an
-xref:latest@manual:ROOT:expression.adoc[Expression] to populate the new
-xref:latest@manual:ROOT:exchange.adoc[Exchange]. Using a processor gives you full power
-over how the xref:latest@manual:ROOT:exchange.adoc[Exchange] is populated as you can set
-properties, headers, etc. An xref:latest@manual:ROOT:expression.adoc[Expression] can only
+xref:manual:ROOT:expression.adoc[Expression] to populate the new
+xref:manual:ROOT:exchange.adoc[Exchange]. Using a processor gives you full power
+over how the xref:manual:ROOT:exchange.adoc[Exchange] is populated as you can set
+properties, headers, etc. An xref:manual:ROOT:expression.adoc[Expression] can only
 be used to set the *`IN`* body.
 
-The xref:latest@manual:ROOT:expression.adoc[Expression] or
-xref:latest@manual:ROOT:processor.adoc[Processor] is pre-populated with a copy of the
-original xref:latest@manual:ROOT:exchange.adoc[Exchange], which allows you to access the
-original message when you prepare a new xref:latest@manual:ROOT:exchange.adoc[Exchange] to
+The xref:manual:ROOT:expression.adoc[Expression] or
+xref:manual:ROOT:processor.adoc[Processor] is pre-populated with a copy of the
+original xref:manual:ROOT:exchange.adoc[Exchange], which allows you to access the
+original message when you prepare a new xref:manual:ROOT:exchange.adoc[Exchange] to
 be sent. You can use the *`copy`* option (enabled by default) to
 indicate whether you want this.
 
 Below is the processor variation,
 where we disable *`copy`* by passing in *`false`* to create a new, empty
-xref:latest@manual:ROOT:exchange.adoc[Exchange]
+xref:manual:ROOT:exchange.adoc[Exchange]
 
 [source,java]
 ----
@@ -159,8 +159,8 @@ part of the queue name:
 
 If you send a new message using xref:wireTap-eip.adoc[Wire Tap], then you
 could only set the message body using an
-xref:latest@manual:ROOT:expression.adoc[Expression] from the DSL. If you also need to set
-headers, you would have to use a xref:latest@manual:ROOT:processor.adoc[Processor]. From
+xref:manual:ROOT:expression.adoc[Expression] from the DSL. If you also need to set
+headers, you would have to use a xref:manual:ROOT:processor.adoc[Processor]. From
 It's possible to set headers as well using the DSL.
 
 The following example sends a new message which has

--- a/docs/components/modules/ROOT/pages/avro-component.adoc
+++ b/docs/components/modules/ROOT/pages/avro-component.adoc
@@ -11,7 +11,7 @@
 :component-header: Both producer and consumer are supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/avro.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: avro
+:camel-spring-boot-name: avro-rpc
 
 *Since Camel {since}*
 

--- a/docs/components/modules/ROOT/pages/aws-summary.adoc
+++ b/docs/components/modules/ROOT/pages/aws-summary.adoc
@@ -13,4 +13,4 @@ provides streaming for Apache Kafka and more. The main reason to use AWS is its 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/docs/components/modules/ROOT/pages/aws2-summary.adoc
+++ b/docs/components/modules/ROOT/pages/aws2-summary.adoc
@@ -13,4 +13,4 @@ storage service, email and queue services. The main reason to use AWS is its clo
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/docs/components/modules/ROOT/pages/azure-summary.adoc
+++ b/docs/components/modules/ROOT/pages/azure-summary.adoc
@@ -13,4 +13,4 @@ provide connectivity to Azure services from Camel.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/docs/components/modules/ROOT/pages/google-summary.adoc
+++ b/docs/components/modules/ROOT/pages/google-summary.adoc
@@ -13,4 +13,4 @@ drive . The main reason to use Google is the G Suite features.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]

--- a/docs/components/modules/ROOT/pages/grape-component.adoc
+++ b/docs/components/modules/ROOT/pages/grape-component.adoc
@@ -10,6 +10,8 @@
 :supportLevel: Stable
 :component-header: Only producer is supported
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/grape.adoc[opts=optional]
+//Manually maintained attributes
+:camel-spring-boot-name: grape
 
 *Since Camel {since}*
 
@@ -255,3 +257,5 @@ command:
         setHeader(GrapeConstats.GRAPE_COMMAND, constant(CamelGrapeCommand.clearPatches)).
         setBody().constant("Installed patches have been deleted."); 
 -----------------------------------------------------------------------------------------
+
+include::spring-boot:partial$starter.adoc[]

--- a/docs/components/modules/ROOT/pages/hazelcast-summary.adoc
+++ b/docs/components/modules/ROOT/pages/hazelcast-summary.adoc
@@ -27,7 +27,7 @@ http://www.hazelcast.com/docs.jsp[http://www.hazelcast.com/docs.jsp].
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/docs/components/modules/ROOT/pages/ignite-summary.adoc
+++ b/docs/components/modules/ROOT/pages/ignite-summary.adoc
@@ -19,7 +19,7 @@ image::apache-ignite.png[]
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/docs/components/modules/ROOT/pages/index.adoc
+++ b/docs/components/modules/ROOT/pages/index.adoc
@@ -9,24 +9,24 @@ services that can not only resolve easy messaging and transferring data but also
 
 Below is the list of core components that are provided by Apache Camel.
 
-Number of Core Components: indexCount:[attributes=core] in indexUniqueCount:[attributes=core,unique=artifactid] JAR artifacts (indexCount:[attributes="core,deprecated"] deprecated)
+Number of Core Components: indexCount:[attributes=core] in indexUniqueCount:[attributes=core,format=artifactid] JAR artifacts (indexCount:[attributes="core,deprecated"] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
-indexTable::[attributes=core,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[attributes=core,cellformats="$xref|artifactid|supportlevel|since|description"]
 
 == Components
 
 Below is the list of non-core components that are provided by Apache Camel.
 
-Number of Non-Core Components: indexCount:[attributes=!core] in indexUniqueCount:[attributes=!core,unique=artifactid] JAR artifacts (indexCount:[attributes="!core,deprecated"] deprecated)
+Number of Non-Core Components: indexCount:[attributes=!core] in indexUniqueCount:[attributes=!core,format=artifactid] JAR artifacts (indexCount:[attributes="!core,deprecated"] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
 //'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,attributes=!core,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[relative=!nav.adoc,attributes=!core,cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/ROOT/pages/kubernetes-summary.adoc
+++ b/docs/components/modules/ROOT/pages/kubernetes-summary.adoc
@@ -17,7 +17,7 @@ The Kubernetes components integrate your application with Kubernetes standalone 
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/docs/components/modules/ROOT/pages/openstack-summary.adoc
+++ b/docs/components/modules/ROOT/pages/openstack-summary.adoc
@@ -18,7 +18,7 @@ https://www.openstack.org//[OpenStack] applications.
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 == Installation
 

--- a/docs/components/modules/ROOT/pages/spring-summary.adoc
+++ b/docs/components/modules/ROOT/pages/spring-summary.adoc
@@ -12,7 +12,7 @@
 
 See the following for usage of each component:
 
-indexDescriptionList::[attributes='group={docTitle}',descAttribute=description]
+indexDescriptionList::[attributes='group={docTitle}',descriptionformat=description]
 
 Apache Camel is designed to work nicely with the
 Spring Framework in a number of ways.

--- a/docs/components/modules/dataformats/pages/index.adoc
+++ b/docs/components/modules/dataformats/pages/index.adoc
@@ -1,14 +1,12 @@
-[list-of-camel-data-formats]
 = Data Formats
 
 Below is the list of data formats that are provided by Apache Camel.
 
-Number of Data Formats: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Data Formats: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Data Format | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/languages/pages/index.adoc
+++ b/docs/components/modules/languages/pages/index.adoc
@@ -1,14 +1,12 @@
-[list-of-camel-expression-languages]
 = Expression Languages
 
 Below is the list of expression languages that are provided by Apache Camel.
 
-Number of Languages: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Languages: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Language | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 

--- a/docs/components/modules/languages/pages/joor-language.adoc
+++ b/docs/components/modules/languages/pages/joor-language.adoc
@@ -10,7 +10,7 @@
 :supportLevel: Preview
 include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/joor.adoc[opts=optional]
 //Manually maintained attributes
-:camel-spring-boot-name: core
+:camel-spring-boot-name: joor
 
 *Since Camel {since}*
 

--- a/docs/components/modules/languages/pages/simple-language.adoc
+++ b/docs/components/modules/languages/pages/simple-language.adoc
@@ -477,19 +477,13 @@ function, otherwise parsed as literal.
 |-- |To decrement a number by one. The left hand side must be a
 function, otherwise parsed as literal.
 
-|\ |To escape a value, eg \$, to indicate a $ sign.
-Special: Use \n for new line, \t for tab, and \r for carriage return.
-*Notice:* Escaping is *not* supported using the
-xref:file-language.adoc[File Language]. *Notice:* The escape character is not supported, use the
-following three special escaping instead.
-
 |\n |To use newline character.
 
 |\t |To use tab character.
 
 |\r |To use carriage return character.
 
-|\} |To use the } character as text
+|\} |To use the } character as text. This may be needed when building a JSon structure with the simple language.
 |===
 
 And the following logical operators can be used to group expressions:

--- a/docs/components/modules/others/pages/index.adoc
+++ b/docs/components/modules/others/pages/index.adoc
@@ -1,18 +1,16 @@
-[list-of-camel-components]
 = Miscellaneous Components
 
 Component references are references used to place a component in an assembly. Apache Component references 
 provides various references that offers services for messaging, sending data, notifications and various other 
 services that can not only resolve easy messaging and transferring data but also provide securing of data.
 
-Number of Miscellaneous Components: indexCount:[] in indexUniqueCount:[unique=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
+Number of Miscellaneous Components: indexCount:[] in indexUniqueCount:[format=artifactid] JAR artifacts (indexCount:[attributes=deprecated] deprecated)
 
 [{index-table-format}]
 |===
 | Component | Artifact | Support Level | Since | Description
 |===
-//'relative=!nav.adoc' is a workaround for https://gitlab.com/antora/xref-validator/-/issues/9
-indexTable::[relative=!nav.adoc,cells="$xref,artifactid,supportlevel,since,description"]
+indexTable::[cellformats="$xref|artifactid|supportlevel|since|description"]
 
 
 


### PR DESCRIPTION
Fix links to user manual

point to current version, not latest from eip docs

fix some spring-boot metadata problems

simple-language.adoc copy, not sure how it was previously missed

See apache/camel-website#648.