### PR TITLE
camel-corda: Combine corda-rpc exclusions in one place

### DIFF
--- a/components/camel-corda/pom.xml
+++ b/components/camel-corda/pom.xml
@@ -40,10 +40,23 @@
         <dependency>
             <groupId>net.corda</groupId>
             <artifactId>corda-rpc</artifactId>
+            <version>${corda-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>co.paralleluniverse</groupId>
+                    <artifactId>quasar-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate.javax.persistence</groupId>
+                    <artifactId>hibernate-jpa-2.1-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2959,25 +2959,6 @@
               <artifactId>jsonapi-converter</artifactId>
               <version>${jasminb-jsonapi-version}</version>
             </dependency>
-            <dependency>
-                <groupId>net.corda</groupId>
-                <artifactId>corda-rpc</artifactId>
-                <version>${corda-version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>co.paralleluniverse</groupId>
-                        <artifactId>quasar-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.hibernate</groupId>
-                        <artifactId>hibernate-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.hibernate.javax.persistence</groupId>
-                        <artifactId>hibernate-jpa-2.1-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <dependency>
                 <groupId>com.alibaba</groupId>


### PR DESCRIPTION
I did not create a Jira for this as it's loosely related to CAMEL-17237.

If you have exclusions for a dependency defined in `camel-parent` and add additional ones in the component POM. Then the ones defined in the component will override those defined in `camel-parent`. So they all need to be defined in one place for things to work properly.