### PR TITLE
[CAMEL-17204] Fix warning message for S3 multipart uploads

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -211,7 +211,6 @@ public class AWS2S3Producer extends DefaultProducer {
                 try (InputStream fileInputStream = new FileInputStream(filePayload)) {
                     if (filePosition > 0) {
                         long skipped = fileInputStream.skip(filePosition);
-                    
                         if (skipped == 0) {
                             LOG.warn("While trying to upload the file {} file, 0 bytes were skipped", keyName);
                         }

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -209,9 +209,12 @@ public class AWS2S3Producer extends DefaultProducer {
 
                 LOG.trace("Uploading part [{}] for {}", part, keyName);
                 try (InputStream fileInputStream = new FileInputStream(filePayload)) {
-                    long skipped = fileInputStream.skip(filePosition);
-                    if (skipped == 0) {
-                        LOG.warn("While trying to upload the file {} file, 0 bytes were skipped", keyName);
+                    if (filePosition > 0) {
+                        long skipped = fileInputStream.skip(filePosition);
+                    
+                        if (skipped == 0) {
+                            LOG.warn("While trying to upload the file {} file, 0 bytes were skipped", keyName);
+                        }
                     }
 
                     String etag = getEndpoint().getS3Client()


### PR DESCRIPTION
Don't log a warning if this is the first part of a multipart upload.

If this is the first part of the file, then filePosition will be zero and we will attempt to skip zero bytes. This change avoids the call to skip entirely for the first part.

https://issues.apache.org/jira/browse/CAMEL-17204

Uncomment and fill this section if your PR is not trivial
- [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [X] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md

