### PR TITLE
CAMEL-17240: cleanup the camel-kafka producer code

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -18,31 +18,29 @@ package org.apache.camel.component.kafka;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.kafka.producer.support.DelegatingCallback;
 import org.apache.camel.component.kafka.producer.support.KafkaProducerCallBack;
+import org.apache.camel.component.kafka.producer.support.KafkaProducerMetadataCallBack;
 import org.apache.camel.component.kafka.producer.support.KeyValueHolderIterator;
+import org.apache.camel.component.kafka.producer.support.ProducerUtil;
 import org.apache.camel.component.kafka.serde.KafkaHeaderSerializer;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.util.KeyValueHolder;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -60,20 +58,29 @@ public class KafkaProducer extends DefaultAsyncProducer {
     @SuppressWarnings("rawtypes")
     private org.apache.kafka.clients.producer.KafkaProducer kafkaProducer;
     private final KafkaEndpoint endpoint;
+    private final KafkaConfiguration configuration;
     private ExecutorService workerPool;
     private boolean shutdownWorkerPool;
     private volatile boolean closeKafkaProducer;
+    private final String endpointTopic;
+    private final Integer configPartitionKey;
+    private final String configKey;
 
     public KafkaProducer(KafkaEndpoint endpoint) {
         super(endpoint);
         this.endpoint = endpoint;
+        this.configuration = endpoint.getConfiguration();
+
+        endpointTopic = URISupport.extractRemainderPath(URI.create(endpoint.getEndpointUri()), true);
+        configPartitionKey = configuration.getPartitionKey();
+        configKey = configuration.getKey();
     }
 
     Properties getProps() {
-        Properties props = endpoint.getConfiguration().createProducerProperties();
+        Properties props = configuration.createProducerProperties();
         endpoint.updateClassProperties(props);
 
-        String brokers = endpoint.getKafkaClientFactory().getBrokers(endpoint.getConfiguration());
+        String brokers = endpoint.getKafkaClientFactory().getBrokers(configuration);
         if (brokers != null) {
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
         }
@@ -111,7 +118,7 @@ public class KafkaProducer extends DefaultAsyncProducer {
         }
 
         // if we are in asynchronous mode we need a worker pool
-        if (!endpoint.getConfiguration().isSynchronous() && workerPool == null) {
+        if (!configuration.isSynchronous() && workerPool == null) {
             workerPool = endpoint.createProducerExecutor();
             // we create a thread pool so we should also shut it down
             shutdownWorkerPool = true;
@@ -143,167 +150,281 @@ public class KafkaProducer extends DefaultAsyncProducer {
         }
 
         if (shutdownWorkerPool && workerPool != null) {
-            int timeout = endpoint.getConfiguration().getShutdownTimeout();
+            int timeout = configuration.getShutdownTimeout();
             LOG.debug("Shutting down Kafka producer worker threads with timeout {} millis", timeout);
             endpoint.getCamelContext().getExecutorServiceManager().shutdownGraceful(workerPool, timeout);
             workerPool = null;
         }
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected Iterator<KeyValueHolder<Object, ProducerRecord>> createRecorder(Exchange exchange) throws Exception {
-        String topic = endpoint.getConfiguration().getTopic();
+    protected Iterator<KeyValueHolder<Object, ProducerRecord<Object, Object>>> createRecordIterable(
+            Exchange exchange, Message message) {
+        String topic = evaluateTopic(message);
+
+        // extracting headers which need to be propagated
+        List<Header> propagatedHeaders = getPropagatedHeaders(exchange, message);
+
+        Object body = message.getBody();
+
+        Iterator<Object> iterator = getObjectIterator(body);
+
+        return new KeyValueHolderIterator(iterator, exchange, configuration, topic, propagatedHeaders);
+    }
+
+    protected ProducerRecord<Object, Object> createRecord(Exchange exchange, Message message) {
+        String topic = evaluateTopic(message);
+
         Long timeStamp = null;
-
-        // must remove header so its not propagated
-        Object overrideTopic = exchange.getIn().removeHeader(KafkaConstants.OVERRIDE_TOPIC);
-        if (overrideTopic != null) {
-            LOG.debug("Using override topic: {}", overrideTopic);
-            topic = overrideTopic.toString();
-        }
-
-        if (topic == null) {
-            // if topic property was not received from configuration or header
-            // parameters take it from the remaining URI
-            topic = URISupport.extractRemainderPath(new URI(endpoint.getEndpointUri()), true);
-        }
-
-        Object overrideTimeStamp = exchange.getIn().removeHeader(KafkaConstants.OVERRIDE_TIMESTAMP);
+        Object overrideTimeStamp = message.removeHeader(KafkaConstants.OVERRIDE_TIMESTAMP);
         if (overrideTimeStamp instanceof Long) {
             LOG.debug("Using override TimeStamp: {}", overrideTimeStamp);
             timeStamp = (Long) overrideTimeStamp;
         }
 
         // extracting headers which need to be propagated
-        List<Header> propagatedHeaders = getPropagatedHeaders(exchange, endpoint.getConfiguration());
+        List<Header> propagatedHeaders = getPropagatedHeaders(exchange, message);
 
-        Object msg = exchange.getIn().getBody();
+        final Integer msgPartitionKey = getOverridePartitionKey(message);
+        Object msgKey = getOverrideKey(message);
 
-        // is the message body a list or something that contains multiple values
-        Iterator<Object> iterator = null;
-        if (msg instanceof Iterable) {
-            iterator = ((Iterable<Object>) msg).iterator();
-        } else if (msg instanceof Iterator) {
-            iterator = (Iterator<Object>) msg;
-        }
-        if (iterator != null) {
-            final Iterator<Object> msgList = iterator;
-            final String msgTopic = topic;
-
-            return new KeyValueHolderIterator(msgList, exchange, endpoint.getConfiguration(), msgTopic, propagatedHeaders);
-        }
-
-        // endpoint take precedence over header configuration
-        final Integer partitionKey = ObjectHelper.supplyIfEmpty(endpoint.getConfiguration().getPartitionKey(),
-                () -> exchange.getIn().getHeader(KafkaConstants.PARTITION_KEY, Integer.class));
-
-        // endpoint take precedence over header configuration
-        Object key = ObjectHelper.supplyIfEmpty(endpoint.getConfiguration().getKey(),
-                () -> exchange.getIn().getHeader(KafkaConstants.KEY));
-
-        if (key != null) {
-            key = tryConvertToSerializedType(exchange, key, endpoint.getConfiguration().getKeySerializer());
+        if (msgKey != null) {
+            msgKey = tryConvertToSerializedType(exchange, msgKey, configuration.getKeySerializer());
         }
 
         // must convert each entry of the iterator into the value according to
         // the serializer
-        Object value = tryConvertToSerializedType(exchange, msg, endpoint.getConfiguration().getValueSerializer());
+        Object value = tryConvertToSerializedType(exchange, message.getBody(), configuration.getValueSerializer());
 
-        ProducerRecord record = new ProducerRecord(topic, partitionKey, timeStamp, key, value, propagatedHeaders);
-        return Collections.singletonList(new KeyValueHolder<Object, ProducerRecord>((Object) exchange, record)).iterator();
+        return new ProducerRecord<>(topic, msgPartitionKey, timeStamp, msgKey, value, propagatedHeaders);
     }
 
-    private List<Header> getPropagatedHeaders(Exchange exchange, KafkaConfiguration getConfiguration) {
-        HeaderFilterStrategy headerFilterStrategy = getConfiguration.getHeaderFilterStrategy();
-        KafkaHeaderSerializer headerSerializer = getConfiguration.getHeaderSerializer();
-        return exchange.getIn().getHeaders().entrySet().stream()
-                .filter(entry -> shouldBeFiltered(entry, exchange, headerFilterStrategy))
-                .map(entry -> getRecordHeader(entry, headerSerializer)).filter(Objects::nonNull).collect(Collectors.toList());
-    }
-
-    private boolean shouldBeFiltered(
-            Map.Entry<String, Object> entry, Exchange exchange, HeaderFilterStrategy headerFilterStrategy) {
-        return !headerFilterStrategy.applyFilterToCamelHeaders(entry.getKey(), entry.getValue(), exchange);
-    }
-
-    private RecordHeader getRecordHeader(Map.Entry<String, Object> entry, KafkaHeaderSerializer headerSerializer) {
-        byte[] headerValue = headerSerializer.serialize(entry.getKey(), entry.getValue());
-        if (headerValue == null) {
-            return null;
+    private Object getOverrideKey(Message message) {
+        if (ObjectHelper.isEmpty(configKey)) {
+            return message.getHeader(KafkaConstants.KEY);
         }
-        return new RecordHeader(entry.getKey(), headerValue);
+
+        return configKey;
+    }
+
+    private Integer getOverridePartitionKey(Message message) {
+        if (ObjectHelper.isEmpty(configPartitionKey)) {
+            return message.getHeader(KafkaConstants.PARTITION_KEY, Integer.class);
+        }
+
+        return configPartitionKey;
+    }
+
+    protected KeyValueHolder<Object, ProducerRecord<Object, Object>> createKeyValueHolder(Exchange exchange, Message message) {
+        ProducerRecord<Object, Object> record = createRecord(exchange, message);
+
+        return new KeyValueHolder<>(exchange, record);
+    }
+
+    private String evaluateTopic(Message message) {
+        // must remove header so it's not propagated.
+        Object overrideTopic = message.removeHeader(KafkaConstants.OVERRIDE_TOPIC);
+        if (overrideTopic != null) {
+            LOG.debug("Using override topic: {}", overrideTopic);
+            return overrideTopic.toString();
+        }
+
+        String topic = configuration.getTopic();
+        if (topic != null) {
+            return topic;
+        }
+
+        return endpointTopic;
+    }
+
+    private boolean isIterable(Object body) {
+        if (body instanceof Iterable || body instanceof Iterator) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private Iterator<Object> getObjectIterator(Object body) {
+        Iterator<Object> iterator = null;
+        if (body instanceof Iterable) {
+            iterator = ((Iterable<Object>) body).iterator();
+        } else if (body instanceof Iterator) {
+            iterator = (Iterator<Object>) body;
+        }
+        return iterator;
+    }
+
+    private List<Header> getPropagatedHeaders(Exchange exchange, Message message) {
+        Map<String, Object> messageHeaders = message.getHeaders();
+        List<Header> propagatedHeaders = new ArrayList<>(messageHeaders.size());
+
+        for (Map.Entry<String, Object> header : messageHeaders.entrySet()) {
+            RecordHeader recordHeader = getRecordHeader(header, exchange);
+            if (recordHeader != null) {
+                propagatedHeaders.add(recordHeader);
+            }
+        }
+
+        return propagatedHeaders;
+    }
+
+    private boolean shouldBeFiltered(String key, Object value, Exchange exchange, HeaderFilterStrategy headerFilterStrategy) {
+        return !headerFilterStrategy.applyFilterToCamelHeaders(key, value, exchange);
+    }
+
+    private RecordHeader getRecordHeader(
+            Map.Entry<String, Object> entry, Exchange exchange) {
+
+        final HeaderFilterStrategy headerFilterStrategy = configuration.getHeaderFilterStrategy();
+
+        final String key = entry.getKey();
+        final Object value = entry.getValue();
+
+        if (shouldBeFiltered(key, value, exchange, headerFilterStrategy)) {
+            final KafkaHeaderSerializer headerSerializer = configuration.getHeaderSerializer();
+            final byte[] headerValue = headerSerializer.serialize(key, value);
+
+            if (headerValue == null) {
+                return null;
+            }
+            return new RecordHeader(key, headerValue);
+        }
+
+        return null;
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     // Camel calls this method if the endpoint isSynchronous(), as the
     // KafkaEndpoint creates a SynchronousDelegateProducer for it
     public void process(Exchange exchange) throws Exception {
-        Iterator<KeyValueHolder<Object, ProducerRecord>> c = createRecorder(exchange);
-        List<KeyValueHolder<Object, Future<RecordMetadata>>> futures = new LinkedList<>();
-        List<RecordMetadata> recordMetadatas = new ArrayList<>();
+        // is the message body a list or something that contains multiple values
+        Message message = exchange.getIn();
 
-        if (endpoint.getConfiguration().isRecordMetadata()) {
-            exchange.getMessage().setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadatas);
-        }
-
-        while (c.hasNext()) {
-            KeyValueHolder<Object, ProducerRecord> exrec = c.next();
-            ProducerRecord rec = exrec.getValue();
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Sending message to topic: {}, partition: {}, key: {}", rec.topic(), rec.partition(), rec.key());
-            }
-            futures.add(new KeyValueHolder(exrec.getKey(), kafkaProducer.send(rec)));
-        }
-        for (KeyValueHolder<Object, Future<RecordMetadata>> f : futures) {
-            // wait for them all to be sent
-            List<RecordMetadata> metadata = Collections.singletonList(f.getValue().get());
-            recordMetadatas.addAll(metadata);
-            Exchange innerExchange = null;
-            if (f.getKey() instanceof Exchange) {
-                innerExchange = (Exchange) f.getKey();
-                if (innerExchange != null) {
-                    if (endpoint.getConfiguration().isRecordMetadata()) {
-                        innerExchange.getMessage().setHeader(KafkaConstants.KAFKA_RECORDMETA, metadata);
-                    }
-                }
-            }
-            Message innerMessage = null;
-            if (f.getKey() instanceof Message) {
-                innerMessage = (Message) f.getKey();
-                if (innerMessage != null) {
-                    if (endpoint.getConfiguration().isRecordMetadata()) {
-                        innerMessage.setHeader(KafkaConstants.KAFKA_RECORDMETA, metadata);
-                    }
-                }
-            }
+        if (isIterable(message.getBody())) {
+            processIterableSync(exchange, message);
+        } else {
+            processSingleMessageSync(exchange, message);
         }
     }
 
-    @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public boolean process(Exchange exchange, AsyncCallback callback) {
-        try {
-            Iterator<KeyValueHolder<Object, ProducerRecord>> c = createRecorder(exchange);
-            KafkaProducerCallBack cb = new KafkaProducerCallBack(exchange, callback, workerPool, endpoint.getConfiguration());
-            while (c.hasNext()) {
-                cb.increment();
-                KeyValueHolder<Object, ProducerRecord> exrec = c.next();
-                ProducerRecord rec = exrec.getValue();
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Sending message to topic: {}, partition: {}, key: {}", rec.topic(), rec.partition(), rec.key());
-                }
-                List<Callback> delegates = new ArrayList<>(Arrays.asList(cb));
-                if (exrec.getKey() != null) {
-                    delegates.add(new KafkaProducerCallBack(exrec.getKey(), workerPool, endpoint.getConfiguration()));
-                }
-                kafkaProducer.send(rec, new DelegatingCallback(delegates.toArray(new Callback[0])));
-            }
-            return cb.allSent();
-        } catch (Exception ex) {
-            exchange.setException(ex);
+    private void processSingleMessageSync(Exchange exchange, Message message) throws InterruptedException, ExecutionException {
+        final ProducerRecord<Object, Object> producerRecord = createRecord(exchange, message);
+
+        final Future<RecordMetadata> future = kafkaProducer.send(producerRecord);
+
+        postProcessMetadata(exchange, future);
+    }
+
+    private void processIterableSync(Exchange exchange, Message message) throws ExecutionException, InterruptedException {
+        List<KeyValueHolder<Object, Future<RecordMetadata>>> futures = new ArrayList<>();
+
+        Iterator<KeyValueHolder<Object, ProducerRecord<Object, Object>>> recordIterable
+                = createRecordIterable(exchange, message);
+
+        // This sets an empty metadata for the very first message on the batch
+        List<RecordMetadata> recordMetadata = new ArrayList<>();
+        if (configuration.isRecordMetadata()) {
+            exchange.getMessage().setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadata);
         }
+
+        while (recordIterable.hasNext()) {
+            KeyValueHolder<Object, ProducerRecord<Object, Object>> exchangeRecord = recordIterable.next();
+            ProducerRecord<Object, Object> rec = exchangeRecord.getValue();
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Sending message to topic: {}, partition: {}, key: {}", rec.topic(), rec.partition(), rec.key());
+            }
+
+            futures.add(new KeyValueHolder<>(exchangeRecord.getKey(), kafkaProducer.send(rec)));
+        }
+
+        postProcessMetadata(futures, recordMetadata);
+    }
+
+    private void postProcessMetadata(
+            List<KeyValueHolder<Object, Future<RecordMetadata>>> futures, List<RecordMetadata> metadataList)
+            throws InterruptedException, ExecutionException {
+        for (KeyValueHolder<Object, Future<RecordMetadata>> f : futures) {
+            metadataList.addAll(postProcessMetadata(f.getKey(), f.getValue()));
+        }
+    }
+
+    private List<RecordMetadata> postProcessMetadata(Object key, Future<RecordMetadata> f)
+            throws InterruptedException, ExecutionException {
+        // wait for them all to be sent
+        RecordMetadata metadata = f.get();
+
+        if (configuration.isRecordMetadata()) {
+            List<RecordMetadata> metadataList = Collections.singletonList(metadata);
+
+            ProducerUtil.setRecordMetadata(key, metadataList);
+
+            return metadataList;
+        }
+
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean process(Exchange exchange, AsyncCallback callback) {
+        final KafkaProducerCallBack producerCallBack
+                = new KafkaProducerCallBack(exchange, callback, workerPool, configuration.isRecordMetadata());
+
+        Message message = exchange.getMessage();
+        Object body = message.getBody();
+
+        try {
+            // is the message body a list or something that contains multiple values
+            if (isIterable(body)) {
+                processIterableAsync(exchange, producerCallBack, message);
+            } else {
+                final ProducerRecord<Object, Object> record = createRecord(exchange, message);
+
+                doSend(exchange, record, producerCallBack);
+            }
+
+            return producerCallBack.allSent();
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+
         callback.done(true);
         return true;
+    }
+
+    private void processIterableAsync(Exchange exchange, KafkaProducerCallBack producerCallBack, Message message) {
+        final Iterator<KeyValueHolder<Object, ProducerRecord<Object, Object>>> c = createRecordIterable(exchange, message);
+
+        while (c.hasNext()) {
+            doSend(c, producerCallBack);
+        }
+    }
+
+    private void doSend(Iterator<KeyValueHolder<Object, ProducerRecord<Object, Object>>> kvIterator, KafkaProducerCallBack cb) {
+        doSend(kvIterator.next(), cb);
+    }
+
+    private void doSend(KeyValueHolder<Object, ProducerRecord<Object, Object>> exchangeRecord, KafkaProducerCallBack cb) {
+        doSend(exchangeRecord.getKey(), exchangeRecord.getValue(), cb);
+    }
+
+    private void doSend(Object key, ProducerRecord<Object, Object> record, KafkaProducerCallBack cb) {
+        cb.increment();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Sending message to topic: {}, partition: {}, key: {}", record.topic(), record.partition(),
+                    record.key());
+        }
+
+        if (key != null) {
+            KafkaProducerMetadataCallBack metadataCallBack = new KafkaProducerMetadataCallBack(
+                    key, configuration.isRecordMetadata());
+
+            DelegatingCallback delegatingCallback = new DelegatingCallback(cb, metadataCallBack);
+
+            kafkaProducer.send(record, delegatingCallback);
+        } else {
+            kafkaProducer.send(record, cb);
+        }
     }
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KafkaProducerCallBack.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KafkaProducerCallBack.java
@@ -19,93 +19,81 @@ package org.apache.camel.component.kafka.producer.support;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.camel.AsyncCallback;
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.component.kafka.KafkaConfiguration;
-import org.apache.camel.component.kafka.KafkaConstants;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KafkaProducerCallBack implements Callback {
+import static org.apache.camel.component.kafka.producer.support.ProducerUtil.setException;
+import static org.apache.camel.component.kafka.producer.support.ProducerUtil.setRecordMetadata;
+
+public final class KafkaProducerCallBack implements Callback {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaProducerCallBack.class);
 
     private final Object body;
     private final AsyncCallback callback;
-    private final AtomicInteger count = new AtomicInteger(1);
-    private final List<RecordMetadata> recordMetadatas = new ArrayList<>();
+    private final LongAdder count = new LongAdder();
     private final ExecutorService workerPool;
-
-    public KafkaProducerCallBack(Object body, ExecutorService workerPool, KafkaConfiguration configuration) {
-        this(body, null, workerPool, configuration);
-    }
+    private final boolean record;
+    private final List<RecordMetadata> recordMetadataList = new ArrayList<>();
 
     public KafkaProducerCallBack(Object body, AsyncCallback callback, ExecutorService workerPool,
-                                 KafkaConfiguration configuration) {
+                                 boolean record) {
         this.body = body;
         this.callback = callback;
-        this.workerPool = Objects.requireNonNull(workerPool, "A worker pool must be provided");
+        // The worker pool should be created for both sync and async modes, so checking it
+        // is merely a safeguard
+        assert workerPool != null;
+        this.workerPool = workerPool;
+        this.record = record;
+        count.increment();
 
-        if (configuration.isRecordMetadata()) {
-            if (body instanceof Exchange) {
-                Exchange ex = (Exchange) body;
-                ex.getMessage().setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadatas);
-            }
-            if (body instanceof Message) {
-                Message msg = (Message) body;
-                msg.setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadatas);
-            }
+        if (record) {
+            setRecordMetadata(body, recordMetadataList);
         }
     }
 
     public void increment() {
-        count.incrementAndGet();
+        count.increment();
     }
 
     public boolean allSent() {
-        if (count.decrementAndGet() == 0) {
+        count.decrement();
+        if (count.intValue() == 0) {
             LOG.trace("All messages sent, continue routing.");
             // was able to get all the work done while queuing the requests
-            if (callback != null) {
-                callback.done(true);
-            }
+            callback.done(true);
+
             return true;
         }
+
         return false;
     }
 
     @Override
     public void onCompletion(RecordMetadata recordMetadata, Exception e) {
-        if (e != null) {
-            if (body instanceof Exchange) {
-                ((Exchange) body).setException(e);
-            }
-            if (body instanceof Message && ((Message) body).getExchange() != null) {
-                ((Message) body).getExchange().setException(e);
-            }
+        setException(body, e);
+
+        if (record) {
+            recordMetadataList.add(recordMetadata);
         }
 
-        recordMetadatas.add(recordMetadata);
-
-        if (count.decrementAndGet() == 0) {
+        count.decrement();
+        if (count.intValue() == 0) {
             // use worker pool to continue routing the exchange
             // as this thread is from Kafka Callback and should not be used
             // by Camel routing
-            workerPool.submit(new Runnable() {
-                @Override
-                public void run() {
-                    LOG.trace("All messages sent, continue routing.");
-                    if (callback != null) {
-                        callback.done(false);
-                    }
-                }
-            });
+            workerPool.submit(this::doContinueRouting);
         }
     }
+
+    private void doContinueRouting() {
+        LOG.trace("All messages sent, continue routing (within thread).");
+        callback.done(false);
+    }
+
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KafkaProducerMetadataCallBack.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KafkaProducerMetadataCallBack.java
@@ -20,20 +20,24 @@ package org.apache.camel.component.kafka.producer.support;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
-public final class DelegatingCallback implements Callback {
+import static org.apache.camel.component.kafka.producer.support.ProducerUtil.setException;
+import static org.apache.camel.component.kafka.producer.support.ProducerUtil.setRecordMetadata;
 
-    private final Callback callback1;
-    private final Callback callback2;
+public class KafkaProducerMetadataCallBack implements Callback {
+    private final Object body;
+    private final boolean record;
 
-    public DelegatingCallback(Callback callback1, Callback callback2) {
-        this.callback1 = callback1;
-        this.callback2 = callback2;
+    public KafkaProducerMetadataCallBack(Object body, boolean record) {
+        this.body = body;
+        this.record = record;
     }
 
     @Override
-    public void onCompletion(RecordMetadata metadata, Exception exception) {
-        callback1.onCompletion(metadata, exception);
-        callback2.onCompletion(metadata, exception);
+    public void onCompletion(RecordMetadata recordMetadata, Exception e) {
+        setException(body, e);
 
+        if (record) {
+            setRecordMetadata(body, recordMetadata);
+        }
     }
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KeyValueHolderIterator.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/KeyValueHolderIterator.java
@@ -30,7 +30,7 @@ import org.apache.kafka.common.header.Header;
 
 import static org.apache.camel.component.kafka.producer.support.ProducerUtil.tryConvertToSerializedType;
 
-public class KeyValueHolderIterator implements Iterator<KeyValueHolder<Object, ProducerRecord>> {
+public class KeyValueHolderIterator implements Iterator<KeyValueHolder<Object, ProducerRecord<Object, Object>>> {
     private final Iterator<Object> msgList;
     private final Exchange exchange;
     private final KafkaConfiguration kafkaConfiguration;
@@ -52,91 +52,102 @@ public class KeyValueHolderIterator implements Iterator<KeyValueHolder<Object, P
     }
 
     @Override
-    public KeyValueHolder<Object, ProducerRecord> next() {
+    public KeyValueHolder<Object, ProducerRecord<Object, Object>> next() {
         // must convert each entry of the iterator into the value
         // according to the serializer
-        Object next = msgList.next();
-        String innerTopic = msgTopic;
-        Object innerKey = null;
-        Integer innerPartitionKey = null;
-        Long innerTimestamp = null;
+        final Object body = msgList.next();
 
-        Object value = next;
-        Exchange ex = null;
-        Object body = next;
+        if (body instanceof Exchange || body instanceof Message) {
+            final Message innerMessage = getInnerMessage(body);
+            final Exchange innerExchange = getInnerExchange(body);
 
-        if (next instanceof Exchange || next instanceof Message) {
-            Exchange innerExchange = null;
-            Message innerMessage = null;
-            if (next instanceof Exchange) {
-                innerExchange = (Exchange) next;
-                innerMessage = innerExchange.getIn();
-            } else {
-                innerMessage = (Message) next;
-            }
+            final String innerTopic = getInnerTopic(innerMessage);
+            final Integer innerPartitionKey = getInnerPartitionKey(innerMessage);
+            final Object innerKey = getInnerKey(innerExchange, innerMessage);
+            final Long innerTimestamp = getOverrideTimestamp(innerMessage);
 
-            innerTopic = getInnerTopic(innerTopic, innerMessage);
+            final Exchange ex = innerExchange == null ? exchange : innerExchange;
 
-            if (innerMessage.getHeader(KafkaConstants.PARTITION_KEY) != null) {
-                innerPartitionKey = getInnerPartitionKey(innerMessage);
-            }
-
-            if (innerMessage.getHeader(KafkaConstants.KEY) != null) {
-                innerKey = getInnerKey(innerExchange, innerMessage);
-            }
-
-            innerTimestamp = getOverrideTimestamp(innerTimestamp, innerMessage);
-
-            ex = innerExchange == null ? exchange : innerExchange;
-            value = tryConvertToSerializedType(ex, innerMessage.getBody(),
+            final Object value = tryConvertToSerializedType(ex, innerMessage.getBody(),
                     kafkaConfiguration.getValueSerializer());
+
+            return new KeyValueHolder<>(
+                    body,
+                    new ProducerRecord<>(
+                            innerTopic, innerPartitionKey, innerTimestamp, innerKey, value, propagatedHeaders));
         }
 
-        return new KeyValueHolder(
+        return new KeyValueHolder<>(
                 body,
-                new ProducerRecord(
-                        innerTopic, innerPartitionKey, innerTimestamp, innerKey, value, propagatedHeaders));
+                new ProducerRecord<>(
+                        msgTopic, null, null, null, body, propagatedHeaders));
     }
 
-    private boolean hasValidTimestampHeader(Message innerMessage) {
-        if (innerMessage.getHeader(KafkaConstants.OVERRIDE_TIMESTAMP) != null) {
-            return innerMessage.getHeader(KafkaConstants.OVERRIDE_TIMESTAMP) instanceof Long;
+    private Message getInnerMessage(Object body) {
+        if (body instanceof Exchange) {
+            return ((Exchange) body).getIn();
+        }
+
+        return (Message) body;
+    }
+
+    private Exchange getInnerExchange(Object body) {
+        if (body instanceof Exchange) {
+            return (Exchange) body;
+        }
+
+        return null;
+    }
+
+    private boolean hasValidTimestampHeader(Object timeStamp) {
+        if (timeStamp != null) {
+            return timeStamp instanceof Long;
         }
 
         return false;
     }
 
-    private Long getOverrideTimestamp(Long innerTimestamp, Message innerMessage) {
-        if (hasValidTimestampHeader(innerMessage)) {
-            innerTimestamp = (Long) innerMessage.removeHeader(KafkaConstants.OVERRIDE_TIMESTAMP);
+    private Long getOverrideTimestamp(Message innerMessage) {
+        Object objTimestamp = innerMessage.getHeader(KafkaConstants.OVERRIDE_TIMESTAMP);
+
+        if (hasValidTimestampHeader(objTimestamp)) {
+            return (Long) innerMessage.removeHeader(KafkaConstants.OVERRIDE_TIMESTAMP);
         }
 
-        return innerTimestamp;
+        return null;
     }
 
-    private String getInnerTopic(String innerTopic, Message innerMessage) {
+    private String getInnerTopic(Message innerMessage) {
         if (innerMessage.getHeader(KafkaConstants.OVERRIDE_TOPIC) != null) {
-            innerTopic = (String) innerMessage.removeHeader(KafkaConstants.OVERRIDE_TOPIC);
+            return (String) innerMessage.removeHeader(KafkaConstants.OVERRIDE_TOPIC);
         }
 
-        return innerTopic;
+        return msgTopic;
     }
 
-    private Object getInnerKey(Exchange innerExchange, Message innerMmessage) {
-        Object innerKey;
-        innerKey = kafkaConfiguration.getKey() != null
-                ? kafkaConfiguration.getKey() : innerMmessage.getHeader(KafkaConstants.KEY);
+    private Object getInnerKey(Exchange innerExchange, Message innerMessage) {
+        Object innerKey = innerMessage.getHeader(KafkaConstants.KEY);
         if (innerKey != null) {
-            innerKey = tryConvertToSerializedType(innerExchange, innerKey,
-                    kafkaConfiguration.getKeySerializer());
+
+            innerKey = kafkaConfiguration.getKey() != null ? kafkaConfiguration.getKey() : innerKey;
+
+            if (innerKey != null) {
+                innerKey = tryConvertToSerializedType(innerExchange, innerKey,
+                        kafkaConfiguration.getKeySerializer());
+            }
+
+            return innerKey;
         }
-        return innerKey;
+
+        return null;
     }
 
     private Integer getInnerPartitionKey(Message innerMessage) {
+        Integer partitionKey = innerMessage.getHeader(KafkaConstants.PARTITION_KEY, Integer.class);
+
         return kafkaConfiguration.getPartitionKey() != null
                 ? kafkaConfiguration.getPartitionKey()
-                : innerMessage.getHeader(KafkaConstants.PARTITION_KEY, Integer.class);
+                : partitionKey;
     }
 
     @Override

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/ProducerUtil.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/producer/support/ProducerUtil.java
@@ -18,9 +18,13 @@
 package org.apache.camel.component.kafka.producer.support;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 import org.apache.camel.component.kafka.KafkaConstants;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.utils.Bytes;
 
 public final class ProducerUtil {
@@ -51,5 +55,33 @@ public final class ProducerUtil {
         }
 
         return answer != null ? answer : object;
+    }
+
+    static void setException(Object body, Exception e) {
+        if (e != null) {
+            if (body instanceof Exchange) {
+                ((Exchange) body).setException(e);
+            }
+            if (body instanceof Message && ((Message) body).getExchange() != null) {
+                ((Message) body).getExchange().setException(e);
+            }
+        }
+    }
+
+    static void setRecordMetadata(Object body, RecordMetadata recordMetadata) {
+        final List<RecordMetadata> recordMetadataList = Collections.singletonList(recordMetadata);
+
+        setRecordMetadata(body, recordMetadataList);
+    }
+
+    public static void setRecordMetadata(Object body, List<RecordMetadata> recordMetadataList) {
+        if (body instanceof Exchange) {
+            Exchange ex = (Exchange) body;
+            ex.getMessage().setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadataList);
+        }
+        if (body instanceof Message) {
+            Message msg = (Message) body;
+            msg.setHeader(KafkaConstants.KAFKA_RECORDMETA, recordMetadataList);
+        }
     }
 }


### PR DESCRIPTION
Includes:
- rework the producer to reduce the number of allocations and GC
  pressure
- replace AtomicInteger with LongAdder to reduce risk of contention in AtomicInteger (and a minor improvement in performance)
- logging improvements in the hot path
- rework the callbacks to prevent creating threads unnecessarily
- avoid creating arrays/collections for the delegating callback
- use collection singleton for single-item arrays when possible
- cleanup to use generics in some of the code
- use an assert to check the internal worker pool for not being null as it seems faster
- do a single pass of the set when iterating over it to get the propagated headers
- cleanup the record iterator to simplify and reduce calls to getHeader


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->