### PR TITLE
CAMEL-17327 Remove hardcoded log4j versions from google-pubsub / kafka /restlet-jdbc examples 

### DIFF
--- a/examples/camel-example-google-pubsub/pom.xml
+++ b/examples/camel-example-google-pubsub/pom.xml
@@ -55,17 +55,14 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.7</version>
     </dependency>
   </dependencies>
 

--- a/examples/camel-example-kafka/pom.xml
+++ b/examples/camel-example-kafka/pom.xml
@@ -55,17 +55,14 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.7</version>
     </dependency>
   </dependencies>
 

--- a/examples/camel-example-restlet-jdbc/pom.xml
+++ b/examples/camel-example-restlet-jdbc/pom.xml
@@ -85,31 +85,26 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>
-      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>runtime</scope>
-      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>runtime</scope>
-      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jcl</artifactId>
       <scope>runtime</scope>
-      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-web</artifactId>
       <scope>runtime</scope>
-      <version>2.8.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
There are a few examples that have hardcoded log4j versions - they should probably be inheriting the log4j 2.16 version from camel-parent.      Cherry pick of the commit to the 2.x branch over to the release branch.