### PR TITLE
CAMEL-17226 Add namespace to path used for leadership election when using Zookeeper with Master component

### DIFF
--- a/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/cluster/ZooKeeperClusterView.java
+++ b/components/camel-zookeeper/src/main/java/org/apache/camel/component/zookeeper/cluster/ZooKeeperClusterView.java
@@ -76,7 +76,8 @@ final class ZooKeeperClusterView extends AbstractCamelClusterView {
                     : Optional.of(new CuratorClusterMember(participant));
         } catch (KeeperException.NoNodeException e) {
             LOGGER.debug("Failed to get get master because node '{}' does not yet exist (error: '{}')",
-                    configuration.getBasePath(), e.getMessage());
+                    getFullPath(),
+                    e.getMessage());
             return Optional.empty();
         } catch (Exception e) {
             throw new RuntimeCamelException(e);
@@ -96,7 +97,8 @@ final class ZooKeeperClusterView extends AbstractCamelClusterView {
                     .collect(Collectors.toList());
         } catch (KeeperException.NoNodeException e) {
             LOGGER.debug("Failed to get members because node '{}' does not yet exist (error: '{}')",
-                    configuration.getBasePath(), e.getMessage());
+                    getFullPath(),
+                    e.getMessage());
             return Collections.emptyList();
         } catch (Exception e) {
             throw new RuntimeCamelException(e);
@@ -106,7 +108,7 @@ final class ZooKeeperClusterView extends AbstractCamelClusterView {
     @Override
     protected void doStart() throws Exception {
         if (leaderSelector == null) {
-            leaderSelector = new LeaderSelector(client, configuration.getBasePath(), new CamelLeaderElectionListener());
+            leaderSelector = new LeaderSelector(client, getFullPath(), new CamelLeaderElectionListener());
             leaderSelector.setId(getClusterService().getId());
             leaderSelector.start();
         } else {
@@ -127,6 +129,10 @@ final class ZooKeeperClusterView extends AbstractCamelClusterView {
         if (leaderSelector != null) {
             leaderSelector.close();
         }
+    }
+
+    private String getFullPath() {
+        return configuration.getBasePath() + "/" + getNamespace();
     }
 
     // ***********************************************

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_14.adoc
@@ -14,3 +14,6 @@ Added method `updateRoutesToCamelContext` to `org.apache.camel.RoutesBuilder` in
 
 The option `debug-level` has been renamed to `logging-level` because the option is for configuring the logging level.
 
+=== camel-zookeeper/camel-master
+
+When using Zookeeper with the Master component, the given namespace is now used to define leadership. In other words, a route defined with `master:lock1` will result in one leader election, while a route defined with `master:lock2` will result in a separate leader election, which may or may not result in the same leader as `lock1`. This matches the existing behavior of the Master component when using Consul.


### PR DESCRIPTION
This allows different routes to have separate leaders based on the namespace defined (i.e. "master:namespace1" and "master:namespace2" could run on separate cluster members, as long as they are each running on only one). The camel-consul component already works this way in conjunction with the camel-master component.
