### PR TITLE
Builds current otel context depending on the exchange's baggage state

### DIFF
--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -138,7 +138,12 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
     protected void inject(SpanAdapter span, InjectAdapter adapter) {
         OpenTelemetrySpanAdapter spanFromExchange = (OpenTelemetrySpanAdapter) span;
         Span otelSpan = spanFromExchange.getOpenTelemetrySpan();
-        Context ctx = Context.current().with(otelSpan).with(spanFromExchange.getBaggage());
+        Context ctx;
+        if (spanFromExchange.getBaggage() != null) {
+            ctx = Context.current().with(otelSpan).with(spanFromExchange.getBaggage());
+        } else {
+            ctx = Context.current().with(otelSpan);
+        }
         GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator().inject(ctx, adapter, new OpenTelemetrySetter());
     }
 


### PR DESCRIPTION
I had a setup where I was trying to use Camel's auto-instrumentation for my workflow. On my services that created a `RouteBuilder`, I had no troubles generating telemetry. However, for my services that only sent messages using a `ProducerTemplate` outside of a predefined route, I encountered a `NullPointerException` when `camel-opentelemetry` was attempting to create that span. 

After looking into the stack trace, I found that `spanFromExchange.getBaggage()` was null. So when they are trying to update the current OpenTelemetry `Context` with it, it would throw that exception and the operation was not traced.

By doing a null check on the `Baggage` before using it to populate the `Context`, it can be ensured that the `Span` would be built when there is no parent span.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
