### PR TITLE
CAMEL-17267 Adding httpMethod to endpoint properties

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
@@ -561,6 +561,7 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
         // build query string, and append any endpoint configuration properties
         if (config.getProducerComponent() == null || config.getProducerComponent().equals("http")) {
             // setup endpoint options
+            map.put("httpMethod", verb);
             if (config.getEndpointProperties() != null && !config.getEndpointProperties().isEmpty()) {
                 map.putAll(config.getEndpointProperties());
             }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HeaderFilteringTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HeaderFilteringTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.camel.component.http.HttpMethods.GET;
+import static org.apache.camel.component.http.HttpMethods.POST;
 import static org.apache.http.HttpHeaders.HOST;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +59,7 @@ public class HeaderFilteringTest {
 
         final HttpComponent http = context.getComponent("http", HttpComponent.class);
 
-        final Producer producer = http.createProducer(context, "http://localhost:" + port, GET.name(), "/test", null, null,
+        final Producer producer = http.createProducer(context, "http://localhost:" + port, POST.name(), "/test", null, null,
                 APPLICATION_JSON.getMimeType(), APPLICATION_JSON.getMimeType(), new RestConfiguration(),
                 Collections.emptyMap());
 


### PR DESCRIPTION
I had to change HeaderFilteringTest because it did a GET with a body and this didn't work after I added httpMethod to the endpoint properties. But you shouldn't send a body with a GET anyway, so this seems to be the right way to do the test...
