### PR TITLE
CAMEL-17336: camel-jackson: useList has no effect

### DIFF
--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/AbstractJacksonDataFormat.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/AbstractJacksonDataFormat.java
@@ -533,6 +533,10 @@ public abstract class AbstractJacksonDataFormat extends ServiceSupport
 
     @Override
     protected void doStart() throws Exception {
+        if (useList) {
+            setCollectionType(ArrayList.class);
+        }
+
         boolean objectMapperFoundRegistry = false;
         if (objectMapper == null) {
             // lookup if there is a single default mapper we can use
@@ -559,9 +563,6 @@ public abstract class AbstractJacksonDataFormat extends ServiceSupport
         }
 
         if (!objectMapperFoundRegistry) {
-            if (useList) {
-                setCollectionType(ArrayList.class);
-            }
             if (include != null) {
                 JsonInclude.Include inc
                         = getCamelContext().getTypeConverter().mandatoryConvertTo(JsonInclude.Include.class, include);


### PR DESCRIPTION
If an ObjectMapper from the registry is used, useList=true has no
effect.

I've got some concerns about changes in the generated files. It seems like there's some back and forth battle:
- collectionType vs collectionTypeName
- unmarshalType vs unmarshalTypeName

Looks like these definitions are coming from somewhere else, maybe here https://github.com/apache/camel/blob/main/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java

Looks like maybe you get different result for these generated files depending on where they're generated from. Not clear to me.