### PR TITLE
fix formatting in table of hl7-dataformat.adoc

### DIFF
--- a/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
+++ b/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
@@ -322,7 +322,7 @@ headers on the Camel message:
 
 |`CamelHL7VersionId` |`MSH-12` |`2.4`
 
-|`CamelHL7Context |`` |`contains the
+|`CamelHL7Context` |`` |`contains the
 http://hl7api.sourceforge.net/base/apidocs/ca/uhn/hl7v2/HapiContext.html[HapiContext]
 that was used to parse the message`
 


### PR DESCRIPTION
sorry in relation to previous PR https://github.com/apache/camel/pull/6363
I didn't realize there was also another formatting typo @oscerd 

This PR intent is to fix this formatting problem in this table:
<img width="498" alt="Screenshot 2021-11-01 at 17 43 09" src="https://user-images.githubusercontent.com/1699252/139708154-00a7a33e-36a4-4138-9c12-11d7d2721c7e.png">
