### PR TITLE
camel-ftp - Upgrade to SSHD 2.7.x

### DIFF
--- a/components/camel-ftp/pom.xml
+++ b/components/camel-ftp/pom.xml
@@ -40,9 +40,6 @@
         <camel.surefire.forkTimeout>1800</camel.surefire.forkTimeout>
         <camel.surefire.parallel>false</camel.surefire.parallel>
 
-        <!-- testing with SSHD does not work with 2.6.0 or 2.7.0: https://issues.apache.org/jira/browse/CAMEL-17163 -->
-        <sshd-version>2.5.0</sshd-version>
-
         <!-- This one can run in parallel rather safely-->
         <camel.failsafe.forkCount>${camel.surefire.forkCount}</camel.failsafe.forkCount>
         <camel.failsafe.forkTimeout>${camel.surefire.forkTimeout}</camel.failsafe.forkTimeout>


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-17163

Sshd 2.6.0+ removes weaker security settings from the default configuration - https://issues.apache.org/jira/browse/SSHD-1004
This PR brings a quick fix, which enables deprecated cipher and signature (which is ok for the server running in the test scope)
Better fix could probably be to use stronger security during the test and get rid of the deprecated cipher and signature.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
