### PR TITLE
CAMEL-16934: Clean up leftover logic from removal of `apiContextIdListing`

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiProcessor.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiProcessor.java
@@ -59,10 +59,8 @@ public class RestOpenApiProcessor implements Processor {
         boolean yaml = false;
         if (route != null && route.endsWith("/openapi.json")) {
             json = true;
-            route = route.substring(0, route.length() - 13);
         } else if (route != null && route.endsWith("/openapi.yaml")) {
             yaml = true;
-            route = route.substring(0, route.length() - 13);
         }
         if (accept != null && !json && !yaml) {
             json = accept.toLowerCase(Locale.US).contains("json");
@@ -74,7 +72,7 @@ public class RestOpenApiProcessor implements Processor {
         }
 
         try {
-            support.renderResourceListing(exchange.getContext(), adapter, openApiConfig, route, json, yaml,
+            support.renderResourceListing(exchange.getContext(), adapter, openApiConfig, json, yaml,
                     exchange.getIn().getHeaders(), exchange.getContext().getClassResolver(), configuration);
         } catch (Exception e) {
             LOG.warn("Error rendering OpenApi API due {}", e.getMessage(), e);

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
@@ -134,13 +134,12 @@ public class RestOpenApiReader {
      *
      * @param  camelContext           the camel context
      * @param  rests                  the rest-dsl
-     * @param  route                  optional route path to filter the rest-dsl to only include from the chose route
      * @param  config                 the openApi configuration
      * @param  classResolver          class resolver to use @return the openApi model
      * @throws ClassNotFoundException is thrown if error loading class
      */
     public OasDocument read(
-            CamelContext camelContext, List<RestDefinition> rests, String route, BeanConfig config,
+            CamelContext camelContext, List<RestDefinition> rests, BeanConfig config,
             String camelContextId, ClassResolver classResolver)
             throws ClassNotFoundException {
 
@@ -152,14 +151,6 @@ public class RestOpenApiReader {
         }
 
         for (RestDefinition rest : rests) {
-            if (org.apache.camel.util.ObjectHelper.isNotEmpty(route) && !route.equals("/")) {
-                // filter by route
-                String path = getValue(camelContext, rest.getPath());
-                if (!path.equals(route)) {
-                    continue;
-                }
-            }
-
             parse(camelContext, openApi, rest, camelContextId, classResolver);
         }
 

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
@@ -372,7 +372,7 @@ public class RestOpenApiSupport {
 
     public void renderResourceListing(
             CamelContext camelContext, RestApiResponseAdapter response,
-            BeanConfig openApiConfig, String route, boolean json,
+            BeanConfig openApiConfig, boolean json,
             boolean yaml, Map<String, Object> headers, ClassResolver classResolver,
             RestConfiguration configuration)
             throws Exception {
@@ -397,7 +397,7 @@ public class RestOpenApiSupport {
 
                 // read the rest-dsl into openApi model
                 OasDocument openApi
-                        = reader.read(camelContext, rests, route, openApiConfig, camelContext.getName(), classResolver);
+                        = reader.read(camelContext, rests, openApiConfig, camelContext.getName(), classResolver);
                 if (configuration.isUseXForwardHeaders()) {
                     setupXForwardedHeaders(openApi, headers);
                 }
@@ -418,7 +418,7 @@ public class RestOpenApiSupport {
 
                 // read the rest-dsl into openApi model
                 OasDocument openApi
-                        = reader.read(camelContext, rests, route, openApiConfig, camelContext.getName(), classResolver);
+                        = reader.read(camelContext, rests, openApiConfig, camelContext.getName(), classResolver);
                 if (configuration.isUseXForwardHeaders()) {
                     setupXForwardedHeaders(openApi, headers);
                 }

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
@@ -123,7 +123,7 @@ public class ComplexTypesTest extends CamelTestSupport {
                 .collect(Collectors.toList());
 
         RestOpenApiReader reader = new RestOpenApiReader();
-        OasDocument openApi = reader.read(context, rests, null, config, context.getName(), new DefaultClassResolver());
+        OasDocument openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
         assertNotNull(openApi);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
@@ -66,7 +66,7 @@ public class RestOpenApiModelApiSecurityRequirementsTest extends CamelTestSuppor
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -99,7 +99,7 @@ public class RestOpenApiModelApiSecurityRequirementsTest extends CamelTestSuppor
         config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
@@ -69,7 +69,7 @@ public class RestOpenApiReaderApiDocsOverrideTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
         OasDocument openApi = null;
-        openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
 
         assertNotNull(openApi);
@@ -97,7 +97,7 @@ public class RestOpenApiReaderApiDocsOverrideTest extends CamelTestSupport {
         config.setBasePath("/api");
         RestOpenApiReader reader = new RestOpenApiReader();
         OasDocument openApi = null;
-        openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
 
         assertNotNull(openApi);

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
@@ -69,7 +69,7 @@ public class RestOpenApiReaderApiDocsTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -100,7 +100,7 @@ public class RestOpenApiReaderApiDocsTest extends CamelTestSupport {
         config.setBasePath("/api");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
@@ -71,7 +71,7 @@ public class RestOpenApiReaderDayOfWeekTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -107,7 +107,7 @@ public class RestOpenApiReaderDayOfWeekTest extends CamelTestSupport {
         //config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
@@ -84,7 +84,7 @@ public class RestOpenApiReaderEnableVendorExtensionTest extends CamelTestSupport
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -120,7 +120,7 @@ public class RestOpenApiReaderEnableVendorExtensionTest extends CamelTestSupport
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
@@ -65,7 +65,7 @@ public class RestOpenApiReaderFileResponseModelTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -91,7 +91,7 @@ public class RestOpenApiReaderFileResponseModelTest extends CamelTestSupport {
         config.setInfo(info);
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
@@ -89,7 +89,7 @@ public class RestOpenApiReaderModelApiSecurityTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -132,7 +132,7 @@ public class RestOpenApiReaderModelApiSecurityTest extends CamelTestSupport {
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
@@ -84,7 +84,7 @@ public class RestOpenApiReaderModelBookOrderTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -120,7 +120,7 @@ public class RestOpenApiReaderModelBookOrderTest extends CamelTestSupport {
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
@@ -82,7 +82,7 @@ public class RestOpenApiReaderModelTest extends CamelTestSupport {
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -116,7 +116,7 @@ public class RestOpenApiReaderModelTest extends CamelTestSupport {
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
@@ -45,7 +45,7 @@ public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderA
         config.setHost("http:mycoolserver:8888/myapi");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -78,7 +78,7 @@ public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderA
         config.setHost("http:mycoolserver:8888/myapi");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
@@ -93,7 +93,7 @@ public class RestOpenApiReaderPropertyPlaceholderTest extends CamelTestSupport {
         RestOpenApiSupport support = new RestOpenApiSupport();
         List<RestDefinition> rests = support.getRestDefinitions(context);
 
-        OasDocument openApi = reader.read(context, rests, null, config, context.getName(), new DefaultClassResolver());
+        OasDocument openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
         assertNotNull(openApi);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
@@ -74,7 +74,7 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -113,7 +113,7 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
         config.setInfo(info);
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV2SecuritySchemesTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV2SecuritySchemesTest.java
@@ -76,7 +76,7 @@ public class RestOpenApiV2SecuritySchemesTest extends CamelTestSupport {
         config.setVersion("2.0");
 
         RestOpenApiReader reader = new RestOpenApiReader();
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV3SecuritySchemesTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV3SecuritySchemesTest.java
@@ -82,7 +82,7 @@ public class RestOpenApiV3SecuritySchemesTest extends CamelTestSupport {
         config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
 
         RestOpenApiReader reader = new RestOpenApiReader();
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -128,7 +128,7 @@ public class RestOpenApiV3SecuritySchemesTest extends CamelTestSupport {
 
         RestOpenApiReader reader = new RestOpenApiReader();
         assertThrows(IllegalStateException.class,
-                () -> reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+                () -> reader.read(context, context.getRestDefinitions(), config, context.getName(),
                         new DefaultClassResolver()));
     }
 }

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
@@ -54,7 +54,7 @@ public class SpringRestOpenApiReaderModelApiSecurityTest extends CamelSpringTest
         config.setVersion("2.0");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
@@ -98,7 +98,7 @@ public class SpringRestOpenApiReaderModelApiSecurityTest extends CamelSpringTest
         config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
         RestOpenApiReader reader = new RestOpenApiReader();
 
-        OasDocument openApi = reader.read(context, context.getRestDefinitions(), null, config, context.getName(),
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
                 new DefaultClassResolver());
         assertNotNull(openApi);
 

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerProcessor.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerProcessor.java
@@ -75,7 +75,7 @@ public class RestSwaggerProcessor implements Processor {
         }
 
         try {
-            support.renderResourceListing(exchange.getContext(), adapter, swaggerConfig, route, json, yaml,
+            support.renderResourceListing(exchange.getContext(), adapter, swaggerConfig, json, yaml,
                     exchange.getIn().getHeaders(), exchange.getContext().getClassResolver(), configuration);
         } catch (Exception e) {
             LOG.warn("Error rendering Swagger API due {}", e.getMessage(), e);

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerReader.java
@@ -90,26 +90,17 @@ public class RestSwaggerReader {
      * Read the REST-DSL definition's and parse that as a Swagger model representation
      *
      * @param  rests                  the rest-dsl
-     * @param  route                  optional route path to filter the rest-dsl to only include from the chose route
      * @param  config                 the swagger configuration
      * @param  classResolver          class resolver to use
      * @return                        the swagger model
      * @throws ClassNotFoundException
      */
     public Swagger read(
-            List<RestDefinition> rests, String route, BeanConfig config, String camelContextId, ClassResolver classResolver)
+            List<RestDefinition> rests, BeanConfig config, String camelContextId, ClassResolver classResolver)
             throws ClassNotFoundException {
         Swagger swagger = new Swagger();
 
         for (RestDefinition rest : rests) {
-
-            if (org.apache.camel.util.ObjectHelper.isNotEmpty(route) && !route.equals("/")) {
-                // filter by route
-                if (!rest.getPath().equals(route)) {
-                    continue;
-                }
-            }
-
             parse(swagger, rest, camelContextId, classResolver);
         }
 

--- a/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerSupport.java
+++ b/components/camel-swagger-java/src/main/java/org/apache/camel/swagger/RestSwaggerSupport.java
@@ -158,7 +158,7 @@ public class RestSwaggerSupport {
 
     public void renderResourceListing(
             CamelContext camelContext, RestApiResponseAdapter response, BeanConfig swaggerConfig,
-            String route, boolean json, boolean yaml,
+            boolean json, boolean yaml,
             Map<String, Object> headers, ClassResolver classResolver, RestConfiguration configuration)
             throws Exception {
         LOG.trace("renderResourceListing");
@@ -181,7 +181,7 @@ public class RestSwaggerSupport {
                         (String) apiProperties.getOrDefault("api.specification.contentType.json", "application/json"));
 
                 // read the rest-dsl into swagger model
-                Swagger swagger = reader.read(rests, route, swaggerConfig, camelContext.getName(), classResolver);
+                Swagger swagger = reader.read(rests, swaggerConfig, camelContext.getName(), classResolver);
                 if (configuration.isUseXForwardHeaders()) {
                     setupXForwardedHeaders(swagger, headers);
                 }
@@ -201,7 +201,7 @@ public class RestSwaggerSupport {
                         (String) apiProperties.getOrDefault("api.specification.contentType.yaml", "text/yaml"));
 
                 // read the rest-dsl into swagger model
-                Swagger swagger = reader.read(rests, route, swaggerConfig, camelContext.getName(), classResolver);
+                Swagger swagger = reader.read(rests, swaggerConfig, camelContext.getName(), classResolver);
                 if (configuration.isUseXForwardHeaders()) {
                     setupXForwardedHeaders(swagger, headers);
                 }

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerArrayEnumTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerArrayEnumTest.java
@@ -57,7 +57,7 @@ public class RestSwaggerArrayEnumTest {
                 .param().name("headerArrayParam").type(RestParamType.header).dataType("array").arrayType("float")
                 .allowableValues("1.1", "2.2", "3.3").endParam();
 
-        final Swagger swagger = reader.read(Collections.singletonList(restDefinition), null, new BeanConfig(),
+        final Swagger swagger = reader.read(Collections.singletonList(restDefinition), new BeanConfig(),
                 "camel-1", new DefaultClassResolver());
 
         assertThat(swagger).isNotNull();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderApiDocsOverrideTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderApiDocsOverrideTest.java
@@ -69,7 +69,7 @@ public class RestSwaggerReaderApiDocsOverrideTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderApiDocsTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderApiDocsTest.java
@@ -70,7 +70,7 @@ public class RestSwaggerReaderApiDocsTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderDayOfWeekTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderDayOfWeekTest.java
@@ -71,7 +71,7 @@ public class RestSwaggerReaderDayOfWeekTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEmptyAllowableValuesTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEmptyAllowableValuesTest.java
@@ -70,7 +70,7 @@ public class RestSwaggerReaderEmptyAllowableValuesTest extends CamelTestSupport 
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEnableVendorExtensionTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderEnableVendorExtensionTest.java
@@ -84,7 +84,7 @@ public class RestSwaggerReaderEnableVendorExtensionTest extends CamelTestSupport
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderFileResponseModelTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderFileResponseModelTest.java
@@ -63,7 +63,7 @@ public class RestSwaggerReaderFileResponseModelTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelApiSecurityTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelApiSecurityTest.java
@@ -89,7 +89,7 @@ public class RestSwaggerReaderModelApiSecurityTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelBookOrderTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelBookOrderTest.java
@@ -74,7 +74,7 @@ public class RestSwaggerReaderModelBookOrderTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderModelTest.java
@@ -82,7 +82,7 @@ public class RestSwaggerReaderModelTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderOverrideHostApiDocsTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderOverrideHostApiDocsTest.java
@@ -45,7 +45,7 @@ public class RestSwaggerReaderOverrideHostApiDocsTest extends RestSwaggerReaderA
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerReaderTest.java
@@ -72,7 +72,7 @@ public class RestSwaggerReaderTest extends CamelTestSupport {
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/SpringRestSwaggerReaderModelApiSecurityTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/SpringRestSwaggerReaderModelApiSecurityTest.java
@@ -54,7 +54,7 @@ public class SpringRestSwaggerReaderModelApiSecurityTest extends CamelSpringTest
         RestSwaggerReader reader = new RestSwaggerReader();
 
         Swagger swagger
-                = reader.read(context.getRestDefinitions(), null, config, context.getName(), new DefaultClassResolver());
+                = reader.read(context.getRestDefinitions(), config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/dsl/camel-xml-jaxb-dsl-test/swagger/src/test/java/org/apache/camel/dsl/xml/jaxb/swagger/RestSwaggerReaderPropertyPlaceholderTest.java
+++ b/dsl/camel-xml-jaxb-dsl-test/swagger/src/test/java/org/apache/camel/dsl/xml/jaxb/swagger/RestSwaggerReaderPropertyPlaceholderTest.java
@@ -93,7 +93,7 @@ public class RestSwaggerReaderPropertyPlaceholderTest extends CamelTestSupport {
         RestSwaggerSupport support = new RestSwaggerSupport();
         List<RestDefinition> rests = support.getRestDefinitions(context);
 
-        Swagger swagger = reader.read(rests, null, config, context.getName(), new DefaultClassResolver());
+        Swagger swagger = reader.read(rests, config, context.getName(), new DefaultClassResolver());
         assertNotNull(swagger);
 
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
All of the `camel-quarkus-openapi-java` tests were failing with `3.13.0-SNAPSHOT` because the generated OpenAPI doc did not contain any of the path info defined by the REST DSL.

I tracked the root cause down to some filtering logic that I think (I'm not 100% sure) was related to the `apiContextIdListing` feature that we removed recently.