### PR TITLE
Proposed changes in the article on stopping a route programmatically

### DIFF
--- a/docs/user-manual/modules/faq/pages/how-can-i-stop-a-route-from-a-route.adoc
+++ b/docs/user-manual/modules/faq/pages/how-can-i-stop-a-route-from-a-route.adoc
@@ -148,7 +148,7 @@ public RouteBuilder createMyRoutes() throws Exception {
                                 @Override
                                 public void run() {
                                     try {
-                                        exchange.getContext().stopRoute("myRoute");
+                                        exchange.getContext().getRouteController().stopRoute("myRoute");
                                     } catch (Exception e) {
                                         // ignore
                                     }


### PR DESCRIPTION
Hi guys,
This article looks outdated.
line 151 contains: exchange.getContext().stopRoute("myRoute");
Meanwhile there is no method stopRoute(String) in org.apache.camel.CamelContext
I suggest this call instead^
exchange.getContext().getRouteController().stopRoute("myRoute");
