### PR TITLE
CAMEL-13180: camel-salesforce: Custom errors

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/SalesforceException.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/SalesforceException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.salesforce.api;
 
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,6 +29,7 @@ public class SalesforceException extends CamelException {
 
     private final List<RestError> errors;
     private final int statusCode;
+    private final InputStream responseContent;
 
     public SalesforceException(Throwable cause) {
         this(null, 0, null, cause);
@@ -38,7 +40,7 @@ public class SalesforceException extends CamelException {
     }
 
     public SalesforceException(String message, int statusCode) {
-        this(null, statusCode, message, null);
+        this(null, statusCode, message, (InputStream) null);
     }
 
     public SalesforceException(String message, int statusCode, Throwable cause) {
@@ -46,7 +48,7 @@ public class SalesforceException extends CamelException {
     }
 
     public SalesforceException(List<RestError> errors, int statusCode) {
-        this(errors, statusCode, null, null);
+        this(errors, statusCode, null, (InputStream) null);
     }
 
     public SalesforceException(List<RestError> errors, int statusCode, Throwable cause) {
@@ -54,13 +56,23 @@ public class SalesforceException extends CamelException {
     }
 
     public SalesforceException(List<RestError> errors, int statusCode, String message) {
-        this(errors, statusCode, message, null);
+        this(errors, statusCode, message, null, null);
+    }
+
+    public SalesforceException(List<RestError> errors, int statusCode, String message, InputStream responseContent) {
+        this(errors, statusCode, message, responseContent, null);
     }
 
     public SalesforceException(List<RestError> errors, int statusCode, String message, Throwable cause) {
+        this(errors, statusCode, message, null, cause);
+    }
+
+    public SalesforceException(List<RestError> errors, int statusCode, String message, InputStream responseContent,
+                               Throwable cause) {
         super(message == null ? toErrorMessage(errors, statusCode) : message, cause);
         this.errors = errors;
         this.statusCode = statusCode;
+        this.responseContent = responseContent;
     }
 
     public List<RestError> getErrors() {
@@ -69,6 +81,10 @@ public class SalesforceException extends CamelException {
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public InputStream getResponseContent() {
+        return responseContent;
     }
 
     private static String toErrorMessage(List<RestError> errors, int statusCode) {
@@ -86,5 +102,4 @@ public class SalesforceException extends CamelException {
 
         return builder.toString();
     }
-
 }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRestClient.java
@@ -89,14 +89,25 @@ public class DefaultRestClient extends AbstractClientBase implements RestClient 
                     choices = objectMapper.readValue(responseContent, TypeReferences.STRING_LIST_TYPE);
                     return new SalesforceMultipleChoicesException(reason, statusCode, choices);
                 } else {
-                    final List<RestError> restErrors = readErrorsFrom(responseContent, objectMapper);
+                    List<RestError> restErrors = null;
+                    try {
+                        restErrors = readErrorsFrom(responseContent, objectMapper);
+                    } catch (IOException ignored) {
+                        // ok. could be a custom response
+                    }
+                    try {
+                        responseContent.reset();
+                    } catch (Throwable t) {
+                        log.warn("Unable to reset HTTP response content input stream.");
+                    }
                     if (statusCode == HttpStatus.NOT_FOUND_404) {
                         return new NoSuchSObjectException(restErrors);
                     }
 
                     return new SalesforceException(
                             restErrors, statusCode,
-                            "Unexpected error: " + reason + ". See exception `errors` property for detail.");
+                            "Unexpected error: " + reason + ". See exception `errors` property for detail.",
+                            responseContent);
                 }
             }
         } catch (IOException e) {

--- a/components/camel-salesforce/it/resources/salesforce/classes/MerchandiseRestResource.cls
+++ b/components/camel-salesforce/it/resources/salesforce/classes/MerchandiseRestResource.cls
@@ -33,7 +33,7 @@ global with sharing class MerchandiseRestResource {
             throw new InvalidParamException('Missing merchandise id in URL and query params');
         }
     }
-  
+
     @HttpPatch
     global static Merchandise__c doPatch(Merchandise__c merchandise) {
         // lookup merchandise
@@ -53,6 +53,12 @@ global with sharing class MerchandiseRestResource {
 
         update current;
         return current;
+    }
+
+    @HttpPost
+    global static void doPost() {
+        RestContext.response.responseBody = Blob.valueOf('test response');
+        RestContext.response.statusCode = 500;
     }
 
     // Invalid Merchandise Id exception


### PR DESCRIPTION
In case of non-2xx responses to Apex REST requests, preserve the
response content since it won't necessarily be in the standard
salesforce exception format.

Is it a terrible idea to return an InputStream in the Exception? Very possible that it would only get closed when the exception gets GC'd. I believe it's always a ByteArrayInputStream, so at least no file/socket handles are involved. I'd like to avoid returning the response content as the message body. Since this is for exceptional situations, I think it makes sense to use an exception and preserve the `in` message body for logging/debugging capabilities.