### PR TITLE
CAMEL-17000: Fix test failures with JUnit > 5.7.1

### DIFF
--- a/core/camel-core/pom.xml
+++ b/core/camel-core/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <camel.surefire.forkTimeout>3000</camel.surefire.forkTimeout>
+        <camel.surefire.parallel.strategy>custom</camel.surefire.parallel.strategy>
     </properties>
 
     <dependencies>

--- a/core/camel-core/src/test/java/org/apache/camel/CamelParallelExecutionStrategy.java
+++ b/core/camel-core/src/test/java/org/apache/camel/CamelParallelExecutionStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import java.util.Optional;
+
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfiguration;
+import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Customize Junit5 parallel execution strategy to use more threads than the default 256. The number of threads and the
+ * parallelism are set in junit-platform.properties.
+ */
+public class CamelParallelExecutionStrategy implements ParallelExecutionConfigurationStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CamelParallelExecutionStrategy.class);
+
+    private static final String CONFIG_CUSTOM_PARALLELISM_PROPERTY_NAME = "custom.parallelism";
+    private static final String CONFIG_CUSTOM_MAXPOOLSIZE_PROPERTY_NAME = "custom.maxPoolSize";
+    private static final int DEFAULT_PARALLELISM = 2;
+
+    int nbParallelExecutions;
+    int maxPoolSize;
+
+    private class CamelParallelExecutionConfiguration implements ParallelExecutionConfiguration {
+
+        @Override
+        public int getParallelism() {
+            return nbParallelExecutions;
+        }
+
+        @Override
+        public int getMinimumRunnable() {
+            return nbParallelExecutions;
+        }
+
+        @Override
+        public int getMaxPoolSize() {
+            return maxPoolSize;
+        }
+
+        @Override
+        public int getCorePoolSize() {
+            return nbParallelExecutions;
+        }
+
+        @Override
+        public int getKeepAliveSeconds() {
+            return 30;
+        }
+
+    }
+
+    @Override
+    public ParallelExecutionConfiguration createConfiguration(ConfigurationParameters configurationParameters) {
+        Optional<Integer> parallelism = configurationParameters.get(CONFIG_CUSTOM_PARALLELISM_PROPERTY_NAME,
+                Integer::valueOf);
+        this.nbParallelExecutions = parallelism.isPresent() ? parallelism.get() : DEFAULT_PARALLELISM;
+        Optional<Integer> poolSize = configurationParameters.get(CONFIG_CUSTOM_MAXPOOLSIZE_PROPERTY_NAME,
+                Integer::valueOf);
+        this.maxPoolSize = poolSize.isPresent() ? poolSize.get() : nbParallelExecutions * 256;
+
+        LOG.info(String.format("Using custom JUnit parallel execution with parallelism=%d and maxPoolSize=%d",
+                nbParallelExecutions, maxPoolSize));
+
+        return new CamelParallelExecutionConfiguration();
+    }
+
+}

--- a/core/camel-core/src/test/resources/junit-platform.properties
+++ b/core/camel-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,24 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = custom
+junit.jupiter.execution.parallel.config.custom.parallelism = 4
+junit.jupiter.execution.parallel.config.custom.maxPoolSize = 4096
+junit.jupiter.execution.parallel.config.custom.class=org.apache.camel.CamelParallelExecutionStrategy

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,6 +42,7 @@
         <camel.surefire.reuseForks>true</camel.surefire.reuseForks>
         <camel.surefire.parallel>false</camel.surefire.parallel>
         <camel.surefire.parallel.factor>1</camel.surefire.parallel.factor>
+        <camel.surefire.parallel.strategy>dynamic</camel.surefire.parallel.strategy>
         <cxf.xjc.jvmArgs/>
         <trimStackTrace>false</trimStackTrace>
         <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
@@ -344,7 +345,7 @@
         <jt400-version>10.7</jt400-version>
         <junit-toolbox-version>2.3</junit-toolbox-version>
         <junit-version>4.13.1</junit-version>
-        <junit-jupiter-version>5.7.1</junit-jupiter-version>
+        <junit-jupiter-version>5.8.1</junit-jupiter-version>
         <jxmpp-version>0.6.4</jxmpp-version>
         <jython-version>2.5.3</jython-version>
         <jython-standalone-version>2.5.3</jython-standalone-version>
@@ -4616,7 +4617,7 @@
                             junit.jupiter.execution.parallel.enabled = ${camel.surefire.parallel}
                             junit.jupiter.execution.parallel.mode.default = same_thread
                             junit.jupiter.execution.parallel.mode.classes.default = concurrent
-                            junit.jupiter.execution.parallel.config.strategy = dynamic
+                            junit.jupiter.execution.parallel.config.strategy = ${camel.surefire.parallel.strategy}
                             junit.jupiter.execution.parallel.config.dynamic.factor = ${camel.surefire.parallel.factor}
                         </configurationParameters>
                     </properties>


### PR DESCRIPTION
Update parent pom to 5.8.1 and add a property to configure the parallel execution strategy.
In camel-core use a custom strategy with more threads and a fixed value for parallelism.
