### PR TITLE
StaxConverter: Make input and output factory pool size implementation…

### DIFF
--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/StaxConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/StaxConverter.java
@@ -62,13 +62,12 @@ public class StaxConverter {
             String s = AccessController.doPrivileged(new PrivilegedAction<String>() {
                 @Override
                 public String run() {
-                    return System.getProperty("org.apache.cxf.staxutils.pool-size", "-1");
+                    return System.getProperty("org.apache.cxf.staxutils.pool-size", "20");
                 }
             });
             i = Integer.parseInt(s);
-        } catch (Exception t) {
-            //ignore 
-            i = 20;
+        } catch (Exception ignored) {
+            // ignore
         }
         try {
             // if we have more cores than 20, then use that
@@ -76,9 +75,8 @@ public class StaxConverter {
             if (cores > i) {
                 i = cores;
             }
-        } catch (Exception t) {
+        } catch (Exception ignored) {
             // ignore
-            i = 20;
         }
 
         if (i <= 0) {

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/StaxConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/StaxConverter.java
@@ -24,8 +24,6 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -57,36 +55,21 @@ public class StaxConverter {
     private static final BlockingQueue<XMLInputFactory> INPUT_FACTORY_POOL;
     private static final BlockingQueue<XMLOutputFactory> OUTPUT_FACTORY_POOL;
     static {
-        int i = 20;
-        try {
-            String s = AccessController.doPrivileged(new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    return System.getProperty("org.apache.cxf.staxutils.pool-size", "20");
-                }
-            });
-            i = Integer.parseInt(s);
-        } catch (Exception ignored) {
-            // ignore
-        }
+        int poolSize = 20;
         try {
             // if we have more cores than 20, then use that
             int cores = Runtime.getRuntime().availableProcessors();
-            if (cores > i) {
-                i = cores;
+            if (cores > poolSize) {
+                poolSize = cores;
             }
         } catch (Exception ignored) {
             // ignore
         }
 
-        if (i <= 0) {
-            i = 20;
-        }
+        LOG.debug("StaxConverter pool size: {}", poolSize);
 
-        LOG.debug("StaxConverter pool size: {}", i);
-
-        INPUT_FACTORY_POOL = new LinkedBlockingQueue<>(i);
-        OUTPUT_FACTORY_POOL = new LinkedBlockingQueue<>(i);
+        INPUT_FACTORY_POOL = new LinkedBlockingQueue<>(poolSize);
+        OUTPUT_FACTORY_POOL = new LinkedBlockingQueue<>(poolSize);
     }
 
     private XMLInputFactory inputFactory;


### PR DESCRIPTION
… match comments.

Comments suggests that Runtime#availableProcessors should be used as pool size when it is greater than 20, but the current implementation uses Runtime#availableProcessors regardless of the amount of processors available if the system property "org.apache.cxf.staxutils.pool-size" is not set.

Not sure if this is the correct way to solve it (open to suggestions).