### PR TITLE
fix formatting typo in hl7-dataformat.adoc

### DIFF
--- a/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
+++ b/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
@@ -329,7 +329,7 @@ that was used to parse the message`
 |`CamelHL7Charset` |`MSH-18` |`UNICODE UTF-8`
 |===
 
-All headers except `CamelHL7Context `are `String` types. If a header
+All headers except `CamelHL7Context` are `String` types. If a header
 value is missing, its value is `null`.
 
 == Dependencies


### PR DESCRIPTION
This PR intent is to fix this formatting typo:
![image](https://user-images.githubusercontent.com/1699252/139707173-bef241a8-8416-47bb-80be-b87e8821e005.png)
